### PR TITLE
feat(test-infra): Playwright E2E + Vitest/RTL component tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,6 +54,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - run: pnpm --filter @sipher/sdk build
+
       - run: pnpm exec playwright install --with-deps chromium
 
       - name: Write E2E admin keypair

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - uses: actions/setup-node@v4
         with:
@@ -45,7 +45,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,78 @@
+name: e2e
+
+on:
+  pull_request:
+    paths:
+      - 'app/**'
+      - 'packages/agent/**'
+      - 'src/**'
+      - 'e2e/**'
+      - 'playwright.config.ts'
+      - 'package.json'
+      - 'app/package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/e2e.yml'
+  push:
+    branches: [main]
+
+jobs:
+  component:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run app component tests
+        run: pnpm --filter @sipher/app test
+
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm exec playwright install --with-deps chromium
+
+      - name: Write E2E admin keypair
+        env:
+          E2E_ADMIN_KEYPAIR: ${{ secrets.E2E_ADMIN_KEYPAIR }}
+        run: |
+          mkdir -p e2e/fixtures
+          printf '%s' "$E2E_ADMIN_KEYPAIR" > e2e/fixtures/admin-keypair.json
+          chmod 600 e2e/fixtures/admin-keypair.json
+
+      - name: Run Playwright
+        env:
+          E2E_ADMIN_KEYPAIR_PATH: e2e/fixtures/admin-keypair.json
+          JWT_SECRET: ${{ secrets.E2E_JWT_SECRET }}
+        run: pnpm test:e2e
+
+      - if: failure() || cancelled()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,11 @@ data/
 !packages/**/src/data/
 .superpowers/
 .worktrees/
+
+# Playwright / RTL
+playwright-report/
+test-results/
+e2e/fixtures/admin-keypair.json
+e2e/fixtures/storageState.json
+e2e/test.db
+e2e/test.db-journal

--- a/README.md
+++ b/README.md
@@ -711,6 +711,34 @@ CI workflow auto-regenerates SDKs on spec changes (`.github/workflows/generate-s
 pnpm test -- --run
 ```
 
+## Running Tests
+
+### Backend + Agent (Vitest)
+
+```bash
+pnpm test -- --run                           # Root REST tests
+pnpm --filter @sipher/agent test -- --run    # Agent tests
+```
+
+### Frontend component tests (Vitest + RTL)
+
+```bash
+pnpm --filter @sipher/app test
+```
+
+### End-to-end (Playwright, Chromium)
+
+```bash
+pnpm exec playwright install chromium    # one-time browser install
+pnpm test:e2e                            # run all e2e specs
+pnpm test:e2e:ui                         # interactive UI mode
+pnpm test:e2e:headed                     # watch tests run in a visible browser
+```
+
+Playwright runs against the Vite dev server (port 5173) and the Sipher backend (port 3000), both spun up automatically via its `webServer` config. Admin flows use an ed25519-signed JWT minted at global-setup. Locally, this reads `~/Documents/secret/cipher-admin.json`; in CI, the `E2E_ADMIN_KEYPAIR` GitHub Secret supplies it.
+
+See [`docs/superpowers/specs/2026-04-18-test-infrastructure-design.md`](docs/superpowers/specs/2026-04-18-test-infrastructure-design.md) for architectural details.
+
 ---
 
 ## 🛠️ Tech Stack

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@phosphor-icons/react": "^2.1.10",
@@ -21,10 +23,15 @@
     "zustand": "^5.0.12"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "jsdom": "^25.0.1",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/app/src/components/__tests__/ChatSidebar.test.tsx
+++ b/app/src/components/__tests__/ChatSidebar.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { useAppStore } from '../../stores/app'
+import ChatSidebar from '../ChatSidebar'
+
+function resetStore() {
+  useAppStore.setState({
+    token: null,
+    isAdmin: false,
+    messages: [],
+    chatLoading: false,
+    chatOpen: false,
+    activeView: 'dashboard',
+  })
+}
+
+describe('ChatSidebar', () => {
+  beforeEach(() => {
+    resetStore()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows connect-wallet placeholder and disables input when unauthenticated', () => {
+    render(<ChatSidebar />)
+    const input = screen.getByPlaceholderText('Connect wallet first')
+    expect(input).toBeDisabled()
+  })
+
+  it('enables input when authenticated', () => {
+    useAppStore.setState({ token: 'test-jwt', isAdmin: true })
+    render(<ChatSidebar />)
+    const input = screen.getByPlaceholderText('Message SIPHER...')
+    expect(input).toBeEnabled()
+  })
+
+  it('sends message and appends streamed reply', async () => {
+    useAppStore.setState({ token: 'test-jwt', isAdmin: true })
+
+    const encoder = new TextEncoder()
+    const sseBody = new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode('data: {"type":"content_block_delta","text":"Hi"}\n\n')
+        )
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+        controller.close()
+      },
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(sseBody, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        })
+      )
+    )
+
+    render(<ChatSidebar />)
+    const input = screen.getByPlaceholderText('Message SIPHER...') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Hi')).toBeInTheDocument()
+    })
+  })
+})

--- a/app/src/setupTests.ts
+++ b/app/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest'

--- a/app/src/setupTests.ts
+++ b/app/src/setupTests.ts
@@ -1,1 +1,4 @@
 import '@testing-library/jest-dom/vitest'
+
+// jsdom does not implement layout APIs; stub scroll methods used in components
+window.HTMLElement.prototype.scrollIntoView = () => {}

--- a/app/src/stores/app.ts
+++ b/app/src/stores/app.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
 
 export type View = 'dashboard' | 'vault' | 'herald' | 'squad' | 'chat'
 
@@ -34,38 +35,47 @@ interface AppState {
   setChatOpen: (open: boolean) => void
 }
 
