### PR TITLE
feat(app): Phase 2 PR 1 — client polish + sentinel advisory

### DIFF
--- a/app/src/components/ActivityEntry.tsx
+++ b/app/src/components/ActivityEntry.tsx
@@ -1,5 +1,6 @@
 import { AGENTS, type AgentName } from '../lib/agents'
 import { timeAgo } from '../lib/format'
+import EventIcon from './EventIcon'
 
 interface Action {
   label: string
@@ -8,14 +9,25 @@ interface Action {
 
 interface Props {
   agent: AgentName
+  type?: string
   title: string
   detail?: string
   time: string
   level: string
+  isLive?: boolean
   actions?: Action[]
 }
 
-export default function ActivityEntry({ agent, title, detail, time, level, actions }: Props) {
+export default function ActivityEntry({
+  agent,
+  type = '',
+  title,
+  detail,
+  time,
+  level,
+  isLive,
+  actions,
+}: Props) {
   const agentConfig = AGENTS[agent] ?? { name: agent.toUpperCase(), color: 'var(--color-text-muted)' }
   const isCritical = level === 'critical'
 
@@ -26,13 +38,9 @@ export default function ActivityEntry({ agent, title, detail, time, level, actio
         isCritical ? 'border-l-[3px] border-l-yellow' : '',
       ].join(' ')}
     >
-      {/* Top row: dot + agent name + time */}
       <div className="flex justify-between items-center">
         <div className="flex items-center gap-2">
-          <div
-            className="w-1.5 h-1.5 rounded-full shrink-0"
-            style={{ backgroundColor: agentConfig.color }}
-          />
+          <EventIcon type={type} color={agentConfig.color} live={isLive} />
           <span
             className="text-[11px] font-semibold tracking-widest uppercase"
             style={{ color: agentConfig.color }}
@@ -43,15 +51,12 @@ export default function ActivityEntry({ agent, title, detail, time, level, actio
         <span className="text-text-muted text-[11px]">{timeAgo(time)}</span>
       </div>
 
-      {/* Title */}
       <p className="text-[14px] text-text leading-snug">{title}</p>
 
-      {/* Detail — monospace, for TX hashes, metrics, etc. */}
       {detail && (
         <p className="text-[12px] text-text-muted font-mono break-all">{detail}</p>
       )}
 
-      {/* Actions */}
       {actions && actions.length > 0 && (
         <div className="flex flex-wrap gap-2 mt-1">
           {actions.map((action, i) => (

--- a/app/src/components/AdminOnly.tsx
+++ b/app/src/components/AdminOnly.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react'
+import { useIsAdmin } from '../hooks/useIsAdmin'
+
+interface Props {
+  children: ReactNode
+  fallback?: ReactNode
+}
+
+export default function AdminOnly({ children, fallback = null }: Props) {
+  return useIsAdmin() ? <>{children}</> : <>{fallback}</>
+}

--- a/app/src/components/ChatSidebar.tsx
+++ b/app/src/components/ChatSidebar.tsx
@@ -1,6 +1,9 @@
 import { useRef, useEffect, useState, useCallback } from 'react'
 import { PaperPlaneTilt, CircleNotch, Wrench } from '@phosphor-icons/react'
 import { useAppStore, type ChatMessage } from '../stores/app'
+import { sanitizeArgs } from '../lib/sanitize-args'
+import ToolTimeline from './ToolTimeline'
+import ConfirmCard from './ConfirmCard'
 
 const API_URL = import.meta.env.VITE_API_URL ?? ''
 
@@ -16,6 +19,10 @@ export default function ChatSidebar({ fullScreen }: Props) {
   const appendToLast = useAppStore((s) => s.appendToLast)
   const finishStreaming = useAppStore((s) => s.finishStreaming)
   const setChatLoading = useAppStore((s) => s.setChatLoading)
+  const appendTool = useAppStore((s) => s.appendTool)
+  const completeTool = useAppStore((s) => s.completeTool)
+  const dismissMessage = useAppStore((s) => s.dismissMessage)
+  const consumePendingPrompt = useAppStore((s) => s.consumePendingPrompt)
 
   const [input, setInput] = useState('')
   const [activeTool, setActiveTool] = useState<string | null>(null)
@@ -26,20 +33,16 @@ export default function ChatSidebar({ fullScreen }: Props) {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages, chatLoading])
 
-  const sendMessage = useCallback(async () => {
-    if (!input.trim() || !token || chatLoading) return
+  const sendMessage = useCallback(async (overrideText?: string) => {
+    const text = (overrideText ?? input).trim()
+    if (!text || !token || chatLoading) return
 
-    const userMsg: ChatMessage = {
-      id: crypto.randomUUID(),
-      role: 'user',
-      content: input.trim(),
-    }
+    const userMsg: ChatMessage = { id: crypto.randomUUID(), role: 'user', content: text }
     addMessage(userMsg)
     setInput('')
     setChatLoading(true)
     setActiveTool(null)
 
-    // Create assistant placeholder
     const assistantMsg: ChatMessage = {
       id: crypto.randomUUID(),
       role: 'assistant',
@@ -49,17 +52,10 @@ export default function ChatSidebar({ fullScreen }: Props) {
     addMessage(assistantMsg)
 
     try {
-      const allMessages = [...messages, userMsg].map((m) => ({
-        role: m.role,
-        content: m.content,
-      }))
-
+      const allMessages = [...messages, userMsg].map((m) => ({ role: m.role, content: m.content }))
       const res = await fetch(`${API_URL}/api/chat/stream`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({ messages: allMessages }),
       })
 
@@ -67,7 +63,6 @@ export default function ChatSidebar({ fullScreen }: Props) {
         const err = await res.json().catch(() => ({}))
         throw new Error((err as { error?: string }).error ?? `Error ${res.status}`)
       }
-
       if (!res.body) throw new Error('No response body')
 
       const reader = res.body.getReader()
@@ -77,7 +72,6 @@ export default function ChatSidebar({ fullScreen }: Props) {
       while (true) {
         const { done, value } = await reader.read()
         if (done) break
-
         buffer += decoder.decode(value, { stream: true })
         const lines = buffer.split('\n')
         buffer = lines.pop() ?? ''
@@ -92,9 +86,24 @@ export default function ChatSidebar({ fullScreen }: Props) {
             if (event.type === 'content_block_delta' && event.text) {
               appendToLast(event.text)
             } else if (event.type === 'tool_use') {
+              appendTool(event.name, sanitizeArgs(event.input))
               setActiveTool(event.name)
             } else if (event.type === 'tool_result') {
+              completeTool(event.name, event.is_error ? 'error' : 'success')
               setActiveTool(null)
+            } else if (event.type === 'sentinel_advisory') {
+              addMessage({
+                id: crypto.randomUUID(),
+                role: 'system',
+                content: '',
+                kind: 'sentinel_advisory',
+                meta: {
+                  action: event.action,
+                  amount: event.amount,
+                  description: event.description,
+                  severity: event.severity,
+                },
+              })
             } else if (event.type === 'error') {
               appendToLast(`\n\nError: ${event.message}`)
             }
@@ -111,15 +120,16 @@ export default function ChatSidebar({ fullScreen }: Props) {
       setChatLoading(false)
       setActiveTool(null)
     }
-  }, [input, token, chatLoading, messages, addMessage, appendToLast, finishStreaming, setChatLoading])
+  }, [input, token, chatLoading, messages, addMessage, appendToLast, finishStreaming, setChatLoading, appendTool, completeTool])
+
+  // Consume seedChat prompt on mount/change
+  useEffect(() => {
+    const p = consumePendingPrompt()
+    if (p && token) sendMessage(p)
+  }, [consumePendingPrompt, sendMessage, token])
 
   return (
-    <div
-      className={`flex flex-col bg-card ${
-        fullScreen ? 'h-full' : 'h-full w-full'
-      }`}
-    >
-      {/* Header */}
+    <div className={`flex flex-col bg-card ${fullScreen ? 'h-full' : 'h-full w-full'}`}>
       <div className="flex items-center gap-2 px-4 py-3 border-b border-border shrink-0">
         <div className="w-1.5 h-1.5 rounded-full bg-sipher" />
         <span className="text-[13px] font-semibold text-text">SIPHER</span>
@@ -134,33 +144,48 @@ export default function ChatSidebar({ fullScreen }: Props) {
         )}
       </div>
 
-      {/* Messages */}
       <div className="flex-1 overflow-y-auto px-3 py-3 flex flex-col gap-2.5">
         {messages.length === 0 && (
-          <p className="text-text-muted text-sm text-center py-8">
-            Ask SIPHER anything about your privacy.
-          </p>
+          <p className="text-text-muted text-sm text-center py-8">Ask SIPHER anything about your privacy.</p>
         )}
-        {messages.map((msg) => (
-          <div
-            key={msg.id}
-            className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
-          >
-            <div
-              className={`max-w-[85%] rounded-lg px-3 py-2 text-[13px] leading-relaxed whitespace-pre-wrap break-words ${
-                msg.role === 'user'
-                  ? 'bg-accent/15 border border-accent/20 text-text'
-                  : 'bg-elevated border border-border text-text'
-              }`}
-            >
-              {msg.content || (msg.streaming ? '...' : '')}
+        {messages.filter((m) => !m.dismissed).map((msg) => {
+          if (msg.role === 'system' && msg.kind === 'sentinel_advisory') {
+            const meta = (msg.meta ?? {}) as { action?: string; amount?: string; description?: string }
+            return (
+              <div key={msg.id} className="flex justify-start">
+                <div className="max-w-[90%] w-full">
+                  <ConfirmCard
+                    variant="warning"
+                    action={meta.action ?? 'Action'}
+                    amount={meta.amount ?? ''}
+                    description={meta.description}
+                    onConfirm={() => sendMessage('Yes, proceed anyway')}
+                    onCancel={() => dismissMessage(msg.id)}
+                  />
+                </div>
+              </div>
+            )
+          }
+          return (
+            <div key={msg.id} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+              <div
+                className={`max-w-[85%] rounded-lg overflow-hidden text-[13px] leading-relaxed whitespace-pre-wrap break-words ${
+                  msg.role === 'user'
+                    ? 'bg-accent/15 border border-accent/20 text-text px-3 py-2'
+                    : 'bg-elevated border border-border text-text'
+                }`}
+              >
+                {msg.role === 'assistant' && <ToolTimeline tools={msg.tools} />}
+                <div className={msg.role === 'assistant' ? 'px-3 py-2' : ''}>
+                  {msg.content || (msg.streaming ? '...' : '')}
+                </div>
+              </div>
             </div>
-          </div>
-        ))}
+          )
+        })}
         <div ref={bottomRef} />
       </div>
 
-      {/* Input */}
       <div className="px-3 py-3 border-t border-border shrink-0">
         <div className="flex gap-2">
           <input
@@ -178,7 +203,7 @@ export default function ChatSidebar({ fullScreen }: Props) {
             disabled={!token || chatLoading}
           />
           <button
-            onClick={sendMessage}
+            onClick={() => sendMessage()}
             disabled={!input.trim() || !token || chatLoading}
             className="bg-accent/15 border border-accent/20 rounded-lg px-3 py-2 text-accent hover:bg-accent/25 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             aria-label="Send"

--- a/app/src/components/ConfirmCard.tsx
+++ b/app/src/components/ConfirmCard.tsx
@@ -1,3 +1,5 @@
+import { Warning } from '@phosphor-icons/react'
+
 type Variant = 'normal' | 'warning'
 
 interface Props {
@@ -7,6 +9,7 @@ interface Props {
   onCancel: () => void
   variant?: Variant
   description?: string
+  // reserved for future countdown display; not currently consumed
   timeout?: number
 }
 
@@ -24,11 +27,14 @@ export default function ConfirmCard({
     ? 'border-yellow/50 text-yellow hover:bg-yellow/10'
     : 'border-sipher/50 text-sipher hover:bg-sipher/10'
   const primaryLabel = isWarning ? 'Override & Send' : 'Confirm & Sign'
-  const labelText = isWarning ? '⚠ Risk Confirm' : 'Confirm Action'
+  const labelText = isWarning ? 'Risk Confirm' : 'Confirm Action'
 
   return (
     <div className={`bg-card border ${borderClass} rounded-lg p-4 flex flex-col gap-3`}>
-      <div className="text-[12px] text-text-muted uppercase tracking-wide">{labelText}</div>
+      <div className="text-[12px] text-text-muted uppercase tracking-wide flex items-center gap-1">
+        {isWarning && <Warning size={12} weight="fill" className="text-yellow" aria-hidden="true" />}
+        <span>{labelText}</span>
+      </div>
       <div className="text-[14px] text-text">{action}: {amount}</div>
       {description && (
         <div className="text-[12px] text-text-muted leading-relaxed">{description}</div>

--- a/app/src/components/ConfirmCard.tsx
+++ b/app/src/components/ConfirmCard.tsx
@@ -1,20 +1,44 @@
-export default function ConfirmCard({ action, amount, onConfirm, onCancel, timeout = 120 }: {
+type Variant = 'normal' | 'warning'
+
+interface Props {
   action: string
   amount: string
   onConfirm: () => void
   onCancel: () => void
+  variant?: Variant
+  description?: string
   timeout?: number
-}) {
+}
+
+export default function ConfirmCard({
+  action,
+  amount,
+  onConfirm,
+  onCancel,
+  variant = 'normal',
+  description,
+}: Props) {
+  const isWarning = variant === 'warning'
+  const borderClass = isWarning ? 'border-yellow/40' : 'border-elevated'
+  const primaryClass = isWarning
+    ? 'border-yellow/50 text-yellow hover:bg-yellow/10'
+    : 'border-sipher/50 text-sipher hover:bg-sipher/10'
+  const primaryLabel = isWarning ? 'Override & Send' : 'Confirm & Sign'
+  const labelText = isWarning ? '⚠ Risk Confirm' : 'Confirm Action'
+
   return (
-    <div className="bg-card border border-elevated rounded-lg p-4 flex flex-col gap-3">
-      <div className="text-[12px] text-text-muted uppercase tracking-wide">Confirm Action</div>
+    <div className={`bg-card border ${borderClass} rounded-lg p-4 flex flex-col gap-3`}>
+      <div className="text-[12px] text-text-muted uppercase tracking-wide">{labelText}</div>
       <div className="text-[14px] text-text">{action}: {amount}</div>
+      {description && (
+        <div className="text-[12px] text-text-muted leading-relaxed">{description}</div>
+      )}
       <div className="flex gap-2">
         <button
           onClick={onConfirm}
-          className="flex-1 border border-sipher/50 text-sipher py-2 rounded-lg text-[12px] font-medium hover:bg-sipher/10"
+          className={`flex-1 border ${primaryClass} py-2 rounded-lg text-[12px] font-medium`}
         >
-          Confirm & Sign
+          {primaryLabel}
         </button>
         <button
           onClick={onCancel}

--- a/app/src/components/EventIcon.tsx
+++ b/app/src/components/EventIcon.tsx
@@ -1,0 +1,17 @@
+import { resolveEventIcon } from '../lib/event-icons'
+
+interface Props {
+  type: string
+  color: string
+  live?: boolean
+  size?: number
+}
+
+export default function EventIcon({ type, color, live = false, size = 14 }: Props) {
+  const Icon = resolveEventIcon(type)
+  return (
+    <span className={`inline-flex shrink-0 ${live ? 'animate-pulse' : ''}`}>
+      <Icon size={size} color={color} weight="fill" />
+    </span>
+  )
+}

--- a/app/src/components/MetricCard.tsx
+++ b/app/src/components/MetricCard.tsx
@@ -1,16 +1,48 @@
 import type { ReactNode } from 'react'
 
+export interface Factor {
+  label: string
+  score: number
+}
+
 interface Props {
   label: string
   value: string
   sub?: string
   icon: ReactNode
   color?: string
+  variant?: 'normal' | 'hero'
+  factors?: Factor[]
+  onClick?: () => void
 }
 
-export default function MetricCard({ label, value, sub, icon, color }: Props) {
+function factorColor(score: number): string {
+  if (score >= 80) return '#22c55e'
+  if (score >= 60) return '#84cc16'
+  if (score >= 40) return '#facc15'
+  return '#fb923c'
+}
+
+export default function MetricCard({
+  label,
+  value,
+  sub,
+  icon,
+  color,
+  variant = 'normal',
+  factors,
+  onClick,
+}: Props) {
+  const isHero = variant === 'hero'
+  const valueSize = isHero ? 'text-[32px]' : 'text-[22px]'
+
   return (
-    <div className="bg-card border border-border rounded-lg p-4 flex flex-col gap-2">
+    <div
+      className={`bg-card border border-border rounded-lg p-4 flex flex-col gap-2 ${
+        onClick ? 'cursor-pointer hover:border-elevated transition-colors' : ''
+      }`}
+      onClick={onClick}
+    >
       <div className="flex items-center justify-between">
         <span className="text-[10px] font-semibold text-text-muted tracking-widest uppercase">
           {label}
@@ -19,13 +51,29 @@ export default function MetricCard({ label, value, sub, icon, color }: Props) {
       </div>
       <div className="flex items-baseline gap-2">
         <span
-          className="text-[22px] font-mono font-bold leading-none"
+          className={`${valueSize} font-mono font-bold leading-none`}
           style={color ? { color } : undefined}
         >
           {value}
         </span>
         {sub && <span className="text-[11px] font-mono text-text-muted">{sub}</span>}
       </div>
+      {isHero && factors && factors.length > 0 && (
+        <div className="border-t border-elevated/40 mt-2 pt-3 flex flex-col gap-1.5">
+          {factors.map((f) => (
+            <div key={f.label} className="flex items-center gap-2 text-[10px] font-mono text-text-muted">
+              <span className="flex-1 truncate">{f.label}</span>
+              <span className="w-10 h-[3px] bg-elevated rounded-full overflow-hidden">
+                <span
+                  className="block h-full rounded-full"
+                  style={{ width: `${Math.min(f.score, 100)}%`, backgroundColor: factorColor(f.score) }}
+                />
+              </span>
+              <span className="w-6 text-right">{f.score}</span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/app/src/components/ToolTimeline.tsx
+++ b/app/src/components/ToolTimeline.tsx
@@ -1,0 +1,31 @@
+import { CircleNotch, CheckCircle, XCircle } from '@phosphor-icons/react'
+import type { ToolCall } from '../stores/app'
+
+interface Props {
+  tools?: ToolCall[]
+}
+
+function StatusIcon({ status }: { status: ToolCall['status'] }) {
+  if (status === 'running') return <CircleNotch size={11} className="animate-spin text-text-muted" />
+  if (status === 'success') return <CheckCircle size={11} weight="fill" className="text-green" />
+  return <XCircle size={11} weight="fill" className="text-red" />
+}
+
+export default function ToolTimeline({ tools }: Props) {
+  if (!tools || tools.length === 0) return null
+
+  return (
+    <div className="border-b border-elevated/40 bg-elevated/20 px-3 py-2 flex flex-col gap-1.5">
+      {tools.map((t, i) => (
+        <div key={`${t.name}-${i}`} className="flex items-center gap-2 text-[10px] font-mono">
+          <StatusIcon status={t.status} />
+          <span className="text-blue font-semibold">{t.name}</span>
+          {t.args && <span className="text-text-muted truncate flex-1">{t.args}</span>}
+          {t.durationMs != null && (
+            <span className="text-text-muted ml-auto shrink-0">{t.durationMs}ms</span>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/app/src/components/__tests__/AdminOnly.test.tsx
+++ b/app/src/components/__tests__/AdminOnly.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { useAppStore } from '../../stores/app'
+import AdminOnly from '../AdminOnly'
+
+describe('AdminOnly', () => {
+  beforeEach(() => {
+    useAppStore.setState({ token: null, isAdmin: false, messages: [], chatLoading: false })
+  })
+
+  it('renders children when isAdmin is true', () => {
+    useAppStore.setState({ isAdmin: true })
+    render(<AdminOnly><div>secret</div></AdminOnly>)
+    expect(screen.getByText('secret')).toBeInTheDocument()
+  })
+
+  it('renders null by default when isAdmin is false', () => {
+    useAppStore.setState({ isAdmin: false })
+    const { container } = render(<AdminOnly><div>secret</div></AdminOnly>)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders fallback when isAdmin is false and fallback provided', () => {
+    useAppStore.setState({ isAdmin: false })
+    render(<AdminOnly fallback={<div>upgrade</div>}><div>secret</div></AdminOnly>)
+    expect(screen.queryByText('secret')).not.toBeInTheDocument()
+    expect(screen.getByText('upgrade')).toBeInTheDocument()
+  })
+})

--- a/app/src/components/__tests__/ConfirmCard.test.tsx
+++ b/app/src/components/__tests__/ConfirmCard.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ConfirmCard from '../ConfirmCard'
+
+describe('ConfirmCard', () => {
+  it('renders normal variant with action and amount', () => {
+    render(
+      <ConfirmCard action="Send" amount="1.5 SOL" onConfirm={() => {}} onCancel={() => {}} />
+    )
+    expect(screen.getByText(/Send.*1\.5 SOL/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /confirm & sign/i })).toBeInTheDocument()
+  })
+
+  it('renders warning variant with description and Override button', () => {
+    render(
+      <ConfirmCard
+        variant="warning"
+        action="Send"
+        amount="5 SOL"
+        description="Address has 2 high-risk signals"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    )
+    expect(screen.getByText(/2 high-risk signals/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /override & send/i })).toBeInTheDocument()
+  })
+
+  it('fires onConfirm and onCancel callbacks', async () => {
+    const onConfirm = vi.fn()
+    const onCancel = vi.fn()
+    render(
+      <ConfirmCard action="Send" amount="1 SOL" onConfirm={onConfirm} onCancel={onCancel} />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /confirm & sign/i }))
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onConfirm).toHaveBeenCalledOnce()
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+})

--- a/app/src/components/__tests__/EventIcon.test.tsx
+++ b/app/src/components/__tests__/EventIcon.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import EventIcon from '../EventIcon'
+
+describe('EventIcon', () => {
+  it('renders an icon by event type', () => {
+    const { container } = render(<EventIcon type="deposit" color="#10B981" />)
+    const svg = container.querySelector('svg')
+    expect(svg).toBeInTheDocument()
+  })
+
+  it('applies pulse animation when live=true', () => {
+    const { container } = render(<EventIcon type="deposit" color="#10B981" live />)
+    expect(container.firstChild).toHaveClass('animate-pulse')
+  })
+
+  it('does not pulse when live=false', () => {
+    const { container } = render(<EventIcon type="deposit" color="#10B981" />)
+    expect(container.firstChild).not.toHaveClass('animate-pulse')
+  })
+
+  it('falls back to a circle icon for unknown event types', () => {
+    const { container } = render(<EventIcon type="bogus" color="#10B981" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+})

--- a/app/src/components/__tests__/MetricCard.test.tsx
+++ b/app/src/components/__tests__/MetricCard.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Wallet } from '@phosphor-icons/react'
+import MetricCard from '../MetricCard'
+
+describe('MetricCard', () => {
+  it('renders normal variant by default', () => {
+    render(<MetricCard label="SOL" value="2.45" sub="SOL" icon={<Wallet />} />)
+    // label and sub both read "SOL" — both must be present
+    expect(screen.getAllByText('SOL')).toHaveLength(2)
+    expect(screen.getByText('2.45')).toBeInTheDocument()
+  })
+
+  it('renders factor bars in hero variant', () => {
+    render(
+      <MetricCard
+        variant="hero"
+        label="Privacy Score"
+        value="78"
+        sub="/100"
+        icon={<Wallet />}
+        factors={[
+          { label: 'Address reuse', score: 85 },
+          { label: 'Amount patterns', score: 72 },
+          { label: 'Timing', score: 68 },
+          { label: 'Counterparty exposure', score: 90 },
+        ]}
+      />
+    )
+    expect(screen.getByText('Address reuse')).toBeInTheDocument()
+    expect(screen.getByText('Counterparty exposure')).toBeInTheDocument()
+  })
+
+  it('does not render factor section when factors undefined', () => {
+    render(<MetricCard variant="hero" label="X" value="1" icon={<Wallet />} />)
+    expect(screen.queryByText('Address reuse')).not.toBeInTheDocument()
+  })
+})

--- a/app/src/components/__tests__/ToolTimeline.test.tsx
+++ b/app/src/components/__tests__/ToolTimeline.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ToolTimeline from '../ToolTimeline'
+import type { ToolCall } from '../../stores/app'
+
+describe('ToolTimeline', () => {
+  it('renders nothing when tools is undefined', () => {
+    const { container } = render(<ToolTimeline tools={undefined} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when tools is empty array', () => {
+    const { container } = render(<ToolTimeline tools={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders single running tool', () => {
+    const tools: ToolCall[] = [
+      { name: 'privacyScore', args: 'wallet=FGSk...8WWr', startedAt: Date.now(), status: 'running' },
+    ]
+    render(<ToolTimeline tools={tools} />)
+    expect(screen.getByText('privacyScore')).toBeInTheDocument()
+    expect(screen.getByText(/wallet=FGSk\.\.\.8WWr/)).toBeInTheDocument()
+  })
+
+  it('renders completed tool with duration', () => {
+    const tools: ToolCall[] = [
+      { name: 'privacyScore', args: 'wallet=FGSk...8WWr', startedAt: 0, durationMs: 285, status: 'success' },
+    ]
+    render(<ToolTimeline tools={tools} />)
+    expect(screen.getByText(/285ms/)).toBeInTheDocument()
+  })
+
+  it('renders multi-tool timeline', () => {
+    const tools: ToolCall[] = [
+      { name: 'privacyScore', startedAt: 0, durationMs: 285, status: 'success' },
+      { name: 'history', startedAt: 0, durationMs: 120, status: 'success' },
+      { name: 'balance', startedAt: 0, durationMs: 45, status: 'error' },
+    ]
+    render(<ToolTimeline tools={tools} />)
+    expect(screen.getByText('privacyScore')).toBeInTheDocument()
+    expect(screen.getByText('history')).toBeInTheDocument()
+    expect(screen.getByText('balance')).toBeInTheDocument()
+  })
+})

--- a/app/src/lib/__tests__/event-icons.test.ts
+++ b/app/src/lib/__tests__/event-icons.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { ArrowDown, Circle, ShieldWarning, PaperPlaneTilt } from '@phosphor-icons/react'
+import { resolveEventIcon } from '../event-icons'
+
+describe('resolveEventIcon', () => {
+  it('matches exact event type', () => {
+    expect(resolveEventIcon('deposit')).toBe(ArrowDown)
+    expect(resolveEventIcon('send')).toBe(PaperPlaneTilt)
+  })
+
+  it('matches prefix.subtype patterns', () => {
+    expect(resolveEventIcon('deposit.success')).toBe(ArrowDown)
+    expect(resolveEventIcon('sentinel.flag')).toBe(ShieldWarning)
+    expect(resolveEventIcon('sentinel.flag.high')).toBe(ShieldWarning)
+  })
+
+  it('falls back to Circle for unknown types', () => {
+    expect(resolveEventIcon('unknown')).toBe(Circle)
+    expect(resolveEventIcon('')).toBe(Circle)
+  })
+})

--- a/app/src/lib/__tests__/sanitize-args.test.ts
+++ b/app/src/lib/__tests__/sanitize-args.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeArgs } from '../sanitize-args'
+
+describe('sanitizeArgs', () => {
+  it('truncates long base58 strings to first-4-last-4', () => {
+    const out = sanitizeArgs({ wallet: 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr' })
+    expect(out).toBe('wallet=FGSk...BWWr')
+  })
+
+  it('redacts sensitive keys', () => {
+    const out = sanitizeArgs({
+      wallet: 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr',
+      privateKey: 'should-not-leak',
+      mnemonic: 'word1 word2 ...',
+    })
+    expect(out).not.toContain('should-not-leak')
+    expect(out).not.toContain('word1')
+    expect(out).toContain('wallet=FGSk...BWWr')
+  })
+
+  it('truncates short non-base58 strings to 40 chars', () => {
+    const out = sanitizeArgs({
+      message: 'a'.repeat(50),
+    })
+    expect(out).toBe(`message=${'a'.repeat(40)}…`)
+  })
+
+  it('passes through small numbers and booleans', () => {
+    const out = sanitizeArgs({ amount: 1.5, dryRun: true })
+    expect(out).toBe('amount=1.5, dryRun=true')
+  })
+
+  it('returns empty string for null/undefined input', () => {
+    expect(sanitizeArgs(null)).toBe('')
+    expect(sanitizeArgs(undefined)).toBe('')
+    expect(sanitizeArgs({})).toBe('')
+  })
+})

--- a/app/src/lib/event-icons.ts
+++ b/app/src/lib/event-icons.ts
@@ -1,0 +1,35 @@
+import {
+  ArrowDown,
+  ArrowUp,
+  PaperPlaneTilt,
+  ArrowsLeftRight,
+  DownloadSimple,
+  ArrowCounterClockwise,
+  Eye,
+  ShieldWarning,
+  Shield,
+  Megaphone,
+  Circle,
+} from '@phosphor-icons/react'
+import type { Icon } from '@phosphor-icons/react'
+
+export const EVENT_ICONS: Record<string, Icon> = {
+  deposit: ArrowDown,
+  withdraw: ArrowUp,
+  send: PaperPlaneTilt,
+  swap: ArrowsLeftRight,
+  claim: DownloadSimple,
+  refund: ArrowCounterClockwise,
+  scan: Eye,
+  'sentinel.flag': ShieldWarning,
+  'sentinel.block': Shield,
+  'herald.posted': Megaphone,
+}
+
+export function resolveEventIcon(type: string): Icon {
+  if (type in EVENT_ICONS) return EVENT_ICONS[type]
+  for (const key of Object.keys(EVENT_ICONS)) {
+    if (type.startsWith(key + '.')) return EVENT_ICONS[key]
+  }
+  return Circle
+}

--- a/app/src/lib/sanitize-args.ts
+++ b/app/src/lib/sanitize-args.ts
@@ -1,0 +1,25 @@
+const SENSITIVE_KEY = /private|secret|mnemonic|password|seed/i
+const BASE58_HEX = /^(?=.*\d)[A-Za-z0-9]{12,}$/
+const MAX_STRING = 40
+
+function shortenIdent(value: string): string {
+  return `${value.slice(0, 4)}...${value.slice(-4)}`
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === 'string') {
+    if (BASE58_HEX.test(value)) return shortenIdent(value)
+    return value.length > MAX_STRING ? value.slice(0, MAX_STRING) + '…' : value
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return ''
+}
+
+export function sanitizeArgs(input: unknown): string {
+  if (!input || typeof input !== 'object') return ''
+  const entries = Object.entries(input as Record<string, unknown>)
+    .filter(([k]) => !SENSITIVE_KEY.test(k))
+    .map(([k, v]) => `${k}=${formatValue(v)}`)
+    .filter(s => !s.endsWith('='))
+  return entries.join(', ')
+}

--- a/app/src/stores/app.ts
+++ b/app/src/stores/app.ts
@@ -2,42 +2,57 @@ import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 
 export type View = 'dashboard' | 'vault' | 'herald' | 'squad' | 'chat'
+export type ToolStatus = 'running' | 'success' | 'error'
+
+export interface ToolCall {
+  name: string
+  args?: string
+  startedAt: number
+  durationMs?: number
+  status: ToolStatus
+}
 
 export interface ChatMessage {
   id: string
-  role: 'user' | 'assistant'
+  role: 'user' | 'assistant' | 'system'
   content: string
   toolName?: string
   streaming?: boolean
+  tools?: ToolCall[]
+  kind?: 'sentinel_advisory'
+  meta?: Record<string, unknown>
+  dismissed?: boolean
 }
 
 interface AppState {
-  // Navigation
   activeView: View
   setActiveView: (view: View) => void
 
-  // Auth
   token: string | null
   isAdmin: boolean
   setAuth: (token: string, isAdmin: boolean) => void
   clearAuth: () => void
 
-  // Chat
   messages: ChatMessage[]
   chatLoading: boolean
   addMessage: (msg: ChatMessage) => void
   appendToLast: (text: string) => void
   finishStreaming: () => void
   setChatLoading: (loading: boolean) => void
+  appendTool: (name: string, args?: string) => void
+  completeTool: (name: string, status: ToolStatus) => void
+  dismissMessage: (id: string) => void
+  seedChat: (prompt: string) => void
 
-  // UI (tablet/mobile chat visibility)
   chatOpen: boolean
   setChatOpen: (open: boolean) => void
+  pendingPrompt: string | null
+  consumePendingPrompt: () => string | null
 }
 
 export const useAppStore = create<AppState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       activeView: 'dashboard',
       setActiveView: (activeView) => set({ activeView }),
 
@@ -68,9 +83,42 @@ export const useAppStore = create<AppState>()(
           return { messages: msgs }
         }),
       setChatLoading: (chatLoading) => set({ chatLoading }),
+      appendTool: (name, args) =>
+        set((s) => {
+          const msgs = [...s.messages]
+          const last = msgs[msgs.length - 1]
+          if (last?.role !== 'assistant') return { messages: msgs }
+          const tools = [...(last.tools ?? []), { name, args, startedAt: Date.now(), status: 'running' as ToolStatus }]
+          msgs[msgs.length - 1] = { ...last, tools }
+          return { messages: msgs }
+        }),
+      completeTool: (name, status) =>
+        set((s) => {
+          const msgs = [...s.messages]
+          const last = msgs[msgs.length - 1]
+          if (last?.role !== 'assistant' || !last.tools) return { messages: msgs }
+          const tools = last.tools.map((t) =>
+            t.name === name && t.status === 'running'
+              ? { ...t, durationMs: Date.now() - t.startedAt, status }
+              : t
+          )
+          msgs[msgs.length - 1] = { ...last, tools }
+          return { messages: msgs }
+        }),
+      dismissMessage: (id) =>
+        set((s) => ({
+          messages: s.messages.map((m) => (m.id === id ? { ...m, dismissed: true } : m)),
+        })),
+      seedChat: (prompt) => set({ chatOpen: true, pendingPrompt: prompt }),
 
       chatOpen: false,
       setChatOpen: (chatOpen) => set({ chatOpen }),
+      pendingPrompt: null,
+      consumePendingPrompt: () => {
+        const p = get().pendingPrompt
+        set({ pendingPrompt: null })
+        return p
+      },
     }),
     {
       name: 'sipher-auth',

--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -74,34 +74,41 @@ export default function DashboardView({
   const [privacyData, setPrivacyData] = useState<PrivacyData | null>(null)
   const [privacyError, setPrivacyError] = useState<string | null>(null)
   const refreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const lastProcessedEventId = useRef<string | null>(null)
   const wallet = vault?.wallet
 
-  const fetchPrivacyScore = useCallback(async () => {
+  const fetchPrivacyScore = useCallback(async (signal?: AbortSignal) => {
     if (!wallet || !token) return
     try {
       const res = await fetch(`${import.meta.env.VITE_API_URL ?? ''}/v1/privacy/score`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({ address: wallet, limit: 100 }),
+        signal,
       })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const json = await res.json()
       setPrivacyData(json.data)
       setPrivacyError(null)
     } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return
       setPrivacyError(err instanceof Error ? err.message : 'Failed to fetch privacy score')
     }
   }, [wallet, token])
 
   useEffect(() => {
-    if (wallet && token) fetchPrivacyScore()
+    if (!wallet || !token) return
+    const controller = new AbortController()
+    fetchPrivacyScore(controller.signal)
+    return () => controller.abort()
   }, [wallet, token, fetchPrivacyScore])
 
   useEffect(() => {
     if (!wallet || !token) return
     const fundMoverPattern = /^(send|swap|claim|refund|deposit)\.(success|completed)$/
     const recent = events.find((e) => fundMoverPattern.test(e.type ?? ''))
-    if (!recent) return
+    if (!recent || recent.id === lastProcessedEventId.current) return
+    lastProcessedEventId.current = recent.id
     if (refreshTimer.current) clearTimeout(refreshTimer.current)
     refreshTimer.current = setTimeout(() => fetchPrivacyScore(), 5000)
     return () => {

--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -8,6 +8,7 @@ import {
 import { apiFetch } from '../api/client'
 import { type ActivityEvent } from '../hooks/useSSE'
 import { useIsAdmin } from '../hooks/useIsAdmin'
+import AdminOnly from '../components/AdminOnly'
 import MetricCard from '../components/MetricCard'
 import ActivityEntry from '../components/ActivityEntry'
 import AgentDot from '../components/AgentDot'
@@ -120,14 +121,14 @@ export default function DashboardView({
           sub="total"
           icon={<ArrowDown size={16} />}
         />
-        {isAdmin && (
+        <AdminOnly>
           <MetricCard
             label="Budget"
             value={budgetSpent != null ? `$${budgetSpent.toFixed(0)}` : '—'}
             sub={budgetLimit != null ? `/ $${budgetLimit}` : ''}
             icon={<Lightning size={16} />}
           />
-        )}
+        </AdminOnly>
       </div>
 
       {/* Two columns: Activity + Agent Status */}
@@ -165,7 +166,7 @@ export default function DashboardView({
         </div>
 
         {/* Guardian Squad (admin only) */}
-        {isAdmin && (
+        <AdminOnly>
           <div>
             <h3 className="text-[10px] font-semibold text-text-muted tracking-widest uppercase mb-3 px-1">
               Guardian Squad
@@ -199,7 +200,7 @@ export default function DashboardView({
               </p>
             )}
           </div>
-        )}
+        </AdminOnly>
       </div>
     </div>
   )

--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   Wallet,
   ShieldCheck,
@@ -6,6 +6,7 @@ import {
   Lightning,
 } from '@phosphor-icons/react'
 import { apiFetch } from '../api/client'
+import { useAppStore } from '../stores/app'
 import { type ActivityEvent } from '../hooks/useSSE'
 import { useIsAdmin } from '../hooks/useIsAdmin'
 import AdminOnly from '../components/AdminOnly'
@@ -29,6 +30,14 @@ interface HealthData {
 
 interface HeraldBudget {
   budget: { spent: number; limit: number; percentage: number; gate: string }
+}
+
+interface PrivacyData {
+  score: number
+  grade: string
+  factors: Record<string, { score: number; detail: string }>
+  recommendations: string[]
+  transactionsAnalyzed: number
 }
 
 interface ActivityRecord {
@@ -57,10 +66,48 @@ export default function DashboardView({
   token: string | null
 }) {
   const isAdmin = useIsAdmin()
+  const seedChat = useAppStore((s) => s.seedChat)
   const [vault, setVault] = useState<VaultData | null>(null)
   const [health, setHealth] = useState<HealthData | null>(null)
   const [heraldBudget, setHeraldBudget] = useState<HeraldBudget | null>(null)
   const [history, setHistory] = useState<ActivityEvent[]>([])
+  const [privacyData, setPrivacyData] = useState<PrivacyData | null>(null)
+  const [privacyError, setPrivacyError] = useState<string | null>(null)
+  const refreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const wallet = vault?.wallet
+
+  const fetchPrivacyScore = useCallback(async () => {
+    if (!wallet || !token) return
+    try {
+      const res = await fetch(`${import.meta.env.VITE_API_URL ?? ''}/v1/privacy/score`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ address: wallet, limit: 100 }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const json = await res.json()
+      setPrivacyData(json.data)
+      setPrivacyError(null)
+    } catch (err) {
+      setPrivacyError(err instanceof Error ? err.message : 'Failed to fetch privacy score')
+    }
+  }, [wallet, token])
+
+  useEffect(() => {
+    if (wallet && token) fetchPrivacyScore()
+  }, [wallet, token, fetchPrivacyScore])
+
+  useEffect(() => {
+    if (!wallet || !token) return
+    const fundMoverPattern = /^(send|swap|claim|refund|deposit)\.(success|completed)$/
+    const recent = events.find((e) => fundMoverPattern.test(e.type ?? ''))
+    if (!recent) return
+    if (refreshTimer.current) clearTimeout(refreshTimer.current)
+    refreshTimer.current = setTimeout(() => fetchPrivacyScore(), 5000)
+    return () => {
+      if (refreshTimer.current) clearTimeout(refreshTimer.current)
+    }
+  }, [events, wallet, token, fetchPrivacyScore])
 
   useEffect(() => {
     if (!token) return
@@ -94,10 +141,6 @@ export default function DashboardView({
     ...history.map(e => ({ ...e, isLive: false })),
   ].slice(0, 30)
 
-  // Privacy score placeholder — computed by SIPHER agent tool, not a REST endpoint
-  const privacyScore = '—'
-  const scoreColor = undefined
-
   const budgetSpent = heraldBudget?.budget?.spent
   const budgetLimit = heraldBudget?.budget?.limit
 
@@ -111,13 +154,34 @@ export default function DashboardView({
           sub="SOL"
           icon={<Wallet size={16} />}
         />
-        <MetricCard
-          label="Privacy Score"
-          value={privacyScore}
-          sub="/100"
-          icon={<ShieldCheck size={16} />}
-          color={scoreColor}
-        />
+        {(() => {
+          const grade = privacyData?.grade
+          const colorByGrade: Record<string, string> = {
+            A: '#22c55e', B: '#84cc16', C: '#facc15', D: '#fb923c', F: '#ef4444',
+          }
+          const factors = privacyData
+            ? [
+                { label: 'Address reuse', score: privacyData.factors.addressReuse.score },
+                { label: 'Amount patterns', score: privacyData.factors.amountPatterns.score },
+                { label: 'Timing correlation', score: privacyData.factors.timingCorrelation.score },
+                { label: 'Counterparty exposure', score: privacyData.factors.counterpartyExposure.score },
+              ]
+            : undefined
+          return (
+            <div className="lg:col-span-2">
+              <MetricCard
+                variant="hero"
+                label={`Privacy Score${grade ? ` · ${grade}` : ''}`}
+                value={privacyData ? String(privacyData.score) : (privacyError ? '—' : '—')}
+                sub="/100"
+                icon={<ShieldCheck size={16} />}
+                color={grade ? colorByGrade[grade] : undefined}
+                factors={factors}
+                onClick={() => privacyData && seedChat(`Why is my privacy score ${privacyData.score}?`)}
+              />
+            </div>
+          )
+        })()}
         <MetricCard
           label="Deposits"
           value={depositCount.toString()}

--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -89,7 +89,10 @@ export default function DashboardView({
 
   const solBalance = vault?.balances?.sol
   const depositCount = history.filter((e) => e.type?.includes('deposit')).length
-  const allEvents = [...events, ...history].slice(0, 30)
+  const allEvents = [
+    ...events.map(e => ({ ...e, isLive: true })),
+    ...history.map(e => ({ ...e, isLive: false })),
+  ].slice(0, 30)
 
   // Privacy score placeholder — computed by SIPHER agent tool, not a REST endpoint
   const privacyScore = '—'
@@ -151,6 +154,7 @@ export default function DashboardView({
                 <ActivityEntry
                   key={event.id}
                   agent={event.agent as AgentName}
+                  type={event.type}
                   title={
                     (event.data?.title as string) ??
                     (event.data?.message as string) ??
@@ -159,6 +163,7 @@ export default function DashboardView({
                   detail={event.data?.detail as string}
                   time={event.timestamp}
                   level={event.level}
+                  isLive={event.isLive}
                 />
               ))}
             </div>

--- a/packages/agent/src/adapters/web.ts
+++ b/packages/agent/src/adapters/web.ts
@@ -34,6 +34,14 @@ function chunkToSSE(chunk: ResponseChunk): Record<string, unknown> {
         id: chunk.toolId,
         success: chunk.success,
       }
+    case 'sentinel_advisory':
+      return {
+        type: 'sentinel_advisory',
+        action: chunk.advisory?.action ?? '',
+        amount: chunk.advisory?.amount ?? '',
+        severity: chunk.advisory?.severity ?? '',
+        description: chunk.advisory?.description ?? '',
+      }
     case 'error':
       return { type: 'error', message: chunk.text }
     case 'done':

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -49,7 +49,8 @@ import type { AgentMessage } from '@mariozechner/pi-agent-core'
 import { createPiAgent } from './pi/sipher-agent.js'
 import { streamPiAgent } from './pi/stream-bridge.js'
 import { attachToolGuard } from './pi/tool-guard.js'
-import { runPreflightGate } from './sentinel/preflight-gate.js'
+import { runPreflightGate, type AdvisoryInfo } from './sentinel/preflight-gate.js'
+import { getSentinelConfig } from './sentinel/config.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // System prompt — Sipher's identity and behavior rules
@@ -140,10 +141,15 @@ const TOOL_EXECUTORS: Record<string, ToolExecutor> = {
  * Execute a tool by name with the given input.
  * Runs preflight gate for fund-moving tools before dispatching.
  * Throws if the tool name is not registered or SENTINEL blocks.
+ *
+ * `onAdvisory` is invoked synchronously (before the underlying executor) when
+ * SENTINEL flagged the action without blocking AND mode === 'advisory'. The
+ * callback is optional — existing callers compile unchanged.
  */
 export async function executeTool(
   name: string,
   input: Record<string, unknown>,
+  onAdvisory?: (info: AdvisoryInfo) => void,
 ): Promise<unknown> {
   const executor = TOOL_EXECUTORS[name]
   if (!executor) {
@@ -153,6 +159,9 @@ export async function executeTool(
   const gate = await runPreflightGate(name, input)
   if (!gate.allowed) {
     throw new Error(`SENTINEL blocked: ${gate.reasons.join('; ')}`)
+  }
+  if (gate.advisory && onAdvisory && getSentinelConfig().mode === 'advisory') {
+    onAdvisory(gate.advisory)
   }
   return executor(input)
 }
@@ -206,12 +215,62 @@ export interface SSEError {
   message: string
 }
 
+export interface SSESentinelAdvisory {
+  type: 'sentinel_advisory'
+  /** Humanized action label, e.g. "Send to Abc...123" */
+  action: string
+  /** Optional amount string, e.g. "5 SOL" — empty when not applicable */
+  amount: string
+  /** Risk severity — low | medium | high */
+  severity: string
+  /** Concatenated reasons from the RiskReport */
+  description: string
+}
+
 export type SSEEvent =
   | SSEContentDelta
   | SSEToolUse
   | SSEToolResult
   | SSEMessageComplete
   | SSEError
+  | SSESentinelAdvisory
+
+// ─── Local helpers — humanize advisory metadata for the UI ──────────────────
+
+/**
+ * Build a short, human-readable label describing the action being taken.
+ * Best-effort — falls back to the tool name when no recipient is present.
+ */
+function humanizeAction(name: string, input: Record<string, unknown>): string {
+  const recipient = typeof input.recipient === 'string' ? input.recipient : undefined
+  const verb =
+    name === 'send' ? 'Send to' :
+    name === 'swap' ? 'Swap' :
+    name === 'deposit' ? 'Deposit' :
+    name === 'refund' ? 'Refund' :
+    name === 'sweep' ? 'Sweep' :
+    name === 'consolidate' ? 'Consolidate' :
+    name === 'splitSend' ? 'Split-send to' :
+    name === 'scheduleSend' ? 'Schedule send to' :
+    name === 'drip' ? 'Drip to' :
+    name === 'recurring' ? 'Recurring send to' :
+    name
+  if (recipient) {
+    const short = recipient.length > 8 ? `${recipient.slice(0, 4)}...${recipient.slice(-4)}` : recipient
+    return `${verb} ${short}`
+  }
+  return verb
+}
+
+/**
+ * Format the input amount + token (e.g. "5 SOL") or empty string when unset.
+ */
+function extractAmount(input: Record<string, unknown>): string {
+  const amount = input.amount
+  if (typeof amount !== 'number' || !Number.isFinite(amount)) return ''
+  const token = typeof input.token === 'string' && input.token ? input.token : 'SOL'
+  return `${amount} ${token}`
+}
 
 /**
  * Run the SIPHER agent loop to completion via Pi SDK.
@@ -271,19 +330,57 @@ export async function chat(
  * Pi SDK drives the agentic tool loop internally. The stream-bridge converts
  * Pi's push-based event model to a pull-based async generator of SSEEvents
  * compatible with AgentCore's SSEEvent vocabulary.
+ *
+ * SENTINEL advisories: When the default executor (`executeTool`) is in use
+ * and SENTINEL flagged the action without blocking, the advisory is captured
+ * via the optional `onAdvisory` callback and emitted as a `sentinel_advisory`
+ * SSE event immediately before the corresponding `tool_result`. Custom
+ * `opts.toolExecutor` overrides bypass advisory capture (no preflight gate).
  */
 export async function* chatStream(
   userMessage: string,
   opts: ChatOptions = {},
 ): AsyncGenerator<SSEEvent> {
+  const advisoryQueue: SSESentinelAdvisory[] = []
+  const baseExecutor = opts.toolExecutor ?? executeTool
+
+  // Wrap the executor so advisory callbacks are routed into a per-request queue.
+  // We keep the wrapper signature `(name, input) => Promise` to match the Pi
+  // executor contract and pass our internal `onAdvisory` only to the default
+  // `executeTool`. Custom executors are invoked unchanged.
+  const wrappedExecutor = (name: string, input: Record<string, unknown>): Promise<unknown> => {
+    if (baseExecutor === executeTool) {
+      return executeTool(name, input, (adv) => {
+        advisoryQueue.push({
+          type: 'sentinel_advisory',
+          action: humanizeAction(name, input),
+          amount: extractAmount(input),
+          severity: adv.severity,
+          description: adv.description,
+        })
+      })
+    }
+    return baseExecutor(name, input)
+  }
+
   const agent = createPiAgent({
     systemPrompt: opts.systemPrompt ?? SYSTEM_PROMPT,
     tools: opts.tools ?? TOOLS,
-    toolExecutor: opts.toolExecutor ?? executeTool,
+    toolExecutor: wrappedExecutor,
     model: opts.model,
     history: opts.history,
     sessionId: opts.sessionId,
   })
 
-  yield* streamPiAgent(agent, userMessage)
+  // Drain the advisory queue before each tool_result so the client renders the
+  // warning alongside the tool's outcome. Advisories are populated synchronously
+  // inside executeTool (which Pi awaits between tool_use and tool_result), so by
+  // the time tool_result arrives the queue holds the matching advisory(ies).
+  for await (const event of streamPiAgent(agent, userMessage)) {
+    if (event.type === 'tool_result' && advisoryQueue.length > 0) {
+      const drained = advisoryQueue.splice(0, advisoryQueue.length)
+      for (const adv of drained) yield adv
+    }
+    yield event
+  }
 }

--- a/packages/agent/src/core/agent-core.ts
+++ b/packages/agent/src/core/agent-core.ts
@@ -172,6 +172,18 @@ export class AgentCore {
           }
           break
 
+        case 'sentinel_advisory':
+          yield {
+            type: 'sentinel_advisory',
+            advisory: {
+              action: event.action,
+              amount: event.amount,
+              severity: event.severity,
+              description: event.description,
+            },
+          }
+          break
+
         case 'error':
           yield { type: 'error', text: event.message }
           break

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -30,11 +30,18 @@ export interface MsgContext {
 
 /** A single response chunk for streaming */
 export interface ResponseChunk {
-  type: 'text' | 'tool_start' | 'tool_end' | 'error' | 'done'
+  type: 'text' | 'tool_start' | 'tool_end' | 'error' | 'done' | 'sentinel_advisory'
   text?: string
   toolName?: string
   toolId?: string
   success?: boolean
+  /** Populated only when type === 'sentinel_advisory' */
+  advisory?: {
+    action: string
+    amount: string
+    severity: string
+    description: string
+  }
 }
 
 /** Full (non-streaming) agent response */

--- a/packages/agent/src/sentinel/preflight-gate.ts
+++ b/packages/agent/src/sentinel/preflight-gate.ts
@@ -16,8 +16,24 @@ export function getSentinelAssessor(): SentinelAssessor | null {
   return assessor
 }
 
+/**
+ * Advisory metadata surfaced when SENTINEL flagged an action but did not block.
+ * Populated only when the LLM analyst returned `recommendation: 'warn'` — static
+ * rules currently only allow or block, so they never produce an advisory.
+ */
+export interface AdvisoryInfo {
+  /** Risk level — low | medium | high (mirrors RiskReport.risk) */
+  severity: string
+  /** Human-readable summary built from RiskReport.reasons */
+  description: string
+  /** Original recommendation — 'warn' for advisories */
+  recommendation: string
+}
+
 export interface PreflightOutcome {
   allowed: true
+  /** Present when SENTINEL flagged but allowed the action (advisory mode) */
+  advisory?: AdvisoryInfo
 }
 
 export interface PreflightBlocked {
@@ -69,6 +85,18 @@ export async function runPreflightGate(
     })
     if (report.recommendation === 'block') {
       return { allowed: false, reasons: report.blockers ?? report.reasons }
+    }
+    // Surface advisory metadata when the LLM warned but didn't block. The caller
+    // decides whether to forward it to the client (e.g. SSE) based on mode.
+    if (report.recommendation === 'warn' && report.reasons.length > 0) {
+      return {
+        allowed: true,
+        advisory: {
+          severity: report.risk,
+          description: report.reasons.join('; '),
+          recommendation: report.recommendation,
+        },
+      }
     }
     return { allowed: true }
   } catch (err) {

--- a/packages/agent/tests/sentinel/advisory-event.test.ts
+++ b/packages/agent/tests/sentinel/advisory-event.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SENTINEL advisory SSE event — covers the path:
+//   runPreflightGate → executeTool(onAdvisory) → chatStream(SSE injection)
+//
+// Two layers of test:
+//   1. runPreflightGate populates `advisory` for warn-recommendation reports
+//   2. executeTool fires the onAdvisory callback only in advisory mode
+//
+// We don't drive a full chatStream here — the queue/injection logic is
+// exercised by integration tests in pi-smoke. The new behavior we need to
+// prove is the gate change + callback wiring.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('runPreflightGate advisory surface', () => {
+  beforeEach(() => {
+    process.env.DB_PATH = ':memory:'
+    vi.resetModules()
+  })
+  afterEach(() => {
+    delete process.env.DB_PATH
+    delete process.env.SENTINEL_MODE
+  })
+
+  async function freshDb() {
+    const { closeDb, getDb } = await import('../../src/db.js')
+    closeDb()
+    getDb()
+  }
+
+  it('returns advisory metadata when LLM recommendation === warn', async () => {
+    await freshDb()
+    const { setSentinelAssessor, runPreflightGate } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(vi.fn().mockResolvedValue({
+      risk: 'medium',
+      score: 50,
+      reasons: ['recipient is new', 'amount is large for this wallet'],
+      recommendation: 'warn',
+      decisionId: 'dec1',
+      durationMs: 200,
+    }) as never)
+
+    const result = await runPreflightGate('send', { wallet: 'w1', recipient: 'stranger', amount: 5 })
+
+    expect(result.allowed).toBe(true)
+    if (result.allowed) {
+      expect(result.advisory).toBeDefined()
+      expect(result.advisory?.severity).toBe('medium')
+      expect(result.advisory?.description).toBe('recipient is new; amount is large for this wallet')
+      expect(result.advisory?.recommendation).toBe('warn')
+    }
+  })
+
+  it('does NOT populate advisory when recommendation === allow', async () => {
+    await freshDb()
+    const { setSentinelAssessor, runPreflightGate } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(vi.fn().mockResolvedValue({
+      risk: 'low',
+      score: 5,
+      reasons: ['ok'],
+      recommendation: 'allow',
+      decisionId: 'dec2',
+      durationMs: 100,
+    }) as never)
+
+    const result = await runPreflightGate('send', { wallet: 'w1', recipient: 'stranger', amount: 5 })
+
+    expect(result.allowed).toBe(true)
+    if (result.allowed) {
+      expect(result.advisory).toBeUndefined()
+    }
+  })
+
+  it('blocks (no advisory) when recommendation === block', async () => {
+    await freshDb()
+    const { setSentinelAssessor, runPreflightGate } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(vi.fn().mockResolvedValue({
+      risk: 'high',
+      score: 90,
+      reasons: ['suspicious'],
+      recommendation: 'block',
+      blockers: ['address was reported'],
+      decisionId: 'dec3',
+      durationMs: 100,
+    }) as never)
+
+    const result = await runPreflightGate('send', { wallet: 'w1', recipient: 'stranger', amount: 5 })
+    expect(result.allowed).toBe(false)
+  })
+})
+
+describe('executeTool onAdvisory callback', () => {
+  beforeEach(() => {
+    process.env.DB_PATH = ':memory:'
+    vi.resetModules()
+  })
+  afterEach(() => {
+    delete process.env.DB_PATH
+    delete process.env.SENTINEL_MODE
+  })
+
+  async function freshDb() {
+    const { closeDb, getDb } = await import('../../src/db.js')
+    closeDb()
+    getDb()
+  }
+
+  it('fires onAdvisory when SENTINEL warns AND mode === advisory', async () => {
+    await freshDb()
+    process.env.SENTINEL_MODE = 'advisory'
+    const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(vi.fn().mockResolvedValue({
+      risk: 'medium',
+      score: 50,
+      reasons: ['unknown recipient'],
+      recommendation: 'warn',
+      decisionId: 'dec1',
+      durationMs: 100,
+    }) as never)
+
+    vi.doMock('../../src/tools/send.js', () => ({
+      executeSend: vi.fn().mockResolvedValue({ action: 'send', success: true }),
+      sendTool: { name: 'send', description: '', input_schema: { type: 'object', properties: {} } },
+    }))
+    const { executeTool } = await import('../../src/agent.js')
+    const onAdvisory = vi.fn()
+
+    const result = await executeTool(
+      'send',
+      { wallet: 'w1', recipient: 'stranger', amount: 5 },
+      onAdvisory,
+    )
+
+    expect(result).toMatchObject({ success: true })
+    expect(onAdvisory).toHaveBeenCalledTimes(1)
+    expect(onAdvisory).toHaveBeenCalledWith({
+      severity: 'medium',
+      description: 'unknown recipient',
+      recommendation: 'warn',
+    })
+    vi.doUnmock('../../src/tools/send.js')
+  })
+
+  it('does NOT fire onAdvisory when mode !== advisory (yolo allows silently)', async () => {
+    await freshDb()
+    // SENTINEL_MODE unset → defaults to 'yolo'
+    const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(vi.fn().mockResolvedValue({
+      risk: 'medium',
+      score: 50,
+      reasons: ['unknown recipient'],
+      recommendation: 'warn',
+      decisionId: 'dec1',
+      durationMs: 100,
+    }) as never)
+
+    vi.doMock('../../src/tools/send.js', () => ({
+      executeSend: vi.fn().mockResolvedValue({ action: 'send', success: true }),
+      sendTool: { name: 'send', description: '', input_schema: { type: 'object', properties: {} } },
+    }))
+    const { executeTool } = await import('../../src/agent.js')
+    const onAdvisory = vi.fn()
+
+    await executeTool(
+      'send',
+      { wallet: 'w1', recipient: 'stranger', amount: 5 },
+      onAdvisory,
+    )
+
+    expect(onAdvisory).not.toHaveBeenCalled()
+    vi.doUnmock('../../src/tools/send.js')
+  })
+
+  it('existing 2-arg callers still work (onAdvisory is optional)', async () => {
+    await freshDb()
+    process.env.SENTINEL_MODE = 'advisory'
+    const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(vi.fn().mockResolvedValue({
+      risk: 'medium',
+      score: 50,
+      reasons: ['unknown recipient'],
+      recommendation: 'warn',
+      decisionId: 'dec1',
+      durationMs: 100,
+    }) as never)
+
+    vi.doMock('../../src/tools/send.js', () => ({
+      executeSend: vi.fn().mockResolvedValue({ action: 'send', success: true }),
+      sendTool: { name: 'send', description: '', input_schema: { type: 'object', properties: {} } },
+    }))
+    const { executeTool } = await import('../../src/agent.js')
+
+    // No onAdvisory passed — must not throw
+    const result = await executeTool('send', { wallet: 'w1', recipient: 'stranger', amount: 5 })
+    expect(result).toMatchObject({ success: true })
+    vi.doUnmock('../../src/tools/send.js')
+  })
+})
+
+describe('chatStream sentinel_advisory SSE injection', () => {
+  beforeEach(() => {
+    process.env.DB_PATH = ':memory:'
+    vi.resetModules()
+  })
+  afterEach(() => {
+    delete process.env.DB_PATH
+    delete process.env.SENTINEL_MODE
+  })
+
+  async function freshDb() {
+    const { closeDb, getDb } = await import('../../src/db.js')
+    closeDb()
+    getDb()
+  }
+
+  it('injects sentinel_advisory event before tool_result in advisory mode', async () => {
+    await freshDb()
+    process.env.SENTINEL_MODE = 'advisory'
+
+    const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(vi.fn().mockResolvedValue({
+      risk: 'high',
+      score: 70,
+      reasons: ['recipient flagged in recent activity'],
+      recommendation: 'warn',
+      decisionId: 'dec1',
+      durationMs: 100,
+    }) as never)
+
+    // Stub Pi agent so we control event emission deterministically.
+    // The fake agent invokes the toolExecutor (which is the chatStream-wrapped
+    // executor) between tool_execution_start and tool_execution_end so the
+    // advisory queue is populated before the tool_result event is yielded.
+    type Subscriber = (event: unknown) => void | Promise<void>
+    vi.doMock('../../src/pi/sipher-agent.js', async (orig) => {
+      const actual = (await orig()) as Record<string, unknown>
+      return {
+        ...actual,
+        createPiAgent: vi.fn((opts: {
+          toolExecutor: (n: string, i: Record<string, unknown>) => Promise<unknown>
+        }) => {
+          const subscribers: Subscriber[] = []
+          const messages: unknown[] = []
+          return {
+            subscribe: (cb: Subscriber) => {
+              subscribers.push(cb)
+              return () => {
+                const idx = subscribers.indexOf(cb)
+                if (idx >= 0) subscribers.splice(idx, 1)
+              }
+            },
+            prompt: async () => {
+              for (const cb of [...subscribers]) {
+                await cb({ type: 'tool_execution_start', toolCallId: 'c1', toolName: 'send' })
+              }
+              try {
+                await opts.toolExecutor('send', { wallet: 'w1', recipient: 'stranger', amount: 5 })
+              } catch {
+                // executor throws if tools/send.js isn't mocked — keep going so we still emit end
+              }
+              for (const cb of [...subscribers]) {
+                await cb({
+                  type: 'tool_execution_end',
+                  toolCallId: 'c1',
+                  toolName: 'send',
+                  isError: false,
+                })
+              }
+              messages.push({ role: 'assistant', content: [{ type: 'text', text: 'done' }] })
+              for (const cb of [...subscribers]) {
+                await cb({ type: 'agent_end', messages })
+              }
+            },
+            abort: () => {},
+            state: { messages },
+          }
+        }),
+      }
+    })
+
+    vi.doMock('../../src/tools/send.js', () => ({
+      executeSend: vi.fn().mockResolvedValue({ action: 'send', success: true }),
+      sendTool: { name: 'send', description: '', input_schema: { type: 'object', properties: {} } },
+    }))
+
+    const { chatStream } = await import('../../src/agent.js')
+    const events: Array<{ type: string }> = []
+    for await (const evt of chatStream('send 5 SOL')) {
+      events.push(evt as { type: string })
+    }
+
+    const types = events.map((e) => e.type)
+    expect(types).toContain('sentinel_advisory')
+
+    const advisoryIdx = types.indexOf('sentinel_advisory')
+    const toolResultIdx = types.indexOf('tool_result')
+    const toolUseIdx = types.indexOf('tool_use')
+
+    // Order must be: tool_use → sentinel_advisory → tool_result
+    expect(toolUseIdx).toBeLessThan(advisoryIdx)
+    expect(advisoryIdx).toBeLessThan(toolResultIdx)
+
+    const advisory = events[advisoryIdx] as {
+      type: string
+      action: string
+      amount: string
+      severity: string
+      description: string
+    }
+    expect(advisory.severity).toBe('high')
+    expect(advisory.description).toBe('recipient flagged in recent activity')
+    expect(advisory.amount).toBe('5 SOL')
+    expect(advisory.action).toContain('Send to')
+
+    vi.doUnmock('../../src/tools/send.js')
+    vi.doUnmock('../../src/pi/sipher-agent.js')
+  })
+})


### PR DESCRIPTION
## Summary

Phase 2 PR 1 of 3 — client polish from the 2026-04-26 audit-driven design (16 tasks executed via subagent-driven-development).

**Spec:** `docs/superpowers/specs/2026-04-26-ui-gaps-design.md`
**Plan:** `docs/superpowers/plans/2026-04-26-phase-2-ui-gaps.md`

### What's in

- **Privacy Score hero widget** (col-span-2, score + grade chip + 4 factor bars). Click → SIPHER chat seeded with explainer prompt. Initial fetch + event-based auto-refresh on fund-mover SSE events (5s debounced, abort-safe, dedup'd by event id).
- **Phosphor event-type icons** replacing static activity dots (`deposit`, `withdraw`, `send`, `swap`, `claim`, `refund`, `scan`, `sentinel.flag`, `sentinel.block`, `herald.posted`). Pulsing animation on live SSE events; static for history.
- **Chat tool-use timeline** rendered above assistant message text (status icon + tool name + sanitized args + duration). Sensitive keys redacted, base58 ids shortened to first-4-last-4.
- **SENTINEL advisory wiring (light)** — server emits `sentinel_advisory` SSE event in `SENTINEL_MODE=advisory`, client renders a warning ConfirmCard inline in chat. Full pause/resume comes in PR 2b.
- **AdminOnly wrapper component** centralizes 4 scattered `{isAdmin && (...)}` guards in DashboardView. Future-extensible via optional `fallback` prop.
- **ConfirmCard** gets `variant` (normal | warning) + `description` props. Warning variant uses Phosphor `<Warning />` icon (no Unicode emoji per project standard).
- **MetricCard** gets `variant` (normal | hero) + `factors` + `onClick` props. Hero variant: 32px value, inline factor bars colored by score thresholds (80/60/40).
- **App store** extended with `ToolCall` type, `'system'` chat role, `tools[]`, `kind`, `meta`, `dismissed`, `pendingPrompt` + `seedChat` / `consumePendingPrompt` actions.
- **Server SSE plumbing** — `ResponseChunk` extended with `sentinel_advisory` variant; `runPreflightGate` surfaces advisory metadata when LLM warns but doesn't block; `chatStream` injects advisories into the stream right before each `tool_result`.

### What's NOT in (deferred)

- **PR 2a (next)** — HERALD inline edit (PATCH /api/herald/queue/:id) + Vault Deposit/Withdraw quick-actions
- **PR 2b** — SENTINEL pause/resume server-side architecture (replaces this PR's light advisory with real flow control)
- **`tool_use` SSE `input` payload** — Task 12 reads `event.input` to render args in ToolTimeline, but the server adapter doesn't currently propagate the tool call input through `ResponseChunk` to SSE. ToolTimeline renders name + status + duration; args column is empty until a small follow-up extends `ResponseChunk.input`. Pre-existing gap surfaced by Task 12 wiring.

### Spec deviations

- **Task 2** — replaced `⚠` Unicode emoji in ConfirmCard with Phosphor `<Warning />` icon (project standard from CLAUDE.md: never use Unicode emojis as icons in components).
- **Task 9** — fixed two real bugs in plan test stubs (wallet suffix `BWWr` not `8WWr`; base58 regex needs digit requirement to discriminate identifier-like strings from filler text).
- **Task 13** — fixed plan test stub that used `getByText('SOL')` against `label="SOL" + sub="SOL"` (would throw on multiple matches); switched to `getAllByText('SOL').toHaveLength(2)`.
- **Task 14** — added AbortController + `lastProcessedEventId` ref after code review found unmount-race + repeat-trigger bugs.
- **Task 15** — extended scope from "~10 line emit" (per plan stub) to proper architecture (advisory → preflight gate → ResponseChunk → web.ts adapter → SSE) since the plan stub didn't match the actual Pi-bridged stream architecture.

### Test plan

- [x] Backend tests: 497/497 (`pnpm test -- --run`)
- [x] App tests: 29/29 (`pnpm --filter @sipher/app test -- --run`) — 8 new test files, 25 new tests
- [x] Agent tests: 919/919 (`pnpm --filter @sipher/agent test -- --run`) — 7 new tests for sentinel advisory
- [x] Workspace typecheck clean (`pnpm typecheck`)
- [ ] **Manual browser smoke test pending** — controller couldn't run dev server in non-interactive shell. Recommend RECTOR verifies: (a) Privacy Score hero card renders with grade chip + factor bars when funded wallet, (b) activity stream icons + pulsing on live events, (c) ToolTimeline appears on chat tool calls (note: args column empty pending follow-up), (d) SENTINEL ConfirmCard renders when triggering a known-flagged tool input in `SENTINEL_MODE=advisory`.

### Base branch

Targets `feat/test-infra` (PR #152) because PR #152 has the Vitest + RTL infrastructure that all the new component tests depend on. When #152 merges to main, GitHub auto-retargets this PR.

### Stats

16 commits, 16 tasks. ~1100 net lines (insertions including tests).