### PR TITLE
feat(sentinel): wire performVaultRefund with authority_refund

### DIFF
--- a/packages/agent/src/sentinel/vault-refund.ts
+++ b/packages/agent/src/sentinel/vault-refund.ts
@@ -1,43 +1,81 @@
+import { Connection, PublicKey, Keypair } from '@solana/web3.js'
+import { getAssociatedTokenAddress } from '@solana/spl-token'
+import { readFileSync } from 'node:fs'
+import {
+  buildAuthorityRefundTx,
+  fetchDepositRecord,
+  createConnection,
+} from '@sipher/sdk'
+
 /**
- * Authority-signed refund via sipher_vault program.
+ * Load a Solana keypair from a JSON file (standard CLI format: [u8; 64]).
+ */
+function loadKeypairFromFile(filepath: string): Keypair {
+  const raw = JSON.parse(readFileSync(filepath, 'utf-8')) as number[]
+  return Keypair.fromSecretKey(Uint8Array.from(raw))
+}
+
+/**
+ * Authority-signed refund via sipher_vault.authority_refund instruction.
  *
- * v1 scope: stub that throws unless overridden by a real SDK integration in
- * subsequent work. Unit tests mock this module. Production wiring will load
- * a keypair from env and submit a sipher_vault.refund ix signed by the
- * authority. Keeping it isolated here lets the plan and tests land without
- * blocking on SDK plumbing.
+ * Loads the authority keypair from SENTINEL_AUTHORITY_KEYPAIR env,
+ * fetches the deposit record on-chain to derive depositor + mint,
+ * builds the TX via @sipher/sdk, signs with authority, and sends.
+ *
+ * Timeout is enforced on-chain — this will fail if the deposit's
+ * refund_timeout (24h default) hasn't elapsed since last_deposit_at.
  */
 export async function performVaultRefund(
   pda: string,
   amount: number,
 ): Promise<{ success: boolean; txId?: string; error?: string }> {
-  void pda
-  void amount
-  throw new Error('performVaultRefund not wired — configure authority keypair + SDK integration')
+  void amount // amount is informational — on-chain refunds all available balance
+
+  const keypairPath = process.env.SENTINEL_AUTHORITY_KEYPAIR
+  if (!keypairPath) {
+    throw new Error('SENTINEL_AUTHORITY_KEYPAIR env not set — cannot sign authority refund')
+  }
+  const authority = loadKeypairFromFile(keypairPath)
+  const network = (process.env.SOLANA_NETWORK ?? 'mainnet-beta') as 'devnet' | 'mainnet-beta'
+  const connection = createConnection(network)
+
+  // Fetch deposit record to get depositor + tokenMint
+  const depositRecord = await fetchDepositRecord(connection, new PublicKey(pda))
+  const depositorTokenAccount = await getAssociatedTokenAddress(
+    depositRecord.tokenMint, depositRecord.depositor,
+  )
+
+  const { transaction } = await buildAuthorityRefundTx(
+    connection,
+    authority.publicKey,
+    depositRecord.depositor,
+    depositRecord.tokenMint,
+    depositorTokenAccount,
+  )
+
+  transaction.sign(authority)
+
+  const txId = await connection.sendRawTransaction(transaction.serialize(), {
+    skipPreflight: true,
+    maxRetries: 3,
+  })
+  await connection.confirmTransaction(txId, 'confirmed')
+
+  return { success: true, txId }
 }
 
 /**
- * Emit a loud startup warning when the vault refund stub is active in a
- * production context where it would actually be invoked (spec §9.4 guard).
- *
- * Conditions for warning:
- *   - NODE_ENV === 'production'
- *   - SENTINEL_MODE is not 'off' (refunds can fire)
- *   - SENTINEL_VAULT_REFUND_WIRED !== 'true' (integration not yet shipped)
- *
- * Set SENTINEL_VAULT_REFUND_WIRED=true once the SDK integration replaces this
- * stub, or run with SENTINEL_MODE=off to suppress during staging.
+ * Startup check: warn if authority keypair is missing in production.
  */
 export function assertVaultRefundWired(): void {
-  const isProduction = process.env.NODE_ENV === 'production'
-  const sentinelMode = process.env.SENTINEL_MODE ?? 'advisory'
-  const wired = process.env.SENTINEL_VAULT_REFUND_WIRED === 'true'
-
-  if (isProduction && sentinelMode !== 'off' && !wired) {
+  if (
+    process.env.NODE_ENV === 'production' &&
+    process.env.SENTINEL_MODE !== 'off' &&
+    !process.env.SENTINEL_AUTHORITY_KEYPAIR
+  ) {
     console.warn(
-      '[SENTINEL] performVaultRefund is a stub; refunds will throw at runtime.\n' +
-      'Set SENTINEL_VAULT_REFUND_WIRED=true once the SDK integration ships,\n' +
-      'or run with SENTINEL_MODE=off until then.',
+      '[SENTINEL] SENTINEL_AUTHORITY_KEYPAIR env not set. Authority refunds will throw at runtime. ' +
+      'Set it to the path of the vault authority keypair JSON, or run with SENTINEL_MODE=off.',
     )
   }
 }

--- a/packages/agent/src/sentinel/vault-refund.ts
+++ b/packages/agent/src/sentinel/vault-refund.ts
@@ -29,8 +29,6 @@ export async function performVaultRefund(
   pda: string,
   amount: number,
 ): Promise<{ success: boolean; txId?: string; error?: string }> {
-  void amount // amount is informational — on-chain refunds all available balance
-
   const keypairPath = process.env.SENTINEL_AUTHORITY_KEYPAIR
   if (!keypairPath) {
     throw new Error('SENTINEL_AUTHORITY_KEYPAIR env not set — cannot sign authority refund')
@@ -45,13 +43,29 @@ export async function performVaultRefund(
     depositRecord.tokenMint, depositRecord.depositor,
   )
 
-  const { transaction } = await buildAuthorityRefundTx(
+  const { transaction, refundAmount } = await buildAuthorityRefundTx(
     connection,
     authority.publicKey,
     depositRecord.depositor,
     depositRecord.tokenMint,
     depositorTokenAccount,
   )
+
+  // Safety check: verify on-chain balance matches what SENTINEL intended.
+  // Convert SOL amount to lamports (1e9) for comparison with refundAmount (bigint, lamports).
+  // Allow 1% tolerance for SOL precision drift.
+  const expectedLamports = BigInt(Math.floor(amount * 1_000_000_000))
+  const actualLamports = refundAmount
+  const tolerance = expectedLamports / 100n // 1%
+  const diff = actualLamports > expectedLamports
+    ? actualLamports - expectedLamports
+    : expectedLamports - actualLamports
+  if (diff > tolerance) {
+    throw new Error(
+      `Refund amount mismatch: SENTINEL expected ${amount} SOL (${expectedLamports} lamports), ` +
+      `on-chain available is ${actualLamports} lamports. Aborting to prevent stale-decision execution.`
+    )
+  }
 
   transaction.sign(authority)
 

--- a/packages/agent/tests/sentinel/vault-refund.test.ts
+++ b/packages/agent/tests/sentinel/vault-refund.test.ts
@@ -6,8 +6,8 @@ describe('vault-refund', () => {
 
   beforeEach(() => {
     originalEnv = { ...process.env }
-    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     vi.resetModules()
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
   })
 
   afterEach(() => {
@@ -15,39 +15,111 @@ describe('vault-refund', () => {
     warnSpy.mockRestore()
   })
 
-  it('assertVaultRefundWired: warns when prod + mode!=off + not wired', async () => {
-    process.env.NODE_ENV = 'production'
-    process.env.SENTINEL_MODE = 'yolo'
-    delete process.env.SENTINEL_VAULT_REFUND_WIRED
-    const { assertVaultRefundWired } = await import('../../src/sentinel/vault-refund.js')
-    assertVaultRefundWired()
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('performVaultRefund is a stub'))
+  describe('performVaultRefund', () => {
+    it('throws when SENTINEL_AUTHORITY_KEYPAIR not set', async () => {
+      delete process.env.SENTINEL_AUTHORITY_KEYPAIR
+      const { performVaultRefund } = await import('../../src/sentinel/vault-refund.js')
+      await expect(performVaultRefund('pda1', 0.5))
+        .rejects.toThrow(/SENTINEL_AUTHORITY_KEYPAIR/)
+    })
+
+    it('calls buildAuthorityRefundTx + signs + sends when keypair is set', async () => {
+      process.env.SENTINEL_AUTHORITY_KEYPAIR = '/tmp/fake-keypair.json'
+
+      const mockTx = {
+        sign: vi.fn(),
+        serialize: vi.fn().mockReturnValue(Buffer.from('fake-tx')),
+      }
+      const mockDepositRecord = {
+        depositor: { toBase58: () => 'depositor1' },
+        tokenMint: { toBase58: () => 'mint1' },
+      }
+
+      vi.doMock('@sipher/sdk', () => ({
+        createConnection: vi.fn().mockReturnValue({
+          sendRawTransaction: vi.fn().mockResolvedValue('txSig123'),
+          confirmTransaction: vi.fn().mockResolvedValue({ value: {} }),
+        }),
+        fetchDepositRecord: vi.fn().mockResolvedValue(mockDepositRecord),
+        buildAuthorityRefundTx: vi.fn().mockResolvedValue({
+          transaction: mockTx,
+          refundAmount: 500_000n,
+          depositorTokenAddress: 'ata1',
+        }),
+      }))
+      vi.doMock('node:fs', () => ({
+        readFileSync: vi.fn().mockReturnValue(JSON.stringify(Array(64).fill(1))),
+      }))
+      vi.doMock('@solana/spl-token', () => ({
+        getAssociatedTokenAddress: vi.fn().mockResolvedValue('ata1'),
+      }))
+      vi.doMock('@solana/web3.js', async () => {
+        const actual = await vi.importActual<typeof import('@solana/web3.js')>('@solana/web3.js')
+        const mockKeypair = {
+          publicKey: new actual.PublicKey('11111111111111111111111111111111'),
+          secretKey: new Uint8Array(64).fill(1),
+          sign: vi.fn(),
+        }
+        return {
+          ...actual,
+          Keypair: {
+            ...actual.Keypair,
+            fromSecretKey: vi.fn().mockReturnValue(mockKeypair),
+            generate: vi.fn().mockReturnValue(mockKeypair),
+          },
+        }
+      })
+
+      const { performVaultRefund } = await import('../../src/sentinel/vault-refund.js')
+      // Use a valid base58 pubkey so `new PublicKey(pda)` doesn't throw
+      const result = await performVaultRefund('11111111111111111111111111111111', 0.5)
+
+      expect(result.success).toBe(true)
+      expect(result.txId).toBe('txSig123')
+      expect(mockTx.sign).toHaveBeenCalled()
+
+      vi.doUnmock('@sipher/sdk')
+      vi.doUnmock('node:fs')
+      vi.doUnmock('@solana/spl-token')
+      vi.doUnmock('@solana/web3.js')
+    })
   })
 
-  it('assertVaultRefundWired: silent when WIRED=true', async () => {
-    process.env.NODE_ENV = 'production'
-    process.env.SENTINEL_MODE = 'yolo'
-    process.env.SENTINEL_VAULT_REFUND_WIRED = 'true'
-    const { assertVaultRefundWired } = await import('../../src/sentinel/vault-refund.js')
-    assertVaultRefundWired()
-    expect(warnSpy).not.toHaveBeenCalled()
-  })
+  describe('assertVaultRefundWired', () => {
+    it('warns when prod + mode!=off + no keypair', async () => {
+      process.env.NODE_ENV = 'production'
+      process.env.SENTINEL_MODE = 'yolo'
+      delete process.env.SENTINEL_AUTHORITY_KEYPAIR
+      const { assertVaultRefundWired } = await import('../../src/sentinel/vault-refund.js')
+      assertVaultRefundWired()
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('SENTINEL_AUTHORITY_KEYPAIR'))
+    })
 
-  it('assertVaultRefundWired: silent when mode=off', async () => {
-    process.env.NODE_ENV = 'production'
-    process.env.SENTINEL_MODE = 'off'
-    delete process.env.SENTINEL_VAULT_REFUND_WIRED
-    const { assertVaultRefundWired } = await import('../../src/sentinel/vault-refund.js')
-    assertVaultRefundWired()
-    expect(warnSpy).not.toHaveBeenCalled()
-  })
+    it('silent when SENTINEL_AUTHORITY_KEYPAIR is set', async () => {
+      process.env.NODE_ENV = 'production'
+      process.env.SENTINEL_MODE = 'yolo'
+      process.env.SENTINEL_AUTHORITY_KEYPAIR = '/some/path.json'
+      const { assertVaultRefundWired } = await import('../../src/sentinel/vault-refund.js')
+      assertVaultRefundWired()
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
 
-  it('assertVaultRefundWired: silent in non-prod', async () => {
-    process.env.NODE_ENV = 'development'
-    process.env.SENTINEL_MODE = 'yolo'
-    delete process.env.SENTINEL_VAULT_REFUND_WIRED
-    const { assertVaultRefundWired } = await import('../../src/sentinel/vault-refund.js')
-    assertVaultRefundWired()
-    expect(warnSpy).not.toHaveBeenCalled()
+    it('silent when mode=off', async () => {
+      process.env.NODE_ENV = 'production'
+      process.env.SENTINEL_MODE = 'off'
+      delete process.env.SENTINEL_AUTHORITY_KEYPAIR
+      const { assertVaultRefundWired } = await import('../../src/sentinel/vault-refund.js')
+      assertVaultRefundWired()
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+
+    it('silent in non-prod', async () => {
+      process.env.NODE_ENV = 'development'
+      process.env.SENTINEL_MODE = 'yolo'
+      delete process.env.SENTINEL_AUTHORITY_KEYPAIR
+      const { assertVaultRefundWired } = await import('../../src/sentinel/vault-refund.js')
+      assertVaultRefundWired()
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/agent/tests/sentinel/vault-refund.test.ts
+++ b/packages/agent/tests/sentinel/vault-refund.test.ts
@@ -43,7 +43,7 @@ describe('vault-refund', () => {
         fetchDepositRecord: vi.fn().mockResolvedValue(mockDepositRecord),
         buildAuthorityRefundTx: vi.fn().mockResolvedValue({
           transaction: mockTx,
-          refundAmount: 500_000n,
+          refundAmount: 500_000_000n,
           depositorTokenAddress: 'ata1',
         }),
       }))
@@ -77,6 +77,64 @@ describe('vault-refund', () => {
       expect(result.success).toBe(true)
       expect(result.txId).toBe('txSig123')
       expect(mockTx.sign).toHaveBeenCalled()
+
+      vi.doUnmock('@sipher/sdk')
+      vi.doUnmock('node:fs')
+      vi.doUnmock('@solana/spl-token')
+      vi.doUnmock('@solana/web3.js')
+    })
+
+    it('throws when on-chain balance differs from requested amount beyond tolerance', async () => {
+      process.env.SENTINEL_AUTHORITY_KEYPAIR = '/tmp/fake-keypair.json'
+
+      const mockTx = {
+        sign: vi.fn(),
+        serialize: vi.fn().mockReturnValue(Buffer.from('fake-tx')),
+      }
+      const mockDepositRecord = {
+        depositor: { toBase58: () => 'depositor1' },
+        tokenMint: { toBase58: () => 'mint1' },
+      }
+
+      vi.doMock('@sipher/sdk', () => ({
+        createConnection: vi.fn().mockReturnValue({
+          sendRawTransaction: vi.fn(),
+          confirmTransaction: vi.fn(),
+        }),
+        fetchDepositRecord: vi.fn().mockResolvedValue(mockDepositRecord),
+        buildAuthorityRefundTx: vi.fn().mockResolvedValue({
+          transaction: mockTx,
+          // SENTINEL expects 1.0 SOL but on-chain has 5.0 SOL → 400% mismatch (way beyond 1%)
+          refundAmount: 5_000_000_000n,
+          depositorTokenAddress: 'ata1',
+        }),
+      }))
+      vi.doMock('node:fs', () => ({
+        readFileSync: vi.fn().mockReturnValue(JSON.stringify(Array(64).fill(1))),
+      }))
+      vi.doMock('@solana/spl-token', () => ({
+        getAssociatedTokenAddress: vi.fn().mockResolvedValue('ata1'),
+      }))
+      vi.doMock('@solana/web3.js', async () => {
+        const actual = await vi.importActual<typeof import('@solana/web3.js')>('@solana/web3.js')
+        const mockKeypair = {
+          publicKey: new actual.PublicKey('11111111111111111111111111111111'),
+          secretKey: new Uint8Array(64).fill(1),
+          sign: vi.fn(),
+        }
+        return {
+          ...actual,
+          Keypair: {
+            ...actual.Keypair,
+            fromSecretKey: vi.fn().mockReturnValue(mockKeypair),
+            generate: vi.fn().mockReturnValue(mockKeypair),
+          },
+        }
+      })
+
+      const { performVaultRefund } = await import('../../src/sentinel/vault-refund.js')
+      await expect(performVaultRefund('11111111111111111111111111111111', 1.0)).rejects.toThrow(/mismatch/i)
+      expect(mockTx.sign).not.toHaveBeenCalled()
 
       vi.doUnmock('@sipher/sdk')
       vi.doUnmock('node:fs')

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -60,6 +60,8 @@ export {
   getVaultBalance,
   buildDepositTx,
   buildRefundTx,
+  fetchDepositRecord,
+  buildAuthorityRefundTx,
 } from './vault.js'
 
 // Privacy operations

--- a/packages/sdk/src/vault.ts
+++ b/packages/sdk/src/vault.ts
@@ -392,3 +392,88 @@ export async function buildRefundTx(
     depositorTokenAddress: depositorTokenAccount,
   }
 }
+
+/**
+ * Fetch and deserialize a DepositRecord from chain.
+ * Used by SENTINEL's performVaultRefund to derive depositor + mint from a PDA.
+ */
+export async function fetchDepositRecord(
+  connection: Connection,
+  depositRecordPDA: PublicKey,
+): Promise<DepositRecord> {
+  const info = await connection.getAccountInfo(depositRecordPDA)
+  if (!info) {
+    throw new Error(`DepositRecord not found at ${depositRecordPDA.toBase58()}`)
+  }
+  return deserializeDepositRecord(Buffer.from(info.data))
+}
+
+/**
+ * Build an authority-signed refund transaction (sipher_vault.authority_refund).
+ *
+ * Unlike buildRefundTx (depositor signs), this is signed by the vault authority.
+ * Used by SENTINEL for autonomous refunds of expired deposits after the
+ * refund_timeout cooldown. Timeout is still enforced on-chain.
+ *
+ * Accounts (order matters — matches AuthorityRefund context in lib.rs):
+ *   0. config           (ro)   — VaultConfig PDA
+ *   1. deposit_record   (mut)  — DepositRecord PDA
+ *   2. vault_token      (mut)  — Vault token PDA
+ *   3. depositor_token  (mut)  — Depositor's token account
+ *   4. depositor        (ro)   — NOT signer, validated by has_one on deposit_record
+ *   5. authority        (mut, signer)
+ *   6. token_program    (ro)
+ */
+export async function buildAuthorityRefundTx(
+  connection: Connection,
+  authority: PublicKey,
+  depositor: PublicKey,
+  tokenMint: PublicKey,
+  depositorTokenAccount: PublicKey,
+  programId: PublicKey = SIPHER_VAULT_PROGRAM_ID
+): Promise<RefundResult> {
+  const [configPDA] = deriveVaultConfigPDA(programId)
+  const [depositRecordPDA] = deriveDepositRecordPDA(depositor, tokenMint, programId)
+  const [vaultTokenPDA] = deriveVaultTokenPDA(tokenMint, programId)
+
+  // Pre-fetch balance to compute refund amount
+  const recordInfo = await connection.getAccountInfo(depositRecordPDA)
+  if (!recordInfo) {
+    throw new Error('No deposit record found — nothing to refund')
+  }
+  const record = deserializeDepositRecord(Buffer.from(recordInfo.data))
+  const refundAmount = record.balance - record.lockedAmount
+  if (refundAmount <= 0n) {
+    throw new Error('No available balance to refund (all funds locked or zero)')
+  }
+
+  // Encode: discriminator(8) only — authority_refund has no params
+  const data = anchorDiscriminator('authority_refund')
+
+  const ix = new TransactionInstruction({
+    programId,
+    keys: [
+      { pubkey: configPDA, isSigner: false, isWritable: false },           // config
+      { pubkey: depositRecordPDA, isSigner: false, isWritable: true },     // deposit_record
+      { pubkey: vaultTokenPDA, isSigner: false, isWritable: true },        // vault_token
+      { pubkey: depositorTokenAccount, isSigner: false, isWritable: true }, // depositor_token
+      { pubkey: depositor, isSigner: false, isWritable: false },           // depositor (NOT signer)
+      { pubkey: authority, isSigner: true, isWritable: true },             // authority (signer)
+      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },    // token_program
+    ],
+    data,
+  })
+
+  const tx = new Transaction()
+  tx.add(ix)
+  tx.feePayer = authority
+
+  const { blockhash } = await connection.getLatestBlockhash()
+  tx.recentBlockhash = blockhash
+
+  return {
+    transaction: tx,
+    refundAmount,
+    depositorTokenAddress: depositorTokenAccount,
+  }
+}


### PR DESCRIPTION
## Summary

Wires SENTINEL's \`performVaultRefund\` to the new \`authority_refund\` instruction (sip-protocol/sip-protocol#1076), replacing the v1 stub with a real implementation. Closes the last functional gap in SENTINEL formalization — autonomous vault refunds now work end-to-end.

### Changes

**SDK (\`packages/sdk/src/vault.ts\`):**
- \`fetchDepositRecord(connection, pda)\` — fetch + deserialize a DepositRecord from chain
- \`buildAuthorityRefundTx(connection, authority, depositor, mint, ata)\` — mirrors \`buildRefundTx\` but authority signs

**Agent (\`packages/agent/src/sentinel/vault-refund.ts\`):**
- \`performVaultRefund(pda, amount)\`: load authority keypair from \`SENTINEL_AUTHORITY_KEYPAIR\` env, fetch deposit record, build TX via SDK, sign + send with skipPreflight
- **Safety check:** verifies on-chain \`refundAmount\` matches SENTINEL's intended \`amount\` (1% tolerance) before signing, prevents stale-decision execution
- \`assertVaultRefundWired()\`: now checks for keypair env presence (no more manual flag)

### Spec / Plan
- Spec: \`/Users/rector/local-dev/sip-protocol/docs/superpowers/specs/2026-04-16-authority-refund-design.md\`
- Plan: \`/Users/rector/local-dev/sip-protocol/docs/superpowers/plans/2026-04-16-authority-refund.md\`

### Test impact
- Agent: 905 → 908 tests (+3): keypair-missing throw, happy path with mocked SDK, amount-mismatch safety check
- REST: 497 unchanged
- SDK: builds clean, no regressions

### Deployment dependency

This PR's runtime correctness depends on the program PR being merged AND the program redeployed to devnet. Until then, runtime calls will fail with \`instruction not found\`. Safe to merge first because:
1. Default \`SENTINEL_MODE=advisory\` (or unset \`SENTINEL_AUTHORITY_KEYPAIR\`) means no runtime calls
2. Startup warning fires if production + yolo + missing keypair

### Rollout order
1. Merge sip-protocol/sip-protocol#1076 (program change)
2. Merge this PR (agent wiring)
3. Redeploy program to devnet
4. Set \`SENTINEL_AUTHORITY_KEYPAIR\` env on VPS
5. \`SENTINEL_MODE=advisory\` for QA
6. \`SENTINEL_MODE=yolo\` with low thresholds (beta)
7. GA thresholds

## Test plan
- [x] pnpm build clean
- [x] pnpm test — 908 agent tests passing
- [x] pnpm test --run — 497 REST tests passing
- [x] Account ordering in SDK verified against Anchor context
- [x] Discriminator verified: \`'authority_refund'\` (not \`'refund'\`)
- [x] Safety check rejects amount-mismatch beyond 1% tolerance
- [ ] Manual smoke after devnet redeploy: \`SENTINEL_MODE=yolo\`, trigger an expired deposit, verify on-chain refund signed by authority