-export const useAppStore = create<AppState>((set) => ({
-  activeView: 'dashboard',
-  setActiveView: (activeView) => set({ activeView }),
+export const useAppStore = create<AppState>()(
+  persist(
+    (set) => ({
+      activeView: 'dashboard',
+      setActiveView: (activeView) => set({ activeView }),
 
-  token: null,
-  isAdmin: false,
-  setAuth: (token, isAdmin) => set({ token, isAdmin }),
-  clearAuth: () => set({ token: null, isAdmin: false, messages: [], activeView: 'dashboard' }),
+      token: null,
+      isAdmin: false,
+      setAuth: (token, isAdmin) => set({ token, isAdmin }),
+      clearAuth: () => set({ token: null, isAdmin: false, messages: [], activeView: 'dashboard' }),
 
-  messages: [],
-  chatLoading: false,
-  addMessage: (msg) => set((s) => ({ messages: [...s.messages, msg] })),
-  appendToLast: (text) =>
-    set((s) => {
-      const msgs = [...s.messages]
-      const last = msgs[msgs.length - 1]
-      if (last?.role === 'assistant') {
-        msgs[msgs.length - 1] = { ...last, content: last.content + text }
-      }
-      return { messages: msgs }
+      messages: [],
+      chatLoading: false,
+      addMessage: (msg) => set((s) => ({ messages: [...s.messages, msg] })),
+      appendToLast: (text) =>
+        set((s) => {
+          const msgs = [...s.messages]
+          const last = msgs[msgs.length - 1]
+          if (last?.role === 'assistant') {
+            msgs[msgs.length - 1] = { ...last, content: last.content + text }
+          }
+          return { messages: msgs }
+        }),
+      finishStreaming: () =>
+        set((s) => {
+          const msgs = [...s.messages]
+          const last = msgs[msgs.length - 1]
+          if (last?.streaming) {
+            msgs[msgs.length - 1] = { ...last, streaming: false }
+          }
+          return { messages: msgs }
+        }),
+      setChatLoading: (chatLoading) => set({ chatLoading }),
+
+      chatOpen: false,
+      setChatOpen: (chatOpen) => set({ chatOpen }),
     }),
-  finishStreaming: () =>
-    set((s) => {
-      const msgs = [...s.messages]
-      const last = msgs[msgs.length - 1]
-      if (last?.streaming) {
-        msgs[msgs.length - 1] = { ...last, streaming: false }
-      }
-      return { messages: msgs }
-    }),
-  setChatLoading: (chatLoading) => set({ chatLoading }),
-
-  chatOpen: false,
-  setChatOpen: (chatOpen) => set({ chatOpen }),
-}))
+    {
+      name: 'sipher-auth',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (s) => ({ token: s.token, isAdmin: s.isAdmin }),
+    }
+  )
+)

--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -98,7 +98,7 @@ export default function DashboardView({
   const budgetLimit = heraldBudget?.budget?.limit
 
   return (
-    <div className="flex flex-col gap-6">
+    <div data-testid="dashboard-view" className="flex flex-col gap-6">
       {/* Metric cards */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         <MetricCard

--- a/app/src/views/HeraldView.tsx
+++ b/app/src/views/HeraldView.tsx
@@ -367,7 +367,7 @@ export default function HeraldView({ token }: { token: string | null }) {
   const budget = data?.budget ?? { spent: 0, limit: 150, gate: 'open', percentage: 0 }
 
   return (
-    <div className="flex flex-col h-full">
+    <div data-testid="herald-view" className="flex flex-col h-full">
       <BudgetBar budget={budget} />
       <SubTabs active={tab} onChange={setTab} />
 

--- a/app/src/views/SquadView.tsx
+++ b/app/src/views/SquadView.tsx
@@ -239,7 +239,7 @@ export default function SquadView({ token }: { token: string | null }) {
   }
 
   return (
-    <div className="flex flex-col gap-6">
+    <div data-testid="squad-view" className="flex flex-col gap-6">
       {error && (
         <div className="text-text-muted text-xs font-mono bg-card border border-border rounded-lg px-3 py-2">
           Live data unavailable — {error}

--- a/app/src/views/VaultView.tsx
+++ b/app/src/views/VaultView.tsx
@@ -87,7 +87,7 @@ export default function VaultView({ token }: { token: string | null }) {
   const wallet = data?.wallet
 
   return (
-    <div className="flex flex-col gap-6 pb-2">
+    <div data-testid="vault-view" className="flex flex-col gap-6 pb-2">
       {error && (
         <div className="text-text-muted text-xs font-mono bg-card border border-border rounded-lg px-3 py-2">
           Could not load vault data

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/setupTests.ts'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    css: false,
+  },
+})

--- a/docs/superpowers/plans/2026-04-18-test-infrastructure.md
+++ b/docs/superpowers/plans/2026-04-18-test-infrastructure.md
@@ -1,0 +1,1292 @@
+# Test Infrastructure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land Playwright E2E (Chromium) + Vitest/RTL/jsdom component test harnesses with one smoke test per UI surface, wired into path-filtered GitHub CI, unblocking all subsequent audit-driven phases.
+
+**Architecture:** Playwright runs against Vite dev (:5173) + the Sipher agent server (`packages/agent`, overridden to :3000 to match Vite's `/api` proxy) via Playwright's native `webServer` config. The legacy root REST (`src/server.ts`) is not started — `/api/auth`, `/api/chat/stream`, and SENTINEL routes live in the agent. Ed25519-signed JWT minted once in `global-setup`, persisted to `storageState.json`, injected into Zustand's new `persist`-backed `sipher-auth` localStorage entry so admin views render immediately. External network (Solana RPC, Jupiter, X, Pi SDK) is intercepted at the Playwright layer or disabled via `HERALD_ENABLED=false` / `SENTINEL_MODE=off` — no API keys required in CI. RTL covers component units independently in jsdom.
+
+**Tech Stack:** Playwright ^1.48 (Chromium only), Vitest, @testing-library/react ^16, @testing-library/jest-dom ^6, jsdom ^25, @noble/curves (reused), zustand/middleware/persist.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-test-infrastructure-design.md`
+
+---
+
+## File Structure
+
+**New files (18):**
+
+| Path | Purpose |
+|------|---------|
+| `playwright.config.ts` | Playwright config: Chromium, dual webServer, storageState default, global setup/teardown |
+| `e2e/fixtures/auth.ts` | Ed25519 JWT minter: nonce → sign → verify → token |
+| `e2e/fixtures/mocks.ts` | Route interceptors for Solana RPC + Jupiter |
+| `e2e/global-setup.ts` | Loads admin keypair, mints JWT, writes storageState.json |
+| `e2e/global-teardown.ts` | Wipes test.db, storageState.json |
+| `e2e/.env.test` | `HERALD_ENABLED=false`, `SIPHER_DB_PATH`, `AUTHORIZED_WALLETS` |
+| `e2e/chat.spec.ts` | Unauth disabled state + auth'd intercepted SSE smoke |
+| `e2e/auth-flow.spec.ts` | Admin view without JWT redirects; with JWT renders |
+| `e2e/dashboard.spec.ts` | Dashboard loads, metric cards render |
+| `e2e/vault.spec.ts` | Vault loads, balance field present |
+| `e2e/squad.spec.ts` | Squad loads, no errors |
+| `e2e/herald.spec.ts` | Herald loads, budget metric visible |
+| `app/vitest.config.ts` | Vitest config with jsdom env + RTL setup |
+| `app/src/setupTests.ts` | `import '@testing-library/jest-dom'` |
+| `app/src/components/__tests__/ChatSidebar.test.tsx` | First RTL component test |
+| `.github/workflows/e2e.yml` | Path-filtered Playwright CI job |
+
+**Modified files (3):**
+
+| Path | Change |
+|------|--------|
+| `app/src/stores/app.ts` | Wrap `create` with `persist` middleware, `partialize` to `{ token, isAdmin }`, storage key `sipher-auth` |
+| `package.json` | Add `@playwright/test`, add `test:e2e`, `test:e2e:ui`, `test:e2e:headed` scripts |
+| `app/package.json` | Add `@testing-library/react`, `@testing-library/jest-dom`, `jsdom`, `vitest`, `test` script |
+| `.gitignore` | Ignore `playwright-report/`, `test-results/`, `e2e/fixtures/admin-keypair.json`, `e2e/fixtures/storageState.json`, `e2e/test.db` |
+| `README.md` | "Running tests" section |
+
+---
+
+## Task 1: Scaffold — install deps, update .gitignore, add scripts
+
+**Files:**
+- Modify: `package.json`
+- Modify: `app/package.json`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Install Playwright in root**
+
+```bash
+cd ~/local-dev/sipher
+pnpm add -D -w @playwright/test@^1.48.0
+pnpm exec playwright install --with-deps chromium
+```
+
+Expected: Playwright installed, Chromium binary downloaded.
+
+- [ ] **Step 2: Install Vitest + RTL in `app/`**
+
+```bash
+pnpm --filter @sipher/app add -D vitest@^2.1.0 @testing-library/react@^16.1.0 @testing-library/jest-dom@^6.6.0 @testing-library/user-event@^14.5.0 jsdom@^25.0.0
+```
+
+Expected: all deps installed, `app/package.json` updated.
+
+- [ ] **Step 3: Add scripts to root `package.json`**
+
+In `package.json` scripts block, add these three entries (keep existing scripts untouched):
+
+```json
+"test:e2e": "playwright test",
+"test:e2e:ui": "playwright test --ui",
+"test:e2e:headed": "playwright test --headed"
+```
+
+- [ ] **Step 4: Add `test` script to `app/package.json`**
+
+In `app/package.json` scripts block, add:
+
+```json
+"test": "vitest run",
+"test:watch": "vitest"
+```
+
+- [ ] **Step 5: Update `.gitignore`**
+
+Append to `/Users/rector/local-dev/sipher/.gitignore`:
+
+```
+# Playwright / RTL
+playwright-report/
+test-results/
+e2e/fixtures/admin-keypair.json
+e2e/fixtures/storageState.json
+e2e/test.db
+e2e/test.db-journal
+```
+
+- [ ] **Step 6: Verify install**
+
+Run:
+```bash
+cd ~/local-dev/sipher
+pnpm exec playwright --version
+pnpm --filter @sipher/app exec vitest --version
+```
+
+Expected: Playwright prints version ≥1.48, Vitest prints version ≥2.1.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git checkout -b feat/test-infra
+git add package.json app/package.json pnpm-lock.yaml .gitignore
+git commit -m "chore(test-infra): install Playwright, Vitest, RTL, jsdom"
+```
+
+---
+
+## Task 2: Add `persist` middleware to Zustand store
+
+**Files:**
+- Modify: `app/src/stores/app.ts`
+
+Rationale: Current store holds `token` in memory only. Playwright's `storageState` can only inject via localStorage. Adding `persist` enables E2E auth injection and delivers a UX win — users stay logged in across page refreshes.
+
+- [ ] **Step 1: Replace the store export with persist wrapper**
+
+Open `app/src/stores/app.ts`. Replace lines 1-2 (`import { create } from 'zustand'`) with:
+
+```ts
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+```
+
+Then replace the `export const useAppStore = create<AppState>((set) => ({ ... }))` block (lines 37-71) with:
+
+```ts
+export const useAppStore = create<AppState>()(
+  persist(
+    (set) => ({
+      activeView: 'dashboard',
+      setActiveView: (activeView) => set({ activeView }),
+
+      token: null,
+      isAdmin: false,
+      setAuth: (token, isAdmin) => set({ token, isAdmin }),
+      clearAuth: () => set({ token: null, isAdmin: false, messages: [], activeView: 'dashboard' }),
+
+      messages: [],
+      chatLoading: false,
+      addMessage: (msg) => set((s) => ({ messages: [...s.messages, msg] })),
+      appendToLast: (text) =>
+        set((s) => {
+          const msgs = [...s.messages]
+          const last = msgs[msgs.length - 1]
+          if (last?.role === 'assistant') {
+            msgs[msgs.length - 1] = { ...last, content: last.content + text }
+          }
+          return { messages: msgs }
+        }),
+      finishStreaming: () =>
+        set((s) => {
+          const msgs = [...s.messages]
+          const last = msgs[msgs.length - 1]
+          if (last?.streaming) {
+            msgs[msgs.length - 1] = { ...last, streaming: false }
+          }
+          return { messages: msgs }
+        }),
+      setChatLoading: (chatLoading) => set({ chatLoading }),
+
+      chatOpen: false,
+      setChatOpen: (chatOpen) => set({ chatOpen }),
+    }),
+    {
+      name: 'sipher-auth',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (s) => ({ token: s.token, isAdmin: s.isAdmin }),
+    }
+  )
+)
+```
+
+Keep lines 3-35 (types `View`, `ChatMessage`, `AppState`) untouched.
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd ~/local-dev/sipher
+pnpm --filter @sipher/app exec tsc --noEmit
+```
+
+Expected: no errors. If `zustand/middleware` is unresolved, bump zustand to a version ≥4 that exports middleware (currently ^5.0.12, which includes it).
+
+- [ ] **Step 3: Manual verification (optional dev check)**
+
+Start Vite dev and backend, authenticate via wallet in browser, refresh the page. Session should persist. This is optional — the critical verification comes via E2E later.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/stores/app.ts
+git commit -m "feat(app): persist auth token across page refreshes"
+```
+
+---
+
+## Task 3: Playwright config
+
+**Files:**
+- Create: `playwright.config.ts`
+
+- [ ] **Step 1: Write the config**
+
+Create `/Users/rector/local-dev/sipher/playwright.config.ts`:
+
+```ts
+import { defineConfig, devices } from '@playwright/test'
+import path from 'node:path'
+
+const PORT_FRONTEND = 5173
+const PORT_BACKEND = 3000
+
+export default defineConfig({
+  testDir: './e2e',
+  testIgnore: ['**/fixtures/**'],
+  fullyParallel: true,
+  workers: process.env.CI ? 2 : undefined,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  timeout: 30_000,
+  reporter: process.env.CI ? [['html'], ['github']] : [['html'], ['list']],
+  globalSetup: path.resolve(__dirname, './e2e/global-setup.ts'),
+  globalTeardown: path.resolve(__dirname, './e2e/global-teardown.ts'),
+  use: {
+    baseURL: `http://localhost:${PORT_FRONTEND}`,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: [
+    {
+      command: 'pnpm --filter @sipher/agent dev',
+      url: `http://localhost:${PORT_BACKEND}/api/health`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+      env: {
+        NODE_ENV: 'test',
+        PORT: String(PORT_BACKEND),
+        HERALD_ENABLED: 'false',
+        SIPHER_DB_PATH: './e2e/test.db',
+        AUTHORIZED_WALLETS: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
+        JWT_SECRET: process.env.JWT_SECRET ?? 'e2e-test-secret-at-least-16-chars',
+        SENTINEL_MODE: 'off',
+      },
+    },
+    {
+      command: 'pnpm --filter @sipher/app dev',
+      url: `http://localhost:${PORT_FRONTEND}`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+    },
+  ],
+})
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add playwright.config.ts
+git commit -m "chore(e2e): add Playwright config with dual webServer"
+```
+
+---
+
+## Task 4: Auth fixture — ed25519 JWT minter
+
+**Files:**
+- Create: `e2e/fixtures/auth.ts`
+
+- [ ] **Step 1: Write the fixture**
+
+Create `/Users/rector/local-dev/sipher/e2e/fixtures/auth.ts`:
+
+```ts
+import fs from 'node:fs'
+import { ed25519 } from '@noble/curves/ed25519'
+
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+export function encodeBase58(bytes: Uint8Array): string {
+  let num = 0n
+  for (const b of bytes) num = num * 256n + BigInt(b)
+  let str = ''
+  while (num > 0n) {
+    str = BASE58_ALPHABET[Number(num % 58n)] + str
+    num = num / 58n
+  }
+  for (const b of bytes) {
+    if (b !== 0) break
+    str = '1' + str
+  }
+  return str || '1'
+}
+
+export interface LoginResult {
+  token: string
+  isAdmin: boolean
+  wallet: string
+}
+
+export async function mintAdminJwt(
+  keypairPath: string,
+  apiBase: string
+): Promise<LoginResult> {
+  const secretKeyArr = JSON.parse(fs.readFileSync(keypairPath, 'utf-8')) as number[]
+  const secretKey64 = Uint8Array.from(secretKeyArr)
+  const privateKey = secretKey64.slice(0, 32)
+  const publicKey = ed25519.getPublicKey(privateKey)
+  const wallet = encodeBase58(publicKey)
+
+  const nonceResp = await fetch(`${apiBase}/api/auth/nonce`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ wallet }),
+  })
+  if (!nonceResp.ok) {
+    throw new Error(`nonce failed: ${nonceResp.status} ${await nonceResp.text()}`)
+  }
+  const { nonce, message } = (await nonceResp.json()) as { nonce: string; message: string }
+
+  const sigBytes = ed25519.sign(new TextEncoder().encode(message), privateKey)
+  const signature = encodeBase58(sigBytes)
+
+  const verifyResp = await fetch(`${apiBase}/api/auth/verify`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ wallet, nonce, signature }),
+  })
+  if (!verifyResp.ok) {
+    throw new Error(`verify failed: ${verifyResp.status} ${await verifyResp.text()}`)
+  }
+  const { token, isAdmin } = (await verifyResp.json()) as {
+    token: string
+    isAdmin: boolean
+  }
+  return { token, isAdmin, wallet }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+mkdir -p e2e/fixtures
+git add e2e/fixtures/auth.ts
+git commit -m "feat(e2e): add ed25519 JWT minter fixture"
+```
+
+---
+
+## Task 5: Global setup + teardown
+
+**Files:**
+- Create: `e2e/global-setup.ts`
+- Create: `e2e/global-teardown.ts`
+
+- [ ] **Step 1: Write global-setup**
+
+Create `/Users/rector/local-dev/sipher/e2e/global-setup.ts`:
+
+```ts
+import fs from 'node:fs'
+import path from 'node:path'
+import { mintAdminJwt } from './fixtures/auth'
+
+const FRONTEND_ORIGIN = 'http://localhost:5173'
+const BACKEND_BASE = 'http://localhost:3000'
+const STORAGE_STATE_PATH = path.resolve(__dirname, './fixtures/storageState.json')
+
+export default async function globalSetup(): Promise<void> {
+  const keypairPath =
+    process.env.E2E_ADMIN_KEYPAIR_PATH ?? '/Users/rector/Documents/secret/cipher-admin.json'
+
+  if (!fs.existsSync(keypairPath)) {
+    throw new Error(
+      `E2E admin keypair not found at ${keypairPath}. Set E2E_ADMIN_KEYPAIR_PATH env var.`
+    )
+  }
+
+  const { token, isAdmin, wallet } = await mintAdminJwt(keypairPath, BACKEND_BASE)
+  if (!isAdmin) {
+    throw new Error(`Minted JWT for ${wallet} is not admin. Check AUTHORIZED_WALLETS env.`)
+  }
+
+  const zustandPayload = {
+    state: { token, isAdmin },
+    version: 0,
+  }
+
+  const storageState = {
+    cookies: [],
+    origins: [
+      {
+        origin: FRONTEND_ORIGIN,
+        localStorage: [{ name: 'sipher-auth', value: JSON.stringify(zustandPayload) }],
+      },
+    ],
+  }
+
+  fs.writeFileSync(STORAGE_STATE_PATH, JSON.stringify(storageState, null, 2))
+  console.log(`[e2e] storageState written (wallet=${wallet}, isAdmin=${isAdmin})`)
+}
+```
+
+- [ ] **Step 2: Write global-teardown**
+
+Create `/Users/rector/local-dev/sipher/e2e/global-teardown.ts`:
+
+```ts
+import fs from 'node:fs'
+import path from 'node:path'
+
+const PATHS_TO_CLEAN = [
+  path.resolve(__dirname, './fixtures/storageState.json'),
+  path.resolve(__dirname, './test.db'),
+  path.resolve(__dirname, './test.db-journal'),
+]
+
+export default async function globalTeardown(): Promise<void> {
+  for (const p of PATHS_TO_CLEAN) {
+    if (fs.existsSync(p)) fs.unlinkSync(p)
+  }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/global-setup.ts e2e/global-teardown.ts
+git commit -m "feat(e2e): add global setup (JWT mint) and teardown (cleanup)"
+```
+
+---
+
+## Task 6: Mocks fixture — Solana RPC + Jupiter interceptors
+
+**Files:**
+- Create: `e2e/fixtures/mocks.ts`
+
+- [ ] **Step 1: Write the mocks module**
+
+Create `/Users/rector/local-dev/sipher/e2e/fixtures/mocks.ts`:
+
+```ts
+import type { Page, Route } from '@playwright/test'
+
+export async function mockSolanaRpc(page: Page): Promise<void> {
+  await page.route('**/api/rpc/**', async (route: Route) => {
+    const body = route.request().postDataJSON() as { method?: string }
+    const method = body?.method ?? ''
+    if (method === 'getBalance') {
+      await route.fulfill({ json: { jsonrpc: '2.0', id: 1, result: { value: 1_000_000_000 } } })
+      return
+    }
+    if (method === 'getSignatureStatuses') {
+      await route.fulfill({
+        json: { jsonrpc: '2.0', id: 1, result: { value: [null] } },
+      })
+      return
+    }
+    await route.fulfill({ json: { jsonrpc: '2.0', id: 1, result: null } })
+  })
+}
+
+export async function mockJupiter(page: Page): Promise<void> {
+  await page.route('**/quote**', async (route: Route) => {
+    await route.fulfill({
+      json: {
+        inAmount: '1000000',
+        outAmount: '980000',
+        priceImpactPct: '0.1',
+        routePlan: [],
+      },
+    })
+  })
+  await page.route('**/swap**', async (route: Route) => {
+    await route.fulfill({ json: { swapTransaction: 'mock-tx-base64' } })
+  })
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add e2e/fixtures/mocks.ts
+git commit -m "feat(e2e): add Solana RPC + Jupiter route interceptors"
+```
+
+---
+
+## Task 7: Chat spec — unauth disabled state + intercepted SSE smoke
+
+**Files:**
+- Create: `e2e/chat.spec.ts`
+
+Note: the ChatSidebar gates sending on presence of `token` (shows placeholder "Connect wallet first" and disables input). Unauth smoke verifies gating. Auth smoke intercepts the POST to `/api/chat/stream` with a canned SSE response so the test is hermetic.
+
+- [ ] **Step 1: Write the spec**
+
+Create `/Users/rector/local-dev/sipher/e2e/chat.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.describe('chat sidebar', () => {
+  test.describe('unauthenticated', () => {
+    test.use({ storageState: { cookies: [], origins: [] } })
+
+    test('input is disabled and shows connect-wallet placeholder', async ({ page }) => {
+      const errors: string[] = []
+      page.on('pageerror', (err) => errors.push(err.message))
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') errors.push(msg.text())
+      })
+
+      await page.goto('/')
+      const input = page.getByPlaceholder('Connect wallet first')
+      await expect(input).toBeVisible()
+      await expect(input).toBeDisabled()
+      expect(errors).toEqual([])
+    })
+  })
+
+  test.describe('authenticated', () => {
+    test.use({ storageState: AUTH_STATE })
+
+    test('sends message and renders streamed reply from mocked SSE', async ({ page }) => {
+      await page.route('**/api/chat/stream', async (route) => {
+        const body =
+          'data: {"type":"content_block_delta","text":"Hello "}\n\n' +
+          'data: {"type":"content_block_delta","text":"from SIPHER."}\n\n' +
+          'data: [DONE]\n\n'
+        await route.fulfill({
+          status: 200,
+          headers: { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' },
+          body,
+        })
+      })
+
+      const errors: string[] = []
+      page.on('pageerror', (err) => errors.push(err.message))
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') errors.push(msg.text())
+      })
+
+      await page.goto('/')
+      const input = page.getByPlaceholder('Message SIPHER...')
+      await expect(input).toBeEnabled()
+      await input.fill('hi')
+      await page.getByRole('button', { name: 'Send' }).click()
+
+      await expect(page.getByText('Hello from SIPHER.')).toBeVisible({ timeout: 5000 })
+      expect(errors).toEqual([])
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the spec locally**
+
+```bash
+cd ~/local-dev/sipher
+pnpm test:e2e chat.spec.ts
+```
+
+Expected: both tests pass. If not, inspect `playwright-report/` output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/chat.spec.ts
+git commit -m "test(e2e): add chat sidebar smoke (unauth disabled + auth'd SSE)"
+```
+
+---
+
+## Task 8: Auth flow spec
+
+**Files:**
+- Create: `e2e/auth-flow.spec.ts`
+
+- [ ] **Step 1: Write the spec**
+
+Create `/Users/rector/local-dev/sipher/e2e/auth-flow.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.describe('auth flow', () => {
+  test('unauth user sees landing, no admin metrics', async ({ page }) => {
+    await page.context().addInitScript(() => window.localStorage.clear())
+    await page.goto('/')
+    await expect(page.getByText(/connect wallet/i).first()).toBeVisible()
+  })
+
+  test.describe('authenticated', () => {
+    test.use({ storageState: AUTH_STATE })
+
+    test('admin user sees dashboard', async ({ page }) => {
+      await page.goto('/')
+      await expect(page.getByText('SIPHER').first()).toBeVisible()
+      const token = await page.evaluate(() => {
+        const raw = window.localStorage.getItem('sipher-auth')
+        return raw ? (JSON.parse(raw) as { state: { token: string } }).state.token : null
+      })
+      expect(token).toBeTruthy()
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+pnpm test:e2e auth-flow.spec.ts
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/auth-flow.spec.ts
+git commit -m "test(e2e): add auth flow smoke (unauth gate + injected JWT)"
+```
+
+---
+
+## Task 9: Dashboard spec
+
+**Files:**
+- Create: `e2e/dashboard.spec.ts`
+
+- [ ] **Step 1: Write the spec**
+
+Create `/Users/rector/local-dev/sipher/e2e/dashboard.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test'
+import { mockSolanaRpc } from './fixtures/mocks'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.use({ storageState: AUTH_STATE })
+
+test('dashboard view renders without errors', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (err) => errors.push(err.message))
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text())
+  })
+
+  await mockSolanaRpc(page)
+  await page.goto('/')
+
+  await page.getByRole('button', { name: /dashboard/i }).click().catch(() => {})
+  await expect(page.locator('main, [data-testid="dashboard-view"]').first()).toBeVisible()
+  expect(errors).toEqual([])
+})
+```
+
+- [ ] **Step 2: Add `data-testid="dashboard-view"` to the view root**
+
+Open `app/src/views/DashboardView.tsx`. Locate the outermost wrapping JSX element in the default-exported component and add `data-testid="dashboard-view"`. If the root already has other attributes, append; do not remove.
+
+- [ ] **Step 3: Run**
+
+```bash
+pnpm test:e2e dashboard.spec.ts
+```
+
+Expected: passes. If the selector misses, inspect the rendered HTML via `pnpm test:e2e:headed dashboard.spec.ts`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/dashboard.spec.ts app/src/views/DashboardView.tsx
+git commit -m "test(e2e): add dashboard view smoke"
+```
+
+---
+
+## Task 10: Vault spec
+
+**Files:**
+- Create: `e2e/vault.spec.ts`
+- Modify: `app/src/views/VaultView.tsx` (add `data-testid="vault-view"`)
+
+- [ ] **Step 1: Write the spec**
+
+Create `/Users/rector/local-dev/sipher/e2e/vault.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test'
+import { mockSolanaRpc } from './fixtures/mocks'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.use({ storageState: AUTH_STATE })
+
+test('vault view renders', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (err) => errors.push(err.message))
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text())
+  })
+
+  await mockSolanaRpc(page)
+  await page.goto('/')
+  await page.getByRole('button', { name: /vault/i }).first().click()
+  await expect(page.locator('[data-testid="vault-view"]')).toBeVisible()
+  expect(errors).toEqual([])
+})
+```
+
+- [ ] **Step 2: Add `data-testid="vault-view"` to `VaultView.tsx` root**
+
+Same pattern as Task 9 Step 2.
+
+- [ ] **Step 3: Run**
+
+```bash
+pnpm test:e2e vault.spec.ts
+```
+
+Expected: passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/vault.spec.ts app/src/views/VaultView.tsx
+git commit -m "test(e2e): add vault view smoke"
+```
+
+---
+
+## Task 11: Squad spec
+
+**Files:**
+- Create: `e2e/squad.spec.ts`
+- Modify: `app/src/views/SquadView.tsx` (add `data-testid="squad-view"`)
+
+- [ ] **Step 1: Write the spec**
+
+Create `/Users/rector/local-dev/sipher/e2e/squad.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.use({ storageState: AUTH_STATE })
+
+test('squad view renders', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (err) => errors.push(err.message))
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text())
+  })
+
+  await page.goto('/')
+  await page.getByRole('button', { name: /squad/i }).first().click()
+  await expect(page.locator('[data-testid="squad-view"]')).toBeVisible()
+  expect(errors).toEqual([])
+})
+```
+
+- [ ] **Step 2: Add `data-testid="squad-view"` to `SquadView.tsx` root**
+
+- [ ] **Step 3: Run**
+
+```bash
+pnpm test:e2e squad.spec.ts
+```
+
+Expected: passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/squad.spec.ts app/src/views/SquadView.tsx
+git commit -m "test(e2e): add squad view smoke"
+```
+
+---
+
+## Task 12: Herald spec
+
+**Files:**
+- Create: `e2e/herald.spec.ts`
+- Modify: `app/src/views/HeraldView.tsx` (add `data-testid="herald-view"`)
+
+- [ ] **Step 1: Write the spec**
+
+Create `/Users/rector/local-dev/sipher/e2e/herald.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.use({ storageState: AUTH_STATE })
+
+test('herald view renders with admin budget visible', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (err) => errors.push(err.message))
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text())
+  })
+
+  await page.route('**/api/herald/**', async (route) => {
+    await route.fulfill({
+      json: { budget: { used: 0, total: 1000 }, queue: [], status: 'idle' },
+    })
+  })
+
+  await page.goto('/')
+  await page.getByRole('button', { name: /herald/i }).first().click()
+  await expect(page.locator('[data-testid="herald-view"]')).toBeVisible()
+  expect(errors).toEqual([])
+})
+```
+
+- [ ] **Step 2: Add `data-testid="herald-view"` to `HeraldView.tsx` root**
+
+- [ ] **Step 3: Run**
+
+```bash
+pnpm test:e2e herald.spec.ts
+```
+
+Expected: passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/herald.spec.ts app/src/views/HeraldView.tsx
+git commit -m "test(e2e): add herald view smoke"
+```
+
+---
+
+## Task 13: Vitest config + RTL setup for `app/`
+
+**Files:**
+- Create: `app/vitest.config.ts`
+- Create: `app/src/setupTests.ts`
+
+- [ ] **Step 1: Write Vitest config**
+
+Create `/Users/rector/local-dev/sipher/app/vitest.config.ts`:
+
+```ts
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/setupTests.ts'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    css: false,
+  },
+})
+```
+
+- [ ] **Step 2: Write setup file**
+
+Create `/Users/rector/local-dev/sipher/app/src/setupTests.ts`:
+
+```ts
+import '@testing-library/jest-dom/vitest'
+```
+
+- [ ] **Step 3: Smoke-test the harness**
+
+Create a temporary `app/src/components/__tests__/smoke.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+describe('rtl harness', () => {
+  it('renders text', () => {
+    render(<div>hello</div>)
+    expect(screen.getByText('hello')).toBeInTheDocument()
+  })
+})
+```
+
+Run:
+
+```bash
+pnpm --filter @sipher/app test
+```
+
+Expected: 1 test passes.
+
+- [ ] **Step 4: Delete the smoke file** (will be replaced by the real ChatSidebar test in Task 14)
+
+```bash
+rm app/src/components/__tests__/smoke.test.tsx
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/vitest.config.ts app/src/setupTests.ts
+git commit -m "chore(app): configure Vitest with jsdom + @testing-library/jest-dom"
+```
+
+---
+
+## Task 14: ChatSidebar component test
+
+**Files:**
+- Create: `app/src/components/__tests__/ChatSidebar.test.tsx`
+
+Covers: unauth placeholder, auth'd send flow (mocked `fetch`), SSE parse → `appendToLast`, tool-use indicator.
+
+- [ ] **Step 1: Write the test**
+
+Create `/Users/rector/local-dev/sipher/app/src/components/__tests__/ChatSidebar.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { useAppStore } from '../../stores/app'
+import ChatSidebar from '../ChatSidebar'
+
+function resetStore() {
+  useAppStore.setState({
+    token: null,
+    isAdmin: false,
+    messages: [],
+    chatLoading: false,
+    chatOpen: false,
+    activeView: 'dashboard',
+  })
+}
+
+describe('ChatSidebar', () => {
+  beforeEach(() => {
+    resetStore()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows connect-wallet placeholder and disables input when unauthenticated', () => {
+    render(<ChatSidebar />)
+    const input = screen.getByPlaceholderText('Connect wallet first')
+    expect(input).toBeDisabled()
+  })
+
+  it('enables input when authenticated', () => {
+    useAppStore.setState({ token: 'test-jwt', isAdmin: true })
+    render(<ChatSidebar />)
+    const input = screen.getByPlaceholderText('Message SIPHER...')
+    expect(input).toBeEnabled()
+  })
+
+  it('sends message and appends streamed reply', async () => {
+    useAppStore.setState({ token: 'test-jwt', isAdmin: true })
+
+    const encoder = new TextEncoder()
+    const sseBody = new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode('data: {"type":"content_block_delta","text":"Hi"}\n\n')
+        )
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+        controller.close()
+      },
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(sseBody, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        })
+      )
+    )
+
+    render(<ChatSidebar />)
+    const input = screen.getByPlaceholderText('Message SIPHER...') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Hi')).toBeInTheDocument()
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+pnpm --filter @sipher/app test
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/components/__tests__/ChatSidebar.test.tsx
+git commit -m "test(app): add ChatSidebar component tests (unauth, auth, stream)"
+```
+
+---
+
+## Task 15: GitHub Actions E2E workflow
+
+**Files:**
+- Create: `.github/workflows/e2e.yml`
+
+- [ ] **Step 1: Write the workflow**
+
+Create `/Users/rector/local-dev/sipher/.github/workflows/e2e.yml`:
+
+```yaml
+name: e2e
+
+on:
+  pull_request:
+    paths:
+      - 'app/**'
+      - 'packages/agent/**'
+      - 'src/**'
+      - 'e2e/**'
+      - 'playwright.config.ts'
+      - 'package.json'
+      - 'app/package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/e2e.yml'
+  push:
+    branches: [main]
+
+jobs:
+  component:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run app component tests
+        run: pnpm --filter @sipher/app test
+
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm exec playwright install --with-deps chromium
+
+      - name: Write E2E admin keypair
+        env:
+          E2E_ADMIN_KEYPAIR: ${{ secrets.E2E_ADMIN_KEYPAIR }}
+        run: |
+          mkdir -p e2e/fixtures
+          printf '%s' "$E2E_ADMIN_KEYPAIR" > e2e/fixtures/admin-keypair.json
+          chmod 600 e2e/fixtures/admin-keypair.json
+
+      - name: Run Playwright
+        env:
+          E2E_ADMIN_KEYPAIR_PATH: e2e/fixtures/admin-keypair.json
+          JWT_SECRET: ${{ secrets.E2E_JWT_SECRET }}
+        run: pnpm test:e2e
+
+      - if: failure() || cancelled()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14
+```
+
+Notes:
+- `continue-on-error: true` on the playwright job is intentional for the initial 2-3 PRs — flip to false once the workflow stabilizes.
+- The `component` job has no `continue-on-error` — Vitest component tests are fast and deterministic; any failure should block.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/e2e.yml
+git commit -m "ci: add Playwright E2E + app component tests workflow (path-filtered)"
+```
+
+---
+
+## Task 16: Document GitHub Secret + README section
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Manually create the GitHub Secret** (operator task, not automated)
+
+RECTOR runs locally (not CI, not code):
+
+```bash
+gh secret set E2E_ADMIN_KEYPAIR < ~/Documents/secret/cipher-admin.json --repo sip-protocol/sipher
+gh secret set E2E_JWT_SECRET --repo sip-protocol/sipher
+# Paste: any 32+ char string, e.g. `openssl rand -hex 32`
+```
+
+- [ ] **Step 2: Append "Running tests" section to `README.md`**
+
+Locate a logical spot in `README.md` (after the "Development" or "Getting Started" section). Append:
+
+```markdown
+## Running Tests
+
+### Backend + Agent (Vitest)
+
+```bash
+pnpm test -- --run                           # Root REST tests
+pnpm --filter @sipher/agent test -- --run    # Agent tests
+```
+
+### Frontend component tests (Vitest + RTL)
+
+```bash
+pnpm --filter @sipher/app test
+```
+
+### End-to-end (Playwright, Chromium)
+
+```bash
+pnpm exec playwright install chromium    # one-time browser install
+pnpm test:e2e                            # run all e2e specs
+pnpm test:e2e:ui                         # interactive UI mode
+pnpm test:e2e:headed                     # watch tests run in a visible browser
+```
+
+Playwright runs against the Vite dev server (port 5173) and the Sipher backend (port 3000), both spun up automatically via its `webServer` config. Admin flows use an ed25519-signed JWT minted at global-setup. Locally, this reads `~/Documents/secret/cipher-admin.json`; in CI, the `E2E_ADMIN_KEYPAIR` GitHub Secret supplies it.
+
+See [`docs/superpowers/specs/2026-04-18-test-infrastructure-design.md`](docs/superpowers/specs/2026-04-18-test-infrastructure-design.md) for architectural details.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): add 'Running Tests' section covering Vitest + Playwright"
+```
+
+---
+
+## Task 17: Final verification — full suite run
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Regenerate `storageState.json` for fresh run**
+
+```bash
+cd ~/local-dev/sipher
+rm -f e2e/fixtures/storageState.json e2e/test.db
+```
+
+- [ ] **Step 2: Run full E2E suite**
+
+```bash
+pnpm test:e2e
+```
+
+Expected: 6 specs pass (chat with 2 cases, auth-flow with 2, dashboard, vault, squad, herald — 8 tests total), under 90s local runtime.
+
+- [ ] **Step 3: Run component tests**
+
+```bash
+pnpm --filter @sipher/app test
+```
+
+Expected: 3 tests pass (ChatSidebar).
+
+- [ ] **Step 4: Check HTML report exists**
+
+```bash
+ls playwright-report/index.html
+```
+
+Expected: file present.
+
+- [ ] **Step 5: Push branch and open PR**
+
+```bash
+git push -u origin feat/test-infra
+gh pr create --title "feat(test-infra): Playwright E2E + Vitest+RTL component tests" --body "$(cat <<'EOF'
+## Summary
+
+Phase 1 of the audit-driven work. Lands the missing test infrastructure layers:
+
+- Playwright ^1.48 (Chromium) — 6 E2E specs, one per UI surface
+- Vitest + @testing-library/react + jsdom — component tests for `app/`
+- Path-filtered GitHub Actions workflow (`.github/workflows/e2e.yml`)
+- Ed25519-signed JWT fixture for authenticated E2E flows
+- Zustand `persist` middleware for `token`/`isAdmin` (UX bonus: session persists on refresh)
+
+All external network (Solana RPC, Jupiter, Pi SDK, X) mocked or disabled — no API keys required in CI.
+
+## Test plan
+
+- [x] All 8 Playwright tests pass locally
+- [x] All 3 Vitest component tests pass locally
+- [x] `pnpm test -- --run` still green (no existing tests broken)
+- [x] `pnpm typecheck` clean
+- [ ] CI run green on PR (manual verify after push)
+- [ ] `E2E_ADMIN_KEYPAIR` + `E2E_JWT_SECRET` GitHub Secrets set before CI run
+
+Spec: `docs/superpowers/specs/2026-04-18-test-infrastructure-design.md`
+EOF
+)"
+```
+
+Expected: PR created. Wait for CI. If green, flip `continue-on-error: true` → `false` in a follow-up PR.
+
+- [ ] **Step 6: Verify CI green** (manual — after push)
+
+Watch `gh pr checks` until green or investigate failure via artifacts.
+
+---
+
+## Success Criteria (from spec)
+
+- [ ] `pnpm test:e2e` runs locally and all 8 test cases pass on a clean checkout
+- [ ] `pnpm --filter @sipher/app test` runs locally and 3 ChatSidebar component tests pass
+- [ ] `.github/workflows/e2e.yml` triggers on a UI-touching PR and passes
+- [ ] `E2E_ADMIN_KEYPAIR` and `E2E_JWT_SECRET` secrets exist in the repo
+- [ ] Path filter correctly skips E2E on backend-only or docs-only PRs
+- [ ] No test makes real network calls to Solana RPC, LLM providers, X API, or Jupiter
+- [ ] HTML report uploaded on failure, downloadable from Actions tab
+- [ ] README has "Running tests" section linking to the spec

--- a/docs/superpowers/specs/2026-04-18-test-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-04-18-test-infrastructure-design.md
@@ -63,7 +63,7 @@ The two layers cover different concerns and do not overlap: Playwright validates
 
 ```
 sipher/
-├── playwright.config.ts              # webServer: pnpm dev on :5174
+├── playwright.config.ts              # webServer: backend on :3000 + Vite on :5173
 ├── e2e/
 │   ├── fixtures/
 │   │   ├── auth.ts                   # ed25519 JWT helper (ported from /tmp/sipher-login.mjs)
@@ -120,10 +120,14 @@ Wallet signing is impossible in a headless browser. Instead, Playwright's `globa
 
 1. `e2e/global-setup.ts` runs once before all tests.
 2. Loads the admin keypair from `E2E_ADMIN_KEYPAIR_PATH` (locally: `~/Documents/secret/cipher-admin.json`; in CI: `e2e/fixtures/admin-keypair.json`, hydrated from the `E2E_ADMIN_KEYPAIR` GitHub Secret).
-3. Fetches a nonce from `POST http://localhost:5174/api/auth/nonce`.
-4. Signs the nonce with `@noble/curves/ed25519`.
-5. Exchanges the signature for a JWT at `POST /api/auth/login`.
-6. Writes `e2e/fixtures/storageState.json` with the JWT in localStorage under Sipher's expected key.
+3. Fetches a nonce from `POST http://localhost:3000/api/auth/nonce` with `{ wallet }`.
+4. Signs the returned `message` with `@noble/curves/ed25519`.
+5. Encodes the signature as base58 and calls `POST /api/auth/verify` with `{ wallet, nonce, signature }`.
+6. Writes `e2e/fixtures/storageState.json` with the Zustand-persist payload in `localStorage['sipher-auth']`.
+
+**Enabling prerequisite — Zustand persist middleware:**
+
+The app's `useAppStore` currently holds `token` and `isAdmin` in memory only, which means Playwright cannot inject authenticated state via `storageState`. The spec adds the `zustand/middleware/persist` adapter over the `token` and `isAdmin` fields under the storage key `sipher-auth`. This is a minimal (~5 line) change with a legitimate UX bonus: real users stay logged in across page refreshes instead of losing their session. Chat state and other ephemeral store fields remain in-memory via `partialize`.
 
 **Per-test opt-in:**
 
@@ -253,7 +257,7 @@ Steps:
 
 - Port the existing `/tmp/sipher-login.mjs` ed25519 signing logic into `e2e/fixtures/auth.ts` as a reusable helper. This is the single source of truth for test-mode JWT minting; if the auth flow changes, this file is the only place to update.
 - Route interceptors live in a shared `e2e/fixtures/mocks.ts` and are attached per-test via a Playwright fixture extension. No per-test boilerplate.
-- `playwright.config.ts` sets `webServer.reuseExistingServer = !process.env.CI` so local reruns are fast but CI always gets a clean boot.
+- `playwright.config.ts` declares two `webServer` entries: the Sipher backend (`pnpm dev`, awaiting `http://localhost:3000/health`) and the Vite frontend (`pnpm --filter app dev`, awaiting `http://localhost:5173`). Both set `reuseExistingServer = !process.env.CI` so local reruns are fast but CI always gets a clean boot. Vite's built-in `/api` proxy routes frontend traffic to the backend.
 - Set `fullyParallel: true` with `workers: 2` in CI to keep under 10-minute timeout.
 
 ## Out of Scope (for later phases)

--- a/docs/superpowers/specs/2026-04-18-test-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-04-18-test-infrastructure-design.md
@@ -1,0 +1,265 @@
+# Test Infrastructure — Design Spec
+
+**Date:** 2026-04-18
+**Status:** Approved, ready for implementation plan
+**Scope:** Phase 1 of the "address all audit findings" multi-phase effort
+**Related audits:** Spec-vs-implementation gap audit, test-coverage audit (both 2026-04-18)
+
+## Summary
+
+Ship the missing test infrastructure layers that Sipher's audits revealed: end-to-end browser tests via Playwright, and React component tests via Vitest + @testing-library/react + jsdom. Land a lean scaffold — one smoke test per UI surface plus one component test — and wire it into GitHub CI with path-filtered triggering. Subsequent phases (UI gap fixes, REST service tests, tool backfills) arrive on top of this foundation already-tested.
+
+## Context
+
+The 2026-04-18 test-coverage audit found:
+
+- **Zero Playwright infrastructure.** No `playwright.config.ts`, no `@playwright/test`, no `e2e/` directory. The entire 2,079-line Command Center UI (`app/`) ships without any browser-level verification.
+- **Zero component tests in `app/`.** 23 React source files (views, hooks, components, Zustand store, API client, SSE hook) have no unit or integration tests at all.
+- **Backend coverage is strong** — 1,553 test cases across Vitest suites — but the UI layer is uncovered.
+
+Subsequent audit-driven work (UI gap fixes in Phase 2, tool unit test backfills in Phase 5) will ship code that either arrives untested or has to be back-tested later. Landing infra first eliminates that choice.
+
+## Goals
+
+- Ship a working Playwright E2E harness on Chromium, spinning up the real Vite dev server.
+- Ship a working Vitest + RTL component test harness for `app/`.
+- Land six E2E smoke tests (one per view + chat public + auth flow) and one component test.
+- Wire both harnesses into GitHub Actions with PR path filtering, failing the build on broken tests.
+- Provide an authenticated test fixture (ed25519 JWT signing) reusable across auth-gated tests.
+
+## Non-goals
+
+- Writing component tests for all 23 UI files. Further component tests arrive during Phase 2 alongside the UI gap fixes they cover.
+- Cross-browser matrix (WebKit, Firefox). Chromium only.
+- Visual regression (Percy, Chromatic, screenshot diffing).
+- Storybook.
+- Coverage reports from Playwright. Vitest already owns source coverage.
+- LLM behavior testing. Chat smoke asserts the stream opens and receives the first SSE event, nothing deeper.
+
+## Architecture
+
+**Two independent test layers, one shared stack:**
+
+```
+┌──────────────────────────────────────────────────┐
+│  Playwright (e2e/)                               │
+│  ─ Launches Vite dev server on :5174             │
+│  ─ Chromium headless                             │
+│  ─ Tests against real browser + real backend     │
+│  ─ Mocks external network (RPC, Jupiter, X)      │
+└──────────────────────────────────────────────────┘
+                       +
+┌──────────────────────────────────────────────────┐
+│  Vitest + RTL + jsdom (app/src/**/__tests__/)    │
+│  ─ Component-level unit/integration              │
+│  ─ Runs in jsdom (no browser)                    │
+│  ─ Reuses existing Vitest config patterns        │
+└──────────────────────────────────────────────────┘
+```
+
+The two layers cover different concerns and do not overlap: Playwright validates that views *render and flow* through real routing + state + SSE + middleware; RTL validates that individual components *behave* in isolation.
+
+## File Layout
+
+```
+sipher/
+├── playwright.config.ts              # webServer: pnpm dev on :5174
+├── e2e/
+│   ├── fixtures/
+│   │   ├── auth.ts                   # ed25519 JWT helper (ported from /tmp/sipher-login.mjs)
+│   │   ├── storageState.json         # gitignored; generated per run
+│   │   └── admin-keypair.json        # gitignored; hydrated from GH secret in CI
+│   ├── global-setup.ts               # mint JWT, write storageState
+│   ├── global-teardown.ts            # wipe test.db + storageState
+│   ├── dashboard.spec.ts
+│   ├── vault.spec.ts
+│   ├── squad.spec.ts
+│   ├── herald.spec.ts
+│   ├── chat-public.spec.ts
+│   └── auth-flow.spec.ts
+├── app/
+│   ├── vitest.config.ts              # jsdom env, setupFiles
+│   ├── src/
+│   │   └── setupTests.ts             # imports @testing-library/jest-dom
+│   └── src/components/__tests__/
+│       └── ChatSidebar.test.tsx      # first component smoke
+└── .github/workflows/
+    └── e2e.yml                       # Playwright PR workflow
+```
+
+**Gitignored:**
+- `e2e/fixtures/storageState.json`
+- `e2e/fixtures/admin-keypair.json`
+- `e2e/test.db`
+- `playwright-report/`
+- `test-results/`
+
+## Smoke Test Surface
+
+Six Playwright specs, each asserting a small set of visible-DOM facts and global "no console errors / pageerror" invariants.
+
+| Spec | Auth | Assertions |
+|------|------|-----------|
+| `chat-public.spec.ts` | none | Sidebar opens, send box accepts input, POST to `/api/chat/stream` fires; Playwright intercepts the request and returns a canned SSE stream so the test validates the client's stream-to-bubble render path without invoking the real agent |
+| `auth-flow.spec.ts` | both | Unauth GET to admin view returns 401/redirect; with injected JWT, admin view renders |
+| `dashboard.spec.ts` | admin | Mounts, all four metric cards render (placeholders ok), activity feed container present |
+| `vault.spec.ts` | admin | Mounts, balance field is populated (not infinite spinner), deposit list container present |
+| `squad.spec.ts` | admin | Mounts, squad grid container present |
+| `herald.spec.ts` | admin | Mounts, agent-status widget renders, budget metric visible (admin-only card actually appears) |
+
+**Global invariants enforced in every test via Playwright fixtures:**
+
+- `page.on('pageerror', ...)` collects uncaught errors — any error fails the test.
+- `page.on('console', msg => msg.type() === 'error')` collects `console.error` — fails test unless explicitly allow-listed.
+
+## Auth Strategy
+
+Wallet signing is impossible in a headless browser. Instead, Playwright's `globalSetup` mints a real JWT out-of-band and injects it into localStorage via `storageState`.
+
+**Flow:**
+
+1. `e2e/global-setup.ts` runs once before all tests.
+2. Loads the admin keypair from `E2E_ADMIN_KEYPAIR_PATH` (locally: `~/Documents/secret/cipher-admin.json`; in CI: `e2e/fixtures/admin-keypair.json`, hydrated from the `E2E_ADMIN_KEYPAIR` GitHub Secret).
+3. Fetches a nonce from `POST http://localhost:5174/api/auth/nonce`.
+4. Signs the nonce with `@noble/curves/ed25519`.
+5. Exchanges the signature for a JWT at `POST /api/auth/login`.
+6. Writes `e2e/fixtures/storageState.json` with the JWT in localStorage under Sipher's expected key.
+
+**Per-test opt-in:**
+
+```ts
+test.use({ storageState: 'e2e/fixtures/storageState.json' })  // admin tests
+test.use({ storageState: { cookies: [], origins: [] } })      // unauth tests
+```
+
+The cipher-admin pubkey (`C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N`) is added to `AUTHORIZED_WALLETS` via `.env.test`, so `isAdmin=true` on login.
+
+## External Network Strategy
+
+All external dependencies are mocked or disabled. No test depends on devnet uptime, LLM API keys, X API quota, or Jupiter liveness.
+
+| Service | Strategy |
+|---------|----------|
+| Solana RPC | Playwright route interceptor on `**/api/rpc/**` returns canned balances and signatures |
+| Pi SDK (LLM) | `chat-public.spec.ts` intercepts `POST **/api/chat/stream` at the Playwright layer and responds with a canned SSE stream. The backend agent and Pi SDK are never invoked during E2E. No `OPENROUTER_API_KEY` required in CI. |
+| X API (HERALD) | Poller disabled via `HERALD_ENABLED=false` in `.env.test` |
+| Jupiter | Route interceptor on `**/quote`, `**/swap` returns canned quotes |
+
+## Test Data
+
+- **Test DB:** `SIPHER_DB_PATH=./e2e/test.db` — isolated SQLite, recreated per run.
+- **Seed:** `global-setup` inserts one dummy deposit, one blacklist entry, and ensures the admin pubkey is in `AUTHORIZED_WALLETS`.
+- **Teardown:** `global-teardown` wipes `test.db` and `storageState.json`.
+
+## Component Test Harness
+
+**Config:** `app/vitest.config.ts`
+
+```ts
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/setupTests.ts'],
+    globals: true,
+  },
+})
+```
+
+**`src/setupTests.ts`:** `import '@testing-library/jest-dom'`
+
+**First test — `ChatSidebar.test.tsx`:**
+
+- Renders closed state, opens on trigger
+- Accepts text input, submit dispatches fetch to `/api/chat/stream`
+- Renders bubble from streamed SSE (mock `EventSource`)
+
+Further component tests land during Phase 2 UI work, not Phase 1.
+
+## CI Integration
+
+**New workflow:** `.github/workflows/e2e.yml`
+
+Triggers:
+- `pull_request` with path filter: `app/**`, `packages/agent/**`, `src/**`, `e2e/**`, `playwright.config.ts`, `package.json`, `pnpm-lock.yaml`, `.github/workflows/e2e.yml`
+- `push` to `main`
+
+Steps:
+1. Checkout, setup pnpm + Node 22
+2. `pnpm install --frozen-lockfile`
+3. `pnpm exec playwright install --with-deps chromium`
+4. Write admin keypair from `E2E_ADMIN_KEYPAIR` secret → `e2e/fixtures/admin-keypair.json` (chmod 600)
+5. `pnpm test:e2e` with env: `E2E_ADMIN_KEYPAIR_PATH`, `HERALD_ENABLED=false`, `SIPHER_DB_PATH=./e2e/test.db`, `AUTHORIZED_WALLETS=C1phr...x85N`
+6. On failure: upload `playwright-report/` as artifact (14-day retention)
+
+**Component test CI:**
+- Add `pnpm --filter app test` to the existing PR check workflow under the same path filter.
+
+**Required GitHub Secret:**
+- `E2E_ADMIN_KEYPAIR` — raw JSON content of `~/Documents/secret/cipher-admin.json`. Added manually via `gh secret set E2E_ADMIN_KEYPAIR < ~/Documents/secret/cipher-admin.json`. Rotatable.
+
+**Rollout safety:**
+- First 2-3 PRs: workflow runs with `continue-on-error: true` so infra flakiness doesn't block real work.
+- Flip to required check once stable.
+- HTML report uploaded on failure.
+
+## Package Additions
+
+**Root `package.json` devDependencies:**
+- `@playwright/test`
+- `@noble/curves` (already present — reused)
+
+**`app/package.json` devDependencies:**
+- `@testing-library/react`
+- `@testing-library/jest-dom`
+- `jsdom`
+- `vitest` (if not already in `app/`)
+- `@vitejs/plugin-react` (if not already in `app/`)
+
+**Root `package.json` scripts:**
+- `test:e2e`: `playwright test`
+- `test:e2e:ui`: `playwright test --ui` (local dev helper)
+- `test:e2e:headed`: `playwright test --headed` (local dev helper)
+
+## Success Criteria
+
+- [ ] `pnpm test:e2e` runs locally and all 6 specs pass on a clean checkout
+- [ ] `pnpm --filter app test` runs locally and the ChatSidebar component test passes
+- [ ] `.github/workflows/e2e.yml` triggers on a UI-touching PR and passes
+- [ ] `E2E_ADMIN_KEYPAIR` secret exists in the repo
+- [ ] Path filter correctly skips E2E on backend-only or docs-only PRs
+- [ ] No test makes real network calls to Solana RPC, LLM providers, X API, or Jupiter
+- [ ] HTML report uploaded on failure, downloadable from Actions tab
+- [ ] README has a short "Running tests" section linking to this spec
+
+## Risks and Alternatives
+
+**Running against the deployed VPS instead of local dev server.** Rejected — would bleed real state into a prod SQLite (blacklist entries, SENTINEL decisions, audit log). Safer to mock in hermetic local runs; prod smoke-testing belongs in a separate manual workflow, not CI.
+
+**Skipping auth and testing unauth views only.** Rejected — half the surface (admin views, vault, herald controls) would go untested forever.
+
+**Mocking the auth hook in-app during E2E mode.** Rejected — bypasses the real auth middleware, letting regressions in auth code ship silently. JWT injection via storageState is only marginally more work and exercises the real path.
+
+**Adding WebKit and Firefox now.** Rejected (YAGNI) — professional-dev audience, Chromium dominates. Easy to add later if real users hit browser-specific bugs.
+
+**Running Playwright on every PR regardless of path.** Rejected — most Sipher PRs touch docs, backend, or infra. Running a 1-2 min E2E job on every PR wastes CI minutes. Path filter gives full coverage where it matters.
+
+**Visual regression (Percy, Chromatic).** Deferred — would catch UI drift but requires third-party service, costs money, and produces noisy diffs during active UI development. Worth revisiting after Phase 2 UI work stabilizes.
+
+## Implementation Notes
+
+- Port the existing `/tmp/sipher-login.mjs` ed25519 signing logic into `e2e/fixtures/auth.ts` as a reusable helper. This is the single source of truth for test-mode JWT minting; if the auth flow changes, this file is the only place to update.
+- Route interceptors live in a shared `e2e/fixtures/mocks.ts` and are attached per-test via a Playwright fixture extension. No per-test boilerplate.
+- `playwright.config.ts` sets `webServer.reuseExistingServer = !process.env.CI` so local reruns are fast but CI always gets a clean boot.
+- Set `fullyParallel: true` with `workers: 2` in CI to keep under 10-minute timeout.
+
+## Out of Scope (for later phases)
+
+- UI gap fixes (privacy score computation, tool-use indicators, color dots, ConfirmCard wiring, HERALD queue, MetricCard gating) — Phase 2.
+- SENTINEL external-tool surface docs cleanup — Phase 3.
+- REST service tests (chain-transfer-builder, transaction-builder, private-swap-builder) — Phase 4.
+- Tool unit test backfills (29 tools) — Phase 5.
+- Chrome MCP QA against live VPS — Phase 6.

--- a/e2e/auth-flow.spec.ts
+++ b/e2e/auth-flow.spec.ts
@@ -3,10 +3,10 @@ import { test, expect } from '@playwright/test'
 const AUTH_STATE = 'e2e/fixtures/storageState.json'
 
 test.describe('auth flow', () => {
-  test('unauth user sees landing, no admin metrics', async ({ page }) => {
+  test('unauth user sees landing with connect button', async ({ page }) => {
     await page.context().addInitScript(() => window.localStorage.clear())
     await page.goto('/')
-    await expect(page.getByText(/connect wallet/i).first()).toBeVisible()
+    await expect(page.getByRole('button', { name: /connect/i })).toBeVisible()
   })
 
   test.describe('authenticated', () => {

--- a/e2e/auth-flow.spec.ts
+++ b/e2e/auth-flow.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.describe('auth flow', () => {
+  test('unauth user sees landing, no admin metrics', async ({ page }) => {
+    await page.context().addInitScript(() => window.localStorage.clear())
+    await page.goto('/')
+    await expect(page.getByText(/connect wallet/i).first()).toBeVisible()
+  })
+
+  test.describe('authenticated', () => {
+    test.use({ storageState: AUTH_STATE })
+
+    test('admin user sees dashboard', async ({ page }) => {
+      await page.goto('/')
+      await expect(page.getByText('SIPHER').first()).toBeVisible()
+      const token = await page.evaluate(() => {
+        const raw = window.localStorage.getItem('sipher-auth')
+        return raw ? (JSON.parse(raw) as { state: { token: string } }).state.token : null
+      })
+      expect(token).toBeTruthy()
+    })
+  })
+})

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.describe('chat sidebar', () => {
+  test.describe('unauthenticated', () => {
+    test.use({ storageState: { cookies: [], origins: [] } })
+
+    test('input is disabled and shows connect-wallet placeholder', async ({ page }) => {
+      const errors: string[] = []
+      page.on('pageerror', (err) => errors.push(err.message))
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') errors.push(msg.text())
+      })
+
+      await page.goto('/')
+      const input = page.getByPlaceholder('Connect wallet first')
+      await expect(input).toBeVisible()
+      await expect(input).toBeDisabled()
+      expect(errors).toEqual([])
+    })
+  })
+
+  test.describe('authenticated', () => {
+    test.use({ storageState: AUTH_STATE })
+
+    test('sends message and renders streamed reply from mocked SSE', async ({ page }) => {
+      await page.route('**/api/chat/stream', async (route) => {
+        const body =
+          'data: {"type":"content_block_delta","text":"Hello "}\n\n' +
+          'data: {"type":"content_block_delta","text":"from SIPHER."}\n\n' +
+          'data: [DONE]\n\n'
+        await route.fulfill({
+          status: 200,
+          headers: { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' },
+          body,
+        })
+      })
+
+      const errors: string[] = []
+      page.on('pageerror', (err) => errors.push(err.message))
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') errors.push(msg.text())
+      })
+
+      await page.goto('/')
+      const input = page.getByPlaceholder('Message SIPHER...')
+      await expect(input).toBeEnabled()
+      await input.fill('hi')
+      await page.getByRole('button', { name: 'Send' }).click()
+
+      await expect(page.getByText('Hello from SIPHER.')).toBeVisible({ timeout: 5000 })
+      expect(errors).toEqual([])
+    })
+  })
+})

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test'
+import { mockSolanaRpc } from './fixtures/mocks'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.use({ storageState: AUTH_STATE })
+
+test('dashboard view renders without errors', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (err) => errors.push(err.message))
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text())
+  })
+
+  await mockSolanaRpc(page)
+  await page.goto('/')
+
+  await page.getByRole('button', { name: /dashboard/i }).click().catch(() => {})
+  await expect(page.locator('main, [data-testid="dashboard-view"]').first()).toBeVisible()
+  expect(errors).toEqual([])
+})

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -15,7 +15,6 @@ test('dashboard view renders without errors', async ({ page }) => {
   await mockSolanaRpc(page)
   await page.goto('/')
 
-  await page.getByRole('button', { name: /dashboard/i }).click().catch(() => {})
-  await expect(page.locator('main, [data-testid="dashboard-view"]').first()).toBeVisible()
+  await expect(page.locator('[data-testid="dashboard-view"]')).toBeVisible()
   expect(errors).toEqual([])
 })

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,0 +1,63 @@
+import fs from 'node:fs'
+import { ed25519 } from '@noble/curves/ed25519'
+
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+export function encodeBase58(bytes: Uint8Array): string {
+  let num = 0n
+  for (const b of bytes) num = num * 256n + BigInt(b)
+  let str = ''
+  while (num > 0n) {
+    str = BASE58_ALPHABET[Number(num % 58n)] + str
+    num = num / 58n
+  }
+  for (const b of bytes) {
+    if (b !== 0) break
+    str = '1' + str
+  }
+  return str || '1'
+}
+
+export interface LoginResult {
+  token: string
+  isAdmin: boolean
+  wallet: string
+}
+
+export async function mintAdminJwt(
+  keypairPath: string,
+  apiBase: string
+): Promise<LoginResult> {
+  const secretKeyArr = JSON.parse(fs.readFileSync(keypairPath, 'utf-8')) as number[]
+  const secretKey64 = Uint8Array.from(secretKeyArr)
+  const privateKey = secretKey64.slice(0, 32)
+  const publicKey = ed25519.getPublicKey(privateKey)
+  const wallet = encodeBase58(publicKey)
+
+  const nonceResp = await fetch(`${apiBase}/api/auth/nonce`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ wallet }),
+  })
+  if (!nonceResp.ok) {
+    throw new Error(`nonce failed: ${nonceResp.status} ${await nonceResp.text()}`)
+  }
+  const { nonce, message } = (await nonceResp.json()) as { nonce: string; message: string }
+
+  const sigBytes = ed25519.sign(new TextEncoder().encode(message), privateKey)
+  const signature = encodeBase58(sigBytes)
+
+  const verifyResp = await fetch(`${apiBase}/api/auth/verify`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ wallet, nonce, signature }),
+  })
+  if (!verifyResp.ok) {
+    throw new Error(`verify failed: ${verifyResp.status} ${await verifyResp.text()}`)
+  }
+  const { token, isAdmin } = (await verifyResp.json()) as {
+    token: string
+    isAdmin: boolean
+  }
+  return { token, isAdmin, wallet }
+}

