### PR TITLE
feat(agent): Phase 2 PR 2b — SENTINEL server pause/resume + override/cancel

### DIFF
--- a/app/src/components/ChatSidebar.tsx
+++ b/app/src/components/ChatSidebar.tsx
@@ -3,7 +3,7 @@ import { PaperPlaneTilt, CircleNotch, Wrench } from '@phosphor-icons/react'
 import { useAppStore, type ChatMessage } from '../stores/app'
 import { sanitizeArgs } from '../lib/sanitize-args'
 import ToolTimeline from './ToolTimeline'
-import ConfirmCard from './ConfirmCard'
+import SentinelConfirm from './SentinelConfirm'
 
 const API_URL = import.meta.env.VITE_API_URL ?? ''
 
@@ -91,13 +91,14 @@ export default function ChatSidebar({ fullScreen }: Props) {
             } else if (event.type === 'tool_result') {
               completeTool(event.name, event.is_error ? 'error' : 'success')
               setActiveTool(null)
-            } else if (event.type === 'sentinel_advisory') {
+            } else if (event.type === 'sentinel_pause') {
               addMessage({
                 id: crypto.randomUUID(),
                 role: 'system',
                 content: '',
-                kind: 'sentinel_advisory',
+                kind: 'sentinel_pause' as const,
                 meta: {
+                  flagId: event.flagId,
                   action: event.action,
                   amount: event.amount,
                   description: event.description,
@@ -149,18 +150,18 @@ export default function ChatSidebar({ fullScreen }: Props) {
           <p className="text-text-muted text-sm text-center py-8">Ask SIPHER anything about your privacy.</p>
         )}
         {messages.filter((m) => !m.dismissed).map((msg) => {
-          if (msg.role === 'system' && msg.kind === 'sentinel_advisory') {
-            const meta = (msg.meta ?? {}) as { action?: string; amount?: string; description?: string }
+          if (msg.role === 'system' && msg.kind === 'sentinel_pause' && token) {
+            const meta = (msg.meta ?? {}) as { flagId?: string; action?: string; amount?: string; description?: string }
             return (
               <div key={msg.id} className="flex justify-start">
                 <div className="max-w-[90%] w-full">
-                  <ConfirmCard
-                    variant="warning"
+                  <SentinelConfirm
+                    flagId={meta.flagId ?? ''}
+                    token={token}
                     action={meta.action ?? 'Action'}
                     amount={meta.amount ?? ''}
                     description={meta.description}
-                    onConfirm={() => sendMessage('Yes, proceed anyway')}
-                    onCancel={() => dismissMessage(msg.id)}
+                    onResolved={() => dismissMessage(msg.id)}
                   />
                 </div>
               </div>

--- a/app/src/components/ConfirmCard.tsx
+++ b/app/src/components/ConfirmCard.tsx
@@ -9,6 +9,8 @@ interface Props {
   onCancel: () => void
   variant?: Variant
   description?: string
+  // disables both buttons (e.g. while a parent dispatches a REST call)
+  disabled?: boolean
   // reserved for future countdown display; not currently consumed
   timeout?: number
 }
@@ -20,6 +22,7 @@ export default function ConfirmCard({
   onCancel,
   variant = 'normal',
   description,
+  disabled = false,
 }: Props) {
   const isWarning = variant === 'warning'
   const borderClass = isWarning ? 'border-yellow/40' : 'border-elevated'
@@ -42,13 +45,15 @@ export default function ConfirmCard({
       <div className="flex gap-2">
         <button
           onClick={onConfirm}
-          className={`flex-1 border ${primaryClass} py-2 rounded-lg text-[12px] font-medium`}
+          disabled={disabled}
+          className={`flex-1 border ${primaryClass} py-2 rounded-lg text-[12px] font-medium disabled:opacity-50 disabled:cursor-not-allowed`}
         >
           {primaryLabel}
         </button>
         <button
           onClick={onCancel}
-          className="px-4 border border-elevated text-text-muted py-2 rounded-lg text-[12px] hover:text-text"
+          disabled={disabled}
+          className="px-4 border border-elevated text-text-muted py-2 rounded-lg text-[12px] hover:text-text disabled:opacity-50 disabled:cursor-not-allowed"
         >
           Cancel
         </button>

--- a/app/src/components/SentinelConfirm.tsx
+++ b/app/src/components/SentinelConfirm.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react'
+import ConfirmCard from './ConfirmCard'
+
+const API_URL = import.meta.env.VITE_API_URL ?? ''
+
+interface Props {
+  flagId: string
+  token: string
+  action: string
+  amount: string
+  description?: string
+  onResolved: (decision: 'override' | 'cancel') => void
+}
+
+export default function SentinelConfirm({ flagId, token, action, amount, description, onResolved }: Props) {
+  const [busy, setBusy] = useState(false)
+
+  const dispatch = async (kind: 'override' | 'cancel') => {
+    if (busy) return
+    setBusy(true)
+    try {
+      await fetch(`${API_URL}/api/sentinel/${kind}/${flagId}`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      onResolved(kind)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <ConfirmCard
+      variant="warning"
+      action={action}
+      amount={amount}
+      description={description}
+      onConfirm={() => dispatch('override')}
+      onCancel={() => dispatch('cancel')}
+    />
+  )
+}

--- a/app/src/components/SentinelConfirm.tsx
+++ b/app/src/components/SentinelConfirm.tsx
@@ -5,6 +5,7 @@ const API_URL = import.meta.env.VITE_API_URL ?? ''
 
 interface Props {
   flagId: string
+  /** Owner JWT — endpoints require requireOwner middleware on the server. */
   token: string
   action: string
   amount: string
@@ -14,29 +15,42 @@ interface Props {
 
 export default function SentinelConfirm({ flagId, token, action, amount, description, onResolved }: Props) {
   const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const dispatch = async (kind: 'override' | 'cancel') => {
     if (busy) return
     setBusy(true)
+    setError(null)
+    let success = false
     try {
-      await fetch(`${API_URL}/api/sentinel/${kind}/${flagId}`, {
+      const res = await fetch(`${API_URL}/api/sentinel/${kind}/${encodeURIComponent(flagId)}`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
       })
-      onResolved(kind)
+      if (!res.ok) {
+        setError(`Action failed (${res.status})`)
+        return
+      }
+      success = true
+    } catch {
+      setError('Network error — try again')
     } finally {
       setBusy(false)
     }
+    if (success) onResolved(kind)
   }
 
   return (
-    <ConfirmCard
-      variant="warning"
-      action={action}
-      amount={amount}
-      description={description}
-      onConfirm={() => dispatch('override')}
-      onCancel={() => dispatch('cancel')}
-    />
+    <div className="flex flex-col gap-2">
+      <ConfirmCard
+        variant="warning"
+        action={action}
+        amount={amount}
+        description={description}
+        onConfirm={() => dispatch('override')}
+        onCancel={() => dispatch('cancel')}
+      />
+      {error && <div className="text-[12px] text-red px-1">{error}</div>}
+    </div>
   )
 }

--- a/app/src/components/SentinelConfirm.tsx
+++ b/app/src/components/SentinelConfirm.tsx
@@ -47,6 +47,7 @@ export default function SentinelConfirm({ flagId, token, action, amount, descrip
         action={action}
         amount={amount}
         description={description}
+        disabled={busy}
         onConfirm={() => dispatch('override')}
         onCancel={() => dispatch('cancel')}
       />

--- a/app/src/components/__tests__/ChatSidebar.test.tsx
+++ b/app/src/components/__tests__/ChatSidebar.test.tsx
@@ -36,6 +36,31 @@ describe('ChatSidebar', () => {
     expect(input).toBeEnabled()
   })
 
+  it('renders SentinelConfirm card when a sentinel_pause message is in the store', () => {
+    useAppStore.setState({
+      token: 'test-jwt',
+      isAdmin: true,
+      messages: [
+        {
+          id: 'm1',
+          role: 'system',
+          content: '',
+          kind: 'sentinel_pause',
+          meta: {
+            flagId: 'flag-123',
+            action: 'Send',
+            amount: '5 SOL',
+            description: 'Risk: blacklisted address',
+            severity: 'high',
+          },
+        },
+      ],
+    })
+    render(<ChatSidebar />)
+    expect(screen.getByText(/blacklisted address/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /override & send/i })).toBeInTheDocument()
+  })
+
   it('sends message and appends streamed reply', async () => {
     useAppStore.setState({ token: 'test-jwt', isAdmin: true })
 

--- a/app/src/components/__tests__/SentinelConfirm.test.tsx
+++ b/app/src/components/__tests__/SentinelConfirm.test.tsx
@@ -62,4 +62,43 @@ describe('SentinelConfirm', () => {
     )
     expect(onResolved).toHaveBeenCalledWith('cancel')
   })
+
+  it('prevents double-dispatch when busy', async () => {
+    // never resolves so busy stays true
+    global.fetch = vi.fn().mockImplementation(() => new Promise(() => {})) as typeof fetch
+    const onResolved = vi.fn()
+    render(
+      <SentinelConfirm
+        flagId="abc"
+        token="t"
+        action="Send"
+        amount="5 SOL"
+        description="x"
+        onResolved={onResolved}
+      />
+    )
+    const btn = screen.getByRole('button', { name: /override & send/i })
+    await userEvent.click(btn)
+    await userEvent.click(btn)
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    expect(onResolved).not.toHaveBeenCalled()
+  })
+
+  it('surfaces error and does not resolve when fetch returns non-ok', async () => {
+    global.fetch = vi.fn().mockResolvedValue(new Response('{"error":"flag expired"}', { status: 404 })) as typeof fetch
+    const onResolved = vi.fn()
+    render(
+      <SentinelConfirm
+        flagId="abc"
+        token="t"
+        action="Send"
+        amount="5 SOL"
+        description="x"
+        onResolved={onResolved}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /override & send/i }))
+    expect(onResolved).not.toHaveBeenCalled()
+    expect(screen.getByText(/failed/i)).toBeInTheDocument()
+  })
 })

--- a/app/src/components/__tests__/SentinelConfirm.test.tsx
+++ b/app/src/components/__tests__/SentinelConfirm.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SentinelConfirm from '../SentinelConfirm'
+
+describe('SentinelConfirm', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 })) as typeof fetch
+  })
+
+  it('renders amber warning ConfirmCard with description', () => {
+    render(
+      <SentinelConfirm
+        flagId="abc"
+        token="t"
+        action="Send"
+        amount="5 SOL"
+        description="Risk: blacklisted address"
+        onResolved={() => {}}
+      />
+    )
+    expect(screen.getByText(/blacklisted address/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /override & send/i })).toBeInTheDocument()
+  })
+
+  it('POSTs to override endpoint on Override click', async () => {
+    const onResolved = vi.fn()
+    render(
+      <SentinelConfirm
+        flagId="abc"
+        token="t"
+        action="Send"
+        amount="5 SOL"
+        description="x"
+        onResolved={onResolved}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /override & send/i }))
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/sentinel/override/abc'),
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(onResolved).toHaveBeenCalledWith('override')
+  })
+
+  it('POSTs to cancel endpoint on Cancel click', async () => {
+    const onResolved = vi.fn()
+    render(
+      <SentinelConfirm
+        flagId="abc"
+        token="t"
+        action="Send"
+        amount="5 SOL"
+        description="x"
+        onResolved={onResolved}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/sentinel/cancel/abc'),
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(onResolved).toHaveBeenCalledWith('cancel')
+  })
+})

--- a/app/src/stores/app.ts
+++ b/app/src/stores/app.ts
@@ -19,7 +19,7 @@ export interface ChatMessage {
   toolName?: string
   streaming?: boolean
   tools?: ToolCall[]
-  kind?: 'sentinel_advisory'
+  kind?: 'sentinel_advisory' | 'sentinel_pause'
   meta?: Record<string, unknown>
   dismissed?: boolean
 }

--- a/app/src/stores/app.ts
+++ b/app/src/stores/app.ts
@@ -19,7 +19,7 @@ export interface ChatMessage {
   toolName?: string
   streaming?: boolean
   tools?: ToolCall[]
-  kind?: 'sentinel_advisory' | 'sentinel_pause'
+  kind?: 'sentinel_pause'
   meta?: Record<string, unknown>
   dismissed?: boolean
 }

--- a/e2e/sentinel-flow.spec.ts
+++ b/e2e/sentinel-flow.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test'
+
+// Skipped pending sip-protocol/sip-protocol#1077 (SDK ESM bundle bug blocks agent startup)
+test.skip('SENTINEL pause/resume flow — full chat → override → tool runs', async ({ page }) => {
+  await page.goto('/')
+
+  // Sign in (using storageState fixture from Phase 1)
+  // Send a message that triggers a SENTINEL flag (e.g., sending to a known-blacklisted devnet address)
+  await page.getByPlaceholder('Message SIPHER...').fill('send 5 SOL to <blacklisted address>')
+  await page.getByRole('button', { name: /send/i }).click()
+
+  // SentinelConfirm card should render
+  const confirmCard = page.getByText(/risk confirm/i).first()
+  await expect(confirmCard).toBeVisible({ timeout: 10000 })
+
+  // Override → tool completes
+  await page.getByRole('button', { name: /override & send/i }).click()
+
+  // Assistant message resumes streaming
+  await expect(page.getByText(/transaction submitted/i)).toBeVisible({ timeout: 30000 })
+})
+
+test.skip('SENTINEL pause/resume flow — cancel produces graceful message', async ({ page }) => {
+  await page.goto('/')
+  await page.getByPlaceholder('Message SIPHER...').fill('send 5 SOL to <blacklisted address>')
+  await page.getByRole('button', { name: /send/i }).click()
+
+  const confirmCard = page.getByText(/risk confirm/i).first()
+  await expect(confirmCard).toBeVisible({ timeout: 10000 })
+
+  await page.getByRole('button', { name: /^cancel$/i }).click()
+
+  await expect(page.getByText(/operation cancelled/i)).toBeVisible({ timeout: 10000 })
+})

--- a/packages/agent/src/adapters/web.ts
+++ b/packages/agent/src/adapters/web.ts
@@ -158,6 +158,9 @@ export function createWebAdapter() {
     // Track client disconnect. On disconnect we also reject any pending
     // sentinel flags for this session so the wrapped executor unblocks and
     // Pi's tool loop can wind down (instead of waiting on the 120s timeout).
+    // Note: session ids are wallet-deterministic, so clearAll affects all
+    // concurrent streams for the same wallet (e.g. multi-tab). Acceptable
+    // because a single wallet realistically has one active stream at a time.
     let aborted = false
     res.on('close', () => {
       aborted = true

--- a/packages/agent/src/adapters/web.ts
+++ b/packages/agent/src/adapters/web.ts
@@ -1,6 +1,8 @@
 import type { Request, Response } from 'express'
 import type { ResponseChunk } from '../core/types.js'
 import { AgentCore } from '../core/agent-core.js'
+import { resolveSession } from '../session.js'
+import { clearAll } from '../sentinel/pending.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Web Adapter — maps Express HTTP requests to AgentCore
@@ -34,13 +36,14 @@ function chunkToSSE(chunk: ResponseChunk): Record<string, unknown> {
         id: chunk.toolId,
         success: chunk.success,
       }
-    case 'sentinel_advisory':
+    case 'sentinel_pause':
       return {
-        type: 'sentinel_advisory',
-        action: chunk.advisory?.action ?? '',
-        amount: chunk.advisory?.amount ?? '',
-        severity: chunk.advisory?.severity ?? '',
-        description: chunk.advisory?.description ?? '',
+        type: 'sentinel_pause',
+        flagId: chunk.pause?.flagId ?? '',
+        action: chunk.pause?.action ?? '',
+        amount: chunk.pause?.amount ?? '',
+        severity: chunk.pause?.severity ?? '',
+        description: chunk.pause?.description ?? '',
       }
     case 'error':
       return { type: 'error', message: chunk.text }
@@ -140,6 +143,11 @@ export function createWebAdapter() {
       return
     }
 
+    // Resolve the session up-front so the disconnect handler has a stable id.
+    // resolveSession is deterministic by wallet, so this is the same session
+    // AgentCore.streamMessage will use internally.
+    const session = resolveSession(wallet)
+
     // Set SSE headers
     res.setHeader('Content-Type', 'text/event-stream')
     res.setHeader('Cache-Control', 'no-cache')
@@ -147,10 +155,13 @@ export function createWebAdapter() {
     res.setHeader('X-Accel-Buffering', 'no')
     res.flushHeaders()
 
-    // Track client disconnect
+    // Track client disconnect. On disconnect we also reject any pending
+    // sentinel flags for this session so the wrapped executor unblocks and
+    // Pi's tool loop can wind down (instead of waiting on the 120s timeout).
     let aborted = false
     res.on('close', () => {
       aborted = true
+      clearAll(session.id)
     })
 
     try {

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto'
 import type { AnthropicTool } from './pi/tool-adapter.js'
 import {
   depositTool,
@@ -373,7 +374,11 @@ export async function* chatStream(
   userMessage: string,
   opts: ChatOptions = {},
 ): AsyncGenerator<SSEEvent> {
-  const sessionId = opts.sessionId ?? 'unknown'
+  // Use a stable fallback UUID when no sessionId is provided so that pending
+  // flags from concurrent anonymous callers (tests, future direct callers)
+  // don't collide under a shared key. Production callers (AgentCore) always
+  // pass a real session id derived from the wallet.
+  const sessionId = opts.sessionId ?? randomUUID()
   const externalQueue: SSESentinelPause[] = []
   let externalWake: (() => void) | null = null
   const baseExecutor = opts.toolExecutor ?? executeTool

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -51,6 +51,7 @@ import { streamPiAgent } from './pi/stream-bridge.js'
 import { attachToolGuard } from './pi/tool-guard.js'
 import { runPreflightGate, type AdvisoryInfo } from './sentinel/preflight-gate.js'
 import { getSentinelConfig } from './sentinel/config.js'
+import { createPending } from './sentinel/pending.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // System prompt — Sipher's identity and behavior rules
@@ -142,14 +143,22 @@ const TOOL_EXECUTORS: Record<string, ToolExecutor> = {
  * Runs preflight gate for fund-moving tools before dispatching.
  * Throws if the tool name is not registered or SENTINEL blocks.
  *
- * `onAdvisory` is invoked synchronously (before the underlying executor) when
- * SENTINEL flagged the action without blocking AND mode === 'advisory'. The
- * callback is optional — existing callers compile unchanged.
+ * `onPause` is awaited (before the underlying executor) when SENTINEL flagged
+ * the action without blocking AND mode === 'advisory'. The callback's promise
+ * represents the user-driven approve/cancel decision:
+ *   - resolves → continue and run the tool
+ *   - rejects  → return a synthetic `{ status: 'cancelled_by_user', reason }`
+ *                result instead of running the tool. Pi treats this as the
+ *                tool's output; the LLM then communicates cancellation to the
+ *                user per its system prompt.
+ *
+ * The callback is optional — existing 2-arg callers compile unchanged and
+ * silently skip the pause (the tool runs as if no advisory existed).
  */
 export async function executeTool(
   name: string,
   input: Record<string, unknown>,
-  onAdvisory?: (info: AdvisoryInfo) => void,
+  onPause?: (info: AdvisoryInfo) => Promise<void>,
 ): Promise<unknown> {
   const executor = TOOL_EXECUTORS[name]
   if (!executor) {
@@ -160,8 +169,18 @@ export async function executeTool(
   if (!gate.allowed) {
     throw new Error(`SENTINEL blocked: ${gate.reasons.join('; ')}`)
   }
-  if (gate.advisory && onAdvisory && getSentinelConfig().mode === 'advisory') {
-    onAdvisory(gate.advisory)
+  if (gate.advisory && onPause && getSentinelConfig().mode === 'advisory') {
+    try {
+      await onPause(gate.advisory)
+    } catch (err) {
+      // User cancelled or the pending promise timed out — return a synthetic
+      // tool result so Pi's tool loop continues instead of throwing. The LLM
+      // sees this output and reports cancellation gracefully to the user.
+      return {
+        status: 'cancelled_by_user',
+        reason: err instanceof Error ? err.message : 'cancelled',
+      }
+    }
   }
   return executor(input)
 }
@@ -215,8 +234,10 @@ export interface SSEError {
   message: string
 }
 
-export interface SSESentinelAdvisory {
-  type: 'sentinel_advisory'
+export interface SSESentinelPause {
+  type: 'sentinel_pause'
+  /** Server-issued ID — client posts to /api/sentinel/override/:flagId or /cancel/:flagId */
+  flagId: string
   /** Humanized action label, e.g. "Send to Abc...123" */
   action: string
   /** Optional amount string, e.g. "5 SOL" — empty when not applicable */
@@ -233,7 +254,7 @@ export type SSEEvent =
   | SSEToolResult
   | SSEMessageComplete
   | SSEError
-  | SSESentinelAdvisory
+  | SSESentinelPause
 
 // ─── Local helpers — humanize advisory metadata for the UI ──────────────────
 
@@ -331,33 +352,54 @@ export async function chat(
  * Pi's push-based event model to a pull-based async generator of SSEEvents
  * compatible with AgentCore's SSEEvent vocabulary.
  *
- * SENTINEL advisories: When the default executor (`executeTool`) is in use
- * and SENTINEL flagged the action without blocking, the advisory is captured
- * via the optional `onAdvisory` callback and emitted as a `sentinel_advisory`
- * SSE event immediately before the corresponding `tool_result`. Custom
- * `opts.toolExecutor` overrides bypass advisory capture (no preflight gate).
+ * SENTINEL pause/resume: When the default executor (`executeTool`) is in use
+ * and SENTINEL flagged the action without blocking, a pending flag is created
+ * (sentinel/pending.ts) and a `sentinel_pause` SSE event is injected into the
+ * stream-bridge's external queue. The executor awaits the pending promise
+ * until the user POSTs to `/api/sentinel/override/:flagId` (resume) or
+ * `/cancel/:flagId` (cancel). Cancellation is surfaced as a synthetic
+ * `{ status: 'cancelled_by_user' }` tool result; the LLM reports it back.
+ *
+ * The pause event MUST go through streamPiAgent's external queue (not a
+ * chatStream-local buffer) — the wrapped executor blocks Pi between
+ * `tool_execution_start` and `tool_execution_end`, so any local drain pattern
+ * keyed on `tool_result` deadlocks: client never sees pause → never approves
+ * → executor blocks forever → bridge yields nothing. The external queue lets
+ * the bridge emit pause events while the executor is still mid-await.
+ *
+ * Custom `opts.toolExecutor` overrides bypass pause capture (no preflight gate).
  */
 export async function* chatStream(
   userMessage: string,
   opts: ChatOptions = {},
 ): AsyncGenerator<SSEEvent> {
-  const advisoryQueue: SSESentinelAdvisory[] = []
+  const sessionId = opts.sessionId ?? 'unknown'
+  const externalQueue: SSESentinelPause[] = []
+  let externalWake: (() => void) | null = null
   const baseExecutor = opts.toolExecutor ?? executeTool
 
-  // Wrap the executor so advisory callbacks are routed into a per-request queue.
-  // We keep the wrapper signature `(name, input) => Promise` to match the Pi
-  // executor contract and pass our internal `onAdvisory` only to the default
-  // `executeTool`. Custom executors are invoked unchanged.
+  // Wrap the executor so SENTINEL advisory pauses are captured and routed
+  // through the stream-bridge's external queue. We keep the wrapper signature
+  // `(name, input) => Promise` to match the Pi executor contract and only
+  // intercept calls that route through the default `executeTool`. Custom
+  // executors are invoked unchanged.
   const wrappedExecutor = (name: string, input: Record<string, unknown>): Promise<unknown> => {
     if (baseExecutor === executeTool) {
-      return executeTool(name, input, (adv) => {
-        advisoryQueue.push({
-          type: 'sentinel_advisory',
+      return executeTool(name, input, async (adv) => {
+        const { flagId, promise } = createPending(sessionId, name, input)
+        externalQueue.push({
+          type: 'sentinel_pause',
+          flagId,
           action: humanizeAction(name, input),
           amount: extractAmount(input),
           severity: adv.severity,
           description: adv.description,
         })
+        // Wake the bridge so it drains externalQueue immediately. Without this
+        // the pause event would sit until Pi emitted another event — which
+        // can't happen because Pi is blocked on this awaiting executor.
+        if (externalWake) externalWake()
+        await promise
       })
     }
     return baseExecutor(name, input)
@@ -372,15 +414,12 @@ export async function* chatStream(
     sessionId: opts.sessionId,
   })
 
-  // Drain the advisory queue before each tool_result so the client renders the
-  // warning alongside the tool's outcome. Advisories are populated synchronously
-  // inside executeTool (which Pi awaits between tool_use and tool_result), so by
-  // the time tool_result arrives the queue holds the matching advisory(ies).
-  for await (const event of streamPiAgent(agent, userMessage)) {
-    if (event.type === 'tool_result' && advisoryQueue.length > 0) {
-      const drained = advisoryQueue.splice(0, advisoryQueue.length)
-      for (const adv of drained) yield adv
-    }
+  for await (const event of streamPiAgent<SSESentinelPause>(agent, userMessage, {
+    externalQueue,
+    attachWake: (wake) => {
+      externalWake = wake
+    },
+  })) {
     yield event
   }
 }

--- a/packages/agent/src/core/agent-core.ts
+++ b/packages/agent/src/core/agent-core.ts
@@ -172,10 +172,11 @@ export class AgentCore {
           }
           break
 
-        case 'sentinel_advisory':
+        case 'sentinel_pause':
           yield {
-            type: 'sentinel_advisory',
-            advisory: {
+            type: 'sentinel_pause',
+            pause: {
+              flagId: event.flagId,
               action: event.action,
               amount: event.amount,
               severity: event.severity,

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -30,13 +30,14 @@ export interface MsgContext {
 
 /** A single response chunk for streaming */
 export interface ResponseChunk {
-  type: 'text' | 'tool_start' | 'tool_end' | 'error' | 'done' | 'sentinel_advisory'
+  type: 'text' | 'tool_start' | 'tool_end' | 'error' | 'done' | 'sentinel_pause'
   text?: string
   toolName?: string
   toolId?: string
   success?: boolean
-  /** Populated only when type === 'sentinel_advisory' */
-  advisory?: {
+  /** Populated only when type === 'sentinel_pause' */
+  pause?: {
+    flagId: string
     action: string
     amount: string
     severity: string

--- a/packages/agent/src/pi/stream-bridge.ts
+++ b/packages/agent/src/pi/stream-bridge.ts
@@ -96,6 +96,31 @@ export function mapPiEventToSSE(event: AgentEvent): SSEEvent[] {
 }
 
 /**
+ * Optional injection points for external producers (e.g. the chatStream
+ * sentinel pause loop) that need to interleave events into the bridge's
+ * output stream WITHOUT waiting for a Pi event to arrive.
+ *
+ * Why this exists: when a tool executor blocks on a user-driven approval
+ * (sentinel pause), the executor is awaited inside Pi's tool loop — Pi
+ * can't emit events until the executor returns. Without this hook the
+ * pause notification can't reach the SSE client until tool_execution_end,
+ * which deadlocks the system (client never sees pause → never approves →
+ * executor never resolves).
+ *
+ * The chatStream wrapper pushes pause events onto `externalQueue` and
+ * calls the wake function (received via `attachWake`) to make the
+ * generator drain its queues.
+ *
+ * Generic `T` lets callers extend the yielded event union with their own
+ * variants (e.g. SSESentinelPause from agent.ts) without forcing this
+ * module to import them.
+ */
+export interface StreamBridgeOptions<T = SSEEvent> {
+  externalQueue?: Array<T>
+  attachWake?: (wake: () => void) => void
+}
+
+/**
  * Wrap a Pi Agent run as an async generator of SSEEvents.
  *
  * The agent must have its tools, model, and system prompt configured before
@@ -108,12 +133,18 @@ export function mapPiEventToSSE(event: AgentEvent): SSEEvent[] {
  * - They are enqueued and a pending Promise is resolved to wake the generator
  * - The generator yields from the queue and waits when empty
  * - Cleanup via unsubscribe() in finally, regardless of early return or throw
+ *
+ * Optional `options.externalQueue` + `options.attachWake` allow callers to
+ * inject events from outside the Pi event stream (used by chatStream's
+ * sentinel pause loop — see chatStream in agent.ts).
  */
-export async function* streamPiAgent(
+export async function* streamPiAgent<T = SSEEvent>(
   agent: Agent,
   userMessage: string,
-): AsyncGenerator<SSEEvent, void, unknown> {
+  options?: StreamBridgeOptions<T>,
+): AsyncGenerator<SSEEvent | T, void, unknown> {
   const queue: SSEEvent[] = []
+  const externalQueue: Array<T> = options?.externalQueue ?? []
   let resolveNext: (() => void) | null = null
   let done = false
   let errorEvent: SSEError | null = null
@@ -124,6 +155,10 @@ export async function* streamPiAgent(
       resolveNext = null
     }
   }
+
+  // Hand the wake function back to the caller so external producers can push
+  // into externalQueue and trigger a drain.
+  if (options?.attachWake) options.attachWake(wake)
 
   const guardUnsub = attachToolGuard(agent)
 
@@ -158,7 +193,13 @@ export async function* streamPiAgent(
   })
 
   try {
-    while (!done || queue.length > 0) {
+    while (!done || queue.length > 0 || externalQueue.length > 0) {
+      // Drain externally-injected events first so pause notifications reach
+      // the client BEFORE the corresponding tool_result.
+      while (externalQueue.length > 0) {
+        const evt = externalQueue.shift()
+        if (evt) yield evt
+      }
       while (queue.length > 0) {
         const evt = queue.shift()
         if (evt) yield evt

--- a/packages/agent/src/routes/sentinel-api.ts
+++ b/packages/agent/src/routes/sentinel-api.ts
@@ -97,6 +97,10 @@ sentinelAdminRouter.get('/decisions', (req: Request, res: Response) => {
   res.json({ decisions: listDecisions({ limit, source }) })
 })
 
+// ─── Promise-gate endpoints (pause/resume for advisory mode) ────────────────
+// NOTE: distinct from /pending/:id/cancel above (circuit-breaker, SQLite-backed).
+// These act on in-memory pending promises owned by sentinel/pending.ts.
+
 sentinelAdminRouter.post('/override/:flagId', (req: Request, res: Response) => {
   const flagId = String(req.params.flagId)
   const ok = resolvePending(flagId)

--- a/packages/agent/src/routes/sentinel-api.ts
+++ b/packages/agent/src/routes/sentinel-api.ts
@@ -6,6 +6,7 @@ import {
 import { cancelCircuitBreakerAction } from '../sentinel/circuit-breaker.js'
 import { getSentinelAssessor } from '../sentinel/preflight-gate.js'
 import { getSentinelConfig } from '../sentinel/config.js'
+import { resolvePending, rejectPending } from '../sentinel/pending.js'
 
 // ─── Public endpoints (verifyJwt only) ──────────────────────────────────────
 export const sentinelPublicRouter: Router = Router()
@@ -94,6 +95,26 @@ sentinelAdminRouter.get('/decisions', (req: Request, res: Response) => {
   const limit = Number(String(req.query.limit ?? '50'))
   const source = (typeof req.query.source === 'string' ? req.query.source : undefined)
   res.json({ decisions: listDecisions({ limit, source }) })
+})
+
+sentinelAdminRouter.post('/override/:flagId', (req: Request, res: Response) => {
+  const flagId = String(req.params.flagId)
+  const ok = resolvePending(flagId)
+  if (!ok) {
+    res.status(404).json({ error: { code: 'NOT_FOUND', message: 'flag not found or expired' } })
+    return
+  }
+  res.status(204).send()
+})
+
+sentinelAdminRouter.post('/cancel/:flagId', (req: Request, res: Response) => {
+  const flagId = String(req.params.flagId)
+  const ok = rejectPending(flagId, 'cancelled_by_user')
+  if (!ok) {
+    res.status(404).json({ error: { code: 'NOT_FOUND', message: 'flag not found or expired' } })
+    return
+  }
+  res.status(204).send()
 })
 
 // ─── Combined router (backwards compatibility) ──────────────────────────────

--- a/packages/agent/src/sentinel/pending.ts
+++ b/packages/agent/src/sentinel/pending.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto'
 
-interface PendingFlag {
+export interface PendingFlag {
   sessionId: string
   toolName: string
   toolInput: unknown

--- a/packages/agent/src/sentinel/pending.ts
+++ b/packages/agent/src/sentinel/pending.ts
@@ -1,0 +1,80 @@
+import { randomUUID } from 'crypto'
+
+interface PendingFlag {
+  sessionId: string
+  toolName: string
+  toolInput: unknown
+  createdAt: number
+  resolver: (value: void) => void
+  rejecter: (reason: Error) => void
+  timeoutHandle: NodeJS.Timeout
+}
+
+let TIMEOUT_MS = 120_000
+const pending = new Map<string, PendingFlag>()
+
+export function _setTimeoutMsForTests(ms: number): void {
+  TIMEOUT_MS = ms
+}
+
+export function createPending(
+  sessionId: string,
+  toolName: string,
+  toolInput: unknown,
+): { flagId: string; promise: Promise<void> } {
+  const flagId = randomUUID()
+  let resolver!: (value: void) => void
+  let rejecter!: (reason: Error) => void
+  const promise = new Promise<void>((resolve, reject) => {
+    resolver = resolve
+    rejecter = reject
+  })
+  const timeoutHandle = setTimeout(() => {
+    if (pending.has(flagId)) {
+      pending.delete(flagId)
+      rejecter(new Error('operation timed out'))
+    }
+  }, TIMEOUT_MS)
+  pending.set(flagId, {
+    sessionId,
+    toolName,
+    toolInput,
+    createdAt: Date.now(),
+    resolver,
+    rejecter,
+    timeoutHandle,
+  })
+  return { flagId, promise }
+}
+
+export function resolvePending(flagId: string): boolean {
+  const entry = pending.get(flagId)
+  if (!entry) return false
+  clearTimeout(entry.timeoutHandle)
+  pending.delete(flagId)
+  entry.resolver()
+  return true
+}
+
+export function rejectPending(flagId: string, reason: string): boolean {
+  const entry = pending.get(flagId)
+  if (!entry) return false
+  clearTimeout(entry.timeoutHandle)
+  pending.delete(flagId)
+  entry.rejecter(new Error(reason))
+  return true
+}
+
+export function clearAll(sessionId: string): void {
+  for (const [flagId, entry] of pending.entries()) {
+    if (entry.sessionId === sessionId) {
+      clearTimeout(entry.timeoutHandle)
+      pending.delete(flagId)
+      entry.rejecter(new Error('client_disconnected'))
+    }
+  }
+}
+
+export function getPending(flagId: string): PendingFlag | undefined {
+  return pending.get(flagId)
+}

--- a/packages/agent/tests/sentinel/pause-event.test.ts
+++ b/packages/agent/tests/sentinel/pause-event.test.ts
@@ -1,16 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 // ─────────────────────────────────────────────────────────────────────────────
-// SENTINEL advisory SSE event — covers the path:
-//   runPreflightGate → executeTool(onAdvisory) → chatStream(SSE injection)
+// SENTINEL pause SSE event — covers the path:
+//   runPreflightGate → executeTool(onPause) → chatStream(SSE injection)
 //
-// Two layers of test:
+// Three layers of test:
 //   1. runPreflightGate populates `advisory` for warn-recommendation reports
-//   2. executeTool fires the onAdvisory callback only in advisory mode
-//
-// We don't drive a full chatStream here — the queue/injection logic is
-// exercised by integration tests in pi-smoke. The new behavior we need to
-// prove is the gate change + callback wiring.
+//      (preflight gate behavior is unchanged from the advisory-light era —
+//      the gate still emits PreflightOutcome.advisory; only the downstream
+//      executor wiring changed)
+//   2. executeTool fires the onPause callback only in advisory mode and
+//      returns a synthetic cancelled result when onPause rejects
+//   3. chatStream injects sentinel_pause events with a flagId before
+//      tool_result, via the stream-bridge external queue
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('runPreflightGate advisory surface', () => {
@@ -90,7 +92,7 @@ describe('runPreflightGate advisory surface', () => {
   })
 })
 
-describe('executeTool onAdvisory callback', () => {
+describe('executeTool onPause callback', () => {
   beforeEach(() => {
     process.env.DB_PATH = ':memory:'
     vi.resetModules()
@@ -106,7 +108,7 @@ describe('executeTool onAdvisory callback', () => {
     getDb()
   }
 
-  it('fires onAdvisory when SENTINEL warns AND mode === advisory', async () => {
+  it('awaits onPause and continues to executor when promise resolves', async () => {
     await freshDb()
     process.env.SENTINEL_MODE = 'advisory'
     const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
@@ -119,30 +121,107 @@ describe('executeTool onAdvisory callback', () => {
       durationMs: 100,
     }) as never)
 
+    const executeSendMock = vi.fn().mockResolvedValue({ action: 'send', success: true })
     vi.doMock('../../src/tools/send.js', () => ({
-      executeSend: vi.fn().mockResolvedValue({ action: 'send', success: true }),
+      executeSend: executeSendMock,
       sendTool: { name: 'send', description: '', input_schema: { type: 'object', properties: {} } },
     }))
     const { executeTool } = await import('../../src/agent.js')
-    const onAdvisory = vi.fn()
+    const onPause = vi.fn().mockResolvedValue(undefined)
 
     const result = await executeTool(
       'send',
       { wallet: 'w1', recipient: 'stranger', amount: 5 },
-      onAdvisory,
+      onPause,
     )
 
-    expect(result).toMatchObject({ success: true })
-    expect(onAdvisory).toHaveBeenCalledTimes(1)
-    expect(onAdvisory).toHaveBeenCalledWith({
+    expect(onPause).toHaveBeenCalledTimes(1)
+    expect(onPause).toHaveBeenCalledWith({
       severity: 'medium',
       description: 'unknown recipient',
       recommendation: 'warn',
     })
+    expect(executeSendMock).toHaveBeenCalledTimes(1)
+    expect(result).toMatchObject({ success: true })
     vi.doUnmock('../../src/tools/send.js')
   })
 
-  it('does NOT fire onAdvisory when mode !== advisory (yolo allows silently)', async () => {
+  it('returns synthetic cancelled result (does NOT throw) when onPause rejects', async () => {
+    await freshDb()
+    process.env.SENTINEL_MODE = 'advisory'
+    const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(vi.fn().mockResolvedValue({
+      risk: 'medium',
+      score: 50,
+      reasons: ['unknown recipient'],
+      recommendation: 'warn',
+      decisionId: 'dec1',
+      durationMs: 100,
+    }) as never)
+
+    const executeSendMock = vi.fn().mockResolvedValue({ action: 'send', success: true })
+    vi.doMock('../../src/tools/send.js', () => ({
+      executeSend: executeSendMock,
+      sendTool: { name: 'send', description: '', input_schema: { type: 'object', properties: {} } },
+    }))
+    const { executeTool } = await import('../../src/agent.js')
+    const onPause = vi.fn().mockRejectedValue(new Error('cancelled_by_user'))
+
+    const result = await executeTool(
+      'send',
+      { wallet: 'w1', recipient: 'stranger', amount: 5 },
+      onPause,
+    )
+
+    expect(onPause).toHaveBeenCalledTimes(1)
+    // Synthetic cancelled tool result — Pi treats this as the tool's output,
+    // and the LLM communicates cancellation to the user.
+    expect(result).toEqual({
+      status: 'cancelled_by_user',
+      reason: 'cancelled_by_user',
+    })
+    // The underlying executor must NOT have run when the user cancelled.
+    expect(executeSendMock).not.toHaveBeenCalled()
+    vi.doUnmock('../../src/tools/send.js')
+  })
+
+  it('returns synthetic cancelled result when onPause rejects with non-Error reason', async () => {
+    await freshDb()
+    process.env.SENTINEL_MODE = 'advisory'
+    const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(vi.fn().mockResolvedValue({
+      risk: 'medium',
+      score: 50,
+      reasons: ['unknown recipient'],
+      recommendation: 'warn',
+      decisionId: 'dec1',
+      durationMs: 100,
+    }) as never)
+
+    const executeSendMock = vi.fn().mockResolvedValue({ action: 'send', success: true })
+    vi.doMock('../../src/tools/send.js', () => ({
+      executeSend: executeSendMock,
+      sendTool: { name: 'send', description: '', input_schema: { type: 'object', properties: {} } },
+    }))
+    const { executeTool } = await import('../../src/agent.js')
+    // Reject with a non-Error to cover the fallback branch in agent.ts
+    const onPause = vi.fn().mockRejectedValue('cancelled_str')
+
+    const result = await executeTool(
+      'send',
+      { wallet: 'w1', recipient: 'stranger', amount: 5 },
+      onPause,
+    )
+
+    expect(result).toEqual({
+      status: 'cancelled_by_user',
+      reason: 'cancelled',
+    })
+    expect(executeSendMock).not.toHaveBeenCalled()
+    vi.doUnmock('../../src/tools/send.js')
+  })
+
+  it('does NOT invoke onPause when mode !== advisory (yolo allows silently)', async () => {
     await freshDb()
     // SENTINEL_MODE unset → defaults to 'yolo'
     const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
@@ -160,19 +239,19 @@ describe('executeTool onAdvisory callback', () => {
       sendTool: { name: 'send', description: '', input_schema: { type: 'object', properties: {} } },
     }))
     const { executeTool } = await import('../../src/agent.js')
-    const onAdvisory = vi.fn()
+    const onPause = vi.fn().mockResolvedValue(undefined)
 
     await executeTool(
       'send',
       { wallet: 'w1', recipient: 'stranger', amount: 5 },
-      onAdvisory,
+      onPause,
     )
 
-    expect(onAdvisory).not.toHaveBeenCalled()
+    expect(onPause).not.toHaveBeenCalled()
     vi.doUnmock('../../src/tools/send.js')
   })
 
-  it('existing 2-arg callers still work (onAdvisory is optional)', async () => {
+  it('existing 2-arg callers still work (onPause is optional)', async () => {
     await freshDb()
     process.env.SENTINEL_MODE = 'advisory'
     const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
@@ -191,14 +270,14 @@ describe('executeTool onAdvisory callback', () => {
     }))
     const { executeTool } = await import('../../src/agent.js')
 
-    // No onAdvisory passed — must not throw
+    // No onPause passed — must not throw, and the executor runs normally.
     const result = await executeTool('send', { wallet: 'w1', recipient: 'stranger', amount: 5 })
     expect(result).toMatchObject({ success: true })
     vi.doUnmock('../../src/tools/send.js')
   })
 })
 
-describe('chatStream sentinel_advisory SSE injection', () => {
+describe('chatStream sentinel_pause SSE injection', () => {
   beforeEach(() => {
     process.env.DB_PATH = ':memory:'
     vi.resetModules()
@@ -214,7 +293,7 @@ describe('chatStream sentinel_advisory SSE injection', () => {
     getDb()
   }
 
-  it('injects sentinel_advisory event before tool_result in advisory mode', async () => {
+  it('injects sentinel_pause event before tool_result with flagId in advisory mode', async () => {
     await freshDb()
     process.env.SENTINEL_MODE = 'advisory'
 
@@ -228,10 +307,19 @@ describe('chatStream sentinel_advisory SSE injection', () => {
       durationMs: 100,
     }) as never)
 
+    // Force pending flags to time out fast so the executor unblocks within
+    // the test (synthetic cancelled result → tool_execution_end fires).
+    // 50ms is generous — tests don't need to wait on real users.
+    const { _setTimeoutMsForTests } = await import('../../src/sentinel/pending.js')
+    _setTimeoutMsForTests(50)
+
     // Stub Pi agent so we control event emission deterministically.
     // The fake agent invokes the toolExecutor (which is the chatStream-wrapped
-    // executor) between tool_execution_start and tool_execution_end so the
-    // advisory queue is populated before the tool_result event is yielded.
+    // executor) between tool_execution_start and tool_execution_end. The
+    // wrapped executor pushes the pause event onto streamPiAgent's external
+    // queue and awaits the pending promise. With the fast timeout above the
+    // promise rejects after ~50ms, the executor returns a synthetic cancelled
+    // result, and Pi proceeds to tool_execution_end.
     type Subscriber = (event: unknown) => void | Promise<void>
     vi.doMock('../../src/pi/sipher-agent.js', async (orig) => {
       const actual = (await orig()) as Record<string, unknown>
@@ -257,7 +345,7 @@ describe('chatStream sentinel_advisory SSE injection', () => {
               try {
                 await opts.toolExecutor('send', { wallet: 'w1', recipient: 'stranger', amount: 5 })
               } catch {
-                // executor throws if tools/send.js isn't mocked — keep going so we still emit end
+                // executor may throw if tools/send.js isn't mocked — keep going so we still emit end
               }
               for (const cb of [...subscribers]) {
                 await cb({
@@ -291,28 +379,34 @@ describe('chatStream sentinel_advisory SSE injection', () => {
     }
 
     const types = events.map((e) => e.type)
-    expect(types).toContain('sentinel_advisory')
+    expect(types).toContain('sentinel_pause')
 
-    const advisoryIdx = types.indexOf('sentinel_advisory')
+    const pauseIdx = types.indexOf('sentinel_pause')
     const toolResultIdx = types.indexOf('tool_result')
     const toolUseIdx = types.indexOf('tool_use')
 
-    // Order must be: tool_use → sentinel_advisory → tool_result
-    expect(toolUseIdx).toBeLessThan(advisoryIdx)
-    expect(advisoryIdx).toBeLessThan(toolResultIdx)
+    // Order must be: tool_use → sentinel_pause → tool_result
+    expect(toolUseIdx).toBeGreaterThanOrEqual(0)
+    expect(pauseIdx).toBeGreaterThan(toolUseIdx)
+    expect(toolResultIdx).toBeGreaterThan(pauseIdx)
 
-    const advisory = events[advisoryIdx] as {
+    const pause = events[pauseIdx] as {
       type: string
+      flagId: string
       action: string
       amount: string
       severity: string
       description: string
     }
-    expect(advisory.severity).toBe('high')
-    expect(advisory.description).toBe('recipient flagged in recent activity')
-    expect(advisory.amount).toBe('5 SOL')
-    expect(advisory.action).toContain('Send to')
+    expect(pause.flagId).toBeTypeOf('string')
+    expect(pause.flagId.length).toBeGreaterThan(0)
+    expect(pause.severity).toBe('high')
+    expect(pause.description).toBe('recipient flagged in recent activity')
+    expect(pause.amount).toBe('5 SOL')
+    expect(pause.action).toContain('Send to')
 
+    // Reset timeout for any other tests that import the module
+    _setTimeoutMsForTests(120_000)
     vi.doUnmock('../../src/tools/send.js')
     vi.doUnmock('../../src/pi/sipher-agent.js')
   })

--- a/packages/agent/tests/sentinel/pause-resume-routes.test.ts
+++ b/packages/agent/tests/sentinel/pause-resume-routes.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import express from 'express'
+import supertest from 'supertest'
+import jwt from 'jsonwebtoken'
+import { createPending, clearAll } from '../../src/sentinel/pending.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ADMIN_WALLET = 'admin-wallet-test'
+const NON_ADMIN_WALLET = 'random-wallet-test'
+const TEST_JWT_SECRET = 'test-secret-for-sentinel-pause-tests'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function signJwt(wallet: string): string {
+  return jwt.sign({ wallet }, TEST_JWT_SECRET, { expiresIn: '1h', algorithm: 'HS256' })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Module imports (top-level await — Vitest ESM)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const { sentinelAdminRouter } = await import('../../src/routes/sentinel-api.js')
+const { verifyJwt, requireOwner } = await import('../../src/routes/auth.js')
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test setup
+// ─────────────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  process.env.NODE_ENV = 'test'
+  process.env.JWT_SECRET = TEST_JWT_SECRET
+  process.env.AUTHORIZED_WALLETS = ADMIN_WALLET
+  for (const s of ['test-session', 's1', 's2']) clearAll(s)
+})
+
+afterEach(() => {
+  delete process.env.JWT_SECRET
+  delete process.env.AUTHORIZED_WALLETS
+  for (const s of ['test-session', 's1', 's2']) clearAll(s)
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// App factory — mounts sentinelAdminRouter with full auth chain
+// ─────────────────────────────────────────────────────────────────────────────
+
+function createApp() {
+  const app = express()
+  app.use(express.json())
+  app.use('/api/sentinel', verifyJwt, requireOwner, sentinelAdminRouter)
+  return app
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('SENTINEL pause/resume routes', () => {
+  it('POST /api/sentinel/override/:flagId resolves the pending promise (204)', async () => {
+    const { flagId, promise } = createPending('test-session', 'send', { amount: 1 })
+    const res = await supertest(createApp())
+      .post(`/api/sentinel/override/${flagId}`)
+      .set('Authorization', `Bearer ${signJwt(ADMIN_WALLET)}`)
+    expect(res.status).toBe(204)
+    await expect(promise).resolves.toBeUndefined()
+  })
+
+  it('POST /api/sentinel/cancel/:flagId rejects the pending promise (204)', async () => {
+    const { flagId, promise } = createPending('test-session', 'send', { amount: 1 })
+    // attach noop catch before the HTTP call so Node doesn't flag the rejection as unhandled
+    // before our .rejects assertion consumes it
+    promise.catch(() => {})
+    const res = await supertest(createApp())
+      .post(`/api/sentinel/cancel/${flagId}`)
+      .set('Authorization', `Bearer ${signJwt(ADMIN_WALLET)}`)
+    expect(res.status).toBe(204)
+    await expect(promise).rejects.toThrow(/cancelled/i)
+  })
+
+  it('returns 404 for unknown flag id', async () => {
+    const res = await supertest(createApp())
+      .post('/api/sentinel/override/does-not-exist')
+      .set('Authorization', `Bearer ${signJwt(ADMIN_WALLET)}`)
+    expect(res.status).toBe(404)
+    expect(res.body.error.code).toBe('NOT_FOUND')
+  })
+
+  it('returns 403 for non-admin wallet', async () => {
+    // attach noop catch — afterEach clearAll rejects this promise, suppress the unhandled noise
+    const { flagId, promise } = createPending('test-session', 'send', { amount: 1 })
+    promise.catch(() => {})
+    const res = await supertest(createApp())
+      .post(`/api/sentinel/override/${flagId}`)
+      .set('Authorization', `Bearer ${signJwt(NON_ADMIN_WALLET)}`)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 401 with no Authorization header', async () => {
+    // attach noop catch — afterEach clearAll rejects this promise, suppress the unhandled noise
+    const { flagId, promise } = createPending('test-session', 'send', { amount: 1 })
+    promise.catch(() => {})
+    const res = await supertest(createApp()).post(`/api/sentinel/override/${flagId}`)
+    expect(res.status).toBe(401)
+  })
+})

--- a/packages/agent/tests/sentinel/pending.test.ts
+++ b/packages/agent/tests/sentinel/pending.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe('sentinel-pending', () => {
   beforeEach(() => {
-    clearAll('test-session')
+    for (const s of ['test-session', 's1', 's2']) clearAll(s)
     _setTimeoutMsForTests(120_000)
     vi.useRealTimers()
   })

--- a/packages/agent/tests/sentinel/pending.test.ts
+++ b/packages/agent/tests/sentinel/pending.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  createPending,
+  resolvePending,
+  rejectPending,
+  clearAll,
+  _setTimeoutMsForTests,
+} from '../../src/sentinel/pending.js'
+
+describe('sentinel-pending', () => {
+  beforeEach(() => {
+    clearAll('test-session')
+    _setTimeoutMsForTests(120_000)
+    vi.useRealTimers()
+  })
+
+  it('resolves the pending promise on resolvePending', async () => {
+    const { flagId, promise } = createPending('test-session', 'send', { amount: 1 })
+    setTimeout(() => resolvePending(flagId), 5)
+    await expect(promise).resolves.toBeUndefined()
+  })
+
+  it('rejects the pending promise on rejectPending', async () => {
+    const { flagId, promise } = createPending('test-session', 'send', { amount: 1 })
+    setTimeout(() => rejectPending(flagId, 'cancelled_by_user'), 5)
+    await expect(promise).rejects.toThrow('cancelled_by_user')
+  })
+
+  it('returns false for unknown flag id', () => {
+    expect(resolvePending('unknown-id')).toBe(false)
+    expect(rejectPending('unknown-id', 'x')).toBe(false)
+  })
+
+  it('rejects with timeout after configured duration', async () => {
+    _setTimeoutMsForTests(50)
+    const { promise } = createPending('test-session', 'send', { amount: 1 })
+    await expect(promise).rejects.toThrow(/timed out/i)
+  })
+
+  it('clearAll rejects all pending in the given session', async () => {
+    const a = createPending('s1', 'send', {})
+    const b = createPending('s1', 'swap', {})
+    const c = createPending('s2', 'send', {})
+    clearAll('s1')
+    await expect(a.promise).rejects.toThrow(/disconnected/i)
+    await expect(b.promise).rejects.toThrow(/disconnected/i)
+    setTimeout(() => resolvePending(c.flagId), 5)
+    await expect(c.promise).resolves.toBeUndefined()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@triton-one/yellowstone-grpc@4.0.2':
+    hash: 3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a
+    path: patches/@triton-one__yellowstone-grpc@4.0.2.patch
+
 importers:
 
   .:
@@ -9106,7 +9111,7 @@ snapshots:
       '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@triton-one/yellowstone-grpc': 4.0.2
+      '@triton-one/yellowstone-grpc': 4.0.2(patch_hash=3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a)
       langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))
       pino: 10.3.0
       zod: 4.3.6
@@ -9153,7 +9158,7 @@ snapshots:
       '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@triton-one/yellowstone-grpc': 4.0.2
+      '@triton-one/yellowstone-grpc': 4.0.2(patch_hash=3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a)
       langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))
       pino: 10.3.0
       zod: 4.3.6
@@ -11463,7 +11468,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@triton-one/yellowstone-grpc@4.0.2':
+  '@triton-one/yellowstone-grpc@4.0.2(patch_hash=3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a)':
     dependencies:
       '@grpc/grpc-js': 1.14.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,11 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-patchedDependencies:
-  '@triton-one/yellowstone-grpc@4.0.2':
-    hash: 3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a
-    path: patches/@triton-one__yellowstone-grpc@4.0.2.patch
-
 importers:
 
   .:
@@ -9111,7 +9106,7 @@ snapshots:
       '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@triton-one/yellowstone-grpc': 4.0.2(patch_hash=3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a)
+      '@triton-one/yellowstone-grpc': 4.0.2
       langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))
       pino: 10.3.0
       zod: 4.3.6
@@ -9158,7 +9153,7 @@ snapshots:
       '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@triton-one/yellowstone-grpc': 4.0.2(patch_hash=3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a)
+      '@triton-one/yellowstone-grpc': 4.0.2
       langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))
       pino: 10.3.0
       zod: 4.3.6
@@ -11468,7 +11463,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@triton-one/yellowstone-grpc@4.0.2(patch_hash=3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a)':
+  '@triton-one/yellowstone-grpc@4.0.2':
     dependencies:
       '@grpc/grpc-js': 1.14.3
 


### PR DESCRIPTION
## Summary

Replaces PR 1's light `sentinel_advisory` SSE wiring with full pause/resume that blocks tool execution until the user resolves via REST.

- New `sentinel-pending` in-memory flag store (`packages/agent/src/sentinel/pending.ts`) — 120s timeout + per-session `clearAll`
- New `POST /api/sentinel/override/:flagId` and `/cancel/:flagId` admin endpoints (`requireOwner`)
- Agent loop pauses tool execution when SENTINEL flags + `MODE=advisory`; resumes on override, returns synthetic `{status: 'cancelled_by_user'}` tool output on cancel/timeout
- New `SentinelConfirm` client component (variant=warning, override/cancel REST POSTs, error state, double-dispatch guard, disabled-button polish)
- ChatSidebar handles `sentinel_pause` SSE event and renders SentinelConfirm; `sentinel_advisory` removed from server emit and from client store union (post-final-review polish)
- Disconnect handler clears all pending flags for the session on SSE close (frees blocked executors instead of waiting for 120s timeout)
- E2E spec added (skipped pending sip-protocol/sip-protocol#1077)

**Architecture note:** the deadlock between drain-on-tool_result and pause-before-tool-runs is solved by injecting pause events into `streamPiAgent`'s internal queue (via new `externalQueue + attachWake` options) so the SSE generator yields them while the wrapped executor is awaiting the pending promise. See commit messages on the agent loop refactor for details.

**Stacked PR:** base `feat/phase-2-herald-vault` (PR #154). Will auto-retarget when ancestors merge.

Spec: `docs/superpowers/specs/2026-04-26-ui-gaps-design.md` (on branch `docs/phase-2-ui-gaps-spec`).
Plan: `docs/superpowers/plans/2026-04-26-phase-2-ui-gaps.md` (on same branch).

## Test plan

- [x] Vitest agent: `pnpm --filter @sipher/agent test -- --run` — 938 passing
- [x] Vitest app: `pnpm --filter @sipher/app test -- --run` — 45 passing
- [x] Workspace typecheck: `pnpm typecheck` — clean
- [x] **Manual UI smoke** (Chrome MCP, UI-isolation against Vite dev server) — see Smoke Results below
- [ ] **Backend integration smoke** (SENTINEL_MODE=advisory + real chat flow + disconnect→clearAll) — blocked by sip-protocol/sip-protocol#1077; covered by `pause-event.test.ts` integration tests with fake Pi agent

## Smoke Results (UI-isolation, 2026-04-27)

Driven via Chrome MCP against `app/` Vite dev server with `window.fetch` mocked + Zustand store directly hydrated with `sentinel_pause` messages. Backend was not started (#1077 blocks `tsx watch src/index.ts`).

| # | Scenario | Result |
|---|---|---|
| 1 | Card render — inject `sentinel_pause` message into store | ✅ "RISK CONFIRM" header, action+amount+description+buttons all visible |
| 2 | Override happy path | ✅ `POST /api/sentinel/override/<flagId>` with `Authorization: Bearer <token>` → message dismissed via `onResolved` |
| 3 | Cancel happy path | ✅ `POST /api/sentinel/cancel/<flagId>` with auth → message dismissed |
| 4 | Error 404 (server returns NOT_FOUND) | ✅ Inline "Action failed (404)" rendered → message stays visible (verifies the silent-success fix from commit `46e7541`) |
| 5 | Busy/double-dispatch | ✅ 3 button clicks → exactly 1 fetch fires; both buttons show `disabled=true` + `opacity: 0.5` (verifies polish from commit `7a57aa2`) |

Console clean across all scenarios.

**Coverage:** scenarios 1–5 exercise everything in this PR's client-side surface (SentinelConfirm + ChatSidebar wiring + store union). Server-side SSE emission, REST resolve/reject, and disconnect→clearAll are covered by the 938 vitest tests including `pause-event.test.ts` (block 3 asserts `tool_use → sentinel_pause → tool_result` ordering with flagId, using a fake Pi agent harness).

## Rollout

Behind existing `SENTINEL_MODE` env (default `advisory` in prod). For soft-launch: temporarily set `SENTINEL_MODE=yolo`, merge, observe logs, flip back.

## Known limitations carried forward

- `tool_use` SSE event missing `input` payload (pre-existing gap surfaced by PR 1 Task 12 — out of scope here)
- Playwright E2E currently RED due to sip-protocol/sip-protocol#1077 (SDK ESM bundle bug blocks agent startup; new spec is `test.skip`'d)
