### PR TITLE
fix(sentinel): correct SENTINEL_MODEL default to Pi SDK provider:modelId format

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,7 +38,7 @@ SSH access: `ssh sip` (the `sipher` container runs under the `sip` user, there i
 | `SOLANA_RPC_URL_FALLBACK` | (empty) | Fallback RPC on primary failure |
 | `SIPHER_HELIUS_API_KEY` | (empty) | Dedicated Helius key (when `RPC_PROVIDER=helius`) |
 | `RPC_PROVIDER` | `generic` | `helius` / `quicknode` / `triton` / `generic` |
-| `SIPHER_MODEL` | `anthropic/claude-sonnet-4-6` | Default SIPHER LLM model |
+| `SIPHER_MODEL` | `anthropic/claude-sonnet-4.6` | Default SIPHER LLM model ID (provider `openrouter` hard-coded in `packages/agent/src/pi/provider.ts`) |
 | `SOLANA_NETWORK` | `mainnet-beta` | `mainnet-beta` / `devnet` |
 | `CORS_ORIGINS` | SIP domains | Comma-separated allowlist |
 | `RATE_LIMIT_MAX` | `100` | Requests per window |
@@ -60,7 +60,7 @@ SENTINEL is an LLM-backed security analyst that performs preflight risk assessme
 | `SENTINEL_CANCEL_WINDOW_MS` | `30000` | Circuit breaker wait time before execution fires |
 | `SENTINEL_RATE_LIMIT_FUND_PER_HOUR` | `5` | Per-wallet fund action limit |
 | `SENTINEL_RATE_LIMIT_BLACKLIST_PER_HOUR` | `20` | Global blacklist add rate limit |
-| `SENTINEL_MODEL` | `anthropic/claude-sonnet-4.6` | SENTINEL LLM (cheaper: `anthropic/claude-haiku-4.5`) |
+| `SENTINEL_MODEL` | `openrouter:anthropic/claude-sonnet-4.6` | SENTINEL LLM in `provider:modelId` format (cheaper: `openrouter:anthropic/claude-haiku-4.5`) |
 | `SENTINEL_DAILY_BUDGET_USD` | `10` | Daily budget cap — emits warning on exceed |
 | `SENTINEL_BLOCK_ON_ERROR` | `false` | Fail-open (default) or fail-closed on LLM preflight errors |
 | `SENTINEL_PREFLIGHT_SCOPE` | `fund-actions` | `fund-actions` / `critical-only` / `never` |

--- a/packages/agent/src/sentinel/config.ts
+++ b/packages/agent/src/sentinel/config.ts
@@ -54,7 +54,7 @@ export function getSentinelConfig(): SentinelConfig {
     cancelWindowMs: Number(process.env.SENTINEL_CANCEL_WINDOW_MS ?? '30000'),
     rateLimitFundPerHour: Number(process.env.SENTINEL_RATE_LIMIT_FUND_PER_HOUR ?? '5'),
     rateLimitBlacklistPerHour: Number(process.env.SENTINEL_RATE_LIMIT_BLACKLIST_PER_HOUR ?? '20'),
-    model: process.env.SENTINEL_MODEL ?? 'anthropic/claude-sonnet-4.6',
+    model: process.env.SENTINEL_MODEL ?? 'openrouter:anthropic/claude-sonnet-4.6',
     dailyBudgetUsd: Number(process.env.SENTINEL_DAILY_BUDGET_USD ?? '10'),
     blockOnError: process.env.SENTINEL_BLOCK_ON_ERROR === 'true',
   }

--- a/packages/agent/tests/sentinel/config.test.ts
+++ b/packages/agent/tests/sentinel/config.test.ts
@@ -104,7 +104,7 @@ describe('getSentinelConfig', () => {
     delete process.env.SENTINEL_DAILY_BUDGET_USD
     delete process.env.SENTINEL_BLOCK_ON_ERROR
     const c = getSentinelConfig()
-    expect(c.model).toBe('anthropic/claude-sonnet-4.6')
+    expect(c.model).toBe('openrouter:anthropic/claude-sonnet-4.6')
     expect(c.dailyBudgetUsd).toBe(10)
     expect(c.blockOnError).toBe(false)
   })


### PR DESCRIPTION
## Summary

Found during SENTINEL advisory-mode QA on production (sipher.sip-protocol.org). `POST /api/sentinel/assess` returned 500:

```
{"error":"createPiAgent: model must be in 'provider:modelId' format, got 'anthropic/claude-sonnet-4.6'"}
```

Root cause: `packages/agent/src/sentinel/config.ts:57` shipped the default `SENTINEL_MODEL` as `anthropic/claude-sonnet-4.6` (no provider prefix), but `core.ts:143` passes it straight to `createPiAgent({ model: config.model })`, and `pi/sipher-agent.ts:70-75` enforces `provider:modelId` format.

**Net effect on production:** every SENTINEL assessment fails LLM invocation. Preflight gate falls through with `SENTINEL_BLOCK_ON_ERROR=false` (fail-open default), so nothing crashes, but SENTINEL is effectively a no-op on the assess path. Advisory-mode QA was blocked on this.

## Fix

One-character shape fix, aligned with HERALD's already-correct pattern (`adapters/x.ts:37` uses `openrouter:anthropic/claude-sonnet-4.6`).

- `packages/agent/src/sentinel/config.ts` — add `openrouter:` prefix to default
- `packages/agent/tests/sentinel/config.test.ts` — update default-model assertion
- `docs/deployment.md` — correct `SENTINEL_MODEL` default format and fix a `SIPHER_MODEL` dot/hyphen typo caught while scanning

## Test plan

- [x] `cd packages/agent && pnpm test -- --run` — 908 tests pass
- [x] `pnpm test -- --run` (root, REST) — 497 tests pass
- [ ] After merge + deploy: re-run `curl POST /api/sentinel/assess` against prod → expect 200 with `RiskReport`