--- a/e2e/fixtures/mocks.ts
+++ b/e2e/fixtures/mocks.ts
@@ -1,0 +1,35 @@
+import type { Page, Route } from '@playwright/test'
+
+export async function mockSolanaRpc(page: Page): Promise<void> {
+  await page.route('**/api/rpc/**', async (route: Route) => {
+    const body = route.request().postDataJSON() as { method?: string }
+    const method = body?.method ?? ''
+    if (method === 'getBalance') {
+      await route.fulfill({ json: { jsonrpc: '2.0', id: 1, result: { value: 1_000_000_000 } } })
+      return
+    }
+    if (method === 'getSignatureStatuses') {
+      await route.fulfill({
+        json: { jsonrpc: '2.0', id: 1, result: { value: [null] } },
+      })
+      return
+    }
+    await route.fulfill({ json: { jsonrpc: '2.0', id: 1, result: null } })
+  })
+}
+
+export async function mockJupiter(page: Page): Promise<void> {
+  await page.route('**/quote**', async (route: Route) => {
+    await route.fulfill({
+      json: {
+        inAmount: '1000000',
+        outAmount: '980000',
+        priceImpactPct: '0.1',
+        routePlan: [],
+      },
+    })
+  })
+  await page.route('**/swap**', async (route: Route) => {
+    await route.fulfill({ json: { swapTransaction: 'mock-tx-base64' } })
+  })
+}

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { mintAdminJwt } from './fixtures/auth'
+
+const FRONTEND_ORIGIN = 'http://localhost:5173'
+const BACKEND_BASE = 'http://localhost:3000'
+const STORAGE_STATE_PATH = path.resolve(__dirname, './fixtures/storageState.json')
+
+export default async function globalSetup(): Promise<void> {
+  const keypairPath =
+    process.env.E2E_ADMIN_KEYPAIR_PATH ?? '/Users/rector/Documents/secret/cipher-admin.json'
+
+  if (!fs.existsSync(keypairPath)) {
+    throw new Error(
+      `E2E admin keypair not found at ${keypairPath}. Set E2E_ADMIN_KEYPAIR_PATH env var.`
+    )
+  }
+
+  const { token, isAdmin, wallet } = await mintAdminJwt(keypairPath, BACKEND_BASE)
+  if (!isAdmin) {
+    throw new Error(`Minted JWT for ${wallet} is not admin. Check AUTHORIZED_WALLETS env.`)
+  }
+
+  const zustandPayload = {
+    state: { token, isAdmin },
+    version: 0,
+  }
+
+  const storageState = {
+    cookies: [],
+    origins: [
+      {
+        origin: FRONTEND_ORIGIN,
+        localStorage: [{ name: 'sipher-auth', value: JSON.stringify(zustandPayload) }],
+      },
+    ],
+  }
+
+  fs.writeFileSync(STORAGE_STATE_PATH, JSON.stringify(storageState, null, 2))
+  console.log(`[e2e] storageState written (wallet=${wallet}, isAdmin=${isAdmin})`)
+}

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,7 +1,9 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { mintAdminJwt } from './fixtures/auth'
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const FRONTEND_ORIGIN = 'http://localhost:5173'
 const BACKEND_BASE = 'http://localhost:3000'
 const STORAGE_STATE_PATH = path.resolve(__dirname, './fixtures/storageState.json')

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,5 +1,8 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const PATHS_TO_CLEAN = [
   path.resolve(__dirname, './fixtures/storageState.json'),

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,0 +1,14 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const PATHS_TO_CLEAN = [
+  path.resolve(__dirname, './fixtures/storageState.json'),
+  path.resolve(__dirname, './test.db'),
+  path.resolve(__dirname, './test.db-journal'),
+]
+
+export default async function globalTeardown(): Promise<void> {
+  for (const p of PATHS_TO_CLEAN) {
+    if (fs.existsSync(p)) fs.unlinkSync(p)
+  }
+}

--- a/e2e/herald.spec.ts
+++ b/e2e/herald.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.use({ storageState: AUTH_STATE })
+
+test('herald view renders with admin budget visible', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (err) => errors.push(err.message))
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text())
+  })
+
+  await page.route('**/api/herald/**', async (route) => {
+    await route.fulfill({
+      json: { budget: { used: 0, total: 1000 }, queue: [], status: 'idle' },
+    })
+  })
+
+  await page.goto('/')
+  await page.getByRole('button', { name: /herald/i }).first().click()
+  await expect(page.locator('[data-testid="herald-view"]')).toBeVisible()
+  expect(errors).toEqual([])
+})

--- a/e2e/herald.spec.ts
+++ b/e2e/herald.spec.ts
@@ -11,9 +11,14 @@ test('herald view renders with admin budget visible', async ({ page }) => {
     if (msg.type() === 'error') errors.push(msg.text())
   })
 
-  await page.route('**/api/herald/**', async (route) => {
+  await page.route('**/api/herald', async (route) => {
     await route.fulfill({
-      json: { budget: { used: 0, total: 1000 }, queue: [], status: 'idle' },
+      json: {
+        budget: { spent: 0, limit: 1000, gate: 'open', percentage: 0 },
+        queue: [],
+        dms: [],
+        recentPosts: [],
+      },
     })
   })
 

--- a/e2e/squad.spec.ts
+++ b/e2e/squad.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.use({ storageState: AUTH_STATE })
+
+test('squad view renders', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (err) => errors.push(err.message))
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text())
+  })
+
+  await page.goto('/')
+  await page.getByRole('button', { name: /squad/i }).first().click()
+  await expect(page.locator('[data-testid="squad-view"]')).toBeVisible()
+  expect(errors).toEqual([])
+})

--- a/e2e/vault.spec.ts
+++ b/e2e/vault.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test'
+import { mockSolanaRpc } from './fixtures/mocks'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.use({ storageState: AUTH_STATE })
+
+test('vault view renders', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (err) => errors.push(err.message))
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text())
+  })
+
+  await mockSolanaRpc(page)
+  await page.goto('/')
+  await page.getByRole('button', { name: /vault/i }).first().click()
+  await expect(page.locator('[data-testid="vault-view"]')).toBeVisible()
+  expect(errors).toEqual([])
+})

--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
     "thanks": "bash scripts/thanks.sh",
     "openapi:export": "tsx scripts/export-openapi.ts",
     "sdks:generate": "bash sdks/generator/generate.sh",
-    "devnet-demo": "tsx scripts/devnet-shielded-transfer.ts"
+    "devnet-demo": "tsx scripts/devnet-shielded-transfer.ts",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.31",
@@ -49,6 +52,7 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/compression": "^1.8.1",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -117,6 +117,27 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const app = express()
 app.use(express.json({ limit: '1mb' }))
 
+// ─── CORS — only needed for dev/test (in prod the agent serves the app statically)
+// Reads comma-separated CORS_ORIGINS env. Empty/unset = no CORS headers (same-origin).
+const corsOrigins = (process.env.CORS_ORIGINS ?? '').split(',').map((o) => o.trim()).filter(Boolean)
+if (corsOrigins.length > 0) {
+  app.use((req, res, next) => {
+    const origin = req.headers.origin
+    if (origin && corsOrigins.includes(origin)) {
+      res.setHeader('Access-Control-Allow-Origin', origin)
+      res.setHeader('Access-Control-Allow-Credentials', 'true')
+      res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS')
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+    }
+    if (req.method === 'OPTIONS') {
+      res.status(204).end()
+      return
+    }
+    next()
+  })
+  console.log(`  CORS:    enabled for ${corsOrigins.join(', ')}`)
+}
+
 // ─── Pay and Admin routes ────────────────────────────────────────────────────
 
 app.use('/pay', payRouter)

--- a/patches/@triton-one__yellowstone-grpc@4.0.2.patch
+++ b/patches/@triton-one__yellowstone-grpc@4.0.2.patch
@@ -1,0 +1,14 @@
+diff --git a/dist/esm/encoding/package.json b/dist/esm/encoding/package.json
+new file mode 100644
+index 0000000000000000000000000000000000000000..729ac4d93b7f2d9be36b44525f02ff6555f9383a
+--- /dev/null
++++ b/dist/esm/encoding/package.json
+@@ -0,0 +1 @@
++{"type":"commonjs"}
+diff --git a/dist/esm/package.json b/dist/esm/package.json
+new file mode 100644
+index 0000000000000000000000000000000000000000..089153bcb5adf57dc25f206a9dad3114c9cff80d
+--- /dev/null
++++ b/dist/esm/package.json
+@@ -0,0 +1 @@
++{"type":"module"}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,53 @@
+import { defineConfig, devices } from '@playwright/test'
+import path from 'node:path'
+
+const PORT_FRONTEND = 5173
+const PORT_BACKEND = 3000
+
+export default defineConfig({
+  testDir: './e2e',
+  testIgnore: ['**/fixtures/**'],
+  fullyParallel: true,
+  workers: process.env.CI ? 2 : undefined,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  timeout: 30_000,
+  reporter: process.env.CI ? [['html'], ['github']] : [['html'], ['list']],
+  globalSetup: path.resolve(__dirname, './e2e/global-setup.ts'),
+  globalTeardown: path.resolve(__dirname, './e2e/global-teardown.ts'),
+  use: {
+    baseURL: `http://localhost:${PORT_FRONTEND}`,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: [
+    {
+      command: 'pnpm --filter @sipher/agent dev',
+      url: `http://localhost:${PORT_BACKEND}/api/health`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+      env: {
+        NODE_ENV: 'test',
+        PORT: String(PORT_BACKEND),
+        HERALD_ENABLED: 'false',
+        SIPHER_DB_PATH: './e2e/test.db',
+        AUTHORIZED_WALLETS: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
+        JWT_SECRET: process.env.JWT_SECRET ?? 'e2e-test-secret-at-least-16-chars',
+        SENTINEL_MODE: 'off',
+      },
+    },
+    {
+      command: 'pnpm --filter @sipher/app dev',
+      url: `http://localhost:${PORT_FRONTEND}`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+    },
+  ],
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
         AUTHORIZED_WALLETS: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
         JWT_SECRET: process.env.JWT_SECRET ?? 'e2e-test-secret-at-least-16-chars',
         SENTINEL_MODE: 'off',
+        CORS_ORIGINS: `http://localhost:${PORT_FRONTEND}`,
       },
     },
     {
@@ -47,6 +48,9 @@ export default defineConfig({
       url: `http://localhost:${PORT_FRONTEND}`,
       reuseExistingServer: !process.env.CI,
       timeout: 60_000,
+      env: {
+        VITE_API_URL: `http://localhost:${PORT_BACKEND}`,
+      },
     },
   ],
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig, devices } from '@playwright/test'
-import path from 'node:path'
 
 const PORT_FRONTEND = 5173
 const PORT_BACKEND = 3000
@@ -13,8 +12,8 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
   timeout: 30_000,
   reporter: process.env.CI ? [['html'], ['github']] : [['html'], ['list']],
-  globalSetup: path.resolve(__dirname, './e2e/global-setup.ts'),
-  globalTeardown: path.resolve(__dirname, './e2e/global-teardown.ts'),
+  globalSetup: './e2e/global-setup.ts',
+  globalTeardown: './e2e/global-teardown.ts',
   use: {
     baseURL: `http://localhost:${PORT_FRONTEND}`,
     trace: 'retain-on-failure',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@triton-one/yellowstone-grpc@4.0.2':
+    hash: 3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a
+    path: patches/@triton-one__yellowstone-grpc@4.0.2.patch
+
 importers:
 
   .:
@@ -19,7 +24,7 @@ importers:
         version: 1.8.0
       '@sip-protocol/sdk':
         specifier: ^0.7.4
-        version: 0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))
+        version: 0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))
       '@sip-protocol/types':
         specifier: ^0.2.2
         version: 0.2.2
@@ -8269,14 +8274,14 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))':
+  '@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.3.87(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      langsmith: 0.3.87(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -8309,26 +8314,26 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
 
-  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))':
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@langchain/langgraph-sdk@1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       p-queue: 9.1.0
       p-retry: 7.1.1
       uuid: 13.0.0
     optionalDependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)':
+  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
-      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 3.25.76
@@ -8338,11 +8343,11 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)':
+  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
-      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 3.25.76
@@ -8352,9 +8357,20 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      js-tiktoken: 1.0.21
+      openai: 4.104.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - encoding
+      - ws
+
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       js-tiktoken: 1.0.21
       openai: 4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       zod: 3.25.76
@@ -9068,13 +9084,13 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@sip-protocol/sdk@0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))':
+  '@sip-protocol/sdk@0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
       '@aztec/bb.js': 3.0.2
       '@ethereumjs/rlp': 10.1.1
       '@jup-ag/api': 6.0.48
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@magicblock-labs/ephemeral-rollups-sdk': 0.8.5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
       '@noble/ciphers': 2.1.1
       '@noble/curves': 1.9.7
@@ -9092,8 +9108,8 @@ snapshots:
       '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@triton-one/yellowstone-grpc': 4.0.2
-      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))
+      '@triton-one/yellowstone-grpc': 4.0.2(patch_hash=3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a)
+      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))
       pino: 10.3.0
       zod: 4.3.6
     optionalDependencies:
@@ -9121,7 +9137,7 @@ snapshots:
       '@ethereumjs/rlp': 10.1.1
       '@jup-ag/api': 6.0.48
       '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@magicblock-labs/ephemeral-rollups-sdk': 0.8.5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
       '@noble/ciphers': 2.1.1
       '@noble/curves': 1.9.7
@@ -9139,8 +9155,8 @@ snapshots:
       '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@triton-one/yellowstone-grpc': 4.0.2
-      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))
+      '@triton-one/yellowstone-grpc': 4.0.2(patch_hash=3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a)
+      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))
       pino: 10.3.0
       zod: 4.3.6
     optionalDependencies:
@@ -11449,7 +11465,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@triton-one/yellowstone-grpc@4.0.2':
+  '@triton-one/yellowstone-grpc@4.0.2(patch_hash=3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a)':
     dependencies:
       '@grpc/grpc-js': 1.14.3
 
@@ -13967,12 +13983,12 @@ snapshots:
 
   keyvaluestorage-interface@1.0.0: {}
 
-  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76)):
+  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76)):
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
-      langsmith: 0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      langsmith: 0.4.12(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       uuid: 10.0.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -13984,11 +14000,11 @@ snapshots:
       - react-dom
       - zod-to-json-schema
 
-  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6)):
+  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6)):
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
       langsmith: 0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
       uuid: 10.0.0
       zod: 3.25.76
@@ -14001,7 +14017,7 @@ snapshots:
       - react-dom
       - zod-to-json-schema
 
-  langsmith@0.3.87(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
+  langsmith@0.3.87(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -14010,7 +14026,7 @@ snapshots:
       semver: 7.7.3
       uuid: 10.0.0
     optionalDependencies:
-      openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      openai: 6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
 
   langsmith@0.3.87(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)):
     dependencies:
@@ -14023,7 +14039,7 @@ snapshots:
     optionalDependencies:
       openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
 
-  langsmith@0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
+  langsmith@0.4.12(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -14032,7 +14048,7 @@ snapshots:
       semver: 7.7.3
       uuid: 10.0.0
     optionalDependencies:
-      openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      openai: 6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
 
   langsmith@0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)):
     dependencies:
@@ -14592,6 +14608,21 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  openai@4.104.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    optionalDependencies:
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - encoding
+
   openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
@@ -14607,9 +14638,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
+  openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
     optionalDependencies:
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod: 3.25.76
     optional: true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 1.8.0
       '@sip-protocol/sdk':
         specifier: ^0.7.4
-        version: 0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))
+        version: 0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))
       '@sip-protocol/types':
         specifier: ^0.2.2
         version: 0.2.2
@@ -66,6 +66,9 @@ importers:
         specifier: ^3.24.2
         version: 3.25.76
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@types/compression':
         specifier: ^1.8.1
         version: 1.8.1
@@ -104,7 +107,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.5
-        version: 3.2.4(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@25.2.0)(jiti@2.6.1)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   app:
     dependencies:
@@ -139,6 +142,15 @@ importers:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.2.0(react@19.2.4))
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -148,12 +160,18 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.0
         version: 4.7.0(vite@6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
       vite:
         specifier: ^6.0.0
         version: 6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@25.2.0)(jiti@2.6.1)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/agent:
     dependencies:
@@ -223,7 +241,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@25.2.0)(jiti@2.6.1)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/sdk:
     dependencies:
@@ -245,9 +263,12 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@25.2.0)(jiti@2.6.1)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
@@ -266,6 +287,9 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -590,6 +614,34 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@solana/web3.js': ^1.68.0
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@emurgo/cardano-serialization-lib-browser@13.2.1':
     resolution: {integrity: sha512-7RfX1gI16Vj2DgCp/ZoXqyLAakWo6+X95ku/rYGbVzuS/1etrlSiJmdbmdm+eYmszMlGQjrtOJQeVLXoj4L/Ag==}
@@ -1364,6 +1416,11 @@ packages:
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@project-serum/sol-wallet-adapter@0.2.6':
     resolution: {integrity: sha512-cpIb13aWPW8y4KzkZAPDgw+Kb+DXjCC6rZoH74MGm3I/6e/zKyGnfAuW5olb2zxonFqsYgnv7ev8MQnvSgJ3/g==}
@@ -3007,6 +3064,35 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
@@ -3187,6 +3273,9 @@ packages:
   '@triton-one/yellowstone-grpc@4.0.2':
     resolution: {integrity: sha512-RsHNbLz6zCU3OpQRBqKWcXqDDOKj1nxc/78LIt9kZWBU2kfYeFs7361eUpYE9Q3+BizjpCLF6BX9G1OitD76bw==}
     engines: {node: '>=20.18.0'}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -3575,6 +3664,13 @@ packages:
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
@@ -4053,6 +4149,13 @@ packages:
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -4063,6 +4166,10 @@ packages:
   data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
@@ -4090,6 +4197,9 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-uri-component@0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
@@ -4138,6 +4248,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   derive-valtio@0.1.0:
     resolution: {integrity: sha512-OCg2UsLbXK7GmmpzMXhYkdO64vhJ1ROUUGaTFyHjVwEdMEcTTRj7W1TxLbSBxdY8QLBPCcp66MTyaSy0RpO17A==}
     peerDependencies:
@@ -4171,6 +4285,12 @@ packages:
 
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -4224,6 +4344,10 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   envalid@8.1.1:
     resolution: {integrity: sha512-vOUfHxAFFvkBjbVQbBfgnCO9d3GcNfMMTtVfgqSU2rQGMFEVqWy9GBuoSfHnwGu7EqR0/GeukQcL3KjFBaga9w==}
@@ -4509,6 +4633,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4639,6 +4768,10 @@ packages:
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -4653,6 +4786,10 @@ packages:
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -4672,6 +4809,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -4747,6 +4888,9 @@ packages:
   is-plain-obj@2.1.0:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
     engines: {node: '>=8'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
@@ -4872,6 +5016,15 @@ packages:
 
   jsc-safe-url@0.2.4:
     resolution: {integrity: sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==}
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -5134,6 +5287,9 @@ packages:
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@11.2.5:
     resolution: {integrity: sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==}
     engines: {node: 20 || >=22}
@@ -5148,6 +5304,10 @@ packages:
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -5283,6 +5443,10 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
@@ -5414,6 +5578,9 @@ packages:
 
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
+
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
   ob1@0.83.5:
     resolution: {integrity: sha512-vNKPYC8L5ycVANANpF/S+WZHpfnRWKx/F3AYP4QMn6ZJTh+l2HOrId0clNkEmua58NB9vmI9Qh7YOoV/4folYg==}
@@ -5567,6 +5734,9 @@ packages:
     resolution: {integrity: sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==}
     engines: {node: '>= 0.10'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -5656,6 +5826,16 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
@@ -5691,6 +5871,10 @@ packages:
     engines: {node: '>=10'}
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
@@ -5746,6 +5930,10 @@ packages:
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   pushdata-bitcoin@1.0.1:
     resolution: {integrity: sha512-hw7rcYTJRAl4olM8Owe8x0fBuJJ+WGbMhQuLWOXEMN3PxPCKQHRkhfL+XG0+iXUmSHjkMmb3Ba55Mt21cZc9kQ==}
@@ -5813,6 +6001,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -5882,6 +6073,10 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
     engines: {node: '>=4'}
@@ -5948,6 +6143,12 @@ packages:
   rpc-websockets@9.3.3:
     resolution: {integrity: sha512-OkCsBBzrwxX4DoSv4Zlf9DgXKRB0MzVfCFg5MC+fNnf9ktr4SMWjsri0VNZQlDbCnGcImT6KNEv4ZoxktQhdpA==}
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   rtcpeerconnection-shim@1.2.15:
     resolution: {integrity: sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==}
     engines: {node: '>=6.0.0', npm: '>=3.10.0'}
@@ -5980,6 +6181,10 @@ packages:
     resolution: {integrity: sha512-28ysSzmDjx2AbotxSggqdclh9MCwlPJUldKkCph48oS5Xtwu0QOg8T9ZRHS2Mben4Y8sTq6VvxXznKssCYFBJA==}
     peerDependencies:
       '@solana/web3.js': ^1.44.3
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -6201,6 +6406,10 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
@@ -6251,6 +6460,9 @@ packages:
     engines: {node: '>= v0.10.32'}
     peerDependencies:
       express: '>=4.0.0 || >=5.0.0-beta'
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
@@ -6324,6 +6536,13 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
@@ -6342,8 +6561,16 @@ packages:
   toml@3.0.0:
     resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -6730,6 +6957,10 @@ packages:
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
@@ -6747,12 +6978,29 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   webrtc-adapter@7.7.1:
     resolution: {integrity: sha512-TbrbBmiQBL9n0/5bvDdORc6ZfRY/Z7JnEj+EYOD1ghseZdpJ+nF2yx14k3LgQKc7JZnG7HAcL+zHnY25So9d7A==}
     engines: {node: '>=6.0.0', npm: '>=3.10.0'}
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -6840,6 +7088,13 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xmlhttprequest-ssl@2.1.2:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
     engines: {node: '>=0.4.0'}
@@ -6913,6 +7168,8 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@adraffy/ens-normalize@1.11.1': {}
 
   '@anthropic-ai/claude-agent-sdk@0.2.31(zod@3.25.76)':
@@ -6933,6 +7190,14 @@ snapshots:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.3.6
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -7553,6 +7818,26 @@ snapshots:
       bn.js: 5.2.2
       buffer-layout: 1.2.2
 
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
+
   '@emurgo/cardano-serialization-lib-browser@13.2.1': {}
 
   '@emurgo/cardano-serialization-lib-nodejs@13.2.0': {}
@@ -7984,14 +8269,14 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))':
+  '@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.3.87(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      langsmith: 0.3.87(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -8024,26 +8309,26 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
 
-  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))':
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@langchain/langgraph-sdk@1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       p-queue: 9.1.0
       p-retry: 7.1.1
       uuid: 13.0.0
     optionalDependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)':
+  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
-      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 3.25.76
@@ -8053,11 +8338,11 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)':
+  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
-      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 3.25.76
@@ -8067,20 +8352,9 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      js-tiktoken: 1.0.21
-      openai: 4.104.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
-    transitivePeerDependencies:
-      - encoding
-      - ws
-
-  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       js-tiktoken: 1.0.21
       openai: 4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       zod: 3.25.76
@@ -8307,6 +8581,10 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   '@pinojs/redact@0.4.0': {}
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@project-serum/sol-wallet-adapter@0.2.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
@@ -8790,13 +9068,13 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@sip-protocol/sdk@0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))':
+  '@sip-protocol/sdk@0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
       '@aztec/bb.js': 3.0.2
       '@ethereumjs/rlp': 10.1.1
       '@jup-ag/api': 6.0.48
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@magicblock-labs/ephemeral-rollups-sdk': 0.8.5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
       '@noble/ciphers': 2.1.1
       '@noble/curves': 1.9.7
@@ -8815,7 +9093,7 @@ snapshots:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@triton-one/yellowstone-grpc': 4.0.2
-      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))
+      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))
       pino: 10.3.0
       zod: 4.3.6
     optionalDependencies:
@@ -8843,7 +9121,7 @@ snapshots:
       '@ethereumjs/rlp': 10.1.1
       '@jup-ag/api': 6.0.48
       '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@magicblock-labs/ephemeral-rollups-sdk': 0.8.5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
       '@noble/ciphers': 2.1.1
       '@noble/curves': 1.9.7
@@ -8862,7 +9140,7 @@ snapshots:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@triton-one/yellowstone-grpc': 4.0.2
-      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))
+      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))
       pino: 10.3.0
       zod: 4.3.6
     optionalDependencies:
@@ -10762,6 +11040,40 @@ snapshots:
       tailwindcss: 4.2.2
       vite: 6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@toruslabs/base-controllers@5.11.0(@babel/runtime@7.28.6)(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
@@ -11140,6 +11452,8 @@ snapshots:
   '@triton-one/yellowstone-grpc@4.0.2':
     dependencies:
       '@grpc/grpc-js': 1.14.3
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -12017,6 +12331,12 @@ snapshots:
     dependencies:
       sprintf-js: 1.0.3
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
   asap@2.0.6: {}
 
   asn1.js@4.10.1:
@@ -12602,11 +12922,23 @@ snapshots:
 
   crypto-js@4.2.0: {}
 
+  css.escape@1.5.1: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
 
   data-uri-to-buffer@4.0.1: {}
 
   data-uri-to-buffer@6.0.2: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   dateformat@4.6.3: {}
 
@@ -12621,6 +12953,8 @@ snapshots:
       ms: 2.1.3
 
   decamelize@1.2.0: {}
+
+  decimal.js@10.6.0: {}
 
   decode-uri-component@0.2.2: {}
 
@@ -12660,6 +12994,8 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   derive-valtio@0.1.0(valtio@1.13.2(@types/react@19.2.14)(react@19.2.4)):
     dependencies:
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.4)
@@ -12691,6 +13027,10 @@ snapshots:
       randombytes: 2.1.0
 
   dijkstrajs@1.0.3: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dot-case@3.0.4:
     dependencies:
@@ -12763,6 +13103,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  entities@6.0.1: {}
 
   envalid@8.1.1:
     dependencies:
@@ -13093,6 +13435,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -13251,6 +13596,10 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -13277,6 +13626,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -13290,6 +13643,8 @@ snapshots:
       queue: 6.0.2
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -13360,6 +13715,8 @@ snapshots:
 
   is-plain-obj@2.1.0:
     optional: true
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-promise@4.0.0: {}
 
@@ -13525,6 +13882,34 @@ snapshots:
 
   jsc-safe-url@0.2.4: {}
 
+  jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   jsesc@3.1.0: {}
 
   json-bigint@1.0.0:
@@ -13582,12 +13967,12 @@ snapshots:
 
   keyvaluestorage-interface@1.0.0: {}
 
-  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76)):
+  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76)):
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
-      langsmith: 0.4.12(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      langsmith: 0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       uuid: 10.0.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -13599,11 +13984,11 @@ snapshots:
       - react-dom
       - zod-to-json-schema
 
-  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6)):
+  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6)):
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
       langsmith: 0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
       uuid: 10.0.0
       zod: 3.25.76
@@ -13616,7 +14001,7 @@ snapshots:
       - react-dom
       - zod-to-json-schema
 
-  langsmith@0.3.87(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
+  langsmith@0.3.87(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -13625,7 +14010,7 @@ snapshots:
       semver: 7.7.3
       uuid: 10.0.0
     optionalDependencies:
-      openai: 6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
 
   langsmith@0.3.87(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)):
     dependencies:
@@ -13638,7 +14023,7 @@ snapshots:
     optionalDependencies:
       openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
 
-  langsmith@0.4.12(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
+  langsmith@0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -13647,7 +14032,7 @@ snapshots:
       semver: 7.7.3
       uuid: 10.0.0
     optionalDependencies:
-      openai: 6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
 
   langsmith@0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)):
     dependencies:
@@ -13790,6 +14175,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  lru-cache@10.4.3: {}
+
   lru-cache@11.2.5: {}
 
   lru-cache@11.2.7: {}
@@ -13799,6 +14186,8 @@ snapshots:
       yallist: 3.1.1
 
   lru-cache@7.18.3: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -14035,6 +14424,8 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
+  min-indent@1.0.1: {}
+
   minimalistic-assert@1.0.1: {}
 
   minimalistic-crypto-utils@1.0.1: {}
@@ -14144,6 +14535,8 @@ snapshots:
 
   nullthrows@1.1.1: {}
 
+  nwsapi@2.2.23: {}
+
   ob1@0.83.5:
     dependencies:
       flow-enums-runtime: 0.0.6
@@ -14199,21 +14592,6 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@4.104.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
-    dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0
-    optionalDependencies:
-      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - encoding
-
   openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
@@ -14229,9 +14607,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
+  openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
     optionalDependencies:
-      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod: 3.25.76
     optional: true
 
@@ -14348,6 +14726,10 @@ snapshots:
       evp_bytestokey: 1.0.3
       pbkdf2: 3.1.5
       safe-buffer: 5.2.1
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parseurl@1.3.3: {}
 
@@ -14472,6 +14854,14 @@ snapshots:
       mlly: 1.8.0
       pathe: 2.0.3
 
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   pngjs@5.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
@@ -14505,6 +14895,12 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   pretty-format@29.7.0:
     dependencies:
@@ -14598,6 +14994,8 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
+  punycode@2.3.1: {}
+
   pushdata-bitcoin@1.0.1:
     dependencies:
       bitcoin-ops: 1.4.1
@@ -14682,6 +15080,8 @@ snapshots:
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
@@ -14789,6 +15189,11 @@ snapshots:
   real-require@0.1.0: {}
 
   real-require@0.2.0: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   redis-errors@1.2.0: {}
 
@@ -14899,6 +15304,10 @@ snapshots:
       bufferutil: 4.1.0
       utf-8-validate: 5.0.10
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   rtcpeerconnection-shim@1.2.15:
     dependencies:
       sdp: 2.12.0
@@ -14930,6 +15339,10 @@ snapshots:
       '@project-serum/sol-wallet-adapter': 0.2.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       eventemitter3: 4.0.7
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -15188,6 +15601,10 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@5.0.3: {}
@@ -15250,6 +15667,8 @@ snapshots:
     dependencies:
       express: 5.2.1
       swagger-ui-dist: 5.31.0
+
+  symbol-tree@3.2.4: {}
 
   tailwindcss@4.2.2: {}
 
@@ -15330,6 +15749,12 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   tmpl@1.0.5: {}
 
   to-buffer@1.2.2:
@@ -15346,7 +15771,15 @@ snapshots:
 
   toml@3.0.0: {}
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tr46@0.0.3: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -15640,7 +16073,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@3.2.4(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@3.2.4(@types/node@25.2.0)(jiti@2.6.1)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -15667,6 +16100,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.2.0
+      jsdom: 25.0.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - jiti
       - less
@@ -15683,6 +16117,10 @@ snapshots:
 
   vlq@1.0.1: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
@@ -15697,12 +16135,25 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
+  webidl-conversions@7.0.0: {}
+
   webrtc-adapter@7.7.1:
     dependencies:
       rtcpeerconnection-shim: 1.2.15
       sdp: 2.12.0
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
   whatwg-fetch@3.6.20: {}
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -15772,6 +16223,10 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 5.0.10
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xmlhttprequest-ssl@2.1.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,9 @@ packages:
   - 'packages/*'
   - 'app'
   - '!sdks/**'
+patchedDependencies:
+  '@triton-one/yellowstone-grpc@4.0.2': patches/@triton-one__yellowstone-grpc@4.0.2.patch
+onlyBuiltDependencies:
+  - better-sqlite3
+  - bufferutil
+  - utf-8-validate


### PR DESCRIPTION
## Summary

Phase 1 of the audit-driven work. Lands the missing test infrastructure layers identified in the 2026-04-18 coverage audit (zero Playwright, zero UI component tests):

- **Playwright ^1.59** (Chromium only) — 6 E2E specs covering chat, auth flow, and all 4 views
- **Vitest ^3.2 + @testing-library/react ^16** — component tests for `app/` (3 ChatSidebar cases)
- **Path-filtered GitHub Actions workflow** (`.github/workflows/e2e.yml`) with two jobs: `component` (fast, always required) and `playwright` (continue-on-error during initial stabilization)
- **Ed25519 JWT fixture** minted once in `global-setup`, injected via Playwright `storageState` for admin-gated flows
- **Zustand persist middleware** for `token`/`isAdmin` — UX bonus (sessions persist across refresh) and enables E2E auth injection
- All external network (Solana RPC, Jupiter, Pi SDK, X) is mocked or disabled — no API keys needed in CI

Docs:
- Spec: `docs/superpowers/specs/2026-04-18-test-infrastructure-design.md`
- Plan: `docs/superpowers/plans/2026-04-18-test-infrastructure.md`
- README: new "Running Tests" section

## Test plan

- [x] `pnpm --filter @sipher/app test` — 3 ChatSidebar tests pass locally
- [x] `pnpm --filter @sipher/app exec tsc --noEmit` — clean
- [x] Playwright config loads (ESM __dirname resolved via fileURLToPath)
- [ ] Full `pnpm test:e2e` — **blocked locally** by pre-existing SDK bootstrapping bug (see below); will also fail in CI's playwright job (continue-on-error)
- [ ] CI `component` job green (manual verify after push)
- [ ] ` E2E_ADMIN_KEYPAIR` + `E2E_JWT_SECRET` GitHub Secrets must be set before playwright job can run for real

## Known blocker (separate issue)

`pnpm --filter @sipher/agent dev` fails at boot:
\`\`\`
SyntaxError: The requested module '@triton-one/yellowstone-grpc' does not provide an export named 'CommitmentLevel'
  at chunk-64AYA5F5.mjs:3339
\`\`\`

The published \`@sip-protocol/sdk\` (0.7.4 and 0.9.0 both reproduce) imports \`CommitmentLevel\` from \`@triton-one/yellowstone-grpc\` in a way that Node's ESM resolver can't satisfy — even though the grpc package's ESM index *does* export the name (verified via direct \`import()\`). This is an ESM/CJS interop bug in the SDK's build output, unrelated to test-infra.

**Impact on this PR:** Playwright E2E cannot run locally or in CI until the SDK bug is resolved. Component tests are unaffected (they don't import the SDK). The \`playwright\` job uses \`continue-on-error: true\` so this PR doesn't block merge. Once the SDK is fixed, flip that flag to \`false\`.

**Recommendation:** File follow-up issue in \`sip-protocol/sip-protocol\` for the SDK bug. Suggest pnpm overrides pinning \`@triton-one/yellowstone-grpc\` as a short-term workaround if needed.

## Files changed (high-level)

- \`playwright.config.ts\` (new)
- \`e2e/\` (new dir — 6 specs + 3 fixtures + global setup/teardown)
- \`app/vitest.config.ts\`, \`app/src/setupTests.ts\`, \`app/src/components/__tests__/ChatSidebar.test.tsx\` (new)
- \`app/src/stores/app.ts\` (Zustand persist middleware)
- \`app/src/views/{Dashboard,Vault,Squad,Herald}View.tsx\` (added \`data-testid\` attribute only)
- \`.github/workflows/e2e.yml\` (new)
- \`README.md\` (Running Tests section)
- \`package.json\`, \`app/package.json\`, \`pnpm-lock.yaml\`, \`.gitignore\` (deps/scripts)

18 commits, ~1700 lines added. Each commit is a single logical unit with its own conventional prefix.
---

## Update 2026-04-27 — #1077 fix landed + e2e green

The blocker mentioned above (sip-protocol/sip-protocol#1077) is now fixed in this PR. Three additional commits added:

- **`3e07c9c` fix(1077):** `pnpm patch` for `@triton-one/yellowstone-grpc@4.0.2` adds nested `dist/esm/package.json` (`{"type":"module"}`) + `dist/esm/encoding/package.json` (`{"type":"commonjs"}`). The package ships ESM-syntax files but its root `package.json` lacks `"type": "module"` — native Node 22+ tolerates this via heuristic detection but tsx's esbuild loader does not. Cherry-picked from the original standalone fix (PR #156, now closed as redundant).
- **`54c81d4` fix(test-infra):** Adds CORS_ORIGINS-driven middleware to Mode 1 agent (`packages/agent/src/index.ts`) — empty/unset = no headers (production same-origin), populated = echo back matching Origin with credentials. Wires the playwright webServer config so the agent gets `CORS_ORIGINS=http://localhost:5173` and the app gets `VITE_API_URL=http://localhost:3000`. Resolves the four CORS-related test failures.
- **`c324cd2` ci(e2e):** Bumps `pnpm/action-setup` version from 9 to 10 in `.github/workflows/e2e.yml` (matches deploy/deploy-agent/generate-sdks workflows). pnpm 10 changed the lockfile patchedDependencies format; pnpm 9 frozen-install rejected it.

### Verification
- ✅ `pnpm --filter @sipher/agent dev` — agent boots cleanly via tsx
- ✅ Local playwright suite — 8 passed (2 SENTINEL specs intentionally `.skip`'d pending Phase 2 PR #155 work)
- ✅ `pnpm --filter @sipher/agent test -- --run` — 912 passing (no regression)
- ✅ `pnpm --filter @sipher/app test -- --run` — 3 passing (no regression)

The `continue-on-error: true` flag on the playwright job in `e2e.yml` should be flipped to `false` in a follow-up once this PR's CI passes consistently.