### PR TITLE
fix(1077): patch yellowstone-grpc — unblocks tsx + Phase 2 stack

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,78 @@
+name: e2e
+
+on:
+  pull_request:
+    paths:
+      - 'app/**'
+      - 'packages/agent/**'
+      - 'src/**'
+      - 'e2e/**'
+      - 'playwright.config.ts'
+      - 'package.json'
+      - 'app/package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/e2e.yml'
+  push:
+    branches: [main]
+
+jobs:
+  component:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run app component tests
+        run: pnpm --filter @sipher/app test
+
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm exec playwright install --with-deps chromium
+
+      - name: Write E2E admin keypair
+        env:
+          E2E_ADMIN_KEYPAIR: ${{ secrets.E2E_ADMIN_KEYPAIR }}
+        run: |
+          mkdir -p e2e/fixtures
+          printf '%s' "$E2E_ADMIN_KEYPAIR" > e2e/fixtures/admin-keypair.json
+          chmod 600 e2e/fixtures/admin-keypair.json
+
+      - name: Run Playwright
+        env:
+          E2E_ADMIN_KEYPAIR_PATH: e2e/fixtures/admin-keypair.json
+          JWT_SECRET: ${{ secrets.E2E_JWT_SECRET }}
+        run: pnpm test:e2e
+
+      - if: failure() || cancelled()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,11 @@ data/
 !packages/**/src/data/
 .superpowers/
 .worktrees/
+
+# Playwright / RTL
+playwright-report/
+test-results/
+e2e/fixtures/admin-keypair.json
+e2e/fixtures/storageState.json
+e2e/test.db
+e2e/test.db-journal

--- a/README.md
+++ b/README.md
@@ -711,6 +711,34 @@ CI workflow auto-regenerates SDKs on spec changes (`.github/workflows/generate-s
 pnpm test -- --run
 ```
 
+## Running Tests
+
+### Backend + Agent (Vitest)
+
+```bash
+pnpm test -- --run                           # Root REST tests
+pnpm --filter @sipher/agent test -- --run    # Agent tests
+```
+
+### Frontend component tests (Vitest + RTL)
+
+```bash
+pnpm --filter @sipher/app test
+```
+
+### End-to-end (Playwright, Chromium)
+
+```bash
+pnpm exec playwright install chromium    # one-time browser install
+pnpm test:e2e                            # run all e2e specs
+pnpm test:e2e:ui                         # interactive UI mode
+pnpm test:e2e:headed                     # watch tests run in a visible browser
+```
+
+Playwright runs against the Vite dev server (port 5173) and the Sipher backend (port 3000), both spun up automatically via its `webServer` config. Admin flows use an ed25519-signed JWT minted at global-setup. Locally, this reads `~/Documents/secret/cipher-admin.json`; in CI, the `E2E_ADMIN_KEYPAIR` GitHub Secret supplies it.
+
+See [`docs/superpowers/specs/2026-04-18-test-infrastructure-design.md`](docs/superpowers/specs/2026-04-18-test-infrastructure-design.md) for architectural details.
+
 ---
 
 ## 🛠️ Tech Stack

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@phosphor-icons/react": "^2.1.10",
@@ -21,10 +23,15 @@
     "zustand": "^5.0.12"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "jsdom": "^25.0.1",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/app/src/components/ActivityEntry.tsx
+++ b/app/src/components/ActivityEntry.tsx
@@ -1,5 +1,6 @@
 import { AGENTS, type AgentName } from '../lib/agents'
 import { timeAgo } from '../lib/format'
+import EventIcon from './EventIcon'
 
 interface Action {
   label: string
@@ -8,14 +9,25 @@ interface Action {
 
 interface Props {
   agent: AgentName
+  type?: string
   title: string
   detail?: string
   time: string
   level: string
+  isLive?: boolean
   actions?: Action[]
 }
 
-export default function ActivityEntry({ agent, title, detail, time, level, actions }: Props) {
+export default function ActivityEntry({
+  agent,
+  type = '',
+  title,
+  detail,
+  time,
+  level,
+  isLive,
+  actions,
+}: Props) {
   const agentConfig = AGENTS[agent] ?? { name: agent.toUpperCase(), color: 'var(--color-text-muted)' }
   const isCritical = level === 'critical'
 
@@ -26,13 +38,9 @@ export default function ActivityEntry({ agent, title, detail, time, level, actio
         isCritical ? 'border-l-[3px] border-l-yellow' : '',
       ].join(' ')}
     >
-      {/* Top row: dot + agent name + time */}
       <div className="flex justify-between items-center">
         <div className="flex items-center gap-2">
-          <div
-            className="w-1.5 h-1.5 rounded-full shrink-0"
-            style={{ backgroundColor: agentConfig.color }}
-          />
+          <EventIcon type={type} color={agentConfig.color} live={isLive} />
           <span
             className="text-[11px] font-semibold tracking-widest uppercase"
             style={{ color: agentConfig.color }}
@@ -43,15 +51,12 @@ export default function ActivityEntry({ agent, title, detail, time, level, actio
         <span className="text-text-muted text-[11px]">{timeAgo(time)}</span>
       </div>
 
-      {/* Title */}
       <p className="text-[14px] text-text leading-snug">{title}</p>
 
-      {/* Detail — monospace, for TX hashes, metrics, etc. */}
       {detail && (
         <p className="text-[12px] text-text-muted font-mono break-all">{detail}</p>
       )}
 
-      {/* Actions */}
       {actions && actions.length > 0 && (
         <div className="flex flex-wrap gap-2 mt-1">
           {actions.map((action, i) => (

--- a/app/src/components/AdminOnly.tsx
+++ b/app/src/components/AdminOnly.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react'
+import { useIsAdmin } from '../hooks/useIsAdmin'
+
+interface Props {
+  children: ReactNode
+  fallback?: ReactNode
+}
+
+export default function AdminOnly({ children, fallback = null }: Props) {
+  return useIsAdmin() ? <>{children}</> : <>{fallback}</>
+}

--- a/app/src/components/AmountForm.tsx
+++ b/app/src/components/AmountForm.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react'
+
+interface Props {
+  action: string
+  max: number
+  onSubmit: (amount: number) => void
+  onCancel: () => void
+}
+
+export default function AmountForm({ action, max, onSubmit, onCancel }: Props) {
+  const [raw, setRaw] = useState('')
+  const parsed = Number(raw)
+  const valid = raw.length > 0 && Number.isFinite(parsed) && parsed > 0 && parsed <= max
+
+  return (
+    <div className="bg-card border border-elevated rounded-lg p-4 flex flex-col gap-3">
+      <div className="text-[12px] text-text-muted uppercase tracking-wide">{action} Amount</div>
+      <div className="flex items-center gap-2">
+        <input
+          type="number"
+          step="0.0001"
+          min={0}
+          max={max}
+          value={raw}
+          onChange={(e) => setRaw(e.target.value)}
+          className="flex-1 bg-elevated border border-border rounded-lg px-3 py-2 text-[14px] font-mono text-text focus:outline-none focus:border-accent/40"
+          placeholder="0.0"
+        />
+        <span className="text-[12px] font-mono text-text-muted">SOL</span>
+      </div>
+      <div className="text-[10px] font-mono text-text-muted">Max: {max} SOL</div>
+      <div className="flex gap-2">
+        <button
+          onClick={() => valid && onSubmit(parsed)}
+          disabled={!valid}
+          className="flex-1 border border-sipher/50 text-sipher py-2 rounded-lg text-[12px] font-medium hover:bg-sipher/10 disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          Continue
+        </button>
+        <button
+          onClick={onCancel}
+          className="px-4 border border-elevated text-text-muted py-2 rounded-lg text-[12px] hover:text-text"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/ChatSidebar.tsx
+++ b/app/src/components/ChatSidebar.tsx
@@ -3,7 +3,7 @@ import { PaperPlaneTilt, CircleNotch, Wrench } from '@phosphor-icons/react'
 import { useAppStore, type ChatMessage } from '../stores/app'
 import { sanitizeArgs } from '../lib/sanitize-args'
 import ToolTimeline from './ToolTimeline'
-import ConfirmCard from './ConfirmCard'
+import SentinelConfirm from './SentinelConfirm'
 
 const API_URL = import.meta.env.VITE_API_URL ?? ''
 
@@ -91,13 +91,14 @@ export default function ChatSidebar({ fullScreen }: Props) {
             } else if (event.type === 'tool_result') {
               completeTool(event.name, event.is_error ? 'error' : 'success')
               setActiveTool(null)
-            } else if (event.type === 'sentinel_advisory') {
+            } else if (event.type === 'sentinel_pause') {
               addMessage({
                 id: crypto.randomUUID(),
                 role: 'system',
                 content: '',
-                kind: 'sentinel_advisory',
+                kind: 'sentinel_pause' as const,
                 meta: {
+                  flagId: event.flagId,
                   action: event.action,
                   amount: event.amount,
                   description: event.description,
@@ -149,18 +150,18 @@ export default function ChatSidebar({ fullScreen }: Props) {
           <p className="text-text-muted text-sm text-center py-8">Ask SIPHER anything about your privacy.</p>
         )}
         {messages.filter((m) => !m.dismissed).map((msg) => {
-          if (msg.role === 'system' && msg.kind === 'sentinel_advisory') {
-            const meta = (msg.meta ?? {}) as { action?: string; amount?: string; description?: string }
+          if (msg.role === 'system' && msg.kind === 'sentinel_pause' && token) {
+            const meta = (msg.meta ?? {}) as { flagId?: string; action?: string; amount?: string; description?: string }
             return (
               <div key={msg.id} className="flex justify-start">
                 <div className="max-w-[90%] w-full">
-                  <ConfirmCard
-                    variant="warning"
+                  <SentinelConfirm
+                    flagId={meta.flagId ?? ''}
+                    token={token}
                     action={meta.action ?? 'Action'}
                     amount={meta.amount ?? ''}
                     description={meta.description}
-                    onConfirm={() => sendMessage('Yes, proceed anyway')}
-                    onCancel={() => dismissMessage(msg.id)}
+                    onResolved={() => dismissMessage(msg.id)}
                   />
                 </div>
               </div>

--- a/app/src/components/ChatSidebar.tsx
+++ b/app/src/components/ChatSidebar.tsx
@@ -1,6 +1,9 @@
 import { useRef, useEffect, useState, useCallback } from 'react'
 import { PaperPlaneTilt, CircleNotch, Wrench } from '@phosphor-icons/react'
 import { useAppStore, type ChatMessage } from '../stores/app'
+import { sanitizeArgs } from '../lib/sanitize-args'
+import ToolTimeline from './ToolTimeline'
+import ConfirmCard from './ConfirmCard'
 
 const API_URL = import.meta.env.VITE_API_URL ?? ''
 
@@ -16,6 +19,10 @@ export default function ChatSidebar({ fullScreen }: Props) {
   const appendToLast = useAppStore((s) => s.appendToLast)
   const finishStreaming = useAppStore((s) => s.finishStreaming)
   const setChatLoading = useAppStore((s) => s.setChatLoading)
+  const appendTool = useAppStore((s) => s.appendTool)
+  const completeTool = useAppStore((s) => s.completeTool)
+  const dismissMessage = useAppStore((s) => s.dismissMessage)
+  const consumePendingPrompt = useAppStore((s) => s.consumePendingPrompt)
 
   const [input, setInput] = useState('')
   const [activeTool, setActiveTool] = useState<string | null>(null)
@@ -26,20 +33,16 @@ export default function ChatSidebar({ fullScreen }: Props) {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages, chatLoading])
 
-  const sendMessage = useCallback(async () => {
-    if (!input.trim() || !token || chatLoading) return
+  const sendMessage = useCallback(async (overrideText?: string) => {
+    const text = (overrideText ?? input).trim()
+    if (!text || !token || chatLoading) return
 
-    const userMsg: ChatMessage = {
-      id: crypto.randomUUID(),
-      role: 'user',
-      content: input.trim(),
-    }
+    const userMsg: ChatMessage = { id: crypto.randomUUID(), role: 'user', content: text }
     addMessage(userMsg)
     setInput('')
     setChatLoading(true)
     setActiveTool(null)
 
-    // Create assistant placeholder
     const assistantMsg: ChatMessage = {
       id: crypto.randomUUID(),
       role: 'assistant',
@@ -49,17 +52,10 @@ export default function ChatSidebar({ fullScreen }: Props) {
     addMessage(assistantMsg)
 
     try {
-      const allMessages = [...messages, userMsg].map((m) => ({
-        role: m.role,
-        content: m.content,
-      }))
-
+      const allMessages = [...messages, userMsg].map((m) => ({ role: m.role, content: m.content }))
       const res = await fetch(`${API_URL}/api/chat/stream`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({ messages: allMessages }),
       })
 
@@ -67,7 +63,6 @@ export default function ChatSidebar({ fullScreen }: Props) {
         const err = await res.json().catch(() => ({}))
         throw new Error((err as { error?: string }).error ?? `Error ${res.status}`)
       }
-
       if (!res.body) throw new Error('No response body')
 
       const reader = res.body.getReader()
@@ -77,7 +72,6 @@ export default function ChatSidebar({ fullScreen }: Props) {
       while (true) {
         const { done, value } = await reader.read()
         if (done) break
-
         buffer += decoder.decode(value, { stream: true })
         const lines = buffer.split('\n')
         buffer = lines.pop() ?? ''
@@ -92,9 +86,24 @@ export default function ChatSidebar({ fullScreen }: Props) {
             if (event.type === 'content_block_delta' && event.text) {
               appendToLast(event.text)
             } else if (event.type === 'tool_use') {
+              appendTool(event.name, sanitizeArgs(event.input))
               setActiveTool(event.name)
             } else if (event.type === 'tool_result') {
+              completeTool(event.name, event.is_error ? 'error' : 'success')
               setActiveTool(null)
+            } else if (event.type === 'sentinel_advisory') {
+              addMessage({
+                id: crypto.randomUUID(),
+                role: 'system',
+                content: '',
+                kind: 'sentinel_advisory',
+                meta: {
+                  action: event.action,
+                  amount: event.amount,
+                  description: event.description,
+                  severity: event.severity,
+                },
+              })
             } else if (event.type === 'error') {
               appendToLast(`\n\nError: ${event.message}`)
             }
@@ -111,15 +120,16 @@ export default function ChatSidebar({ fullScreen }: Props) {
       setChatLoading(false)
       setActiveTool(null)
     }
-  }, [input, token, chatLoading, messages, addMessage, appendToLast, finishStreaming, setChatLoading])
+  }, [input, token, chatLoading, messages, addMessage, appendToLast, finishStreaming, setChatLoading, appendTool, completeTool])
+
+  // Consume seedChat prompt on mount/change
+  useEffect(() => {
+    const p = consumePendingPrompt()
+    if (p && token) sendMessage(p)
+  }, [consumePendingPrompt, sendMessage, token])
 
   return (
-    <div
-      className={`flex flex-col bg-card ${
-        fullScreen ? 'h-full' : 'h-full w-full'
-      }`}
-    >
-      {/* Header */}
+    <div className={`flex flex-col bg-card ${fullScreen ? 'h-full' : 'h-full w-full'}`}>
       <div className="flex items-center gap-2 px-4 py-3 border-b border-border shrink-0">
         <div className="w-1.5 h-1.5 rounded-full bg-sipher" />
         <span className="text-[13px] font-semibold text-text">SIPHER</span>
@@ -134,33 +144,48 @@ export default function ChatSidebar({ fullScreen }: Props) {
         )}
       </div>
 
-      {/* Messages */}
       <div className="flex-1 overflow-y-auto px-3 py-3 flex flex-col gap-2.5">
         {messages.length === 0 && (
-          <p className="text-text-muted text-sm text-center py-8">
-            Ask SIPHER anything about your privacy.
-          </p>
+          <p className="text-text-muted text-sm text-center py-8">Ask SIPHER anything about your privacy.</p>
         )}
-        {messages.map((msg) => (
-          <div
-            key={msg.id}
-            className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
-          >
-            <div
-              className={`max-w-[85%] rounded-lg px-3 py-2 text-[13px] leading-relaxed whitespace-pre-wrap break-words ${
-                msg.role === 'user'
-                  ? 'bg-accent/15 border border-accent/20 text-text'
-                  : 'bg-elevated border border-border text-text'
-              }`}
-            >
-              {msg.content || (msg.streaming ? '...' : '')}
+        {messages.filter((m) => !m.dismissed).map((msg) => {
+          if (msg.role === 'system' && msg.kind === 'sentinel_advisory') {
+            const meta = (msg.meta ?? {}) as { action?: string; amount?: string; description?: string }
+            return (
+              <div key={msg.id} className="flex justify-start">
+                <div className="max-w-[90%] w-full">
+                  <ConfirmCard
+                    variant="warning"
+                    action={meta.action ?? 'Action'}
+                    amount={meta.amount ?? ''}
+                    description={meta.description}
+                    onConfirm={() => sendMessage('Yes, proceed anyway')}
+                    onCancel={() => dismissMessage(msg.id)}
+                  />
+                </div>
+              </div>
+            )
+          }
+          return (
+            <div key={msg.id} className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}>
+              <div
+                className={`max-w-[85%] rounded-lg overflow-hidden text-[13px] leading-relaxed whitespace-pre-wrap break-words ${
+                  msg.role === 'user'
+                    ? 'bg-accent/15 border border-accent/20 text-text px-3 py-2'
+                    : 'bg-elevated border border-border text-text'
+                }`}
+              >
+                {msg.role === 'assistant' && <ToolTimeline tools={msg.tools} />}
+                <div className={msg.role === 'assistant' ? 'px-3 py-2' : ''}>
+                  {msg.content || (msg.streaming ? '...' : '')}
+                </div>
+              </div>
             </div>
-          </div>
-        ))}
+          )
+        })}
         <div ref={bottomRef} />
       </div>
 
-      {/* Input */}
       <div className="px-3 py-3 border-t border-border shrink-0">
         <div className="flex gap-2">
           <input
@@ -178,7 +203,7 @@ export default function ChatSidebar({ fullScreen }: Props) {
             disabled={!token || chatLoading}
           />
           <button
-            onClick={sendMessage}
+            onClick={() => sendMessage()}
             disabled={!input.trim() || !token || chatLoading}
             className="bg-accent/15 border border-accent/20 rounded-lg px-3 py-2 text-accent hover:bg-accent/25 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             aria-label="Send"

--- a/app/src/components/ConfirmCard.tsx
+++ b/app/src/components/ConfirmCard.tsx
@@ -1,3 +1,5 @@
+import { Warning } from '@phosphor-icons/react'
+
 type Variant = 'normal' | 'warning'
 
 interface Props {
@@ -7,6 +9,7 @@ interface Props {
   onCancel: () => void
   variant?: Variant
   description?: string
+  // reserved for future countdown display; not currently consumed
   timeout?: number
 }
 
@@ -24,11 +27,14 @@ export default function ConfirmCard({
     ? 'border-yellow/50 text-yellow hover:bg-yellow/10'
     : 'border-sipher/50 text-sipher hover:bg-sipher/10'
   const primaryLabel = isWarning ? 'Override & Send' : 'Confirm & Sign'
-  const labelText = isWarning ? '⚠ Risk Confirm' : 'Confirm Action'
+  const labelText = isWarning ? 'Risk Confirm' : 'Confirm Action'
 
   return (
     <div className={`bg-card border ${borderClass} rounded-lg p-4 flex flex-col gap-3`}>
-      <div className="text-[12px] text-text-muted uppercase tracking-wide">{labelText}</div>
+      <div className="text-[12px] text-text-muted uppercase tracking-wide flex items-center gap-1">
+        {isWarning && <Warning size={12} weight="fill" className="text-yellow" aria-hidden="true" />}
+        <span>{labelText}</span>
+      </div>
       <div className="text-[14px] text-text">{action}: {amount}</div>
       {description && (
         <div className="text-[12px] text-text-muted leading-relaxed">{description}</div>

--- a/app/src/components/ConfirmCard.tsx
+++ b/app/src/components/ConfirmCard.tsx
@@ -1,20 +1,44 @@
-export default function ConfirmCard({ action, amount, onConfirm, onCancel, timeout = 120 }: {
+type Variant = 'normal' | 'warning'
+
+interface Props {
   action: string
   amount: string
   onConfirm: () => void
   onCancel: () => void
+  variant?: Variant
+  description?: string
   timeout?: number
-}) {
+}
+
+export default function ConfirmCard({
+  action,
+  amount,
+  onConfirm,
+  onCancel,
+  variant = 'normal',
+  description,
+}: Props) {
+  const isWarning = variant === 'warning'
+  const borderClass = isWarning ? 'border-yellow/40' : 'border-elevated'
+  const primaryClass = isWarning
+    ? 'border-yellow/50 text-yellow hover:bg-yellow/10'
+    : 'border-sipher/50 text-sipher hover:bg-sipher/10'
+  const primaryLabel = isWarning ? 'Override & Send' : 'Confirm & Sign'
+  const labelText = isWarning ? '⚠ Risk Confirm' : 'Confirm Action'
+
   return (
-    <div className="bg-card border border-elevated rounded-lg p-4 flex flex-col gap-3">
-      <div className="text-[12px] text-text-muted uppercase tracking-wide">Confirm Action</div>
+    <div className={`bg-card border ${borderClass} rounded-lg p-4 flex flex-col gap-3`}>
+      <div className="text-[12px] text-text-muted uppercase tracking-wide">{labelText}</div>
       <div className="text-[14px] text-text">{action}: {amount}</div>
+      {description && (
+        <div className="text-[12px] text-text-muted leading-relaxed">{description}</div>
+      )}
       <div className="flex gap-2">
         <button
           onClick={onConfirm}
-          className="flex-1 border border-sipher/50 text-sipher py-2 rounded-lg text-[12px] font-medium hover:bg-sipher/10"
+          className={`flex-1 border ${primaryClass} py-2 rounded-lg text-[12px] font-medium`}
         >
-          Confirm & Sign
+          {primaryLabel}
         </button>
         <button
           onClick={onCancel}

--- a/app/src/components/ConfirmCard.tsx
+++ b/app/src/components/ConfirmCard.tsx
@@ -9,6 +9,8 @@ interface Props {
   onCancel: () => void
   variant?: Variant
   description?: string
+  // disables both buttons (e.g. while a parent dispatches a REST call)
+  disabled?: boolean
   // reserved for future countdown display; not currently consumed
   timeout?: number
 }
@@ -20,6 +22,7 @@ export default function ConfirmCard({
   onCancel,
   variant = 'normal',
   description,
+  disabled = false,
 }: Props) {
   const isWarning = variant === 'warning'
   const borderClass = isWarning ? 'border-yellow/40' : 'border-elevated'
@@ -42,13 +45,15 @@ export default function ConfirmCard({
       <div className="flex gap-2">
         <button
           onClick={onConfirm}
-          className={`flex-1 border ${primaryClass} py-2 rounded-lg text-[12px] font-medium`}
+          disabled={disabled}
+          className={`flex-1 border ${primaryClass} py-2 rounded-lg text-[12px] font-medium disabled:opacity-50 disabled:cursor-not-allowed`}
         >
           {primaryLabel}
         </button>
         <button
           onClick={onCancel}
-          className="px-4 border border-elevated text-text-muted py-2 rounded-lg text-[12px] hover:text-text"
+          disabled={disabled}
+          className="px-4 border border-elevated text-text-muted py-2 rounded-lg text-[12px] hover:text-text disabled:opacity-50 disabled:cursor-not-allowed"
         >
           Cancel
         </button>

--- a/app/src/components/EventIcon.tsx
+++ b/app/src/components/EventIcon.tsx
@@ -1,0 +1,17 @@
+import { resolveEventIcon } from '../lib/event-icons'
+
+interface Props {
+  type: string
+  color: string
+  live?: boolean
+  size?: number
+}
+
+export default function EventIcon({ type, color, live = false, size = 14 }: Props) {
+  const Icon = resolveEventIcon(type)
+  return (
+    <span className={`inline-flex shrink-0 ${live ? 'animate-pulse' : ''}`}>
+      <Icon size={size} color={color} weight="fill" />
+    </span>
+  )
+}

--- a/app/src/components/MetricCard.tsx
+++ b/app/src/components/MetricCard.tsx
@@ -1,16 +1,48 @@
 import type { ReactNode } from 'react'
 
+export interface Factor {
+  label: string
+  score: number
+}
+
 interface Props {
   label: string
   value: string
   sub?: string
   icon: ReactNode
   color?: string
+  variant?: 'normal' | 'hero'
+  factors?: Factor[]
+  onClick?: () => void
 }
 
-export default function MetricCard({ label, value, sub, icon, color }: Props) {
+function factorColor(score: number): string {
+  if (score >= 80) return '#22c55e'
+  if (score >= 60) return '#84cc16'
+  if (score >= 40) return '#facc15'
+  return '#fb923c'
+}
+
+export default function MetricCard({
+  label,
+  value,
+  sub,
+  icon,
+  color,
+  variant = 'normal',
+  factors,
+  onClick,
+}: Props) {
+  const isHero = variant === 'hero'
+  const valueSize = isHero ? 'text-[32px]' : 'text-[22px]'
+
   return (
-    <div className="bg-card border border-border rounded-lg p-4 flex flex-col gap-2">
+    <div
+      className={`bg-card border border-border rounded-lg p-4 flex flex-col gap-2 ${
+        onClick ? 'cursor-pointer hover:border-elevated transition-colors' : ''
+      }`}
+      onClick={onClick}
+    >
       <div className="flex items-center justify-between">
         <span className="text-[10px] font-semibold text-text-muted tracking-widest uppercase">
           {label}
@@ -19,13 +51,29 @@ export default function MetricCard({ label, value, sub, icon, color }: Props) {
       </div>
       <div className="flex items-baseline gap-2">
         <span
-          className="text-[22px] font-mono font-bold leading-none"
+          className={`${valueSize} font-mono font-bold leading-none`}
           style={color ? { color } : undefined}
         >
           {value}
         </span>
         {sub && <span className="text-[11px] font-mono text-text-muted">{sub}</span>}
       </div>
+      {isHero && factors && factors.length > 0 && (
+        <div className="border-t border-elevated/40 mt-2 pt-3 flex flex-col gap-1.5">
+          {factors.map((f) => (
+            <div key={f.label} className="flex items-center gap-2 text-[10px] font-mono text-text-muted">
+              <span className="flex-1 truncate">{f.label}</span>
+              <span className="w-10 h-[3px] bg-elevated rounded-full overflow-hidden">
+                <span
+                  className="block h-full rounded-full"
+                  style={{ width: `${Math.min(f.score, 100)}%`, backgroundColor: factorColor(f.score) }}
+                />
+              </span>
+              <span className="w-6 text-right">{f.score}</span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/app/src/components/SentinelConfirm.tsx
+++ b/app/src/components/SentinelConfirm.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react'
+import ConfirmCard from './ConfirmCard'
+
+const API_URL = import.meta.env.VITE_API_URL ?? ''
+
+interface Props {
+  flagId: string
+  token: string
+  action: string
+  amount: string
+  description?: string
+  onResolved: (decision: 'override' | 'cancel') => void
+}
+
+export default function SentinelConfirm({ flagId, token, action, amount, description, onResolved }: Props) {
+  const [busy, setBusy] = useState(false)
+
+  const dispatch = async (kind: 'override' | 'cancel') => {
+    if (busy) return
+    setBusy(true)
+    try {
+      await fetch(`${API_URL}/api/sentinel/${kind}/${flagId}`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      onResolved(kind)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <ConfirmCard
+      variant="warning"
+      action={action}
+      amount={amount}
+      description={description}
+      onConfirm={() => dispatch('override')}
+      onCancel={() => dispatch('cancel')}
+    />
+  )
+}

--- a/app/src/components/SentinelConfirm.tsx
+++ b/app/src/components/SentinelConfirm.tsx
@@ -5,6 +5,7 @@ const API_URL = import.meta.env.VITE_API_URL ?? ''
 
 interface Props {
   flagId: string
+  /** Owner JWT — endpoints require requireOwner middleware on the server. */
   token: string
   action: string
   amount: string
@@ -14,29 +15,42 @@ interface Props {
 
 export default function SentinelConfirm({ flagId, token, action, amount, description, onResolved }: Props) {
   const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const dispatch = async (kind: 'override' | 'cancel') => {
     if (busy) return
     setBusy(true)
+    setError(null)
+    let success = false
     try {
-      await fetch(`${API_URL}/api/sentinel/${kind}/${flagId}`, {
+      const res = await fetch(`${API_URL}/api/sentinel/${kind}/${encodeURIComponent(flagId)}`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
       })
-      onResolved(kind)
+      if (!res.ok) {
+        setError(`Action failed (${res.status})`)
+        return
+      }
+      success = true
+    } catch {
+      setError('Network error — try again')
     } finally {
       setBusy(false)
     }
+    if (success) onResolved(kind)
   }
 
   return (
-    <ConfirmCard
-      variant="warning"
-      action={action}
-      amount={amount}
-      description={description}
-      onConfirm={() => dispatch('override')}
-      onCancel={() => dispatch('cancel')}
-    />
+    <div className="flex flex-col gap-2">
+      <ConfirmCard
+        variant="warning"
+        action={action}
+        amount={amount}
+        description={description}
+        onConfirm={() => dispatch('override')}
+        onCancel={() => dispatch('cancel')}
+      />
+      {error && <div className="text-[12px] text-red px-1">{error}</div>}
+    </div>
   )
 }

--- a/app/src/components/SentinelConfirm.tsx
+++ b/app/src/components/SentinelConfirm.tsx
@@ -47,6 +47,7 @@ export default function SentinelConfirm({ flagId, token, action, amount, descrip
         action={action}
         amount={amount}
         description={description}
+        disabled={busy}
         onConfirm={() => dispatch('override')}
         onCancel={() => dispatch('cancel')}
       />

--- a/app/src/components/ToolTimeline.tsx
+++ b/app/src/components/ToolTimeline.tsx
@@ -1,0 +1,31 @@
+import { CircleNotch, CheckCircle, XCircle } from '@phosphor-icons/react'
+import type { ToolCall } from '../stores/app'
+
+interface Props {
+  tools?: ToolCall[]
+}
+
+function StatusIcon({ status }: { status: ToolCall['status'] }) {
+  if (status === 'running') return <CircleNotch size={11} className="animate-spin text-text-muted" />
+  if (status === 'success') return <CheckCircle size={11} weight="fill" className="text-green" />
+  return <XCircle size={11} weight="fill" className="text-red" />
+}
+
+export default function ToolTimeline({ tools }: Props) {
+  if (!tools || tools.length === 0) return null
+
+  return (
+    <div className="border-b border-elevated/40 bg-elevated/20 px-3 py-2 flex flex-col gap-1.5">
+      {tools.map((t, i) => (
+        <div key={`${t.name}-${i}`} className="flex items-center gap-2 text-[10px] font-mono">
+          <StatusIcon status={t.status} />
+          <span className="text-blue font-semibold">{t.name}</span>
+          {t.args && <span className="text-text-muted truncate flex-1">{t.args}</span>}
+          {t.durationMs != null && (
+            <span className="text-text-muted ml-auto shrink-0">{t.durationMs}ms</span>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/app/src/components/__tests__/AdminOnly.test.tsx
+++ b/app/src/components/__tests__/AdminOnly.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { useAppStore } from '../../stores/app'
+import AdminOnly from '../AdminOnly'
+
+describe('AdminOnly', () => {
+  beforeEach(() => {
+    useAppStore.setState({ token: null, isAdmin: false, messages: [], chatLoading: false })
+  })
+
+  it('renders children when isAdmin is true', () => {
+    useAppStore.setState({ isAdmin: true })
+    render(<AdminOnly><div>secret</div></AdminOnly>)
+    expect(screen.getByText('secret')).toBeInTheDocument()
+  })
+
+  it('renders null by default when isAdmin is false', () => {
+    useAppStore.setState({ isAdmin: false })
+    const { container } = render(<AdminOnly><div>secret</div></AdminOnly>)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders fallback when isAdmin is false and fallback provided', () => {
+    useAppStore.setState({ isAdmin: false })
+    render(<AdminOnly fallback={<div>upgrade</div>}><div>secret</div></AdminOnly>)
+    expect(screen.queryByText('secret')).not.toBeInTheDocument()
+    expect(screen.getByText('upgrade')).toBeInTheDocument()
+  })
+})

--- a/app/src/components/__tests__/AmountForm.test.tsx
+++ b/app/src/components/__tests__/AmountForm.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AmountForm from '../AmountForm'
+
+describe('AmountForm', () => {
+  it('renders inputs and buttons', () => {
+    render(<AmountForm action="Deposit" max={5} onSubmit={() => {}} onCancel={() => {}} />)
+    expect(screen.getByRole('spinbutton')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /continue/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('disables Continue when amount is zero or negative', () => {
+    render(<AmountForm action="Deposit" max={5} onSubmit={() => {}} onCancel={() => {}} />)
+    expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled()
+  })
+
+  it('disables Continue when amount exceeds max', async () => {
+    render(<AmountForm action="Deposit" max={5} onSubmit={() => {}} onCancel={() => {}} />)
+    await userEvent.type(screen.getByRole('spinbutton'), '10')
+    expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled()
+  })
+
+  it('calls onSubmit with parsed amount', async () => {
+    const onSubmit = vi.fn()
+    render(<AmountForm action="Deposit" max={5} onSubmit={onSubmit} onCancel={() => {}} />)
+    await userEvent.type(screen.getByRole('spinbutton'), '1.5')
+    await userEvent.click(screen.getByRole('button', { name: /continue/i }))
+    expect(onSubmit).toHaveBeenCalledWith(1.5)
+  })
+
+  it('calls onCancel', async () => {
+    const onCancel = vi.fn()
+    render(<AmountForm action="Deposit" max={5} onSubmit={() => {}} onCancel={onCancel} />)
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onCancel).toHaveBeenCalled()
+  })
+})

--- a/app/src/components/__tests__/ChatSidebar.test.tsx
+++ b/app/src/components/__tests__/ChatSidebar.test.tsx
@@ -36,6 +36,31 @@ describe('ChatSidebar', () => {
     expect(input).toBeEnabled()
   })
 
+  it('renders SentinelConfirm card when a sentinel_pause message is in the store', () => {
+    useAppStore.setState({
+      token: 'test-jwt',
+      isAdmin: true,
+      messages: [
+        {
+          id: 'm1',
+          role: 'system',
+          content: '',
+          kind: 'sentinel_pause',
+          meta: {
+            flagId: 'flag-123',
+            action: 'Send',
+            amount: '5 SOL',
+            description: 'Risk: blacklisted address',
+            severity: 'high',
+          },
+        },
+      ],
+    })
+    render(<ChatSidebar />)
+    expect(screen.getByText(/blacklisted address/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /override & send/i })).toBeInTheDocument()
+  })
+
   it('sends message and appends streamed reply', async () => {
     useAppStore.setState({ token: 'test-jwt', isAdmin: true })
 

--- a/app/src/components/__tests__/ChatSidebar.test.tsx
+++ b/app/src/components/__tests__/ChatSidebar.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { useAppStore } from '../../stores/app'
+import ChatSidebar from '../ChatSidebar'
+
+function resetStore() {
+  useAppStore.setState({
+    token: null,
+    isAdmin: false,
+    messages: [],
+    chatLoading: false,
+    chatOpen: false,
+    activeView: 'dashboard',
+  })
+}
+
+describe('ChatSidebar', () => {
+  beforeEach(() => {
+    resetStore()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows connect-wallet placeholder and disables input when unauthenticated', () => {
+    render(<ChatSidebar />)
+    const input = screen.getByPlaceholderText('Connect wallet first')
+    expect(input).toBeDisabled()
+  })
+
+  it('enables input when authenticated', () => {
+    useAppStore.setState({ token: 'test-jwt', isAdmin: true })
+    render(<ChatSidebar />)
+    const input = screen.getByPlaceholderText('Message SIPHER...')
+    expect(input).toBeEnabled()
+  })
+
+  it('sends message and appends streamed reply', async () => {
+    useAppStore.setState({ token: 'test-jwt', isAdmin: true })
+
+    const encoder = new TextEncoder()
+    const sseBody = new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode('data: {"type":"content_block_delta","text":"Hi"}\n\n')
+        )
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+        controller.close()
+      },
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(sseBody, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        })
+      )
+    )
+
+    render(<ChatSidebar />)
+    const input = screen.getByPlaceholderText('Message SIPHER...') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Hi')).toBeInTheDocument()
+    })
+  })
+})

--- a/app/src/components/__tests__/ConfirmCard.test.tsx
+++ b/app/src/components/__tests__/ConfirmCard.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ConfirmCard from '../ConfirmCard'
+
+describe('ConfirmCard', () => {
+  it('renders normal variant with action and amount', () => {
+    render(
+      <ConfirmCard action="Send" amount="1.5 SOL" onConfirm={() => {}} onCancel={() => {}} />
+    )
+    expect(screen.getByText(/Send.*1\.5 SOL/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /confirm & sign/i })).toBeInTheDocument()
+  })
+
+  it('renders warning variant with description and Override button', () => {
+    render(
+      <ConfirmCard
+        variant="warning"
+        action="Send"
+        amount="5 SOL"
+        description="Address has 2 high-risk signals"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    )
+    expect(screen.getByText(/2 high-risk signals/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /override & send/i })).toBeInTheDocument()
+  })
+
+  it('fires onConfirm and onCancel callbacks', async () => {
+    const onConfirm = vi.fn()
+    const onCancel = vi.fn()
+    render(
+      <ConfirmCard action="Send" amount="1 SOL" onConfirm={onConfirm} onCancel={onCancel} />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /confirm & sign/i }))
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onConfirm).toHaveBeenCalledOnce()
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+})

--- a/app/src/components/__tests__/EventIcon.test.tsx
+++ b/app/src/components/__tests__/EventIcon.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import EventIcon from '../EventIcon'
+
+describe('EventIcon', () => {
+  it('renders an icon by event type', () => {
+    const { container } = render(<EventIcon type="deposit" color="#10B981" />)
+    const svg = container.querySelector('svg')
+    expect(svg).toBeInTheDocument()
+  })
+
+  it('applies pulse animation when live=true', () => {
+    const { container } = render(<EventIcon type="deposit" color="#10B981" live />)
+    expect(container.firstChild).toHaveClass('animate-pulse')
+  })
+
+  it('does not pulse when live=false', () => {
+    const { container } = render(<EventIcon type="deposit" color="#10B981" />)
+    expect(container.firstChild).not.toHaveClass('animate-pulse')
+  })
+
+  it('falls back to a circle icon for unknown event types', () => {
+    const { container } = render(<EventIcon type="bogus" color="#10B981" />)
+    expect(container.querySelector('svg')).toBeInTheDocument()
+  })
+})

--- a/app/src/components/__tests__/MetricCard.test.tsx
+++ b/app/src/components/__tests__/MetricCard.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Wallet } from '@phosphor-icons/react'
+import MetricCard from '../MetricCard'
+
+describe('MetricCard', () => {
+  it('renders normal variant by default', () => {
+    render(<MetricCard label="SOL" value="2.45" sub="SOL" icon={<Wallet />} />)
+    // label and sub both read "SOL" — both must be present
+    expect(screen.getAllByText('SOL')).toHaveLength(2)
+    expect(screen.getByText('2.45')).toBeInTheDocument()
+  })
+
+  it('renders factor bars in hero variant', () => {
+    render(
+      <MetricCard
+        variant="hero"
+        label="Privacy Score"
+        value="78"
+        sub="/100"
+        icon={<Wallet />}
+        factors={[
+          { label: 'Address reuse', score: 85 },
+          { label: 'Amount patterns', score: 72 },
+          { label: 'Timing', score: 68 },
+          { label: 'Counterparty exposure', score: 90 },
+        ]}
+      />
+    )
+    expect(screen.getByText('Address reuse')).toBeInTheDocument()
+    expect(screen.getByText('Counterparty exposure')).toBeInTheDocument()
+  })
+
+  it('does not render factor section when factors undefined', () => {
+    render(<MetricCard variant="hero" label="X" value="1" icon={<Wallet />} />)
+    expect(screen.queryByText('Address reuse')).not.toBeInTheDocument()
+  })
+})

--- a/app/src/components/__tests__/SentinelConfirm.test.tsx
+++ b/app/src/components/__tests__/SentinelConfirm.test.tsx
@@ -62,4 +62,43 @@ describe('SentinelConfirm', () => {
     )
     expect(onResolved).toHaveBeenCalledWith('cancel')
   })
+
+  it('prevents double-dispatch when busy', async () => {
+    // never resolves so busy stays true
+    global.fetch = vi.fn().mockImplementation(() => new Promise(() => {})) as typeof fetch
+    const onResolved = vi.fn()
+    render(
+      <SentinelConfirm
+        flagId="abc"
+        token="t"
+        action="Send"
+        amount="5 SOL"
+        description="x"
+        onResolved={onResolved}
+      />
+    )
+    const btn = screen.getByRole('button', { name: /override & send/i })
+    await userEvent.click(btn)
+    await userEvent.click(btn)
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    expect(onResolved).not.toHaveBeenCalled()
+  })
+
+  it('surfaces error and does not resolve when fetch returns non-ok', async () => {
+    global.fetch = vi.fn().mockResolvedValue(new Response('{"error":"flag expired"}', { status: 404 })) as typeof fetch
+    const onResolved = vi.fn()
+    render(
+      <SentinelConfirm
+        flagId="abc"
+        token="t"
+        action="Send"
+        amount="5 SOL"
+        description="x"
+        onResolved={onResolved}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /override & send/i }))
+    expect(onResolved).not.toHaveBeenCalled()
+    expect(screen.getByText(/failed/i)).toBeInTheDocument()
+  })
 })

--- a/app/src/components/__tests__/SentinelConfirm.test.tsx
+++ b/app/src/components/__tests__/SentinelConfirm.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SentinelConfirm from '../SentinelConfirm'
+
+describe('SentinelConfirm', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 })) as typeof fetch
+  })
+
+  it('renders amber warning ConfirmCard with description', () => {
+    render(
+      <SentinelConfirm
+        flagId="abc"
+        token="t"
+        action="Send"
+        amount="5 SOL"
+        description="Risk: blacklisted address"
+        onResolved={() => {}}
+      />
+    )
+    expect(screen.getByText(/blacklisted address/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /override & send/i })).toBeInTheDocument()
+  })
+
+  it('POSTs to override endpoint on Override click', async () => {
+    const onResolved = vi.fn()
+    render(
+      <SentinelConfirm
+        flagId="abc"
+        token="t"
+        action="Send"
+        amount="5 SOL"
+        description="x"
+        onResolved={onResolved}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /override & send/i }))
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/sentinel/override/abc'),
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(onResolved).toHaveBeenCalledWith('override')
+  })
+
+  it('POSTs to cancel endpoint on Cancel click', async () => {
+    const onResolved = vi.fn()
+    render(
+      <SentinelConfirm
+        flagId="abc"
+        token="t"
+        action="Send"
+        amount="5 SOL"
+        description="x"
+        onResolved={onResolved}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/sentinel/cancel/abc'),
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(onResolved).toHaveBeenCalledWith('cancel')
+  })
+})

--- a/app/src/components/__tests__/ToolTimeline.test.tsx
+++ b/app/src/components/__tests__/ToolTimeline.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ToolTimeline from '../ToolTimeline'
+import type { ToolCall } from '../../stores/app'
+
+describe('ToolTimeline', () => {
+  it('renders nothing when tools is undefined', () => {
+    const { container } = render(<ToolTimeline tools={undefined} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when tools is empty array', () => {
+    const { container } = render(<ToolTimeline tools={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders single running tool', () => {
+    const tools: ToolCall[] = [
+      { name: 'privacyScore', args: 'wallet=FGSk...8WWr', startedAt: Date.now(), status: 'running' },
+    ]
+    render(<ToolTimeline tools={tools} />)
+    expect(screen.getByText('privacyScore')).toBeInTheDocument()
+    expect(screen.getByText(/wallet=FGSk\.\.\.8WWr/)).toBeInTheDocument()
+  })
+
+  it('renders completed tool with duration', () => {
+    const tools: ToolCall[] = [
+      { name: 'privacyScore', args: 'wallet=FGSk...8WWr', startedAt: 0, durationMs: 285, status: 'success' },
+    ]
+    render(<ToolTimeline tools={tools} />)
+    expect(screen.getByText(/285ms/)).toBeInTheDocument()
+  })
+
+  it('renders multi-tool timeline', () => {
+    const tools: ToolCall[] = [
+      { name: 'privacyScore', startedAt: 0, durationMs: 285, status: 'success' },
+      { name: 'history', startedAt: 0, durationMs: 120, status: 'success' },
+      { name: 'balance', startedAt: 0, durationMs: 45, status: 'error' },
+    ]
+    render(<ToolTimeline tools={tools} />)
+    expect(screen.getByText('privacyScore')).toBeInTheDocument()
+    expect(screen.getByText('history')).toBeInTheDocument()
+    expect(screen.getByText('balance')).toBeInTheDocument()
+  })
+})

--- a/app/src/lib/__tests__/event-icons.test.ts
+++ b/app/src/lib/__tests__/event-icons.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { ArrowDown, Circle, ShieldWarning, PaperPlaneTilt } from '@phosphor-icons/react'
+import { resolveEventIcon } from '../event-icons'
+
+describe('resolveEventIcon', () => {
+  it('matches exact event type', () => {
+    expect(resolveEventIcon('deposit')).toBe(ArrowDown)
+    expect(resolveEventIcon('send')).toBe(PaperPlaneTilt)
+  })
+
+  it('matches prefix.subtype patterns', () => {
+    expect(resolveEventIcon('deposit.success')).toBe(ArrowDown)
+    expect(resolveEventIcon('sentinel.flag')).toBe(ShieldWarning)
+    expect(resolveEventIcon('sentinel.flag.high')).toBe(ShieldWarning)
+  })
+
+  it('falls back to Circle for unknown types', () => {
+    expect(resolveEventIcon('unknown')).toBe(Circle)
+    expect(resolveEventIcon('')).toBe(Circle)
+  })
+})

--- a/app/src/lib/__tests__/sanitize-args.test.ts
+++ b/app/src/lib/__tests__/sanitize-args.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { sanitizeArgs } from '../sanitize-args'
+
+describe('sanitizeArgs', () => {
+  it('truncates long base58 strings to first-4-last-4', () => {
+    const out = sanitizeArgs({ wallet: 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr' })
+    expect(out).toBe('wallet=FGSk...BWWr')
+  })
+
+  it('redacts sensitive keys', () => {
+    const out = sanitizeArgs({
+      wallet: 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr',
+      privateKey: 'should-not-leak',
+      mnemonic: 'word1 word2 ...',
+    })
+    expect(out).not.toContain('should-not-leak')
+    expect(out).not.toContain('word1')
+    expect(out).toContain('wallet=FGSk...BWWr')
+  })
+
+  it('truncates short non-base58 strings to 40 chars', () => {
+    const out = sanitizeArgs({
+      message: 'a'.repeat(50),
+    })
+    expect(out).toBe(`message=${'a'.repeat(40)}…`)
+  })
+
+  it('passes through small numbers and booleans', () => {
+    const out = sanitizeArgs({ amount: 1.5, dryRun: true })
+    expect(out).toBe('amount=1.5, dryRun=true')
+  })
+
+  it('returns empty string for null/undefined input', () => {
+    expect(sanitizeArgs(null)).toBe('')
+    expect(sanitizeArgs(undefined)).toBe('')
+    expect(sanitizeArgs({})).toBe('')
+  })
+})

--- a/app/src/lib/event-icons.ts
+++ b/app/src/lib/event-icons.ts
@@ -1,0 +1,35 @@
+import {
+  ArrowDown,
+  ArrowUp,
+  PaperPlaneTilt,
+  ArrowsLeftRight,
+  DownloadSimple,
+  ArrowCounterClockwise,
+  Eye,
+  ShieldWarning,
+  Shield,
+  Megaphone,
+  Circle,
+} from '@phosphor-icons/react'
+import type { Icon } from '@phosphor-icons/react'
+
+export const EVENT_ICONS: Record<string, Icon> = {
+  deposit: ArrowDown,
+  withdraw: ArrowUp,
+  send: PaperPlaneTilt,
+  swap: ArrowsLeftRight,
+  claim: DownloadSimple,
+  refund: ArrowCounterClockwise,
+  scan: Eye,
+  'sentinel.flag': ShieldWarning,
+  'sentinel.block': Shield,
+  'herald.posted': Megaphone,
+}
+
+export function resolveEventIcon(type: string): Icon {
+  if (type in EVENT_ICONS) return EVENT_ICONS[type]
+  for (const key of Object.keys(EVENT_ICONS)) {
+    if (type.startsWith(key + '.')) return EVENT_ICONS[key]
+  }
+  return Circle
+}

--- a/app/src/lib/sanitize-args.ts
+++ b/app/src/lib/sanitize-args.ts
@@ -1,0 +1,25 @@
+const SENSITIVE_KEY = /private|secret|mnemonic|password|seed/i
+const BASE58_HEX = /^(?=.*\d)[A-Za-z0-9]{12,}$/
+const MAX_STRING = 40
+
+function shortenIdent(value: string): string {
+  return `${value.slice(0, 4)}...${value.slice(-4)}`
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === 'string') {
+    if (BASE58_HEX.test(value)) return shortenIdent(value)
+    return value.length > MAX_STRING ? value.slice(0, MAX_STRING) + '…' : value
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  return ''
+}
+
+export function sanitizeArgs(input: unknown): string {
+  if (!input || typeof input !== 'object') return ''
+  const entries = Object.entries(input as Record<string, unknown>)
+    .filter(([k]) => !SENSITIVE_KEY.test(k))
+    .map(([k, v]) => `${k}=${formatValue(v)}`)
+    .filter(s => !s.endsWith('='))
+  return entries.join(', ')
+}

--- a/app/src/setupTests.ts
+++ b/app/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest'

--- a/app/src/setupTests.ts
+++ b/app/src/setupTests.ts
@@ -1,1 +1,4 @@
 import '@testing-library/jest-dom/vitest'
+
+// jsdom does not implement layout APIs; stub scroll methods used in components
+window.HTMLElement.prototype.scrollIntoView = () => {}

--- a/app/src/stores/app.ts
+++ b/app/src/stores/app.ts
@@ -19,7 +19,7 @@ export interface ChatMessage {
   toolName?: string
   streaming?: boolean
   tools?: ToolCall[]
-  kind?: 'sentinel_advisory'
+  kind?: 'sentinel_advisory' | 'sentinel_pause'
   meta?: Record<string, unknown>
   dismissed?: boolean
 }

--- a/app/src/stores/app.ts
+++ b/app/src/stores/app.ts
@@ -19,7 +19,7 @@ export interface ChatMessage {
   toolName?: string
   streaming?: boolean
   tools?: ToolCall[]
-  kind?: 'sentinel_advisory' | 'sentinel_pause'
+  kind?: 'sentinel_pause'
   meta?: Record<string, unknown>
   dismissed?: boolean
 }

--- a/app/src/stores/app.ts
+++ b/app/src/stores/app.ts
@@ -2,42 +2,57 @@ import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 
 export type View = 'dashboard' | 'vault' | 'herald' | 'squad' | 'chat'
+export type ToolStatus = 'running' | 'success' | 'error'
+
+export interface ToolCall {
+  name: string
+  args?: string
+  startedAt: number
+  durationMs?: number
+  status: ToolStatus
+}
 
 export interface ChatMessage {
   id: string
-  role: 'user' | 'assistant'
+  role: 'user' | 'assistant' | 'system'
   content: string
   toolName?: string
   streaming?: boolean
+  tools?: ToolCall[]
+  kind?: 'sentinel_advisory'
+  meta?: Record<string, unknown>
+  dismissed?: boolean
 }
 
 interface AppState {
-  // Navigation
   activeView: View
   setActiveView: (view: View) => void
 
-  // Auth
   token: string | null
   isAdmin: boolean
   setAuth: (token: string, isAdmin: boolean) => void
   clearAuth: () => void
 
-  // Chat
   messages: ChatMessage[]
   chatLoading: boolean
   addMessage: (msg: ChatMessage) => void
   appendToLast: (text: string) => void
   finishStreaming: () => void
   setChatLoading: (loading: boolean) => void
+  appendTool: (name: string, args?: string) => void
+  completeTool: (name: string, status: ToolStatus) => void
+  dismissMessage: (id: string) => void
+  seedChat: (prompt: string) => void
 
-  // UI (tablet/mobile chat visibility)
   chatOpen: boolean
   setChatOpen: (open: boolean) => void
+  pendingPrompt: string | null
+  consumePendingPrompt: () => string | null
 }
 
 export const useAppStore = create<AppState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       activeView: 'dashboard',
       setActiveView: (activeView) => set({ activeView }),
 
@@ -68,9 +83,42 @@ export const useAppStore = create<AppState>()(
           return { messages: msgs }
         }),
       setChatLoading: (chatLoading) => set({ chatLoading }),
+      appendTool: (name, args) =>
+        set((s) => {
+          const msgs = [...s.messages]
+          const last = msgs[msgs.length - 1]
+          if (last?.role !== 'assistant') return { messages: msgs }
+          const tools = [...(last.tools ?? []), { name, args, startedAt: Date.now(), status: 'running' as ToolStatus }]
+          msgs[msgs.length - 1] = { ...last, tools }
+          return { messages: msgs }
+        }),
+      completeTool: (name, status) =>
+        set((s) => {
+          const msgs = [...s.messages]
+          const last = msgs[msgs.length - 1]
+          if (last?.role !== 'assistant' || !last.tools) return { messages: msgs }
+          const tools = last.tools.map((t) =>
+            t.name === name && t.status === 'running'
+              ? { ...t, durationMs: Date.now() - t.startedAt, status }
+              : t
+          )
+          msgs[msgs.length - 1] = { ...last, tools }
+          return { messages: msgs }
+        }),
+      dismissMessage: (id) =>
+        set((s) => ({
+          messages: s.messages.map((m) => (m.id === id ? { ...m, dismissed: true } : m)),
+        })),
+      seedChat: (prompt) => set({ chatOpen: true, pendingPrompt: prompt }),
 
       chatOpen: false,
       setChatOpen: (chatOpen) => set({ chatOpen }),
+      pendingPrompt: null,
+      consumePendingPrompt: () => {
+        const p = get().pendingPrompt
+        set({ pendingPrompt: null })
+        return p
+      },
     }),
     {
       name: 'sipher-auth',

--- a/app/src/stores/app.ts
+++ b/app/src/stores/app.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
 
 export type View = 'dashboard' | 'vault' | 'herald' | 'squad' | 'chat'
 
@@ -34,38 +35,47 @@ interface AppState {
   setChatOpen: (open: boolean) => void
 }
 
-export const useAppStore = create<AppState>((set) => ({
-  activeView: 'dashboard',
-  setActiveView: (activeView) => set({ activeView }),
+export const useAppStore = create<AppState>()(
+  persist(
+    (set) => ({
+      activeView: 'dashboard',
+      setActiveView: (activeView) => set({ activeView }),
 
-  token: null,
-  isAdmin: false,
-  setAuth: (token, isAdmin) => set({ token, isAdmin }),
-  clearAuth: () => set({ token: null, isAdmin: false, messages: [], activeView: 'dashboard' }),
+      token: null,
+      isAdmin: false,
+      setAuth: (token, isAdmin) => set({ token, isAdmin }),
+      clearAuth: () => set({ token: null, isAdmin: false, messages: [], activeView: 'dashboard' }),
 
-  messages: [],
-  chatLoading: false,
-  addMessage: (msg) => set((s) => ({ messages: [...s.messages, msg] })),
-  appendToLast: (text) =>
-    set((s) => {
-      const msgs = [...s.messages]
-      const last = msgs[msgs.length - 1]
-      if (last?.role === 'assistant') {
-        msgs[msgs.length - 1] = { ...last, content: last.content + text }
-      }
-      return { messages: msgs }
+      messages: [],
+      chatLoading: false,
+      addMessage: (msg) => set((s) => ({ messages: [...s.messages, msg] })),
+      appendToLast: (text) =>
+        set((s) => {
+          const msgs = [...s.messages]
+          const last = msgs[msgs.length - 1]
+          if (last?.role === 'assistant') {
+            msgs[msgs.length - 1] = { ...last, content: last.content + text }
+          }
+          return { messages: msgs }
+        }),
+      finishStreaming: () =>
+        set((s) => {
+          const msgs = [...s.messages]
+          const last = msgs[msgs.length - 1]
+          if (last?.streaming) {
+            msgs[msgs.length - 1] = { ...last, streaming: false }
+          }
+          return { messages: msgs }
+        }),
+      setChatLoading: (chatLoading) => set({ chatLoading }),
+
+      chatOpen: false,
+      setChatOpen: (chatOpen) => set({ chatOpen }),
     }),
-  finishStreaming: () =>
-    set((s) => {
-      const msgs = [...s.messages]
-      const last = msgs[msgs.length - 1]
-      if (last?.streaming) {
-        msgs[msgs.length - 1] = { ...last, streaming: false }
-      }
-      return { messages: msgs }
-    }),
-  setChatLoading: (chatLoading) => set({ chatLoading }),
-
-  chatOpen: false,
-  setChatOpen: (chatOpen) => set({ chatOpen }),
-}))
+    {
+      name: 'sipher-auth',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (s) => ({ token: s.token, isAdmin: s.isAdmin }),
+    }
+  )
+)

--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -74,34 +74,41 @@ export default function DashboardView({
   const [privacyData, setPrivacyData] = useState<PrivacyData | null>(null)
   const [privacyError, setPrivacyError] = useState<string | null>(null)
   const refreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const lastProcessedEventId = useRef<string | null>(null)
   const wallet = vault?.wallet
 
-  const fetchPrivacyScore = useCallback(async () => {
+  const fetchPrivacyScore = useCallback(async (signal?: AbortSignal) => {
     if (!wallet || !token) return
     try {
       const res = await fetch(`${import.meta.env.VITE_API_URL ?? ''}/v1/privacy/score`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({ address: wallet, limit: 100 }),
+        signal,
       })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const json = await res.json()
       setPrivacyData(json.data)
       setPrivacyError(null)
     } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') return
       setPrivacyError(err instanceof Error ? err.message : 'Failed to fetch privacy score')
     }
   }, [wallet, token])
 
   useEffect(() => {
-    if (wallet && token) fetchPrivacyScore()
+    if (!wallet || !token) return
+    const controller = new AbortController()
+    fetchPrivacyScore(controller.signal)
+    return () => controller.abort()
   }, [wallet, token, fetchPrivacyScore])
 
   useEffect(() => {
     if (!wallet || !token) return
     const fundMoverPattern = /^(send|swap|claim|refund|deposit)\.(success|completed)$/
     const recent = events.find((e) => fundMoverPattern.test(e.type ?? ''))
-    if (!recent) return
+    if (!recent || recent.id === lastProcessedEventId.current) return
+    lastProcessedEventId.current = recent.id
     if (refreshTimer.current) clearTimeout(refreshTimer.current)
     refreshTimer.current = setTimeout(() => fetchPrivacyScore(), 5000)
     return () => {

--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -8,6 +8,7 @@ import {
 import { apiFetch } from '../api/client'
 import { type ActivityEvent } from '../hooks/useSSE'
 import { useIsAdmin } from '../hooks/useIsAdmin'
+import AdminOnly from '../components/AdminOnly'
 import MetricCard from '../components/MetricCard'
 import ActivityEntry from '../components/ActivityEntry'
 import AgentDot from '../components/AgentDot'
@@ -120,14 +121,14 @@ export default function DashboardView({
           sub="total"
           icon={<ArrowDown size={16} />}
         />
-        {isAdmin && (
+        <AdminOnly>
           <MetricCard
             label="Budget"
             value={budgetSpent != null ? `$${budgetSpent.toFixed(0)}` : '—'}
             sub={budgetLimit != null ? `/ $${budgetLimit}` : ''}
             icon={<Lightning size={16} />}
           />
-        )}
+        </AdminOnly>
       </div>
 
       {/* Two columns: Activity + Agent Status */}
@@ -165,7 +166,7 @@ export default function DashboardView({
         </div>
 
         {/* Guardian Squad (admin only) */}
-        {isAdmin && (
+        <AdminOnly>
           <div>
             <h3 className="text-[10px] font-semibold text-text-muted tracking-widest uppercase mb-3 px-1">
               Guardian Squad
@@ -199,7 +200,7 @@ export default function DashboardView({
               </p>
             )}
           </div>
-        )}
+        </AdminOnly>
       </div>
     </div>
   )

--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   Wallet,
   ShieldCheck,
@@ -6,6 +6,7 @@ import {
   Lightning,
 } from '@phosphor-icons/react'
 import { apiFetch } from '../api/client'
+import { useAppStore } from '../stores/app'
 import { type ActivityEvent } from '../hooks/useSSE'
 import { useIsAdmin } from '../hooks/useIsAdmin'
 import AdminOnly from '../components/AdminOnly'
@@ -29,6 +30,14 @@ interface HealthData {
 
 interface HeraldBudget {
   budget: { spent: number; limit: number; percentage: number; gate: string }
+}
+
+interface PrivacyData {
+  score: number
+  grade: string
+  factors: Record<string, { score: number; detail: string }>
+  recommendations: string[]
+  transactionsAnalyzed: number
 }
 
 interface ActivityRecord {
@@ -57,10 +66,48 @@ export default function DashboardView({
   token: string | null
 }) {
   const isAdmin = useIsAdmin()
+  const seedChat = useAppStore((s) => s.seedChat)
   const [vault, setVault] = useState<VaultData | null>(null)
   const [health, setHealth] = useState<HealthData | null>(null)
   const [heraldBudget, setHeraldBudget] = useState<HeraldBudget | null>(null)
   const [history, setHistory] = useState<ActivityEvent[]>([])
+  const [privacyData, setPrivacyData] = useState<PrivacyData | null>(null)
+  const [privacyError, setPrivacyError] = useState<string | null>(null)
+  const refreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const wallet = vault?.wallet
+
+  const fetchPrivacyScore = useCallback(async () => {
+    if (!wallet || !token) return
+    try {
+      const res = await fetch(`${import.meta.env.VITE_API_URL ?? ''}/v1/privacy/score`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ address: wallet, limit: 100 }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const json = await res.json()
+      setPrivacyData(json.data)
+      setPrivacyError(null)
+    } catch (err) {
+      setPrivacyError(err instanceof Error ? err.message : 'Failed to fetch privacy score')
+    }
+  }, [wallet, token])
+
+  useEffect(() => {
+    if (wallet && token) fetchPrivacyScore()
+  }, [wallet, token, fetchPrivacyScore])
+
+  useEffect(() => {
+    if (!wallet || !token) return
+    const fundMoverPattern = /^(send|swap|claim|refund|deposit)\.(success|completed)$/
+    const recent = events.find((e) => fundMoverPattern.test(e.type ?? ''))
+    if (!recent) return
+    if (refreshTimer.current) clearTimeout(refreshTimer.current)
+    refreshTimer.current = setTimeout(() => fetchPrivacyScore(), 5000)
+    return () => {
+      if (refreshTimer.current) clearTimeout(refreshTimer.current)
+    }
+  }, [events, wallet, token, fetchPrivacyScore])
 
   useEffect(() => {
     if (!token) return
@@ -94,10 +141,6 @@ export default function DashboardView({
     ...history.map(e => ({ ...e, isLive: false })),
   ].slice(0, 30)
 
-  // Privacy score placeholder — computed by SIPHER agent tool, not a REST endpoint
-  const privacyScore = '—'
-  const scoreColor = undefined
-
   const budgetSpent = heraldBudget?.budget?.spent
   const budgetLimit = heraldBudget?.budget?.limit
 
@@ -111,13 +154,34 @@ export default function DashboardView({
           sub="SOL"
           icon={<Wallet size={16} />}
         />
-        <MetricCard
-          label="Privacy Score"
-          value={privacyScore}
-          sub="/100"
-          icon={<ShieldCheck size={16} />}
-          color={scoreColor}
-        />
+        {(() => {
+          const grade = privacyData?.grade
+          const colorByGrade: Record<string, string> = {
+            A: '#22c55e', B: '#84cc16', C: '#facc15', D: '#fb923c', F: '#ef4444',
+          }
+          const factors = privacyData
+            ? [
+                { label: 'Address reuse', score: privacyData.factors.addressReuse.score },
+                { label: 'Amount patterns', score: privacyData.factors.amountPatterns.score },
+                { label: 'Timing correlation', score: privacyData.factors.timingCorrelation.score },
+                { label: 'Counterparty exposure', score: privacyData.factors.counterpartyExposure.score },
+              ]
+            : undefined
+          return (
+            <div className="lg:col-span-2">
+              <MetricCard
+                variant="hero"
+                label={`Privacy Score${grade ? ` · ${grade}` : ''}`}
+                value={privacyData ? String(privacyData.score) : (privacyError ? '—' : '—')}
+                sub="/100"
+                icon={<ShieldCheck size={16} />}
+                color={grade ? colorByGrade[grade] : undefined}
+                factors={factors}
+                onClick={() => privacyData && seedChat(`Why is my privacy score ${privacyData.score}?`)}
+              />
+            </div>
+          )
+        })()}
         <MetricCard
           label="Deposits"
           value={depositCount.toString()}

--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -98,7 +98,7 @@ export default function DashboardView({
   const budgetLimit = heraldBudget?.budget?.limit
 
   return (
-    <div className="flex flex-col gap-6">
+    <div data-testid="dashboard-view" className="flex flex-col gap-6">
       {/* Metric cards */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
         <MetricCard

--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -89,7 +89,10 @@ export default function DashboardView({
 
   const solBalance = vault?.balances?.sol
   const depositCount = history.filter((e) => e.type?.includes('deposit')).length
-  const allEvents = [...events, ...history].slice(0, 30)
+  const allEvents = [
+    ...events.map(e => ({ ...e, isLive: true })),
+    ...history.map(e => ({ ...e, isLive: false })),
+  ].slice(0, 30)
 
   // Privacy score placeholder — computed by SIPHER agent tool, not a REST endpoint
   const privacyScore = '—'
@@ -151,6 +154,7 @@ export default function DashboardView({
                 <ActivityEntry
                   key={event.id}
                   agent={event.agent as AgentName}
+                  type={event.type}
                   title={
                     (event.data?.title as string) ??
                     (event.data?.message as string) ??
@@ -159,6 +163,7 @@ export default function DashboardView({
                   detail={event.data?.detail as string}
                   time={event.timestamp}
                   level={event.level}
+                  isLive={event.isLive}
                 />
               ))}
             </div>

--- a/app/src/views/HeraldView.tsx
+++ b/app/src/views/HeraldView.tsx
@@ -367,7 +367,7 @@ export default function HeraldView({ token }: { token: string | null }) {
   const budget = data?.budget ?? { spent: 0, limit: 150, gate: 'open', percentage: 0 }
 
   return (
-    <div className="flex flex-col h-full">
+    <div data-testid="herald-view" className="flex flex-col h-full">
       <BudgetBar budget={budget} />
       <SubTabs active={tab} onChange={setTab} />
 

--- a/app/src/views/HeraldView.tsx
+++ b/app/src/views/HeraldView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback } from 'react'
+import { Calendar, X as XIcon } from '@phosphor-icons/react'
 import { apiFetch } from '../api/client'
 import { timeAgo } from '../lib/format'
 
@@ -233,18 +234,44 @@ function ActivityTimeline({ entries }: { entries: ActivityEntry[] }) {
 function QueueTab({
   items,
   onAction,
+  onEditSave,
 }: {
   items: QueueItem[]
   onAction: (id: string, action: 'approve' | 'reject') => Promise<void>
+  onEditSave: (id: string, content: string) => Promise<void>
 }) {
   const [pending, setPending] = useState<Record<string, boolean>>({})
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editDraft, setEditDraft] = useState('')
+  const [saving, setSaving] = useState(false)
 
   const handleAction = async (id: string, action: 'approve' | 'reject') => {
-    setPending(p => ({ ...p, [id]: true }))
+    setPending((p) => ({ ...p, [id]: true }))
     try {
       await onAction(id, action)
     } finally {
-      setPending(p => ({ ...p, [id]: false }))
+      setPending((p) => ({ ...p, [id]: false }))
+    }
+  }
+
+  const beginEdit = (item: QueueItem) => {
+    setEditingId(item.id)
+    setEditDraft(item.content)
+  }
+
+  const cancelEdit = () => {
+    setEditingId(null)
+    setEditDraft('')
+  }
+
+  const saveEdit = async () => {
+    if (!editingId) return
+    setSaving(true)
+    try {
+      await onEditSave(editingId, editDraft.trim())
+      cancelEdit()
+    } finally {
+      setSaving(false)
     }
   }
 
@@ -256,38 +283,75 @@ function QueueTab({
 
   return (
     <div className="flex flex-col gap-3">
-      {items.map(item => (
-        <div key={item.id} className="bg-card border border-border rounded-lg p-4 flex flex-col gap-3">
-          <p className="text-sm text-text-secondary">{item.content}</p>
-          <div className="flex items-center gap-2 font-mono text-[10px] text-text-muted">
-            <span>📅</span>
-            <span>{item.scheduled_at ?? '—'}</span>
+      {items.map((item) => {
+        const isEditing = editingId === item.id
+        return (
+          <div key={item.id} className="bg-card border border-border rounded-lg p-4 flex flex-col gap-3">
+            {isEditing ? (
+              <>
+                <textarea
+                  className="bg-elevated border border-border rounded-lg px-3 py-2 text-[13px] text-text font-mono resize-none focus:outline-none focus:border-accent/40"
+                  rows={4}
+                  value={editDraft}
+                  maxLength={280}
+                  onChange={(e) => setEditDraft(e.target.value)}
+                />
+                <div className="flex justify-between items-center text-[10px] font-mono text-text-muted">
+                  <span>{editDraft.length}/280</span>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={saveEdit}
+                      disabled={saving || editDraft.trim().length === 0 || editDraft.length > 280}
+                      className="text-[11px] border border-green/40 text-green bg-green/10 px-3 py-1.5 rounded-lg font-medium hover:bg-green/20 disabled:opacity-50"
+                    >
+                      {saving ? 'Saving...' : 'Save'}
+                    </button>
+                    <button
+                      onClick={cancelEdit}
+                      disabled={saving}
+                      className="text-[11px] border border-border text-text-secondary bg-bg px-3 py-1.5 rounded-lg hover:bg-border disabled:opacity-50"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              </>
+            ) : (
+              <>
+                <p className="text-sm text-text-secondary">{item.content}</p>
+                <div className="flex items-center gap-2 font-mono text-[10px] text-text-muted">
+                  <Calendar size={11} className="text-text-muted" aria-hidden="true" />
+                  <span>{item.scheduled_at ?? '—'}</span>
+                </div>
+                <div className="flex gap-2 mt-1">
+                  <button
+                    onClick={() => handleAction(item.id, 'approve')}
+                    disabled={pending[item.id]}
+                    className="flex-1 text-[11px] border border-green/40 text-green bg-green/10 py-1.5 rounded-lg font-medium hover:bg-green/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {pending[item.id] ? '...' : 'Approve'}
+                  </button>
+                  <button
+                    onClick={() => beginEdit(item)}
+                    disabled={pending[item.id]}
+                    className="px-4 text-[11px] border border-border text-text-secondary bg-bg py-1.5 rounded-lg hover:bg-border transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => handleAction(item.id, 'reject')}
+                    disabled={pending[item.id]}
+                    className="px-3 border border-border text-text-muted bg-bg py-1.5 rounded-lg hover:text-red hover:border-red/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    aria-label="Reject"
+                  >
+                    <XIcon size={12} weight="bold" />
+                  </button>
+                </div>
+              </>
+            )}
           </div>
-          <div className="flex gap-2 mt-1">
-            <button
-              onClick={() => handleAction(item.id, 'approve')}
-              disabled={pending[item.id]}
-              className="flex-1 text-[11px] border border-green/40 text-green bg-green/10 py-1.5 rounded-lg font-medium hover:bg-green/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {pending[item.id] ? '...' : 'Approve'}
-            </button>
-            <button
-              disabled={pending[item.id]}
-              className="px-4 text-[11px] border border-border text-text-secondary bg-bg py-1.5 rounded-lg hover:bg-border transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              Edit
-            </button>
-            <button
-              onClick={() => handleAction(item.id, 'reject')}
-              disabled={pending[item.id]}
-              className="px-3 border border-border text-text-muted bg-bg py-1.5 rounded-lg hover:text-red hover:border-red/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              aria-label="Reject"
-            >
-              ✕
-            </button>
-          </div>
-        </div>
-      ))}
+        )
+      })}
     </div>
   )
 }
@@ -356,6 +420,15 @@ export default function HeraldView({ token }: { token: string | null }) {
     load()
   }
 
+  const handleEditSave = async (id: string, content: string) => {
+    await apiFetch(`/api/herald/queue/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ content }),
+      token: token!,
+    })
+    load()
+  }
+
   if (!token) {
     return (
       <div className="text-text-muted text-sm text-center py-20">
@@ -387,7 +460,7 @@ export default function HeraldView({ token }: { token: string | null }) {
         )}
 
         {data && tab === 'queue' && (
-          <QueueTab items={data.queue ?? []} onAction={handleApprove} />
+          <QueueTab items={data.queue ?? []} onAction={handleApprove} onEditSave={handleEditSave} />
         )}
 
         {data && tab === 'dms' && (

--- a/app/src/views/SquadView.tsx
+++ b/app/src/views/SquadView.tsx
@@ -239,7 +239,7 @@ export default function SquadView({ token }: { token: string | null }) {
   }
 
   return (
-    <div className="flex flex-col gap-6">
+    <div data-testid="squad-view" className="flex flex-col gap-6">
       {error && (
         <div className="text-text-muted text-xs font-mono bg-card border border-border rounded-lg px-3 py-2">
           Live data unavailable — {error}

--- a/app/src/views/VaultView.tsx
+++ b/app/src/views/VaultView.tsx
@@ -13,6 +13,9 @@ import {
   CheckCircle,
   Binoculars,
 } from '@phosphor-icons/react'
+import AmountForm from '../components/AmountForm'
+import ConfirmCard from '../components/ConfirmCard'
+import { useAppStore } from '../stores/app'
 
 interface TokenBalance {
   mint: string
@@ -32,6 +35,9 @@ interface ActivityRow {
   wallet?: string
   created_at: string
 }
+
+type VaultAction = 'deposit' | 'withdraw'
+type Step = 'idle' | 'amount' | 'confirm'
 
 interface VaultData {
   wallet: string
@@ -70,6 +76,21 @@ export default function VaultView({ token }: { token: string | null }) {
   const [data, setData] = useState<VaultData | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(false)
+
+  const seedChat = useAppStore((s) => s.seedChat)
+  const [step, setStep] = useState<Step>('idle')
+  const [pendingAction, setPendingAction] = useState<VaultAction | null>(null)
+  const [pendingAmount, setPendingAmount] = useState<number>(0)
+
+  const reset = () => { setPendingAction(null); setPendingAmount(0); setStep('idle') }
+  const begin = (a: VaultAction) => { setPendingAction(a); setStep('amount') }
+  const submitAmount = (n: number) => { setPendingAmount(n); setStep('confirm') }
+  const confirm = () => {
+    if (!pendingAction || !pendingAmount) return
+    const direction = pendingAction === 'deposit' ? 'to' : 'from'
+    seedChat(`${pendingAction} ${pendingAmount} SOL ${direction} vault`)
+    reset()
+  }
 
   useEffect(() => {
     if (!token) return
@@ -123,11 +144,19 @@ export default function VaultView({ token }: { token: string | null }) {
           </p>
         )}
         <div className="flex gap-3">
-          <button className="flex-1 border border-green/40 text-green py-2.5 px-4 rounded-lg text-sm font-medium hover:bg-green/10 transition-colors flex justify-center items-center gap-2">
+          <button
+            onClick={() => begin('deposit')}
+            disabled={step !== 'idle' || (sol ?? 0) <= 0}
+            className="flex-1 border border-green/40 text-green py-2.5 px-4 rounded-lg text-sm font-medium hover:bg-green/10 transition-colors flex justify-center items-center gap-2 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
             <ArrowDownLeft size={16} />
             Deposit
           </button>
-          <button className="flex-1 border border-border text-text py-2.5 px-4 rounded-lg text-sm font-medium hover:bg-elevated transition-colors flex justify-center items-center gap-2">
+          <button
+            onClick={() => begin('withdraw')}
+            disabled={step !== 'idle' || (sol ?? 0) <= 0}
+            className="flex-1 border border-border text-text py-2.5 px-4 rounded-lg text-sm font-medium hover:bg-elevated transition-colors flex justify-center items-center gap-2 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
             <MaskHappy size={16} />
             Withdraw
           </button>
@@ -137,6 +166,25 @@ export default function VaultView({ token }: { token: string | null }) {
           </button>
         </div>
       </section>
+
+      {/* Deposit / Withdraw flow */}
+      {step === 'amount' && pendingAction && (
+        <AmountForm
+          action={pendingAction.charAt(0).toUpperCase() + pendingAction.slice(1)}
+          max={sol ?? 0}
+          onSubmit={submitAmount}
+          onCancel={reset}
+        />
+      )}
+
+      {step === 'confirm' && pendingAction && (
+        <ConfirmCard
+          action={pendingAction.charAt(0).toUpperCase() + pendingAction.slice(1)}
+          amount={`${pendingAmount} SOL`}
+          onConfirm={confirm}
+          onCancel={reset}
+        />
+      )}
 
       {/* Recent Activity */}
       <section className="flex flex-col gap-3">

--- a/app/src/views/VaultView.tsx
+++ b/app/src/views/VaultView.tsx
@@ -87,7 +87,7 @@ export default function VaultView({ token }: { token: string | null }) {
   const wallet = data?.wallet
 
   return (
-    <div className="flex flex-col gap-6 pb-2">
+    <div data-testid="vault-view" className="flex flex-col gap-6 pb-2">
       {error && (
         <div className="text-text-muted text-xs font-mono bg-card border border-border rounded-lg px-3 py-2">
           Could not load vault data

--- a/app/src/views/__tests__/HeraldView-edit.test.tsx
+++ b/app/src/views/__tests__/HeraldView-edit.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useAppStore } from '../../stores/app'
+import HeraldView from '../HeraldView'
+
+describe('HeraldView Edit flow', () => {
+  beforeEach(() => {
+    useAppStore.setState({ token: 'test-token', isAdmin: true, messages: [], chatLoading: false })
+    global.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.endsWith('/api/herald') && (!init || init.method !== 'PATCH')) {
+        return new Response(
+          JSON.stringify({
+            queue: [{ id: 'q1', content: 'old tweet', scheduled_at: '2026-04-27T10:00:00Z', status: 'pending' }],
+            budget: { spent: 0, limit: 150, gate: 'open', percentage: 0 },
+            dms: [],
+            recentPosts: [],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      }
+      if (url.includes('/api/herald/queue/q1') && init?.method === 'PATCH') {
+        return new Response(JSON.stringify({ id: 'q1', content: 'new tweet' }), { status: 200 })
+      }
+      return new Response('{}', { status: 200 })
+    }) as typeof fetch
+  })
+
+  it('toggles into edit mode and shows textarea on Edit click', async () => {
+    render(<HeraldView token="test-token" />)
+    await userEvent.click(screen.getByRole('button', { name: /^queue$/i }))
+    await screen.findByText('old tweet')
+    await userEvent.click(screen.getByRole('button', { name: /edit/i }))
+    expect(screen.getByRole('textbox')).toHaveValue('old tweet')
+    expect(screen.getByRole('button', { name: /save/i })).toBeInTheDocument()
+  })
+
+  it('saves the edit via PATCH and exits edit mode', async () => {
+    render(<HeraldView token="test-token" />)
+    await userEvent.click(screen.getByRole('button', { name: /^queue$/i }))
+    await screen.findByText('old tweet')
+    await userEvent.click(screen.getByRole('button', { name: /edit/i }))
+    const textarea = screen.getByRole('textbox')
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, 'new tweet')
+    await userEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/herald/queue/q1'),
+      expect.objectContaining({ method: 'PATCH' })
+    )
+  })
+})

--- a/app/src/views/__tests__/VaultView-actions.test.tsx
+++ b/app/src/views/__tests__/VaultView-actions.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useAppStore } from '../../stores/app'
+import VaultView from '../VaultView'
+
+describe('VaultView Deposit/Withdraw flow', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      token: 'test-token',
+      isAdmin: false,
+      messages: [],
+      chatLoading: false,
+      pendingPrompt: null,
+    })
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          wallet: 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr',
+          activity: [],
+          balances: { sol: 5, tokens: [], status: 'ok' },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    ) as typeof fetch
+  })
+
+  it('shows Deposit and Withdraw buttons initially', async () => {
+    render(<VaultView token="test-token" />)
+    expect(await screen.findByRole('button', { name: /deposit/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /withdraw/i })).toBeInTheDocument()
+  })
+
+  it('opens AmountForm on Deposit click', async () => {
+    render(<VaultView token="test-token" />)
+    await userEvent.click(await screen.findByRole('button', { name: /deposit/i }))
+    expect(screen.getByText(/deposit amount/i)).toBeInTheDocument()
+  })
+
+  it('moves through 3-step flow and calls seedChat on confirm', async () => {
+    const seedChat = vi.fn()
+    useAppStore.setState({ seedChat })
+    render(<VaultView token="test-token" />)
+    await userEvent.click(await screen.findByRole('button', { name: /deposit/i }))
+    await userEvent.type(screen.getByRole('spinbutton'), '1')
+    await userEvent.click(screen.getByRole('button', { name: /continue/i }))
+    expect(screen.getByText(/Confirm Action/i)).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: /confirm & sign/i }))
+    expect(seedChat).toHaveBeenCalledWith(expect.stringContaining('deposit 1 SOL'))
+  })
+})

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/setupTests.ts'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    css: false,
+  },
+})

--- a/docs/superpowers/plans/2026-04-18-test-infrastructure.md
+++ b/docs/superpowers/plans/2026-04-18-test-infrastructure.md
@@ -1,0 +1,1292 @@
+# Test Infrastructure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land Playwright E2E (Chromium) + Vitest/RTL/jsdom component test harnesses with one smoke test per UI surface, wired into path-filtered GitHub CI, unblocking all subsequent audit-driven phases.
+
+**Architecture:** Playwright runs against Vite dev (:5173) + the Sipher agent server (`packages/agent`, overridden to :3000 to match Vite's `/api` proxy) via Playwright's native `webServer` config. The legacy root REST (`src/server.ts`) is not started — `/api/auth`, `/api/chat/stream`, and SENTINEL routes live in the agent. Ed25519-signed JWT minted once in `global-setup`, persisted to `storageState.json`, injected into Zustand's new `persist`-backed `sipher-auth` localStorage entry so admin views render immediately. External network (Solana RPC, Jupiter, X, Pi SDK) is intercepted at the Playwright layer or disabled via `HERALD_ENABLED=false` / `SENTINEL_MODE=off` — no API keys required in CI. RTL covers component units independently in jsdom.
+
+**Tech Stack:** Playwright ^1.48 (Chromium only), Vitest, @testing-library/react ^16, @testing-library/jest-dom ^6, jsdom ^25, @noble/curves (reused), zustand/middleware/persist.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-test-infrastructure-design.md`
+
+---
+
+## File Structure
+
+**New files (18):**
+
+| Path | Purpose |
+|------|---------|
+| `playwright.config.ts` | Playwright config: Chromium, dual webServer, storageState default, global setup/teardown |
+| `e2e/fixtures/auth.ts` | Ed25519 JWT minter: nonce → sign → verify → token |
+| `e2e/fixtures/mocks.ts` | Route interceptors for Solana RPC + Jupiter |
+| `e2e/global-setup.ts` | Loads admin keypair, mints JWT, writes storageState.json |
+| `e2e/global-teardown.ts` | Wipes test.db, storageState.json |
+| `e2e/.env.test` | `HERALD_ENABLED=false`, `SIPHER_DB_PATH`, `AUTHORIZED_WALLETS` |
+| `e2e/chat.spec.ts` | Unauth disabled state + auth'd intercepted SSE smoke |
+| `e2e/auth-flow.spec.ts` | Admin view without JWT redirects; with JWT renders |
+| `e2e/dashboard.spec.ts` | Dashboard loads, metric cards render |
+| `e2e/vault.spec.ts` | Vault loads, balance field present |
+| `e2e/squad.spec.ts` | Squad loads, no errors |
+| `e2e/herald.spec.ts` | Herald loads, budget metric visible |
+| `app/vitest.config.ts` | Vitest config with jsdom env + RTL setup |
+| `app/src/setupTests.ts` | `import '@testing-library/jest-dom'` |
+| `app/src/components/__tests__/ChatSidebar.test.tsx` | First RTL component test |
+| `.github/workflows/e2e.yml` | Path-filtered Playwright CI job |
+
+**Modified files (3):**
+
+| Path | Change |
+|------|--------|
+| `app/src/stores/app.ts` | Wrap `create` with `persist` middleware, `partialize` to `{ token, isAdmin }`, storage key `sipher-auth` |
+| `package.json` | Add `@playwright/test`, add `test:e2e`, `test:e2e:ui`, `test:e2e:headed` scripts |
+| `app/package.json` | Add `@testing-library/react`, `@testing-library/jest-dom`, `jsdom`, `vitest`, `test` script |
+| `.gitignore` | Ignore `playwright-report/`, `test-results/`, `e2e/fixtures/admin-keypair.json`, `e2e/fixtures/storageState.json`, `e2e/test.db` |
+| `README.md` | "Running tests" section |
+
+---
+
+## Task 1: Scaffold — install deps, update .gitignore, add scripts
+
+**Files:**
+- Modify: `package.json`
+- Modify: `app/package.json`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Install Playwright in root**
+
+```bash
+cd ~/local-dev/sipher
+pnpm add -D -w @playwright/test@^1.48.0
+pnpm exec playwright install --with-deps chromium
+```
+
+Expected: Playwright installed, Chromium binary downloaded.
+
+- [ ] **Step 2: Install Vitest + RTL in `app/`**
+
+```bash
+pnpm --filter @sipher/app add -D vitest@^2.1.0 @testing-library/react@^16.1.0 @testing-library/jest-dom@^6.6.0 @testing-library/user-event@^14.5.0 jsdom@^25.0.0
+```
+
+Expected: all deps installed, `app/package.json` updated.
+
+- [ ] **Step 3: Add scripts to root `package.json`**
+
+In `package.json` scripts block, add these three entries (keep existing scripts untouched):
+
+```json
+"test:e2e": "playwright test",
+"test:e2e:ui": "playwright test --ui",
+"test:e2e:headed": "playwright test --headed"
+```
+
+- [ ] **Step 4: Add `test` script to `app/package.json`**
+
+In `app/package.json` scripts block, add:
+
+```json
+"test": "vitest run",
+"test:watch": "vitest"
+```
+
+- [ ] **Step 5: Update `.gitignore`**
+
+Append to `/Users/rector/local-dev/sipher/.gitignore`:
+
+```
+# Playwright / RTL
+playwright-report/
+test-results/
+e2e/fixtures/admin-keypair.json
+e2e/fixtures/storageState.json
+e2e/test.db
+e2e/test.db-journal
+```
+
+- [ ] **Step 6: Verify install**
+
+Run:
+```bash
+cd ~/local-dev/sipher
+pnpm exec playwright --version
+pnpm --filter @sipher/app exec vitest --version
+```
+
+Expected: Playwright prints version ≥1.48, Vitest prints version ≥2.1.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git checkout -b feat/test-infra
+git add package.json app/package.json pnpm-lock.yaml .gitignore
+git commit -m "chore(test-infra): install Playwright, Vitest, RTL, jsdom"
+```
+
+---
+
+## Task 2: Add `persist` middleware to Zustand store
+
+**Files:**
+- Modify: `app/src/stores/app.ts`
+
+Rationale: Current store holds `token` in memory only. Playwright's `storageState` can only inject via localStorage. Adding `persist` enables E2E auth injection and delivers a UX win — users stay logged in across page refreshes.
+
+- [ ] **Step 1: Replace the store export with persist wrapper**
+
+Open `app/src/stores/app.ts`. Replace lines 1-2 (`import { create } from 'zustand'`) with:
+
+```ts
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+```
+
+Then replace the `export const useAppStore = create<AppState>((set) => ({ ... }))` block (lines 37-71) with:
+
+```ts
+export const useAppStore = create<AppState>()(
+  persist(
+    (set) => ({
+      activeView: 'dashboard',
+      setActiveView: (activeView) => set({ activeView }),
+
+      token: null,
+      isAdmin: false,
+      setAuth: (token, isAdmin) => set({ token, isAdmin }),
+      clearAuth: () => set({ token: null, isAdmin: false, messages: [], activeView: 'dashboard' }),
+
+      messages: [],
+      chatLoading: false,
+      addMessage: (msg) => set((s) => ({ messages: [...s.messages, msg] })),
+      appendToLast: (text) =>
+        set((s) => {
+          const msgs = [...s.messages]
+          const last = msgs[msgs.length - 1]
+          if (last?.role === 'assistant') {
+            msgs[msgs.length - 1] = { ...last, content: last.content + text }
+          }
+          return { messages: msgs }
+        }),
+      finishStreaming: () =>
+        set((s) => {
+          const msgs = [...s.messages]
+          const last = msgs[msgs.length - 1]
+          if (last?.streaming) {
+            msgs[msgs.length - 1] = { ...last, streaming: false }
+          }
+          return { messages: msgs }
+        }),
+      setChatLoading: (chatLoading) => set({ chatLoading }),
+
+      chatOpen: false,
+      setChatOpen: (chatOpen) => set({ chatOpen }),
+    }),
+    {
+      name: 'sipher-auth',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (s) => ({ token: s.token, isAdmin: s.isAdmin }),
+    }
+  )
+)
+```
+
+Keep lines 3-35 (types `View`, `ChatMessage`, `AppState`) untouched.
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd ~/local-dev/sipher
+pnpm --filter @sipher/app exec tsc --noEmit
+```
+
+Expected: no errors. If `zustand/middleware` is unresolved, bump zustand to a version ≥4 that exports middleware (currently ^5.0.12, which includes it).
+
+- [ ] **Step 3: Manual verification (optional dev check)**
+
+Start Vite dev and backend, authenticate via wallet in browser, refresh the page. Session should persist. This is optional — the critical verification comes via E2E later.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/stores/app.ts
+git commit -m "feat(app): persist auth token across page refreshes"
+```
+
+---
+
+## Task 3: Playwright config
+
+**Files:**
+- Create: `playwright.config.ts`
+
+- [ ] **Step 1: Write the config**
+
+Create `/Users/rector/local-dev/sipher/playwright.config.ts`:
+
+```ts
+import { defineConfig, devices } from '@playwright/test'
+import path from 'node:path'
+
+const PORT_FRONTEND = 5173
+const PORT_BACKEND = 3000
+
+export default defineConfig({
+  testDir: './e2e',
+  testIgnore: ['**/fixtures/**'],
+  fullyParallel: true,
+  workers: process.env.CI ? 2 : undefined,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  timeout: 30_000,
+  reporter: process.env.CI ? [['html'], ['github']] : [['html'], ['list']],
+  globalSetup: path.resolve(__dirname, './e2e/global-setup.ts'),
+  globalTeardown: path.resolve(__dirname, './e2e/global-teardown.ts'),
+  use: {
+    baseURL: `http://localhost:${PORT_FRONTEND}`,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: [
+    {
+      command: 'pnpm --filter @sipher/agent dev',
+      url: `http://localhost:${PORT_BACKEND}/api/health`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+      env: {
+        NODE_ENV: 'test',
+        PORT: String(PORT_BACKEND),
+        HERALD_ENABLED: 'false',
+        SIPHER_DB_PATH: './e2e/test.db',
+        AUTHORIZED_WALLETS: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
+        JWT_SECRET: process.env.JWT_SECRET ?? 'e2e-test-secret-at-least-16-chars',
+        SENTINEL_MODE: 'off',
+      },
+    },
+    {
+      command: 'pnpm --filter @sipher/app dev',
+      url: `http://localhost:${PORT_FRONTEND}`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+    },
+  ],
+})
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add playwright.config.ts
+git commit -m "chore(e2e): add Playwright config with dual webServer"
+```
+
+---
+
+## Task 4: Auth fixture — ed25519 JWT minter
+
+**Files:**
+- Create: `e2e/fixtures/auth.ts`
+
+- [ ] **Step 1: Write the fixture**
+
+Create `/Users/rector/local-dev/sipher/e2e/fixtures/auth.ts`:
+
+```ts
+import fs from 'node:fs'
+import { ed25519 } from '@noble/curves/ed25519'
+
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+export function encodeBase58(bytes: Uint8Array): string {
+  let num = 0n
+  for (const b of bytes) num = num * 256n + BigInt(b)
+  let str = ''
+  while (num > 0n) {
+    str = BASE58_ALPHABET[Number(num % 58n)] + str
+    num = num / 58n
+  }
+  for (const b of bytes) {
+    if (b !== 0) break
+    str = '1' + str
+  }
+  return str || '1'
+}
+
+export interface LoginResult {
+  token: string
+  isAdmin: boolean
+  wallet: string
+}
+
+export async function mintAdminJwt(
+  keypairPath: string,
+  apiBase: string
+): Promise<LoginResult> {
+  const secretKeyArr = JSON.parse(fs.readFileSync(keypairPath, 'utf-8')) as number[]
+  const secretKey64 = Uint8Array.from(secretKeyArr)
+  const privateKey = secretKey64.slice(0, 32)
+  const publicKey = ed25519.getPublicKey(privateKey)
+  const wallet = encodeBase58(publicKey)
+
+  const nonceResp = await fetch(`${apiBase}/api/auth/nonce`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ wallet }),
+  })
+  if (!nonceResp.ok) {
+    throw new Error(`nonce failed: ${nonceResp.status} ${await nonceResp.text()}`)
+  }
+  const { nonce, message } = (await nonceResp.json()) as { nonce: string; message: string }
+
+  const sigBytes = ed25519.sign(new TextEncoder().encode(message), privateKey)
+  const signature = encodeBase58(sigBytes)
+
+  const verifyResp = await fetch(`${apiBase}/api/auth/verify`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ wallet, nonce, signature }),
+  })
+  if (!verifyResp.ok) {
+    throw new Error(`verify failed: ${verifyResp.status} ${await verifyResp.text()}`)
+  }
+  const { token, isAdmin } = (await verifyResp.json()) as {
+    token: string
+    isAdmin: boolean
+  }
+  return { token, isAdmin, wallet }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+mkdir -p e2e/fixtures
+git add e2e/fixtures/auth.ts
+git commit -m "feat(e2e): add ed25519 JWT minter fixture"
+```
+
+---
+
+## Task 5: Global setup + teardown
+
+**Files:**
+- Create: `e2e/global-setup.ts`
+- Create: `e2e/global-teardown.ts`
+
+- [ ] **Step 1: Write global-setup**
+
+Create `/Users/rector/local-dev/sipher/e2e/global-setup.ts`:
+
+```ts
+import fs from 'node:fs'
+import path from 'node:path'
+import { mintAdminJwt } from './fixtures/auth'
+
+const FRONTEND_ORIGIN = 'http://localhost:5173'
+const BACKEND_BASE = 'http://localhost:3000'
+const STORAGE_STATE_PATH = path.resolve(__dirname, './fixtures/storageState.json')
+
+export default async function globalSetup(): Promise<void> {
+  const keypairPath =
+    process.env.E2E_ADMIN_KEYPAIR_PATH ?? '/Users/rector/Documents/secret/cipher-admin.json'
+
+  if (!fs.existsSync(keypairPath)) {
+    throw new Error(
+      `E2E admin keypair not found at ${keypairPath}. Set E2E_ADMIN_KEYPAIR_PATH env var.`
+    )
+  }
+
+  const { token, isAdmin, wallet } = await mintAdminJwt(keypairPath, BACKEND_BASE)
+  if (!isAdmin) {
+    throw new Error(`Minted JWT for ${wallet} is not admin. Check AUTHORIZED_WALLETS env.`)
+  }
+
+  const zustandPayload = {
+    state: { token, isAdmin },
+    version: 0,
+  }
+
+  const storageState = {
+    cookies: [],
+    origins: [
+      {
+        origin: FRONTEND_ORIGIN,
+        localStorage: [{ name: 'sipher-auth', value: JSON.stringify(zustandPayload) }],
+      },
+    ],
+  }
+
+  fs.writeFileSync(STORAGE_STATE_PATH, JSON.stringify(storageState, null, 2))
+  console.log(`[e2e] storageState written (wallet=${wallet}, isAdmin=${isAdmin})`)
+}
+```
+
+- [ ] **Step 2: Write global-teardown**
+
+Create `/Users/rector/local-dev/sipher/e2e/global-teardown.ts`:
+
+```ts
+import fs from 'node:fs'
+import path from 'node:path'
+
+const PATHS_TO_CLEAN = [
+  path.resolve(__dirname, './fixtures/storageState.json'),
+  path.resolve(__dirname, './test.db'),
+  path.resolve(__dirname, './test.db-journal'),
+]
+
+export default async function globalTeardown(): Promise<void> {
+  for (const p of PATHS_TO_CLEAN) {
+    if (fs.existsSync(p)) fs.unlinkSync(p)
+  }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/global-setup.ts e2e/global-teardown.ts
+git commit -m "feat(e2e): add global setup (JWT mint) and teardown (cleanup)"
+```
+
+---
+
+## Task 6: Mocks fixture — Solana RPC + Jupiter interceptors
+
+**Files:**
+- Create: `e2e/fixtures/mocks.ts`
+
+- [ ] **Step 1: Write the mocks module**
+
+Create `/Users/rector/local-dev/sipher/e2e/fixtures/mocks.ts`:
+
+```ts
+import type { Page, Route } from '@playwright/test'
+
+export async function mockSolanaRpc(page: Page): Promise<void> {
+  await page.route('**/api/rpc/**', async (route: Route) => {
+    const body = route.request().postDataJSON() as { method?: string }
+    const method = body?.method ?? ''
+    if (method === 'getBalance') {
+      await route.fulfill({ json: { jsonrpc: '2.0', id: 1, result: { value: 1_000_000_000 } } })
+      return
+    }
+    if (method === 'getSignatureStatuses') {
+      await route.fulfill({
+        json: { jsonrpc: '2.0', id: 1, result: { value: [null] } },
+      })
+      return
+    }
+    await route.fulfill({ json: { jsonrpc: '2.0', id: 1, result: null } })
+  })
+}
+
+export async function mockJupiter(page: Page): Promise<void> {
+  await page.route('**/quote**', async (route: Route) => {
+    await route.fulfill({
+      json: {
+        inAmount: '1000000',
+        outAmount: '980000',
+        priceImpactPct: '0.1',
+        routePlan: [],
+      },
+    })
+  })
+  await page.route('**/swap**', async (route: Route) => {
+    await route.fulfill({ json: { swapTransaction: 'mock-tx-base64' } })
+  })
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add e2e/fixtures/mocks.ts
+git commit -m "feat(e2e): add Solana RPC + Jupiter route interceptors"
+```
+
+---
+
+## Task 7: Chat spec — unauth disabled state + intercepted SSE smoke
+
+**Files:**
+- Create: `e2e/chat.spec.ts`
+
+Note: the ChatSidebar gates sending on presence of `token` (shows placeholder "Connect wallet first" and disables input). Unauth smoke verifies gating. Auth smoke intercepts the POST to `/api/chat/stream` with a canned SSE response so the test is hermetic.
+
+- [ ] **Step 1: Write the spec**
+
+Create `/Users/rector/local-dev/sipher/e2e/chat.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.describe('chat sidebar', () => {
+  test.describe('unauthenticated', () => {
+    test.use({ storageState: { cookies: [], origins: [] } })
+
+    test('input is disabled and shows connect-wallet placeholder', async ({ page }) => {
+      const errors: string[] = []
+      page.on('pageerror', (err) => errors.push(err.message))
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') errors.push(msg.text())
+      })
+
+      await page.goto('/')
+      const input = page.getByPlaceholder('Connect wallet first')
+      await expect(input).toBeVisible()
+      await expect(input).toBeDisabled()
+      expect(errors).toEqual([])
+    })
+  })
+
+  test.describe('authenticated', () => {
+    test.use({ storageState: AUTH_STATE })
+
+    test('sends message and renders streamed reply from mocked SSE', async ({ page }) => {
+      await page.route('**/api/chat/stream', async (route) => {
+        const body =
+          'data: {"type":"content_block_delta","text":"Hello "}\n\n' +
+          'data: {"type":"content_block_delta","text":"from SIPHER."}\n\n' +
+          'data: [DONE]\n\n'
+        await route.fulfill({
+          status: 200,
+          headers: { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' },
+          body,
+        })
+      })
+
+      const errors: string[] = []
+      page.on('pageerror', (err) => errors.push(err.message))
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') errors.push(msg.text())
+      })
+
+      await page.goto('/')
+      const input = page.getByPlaceholder('Message SIPHER...')
+      await expect(input).toBeEnabled()
+      await input.fill('hi')
+      await page.getByRole('button', { name: 'Send' }).click()
+
+      await expect(page.getByText('Hello from SIPHER.')).toBeVisible({ timeout: 5000 })
+      expect(errors).toEqual([])
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run the spec locally**
+
+```bash
+cd ~/local-dev/sipher
+pnpm test:e2e chat.spec.ts
+```
+
+Expected: both tests pass. If not, inspect `playwright-report/` output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/chat.spec.ts
+git commit -m "test(e2e): add chat sidebar smoke (unauth disabled + auth'd SSE)"
+```
+
+---
+
+## Task 8: Auth flow spec
+
+**Files:**
+- Create: `e2e/auth-flow.spec.ts`
+
+- [ ] **Step 1: Write the spec**
+
+Create `/Users/rector/local-dev/sipher/e2e/auth-flow.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.describe('auth flow', () => {
+  test('unauth user sees landing, no admin metrics', async ({ page }) => {
+    await page.context().addInitScript(() => window.localStorage.clear())
+    await page.goto('/')
+    await expect(page.getByText(/connect wallet/i).first()).toBeVisible()
+  })
+
+  test.describe('authenticated', () => {
+    test.use({ storageState: AUTH_STATE })
+
+    test('admin user sees dashboard', async ({ page }) => {
+      await page.goto('/')
+      await expect(page.getByText('SIPHER').first()).toBeVisible()
+      const token = await page.evaluate(() => {
+        const raw = window.localStorage.getItem('sipher-auth')
+        return raw ? (JSON.parse(raw) as { state: { token: string } }).state.token : null
+      })
+      expect(token).toBeTruthy()
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+pnpm test:e2e auth-flow.spec.ts
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/auth-flow.spec.ts
+git commit -m "test(e2e): add auth flow smoke (unauth gate + injected JWT)"
+```
+
+---
+
+## Task 9: Dashboard spec
+
+**Files:**
+- Create: `e2e/dashboard.spec.ts`
+
+- [ ] **Step 1: Write the spec**
+
+Create `/Users/rector/local-dev/sipher/e2e/dashboard.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test'
+import { mockSolanaRpc } from './fixtures/mocks'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.use({ storageState: AUTH_STATE })
+
+test('dashboard view renders without errors', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (err) => errors.push(err.message))
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text())
+  })
+
+  await mockSolanaRpc(page)
+  await page.goto('/')
+
+  await page.getByRole('button', { name: /dashboard/i }).click().catch(() => {})
+  await expect(page.locator('main, [data-testid="dashboard-view"]').first()).toBeVisible()
+  expect(errors).toEqual([])
+})
+```
+
+- [ ] **Step 2: Add `data-testid="dashboard-view"` to the view root**
+
+Open `app/src/views/DashboardView.tsx`. Locate the outermost wrapping JSX element in the default-exported component and add `data-testid="dashboard-view"`. If the root already has other attributes, append; do not remove.
+
+- [ ] **Step 3: Run**
+
+```bash
+pnpm test:e2e dashboard.spec.ts
+```
+
+Expected: passes. If the selector misses, inspect the rendered HTML via `pnpm test:e2e:headed dashboard.spec.ts`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/dashboard.spec.ts app/src/views/DashboardView.tsx
+git commit -m "test(e2e): add dashboard view smoke"
+```
+
+---
+
+## Task 10: Vault spec
+
+**Files:**
+- Create: `e2e/vault.spec.ts`
+- Modify: `app/src/views/VaultView.tsx` (add `data-testid="vault-view"`)
+
+- [ ] **Step 1: Write the spec**
+
+Create `/Users/rector/local-dev/sipher/e2e/vault.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test'
+import { mockSolanaRpc } from './fixtures/mocks'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.use({ storageState: AUTH_STATE })
+
+test('vault view renders', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (err) => errors.push(err.message))
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text())
+  })
+
+  await mockSolanaRpc(page)
+  await page.goto('/')
+  await page.getByRole('button', { name: /vault/i }).first().click()
+  await expect(page.locator('[data-testid="vault-view"]')).toBeVisible()
+  expect(errors).toEqual([])
+})
+```
+
+- [ ] **Step 2: Add `data-testid="vault-view"` to `VaultView.tsx` root**
+
+Same pattern as Task 9 Step 2.
+
+- [ ] **Step 3: Run**
+
+```bash
+pnpm test:e2e vault.spec.ts
+```
+
+Expected: passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/vault.spec.ts app/src/views/VaultView.tsx
+git commit -m "test(e2e): add vault view smoke"
+```
+
+---
+
+## Task 11: Squad spec
+
+**Files:**
+- Create: `e2e/squad.spec.ts`
+- Modify: `app/src/views/SquadView.tsx` (add `data-testid="squad-view"`)
+
+- [ ] **Step 1: Write the spec**
+
+Create `/Users/rector/local-dev/sipher/e2e/squad.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.use({ storageState: AUTH_STATE })
+
+test('squad view renders', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (err) => errors.push(err.message))
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text())
+  })
+
+  await page.goto('/')
+  await page.getByRole('button', { name: /squad/i }).first().click()
+  await expect(page.locator('[data-testid="squad-view"]')).toBeVisible()
+  expect(errors).toEqual([])
+})
+```
+
+- [ ] **Step 2: Add `data-testid="squad-view"` to `SquadView.tsx` root**
+
+- [ ] **Step 3: Run**
+
+```bash
+pnpm test:e2e squad.spec.ts
+```
+
+Expected: passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/squad.spec.ts app/src/views/SquadView.tsx
+git commit -m "test(e2e): add squad view smoke"
+```
+
+---
+
+## Task 12: Herald spec
+
+**Files:**
+- Create: `e2e/herald.spec.ts`
+- Modify: `app/src/views/HeraldView.tsx` (add `data-testid="herald-view"`)
+
+- [ ] **Step 1: Write the spec**
+
+Create `/Users/rector/local-dev/sipher/e2e/herald.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.use({ storageState: AUTH_STATE })
+
+test('herald view renders with admin budget visible', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (err) => errors.push(err.message))
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text())
+  })
+
+  await page.route('**/api/herald/**', async (route) => {
+    await route.fulfill({
+      json: { budget: { used: 0, total: 1000 }, queue: [], status: 'idle' },
+    })
+  })
+
+  await page.goto('/')
+  await page.getByRole('button', { name: /herald/i }).first().click()
+  await expect(page.locator('[data-testid="herald-view"]')).toBeVisible()
+  expect(errors).toEqual([])
+})
+```
+
+- [ ] **Step 2: Add `data-testid="herald-view"` to `HeraldView.tsx` root**
+
+- [ ] **Step 3: Run**
+
+```bash
+pnpm test:e2e herald.spec.ts
+```
+
+Expected: passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/herald.spec.ts app/src/views/HeraldView.tsx
+git commit -m "test(e2e): add herald view smoke"
+```
+
+---
+
+## Task 13: Vitest config + RTL setup for `app/`
+
+**Files:**
+- Create: `app/vitest.config.ts`
+- Create: `app/src/setupTests.ts`
+
+- [ ] **Step 1: Write Vitest config**
+
+Create `/Users/rector/local-dev/sipher/app/vitest.config.ts`:
+
+```ts
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/setupTests.ts'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    css: false,
+  },
+})
+```
+
+- [ ] **Step 2: Write setup file**
+
+Create `/Users/rector/local-dev/sipher/app/src/setupTests.ts`:
+
+```ts
+import '@testing-library/jest-dom/vitest'
+```
+
+- [ ] **Step 3: Smoke-test the harness**
+
+Create a temporary `app/src/components/__tests__/smoke.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+describe('rtl harness', () => {
+  it('renders text', () => {
+    render(<div>hello</div>)
+    expect(screen.getByText('hello')).toBeInTheDocument()
+  })
+})
+```
+
+Run:
+
+```bash
+pnpm --filter @sipher/app test
+```
+
+Expected: 1 test passes.
+
+- [ ] **Step 4: Delete the smoke file** (will be replaced by the real ChatSidebar test in Task 14)
+
+```bash
+rm app/src/components/__tests__/smoke.test.tsx
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/vitest.config.ts app/src/setupTests.ts
+git commit -m "chore(app): configure Vitest with jsdom + @testing-library/jest-dom"
+```
+
+---
+
+## Task 14: ChatSidebar component test
+
+**Files:**
+- Create: `app/src/components/__tests__/ChatSidebar.test.tsx`
+
+Covers: unauth placeholder, auth'd send flow (mocked `fetch`), SSE parse → `appendToLast`, tool-use indicator.
+
+- [ ] **Step 1: Write the test**
+
+Create `/Users/rector/local-dev/sipher/app/src/components/__tests__/ChatSidebar.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { useAppStore } from '../../stores/app'
+import ChatSidebar from '../ChatSidebar'
+
+function resetStore() {
+  useAppStore.setState({
+    token: null,
+    isAdmin: false,
+    messages: [],
+    chatLoading: false,
+    chatOpen: false,
+    activeView: 'dashboard',
+  })
+}
+
+describe('ChatSidebar', () => {
+  beforeEach(() => {
+    resetStore()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows connect-wallet placeholder and disables input when unauthenticated', () => {
+    render(<ChatSidebar />)
+    const input = screen.getByPlaceholderText('Connect wallet first')
+    expect(input).toBeDisabled()
+  })
+
+  it('enables input when authenticated', () => {
+    useAppStore.setState({ token: 'test-jwt', isAdmin: true })
+    render(<ChatSidebar />)
+    const input = screen.getByPlaceholderText('Message SIPHER...')
+    expect(input).toBeEnabled()
+  })
+
+  it('sends message and appends streamed reply', async () => {
+    useAppStore.setState({ token: 'test-jwt', isAdmin: true })
+
+    const encoder = new TextEncoder()
+    const sseBody = new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode('data: {"type":"content_block_delta","text":"Hi"}\n\n')
+        )
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+        controller.close()
+      },
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(sseBody, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        })
+      )
+    )
+
+    render(<ChatSidebar />)
+    const input = screen.getByPlaceholderText('Message SIPHER...') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Hi')).toBeInTheDocument()
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+pnpm --filter @sipher/app test
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/components/__tests__/ChatSidebar.test.tsx
+git commit -m "test(app): add ChatSidebar component tests (unauth, auth, stream)"
+```
+
+---
+
+## Task 15: GitHub Actions E2E workflow
+
+**Files:**
+- Create: `.github/workflows/e2e.yml`
+
+- [ ] **Step 1: Write the workflow**
+
+Create `/Users/rector/local-dev/sipher/.github/workflows/e2e.yml`:
+
+```yaml
+name: e2e
+
+on:
+  pull_request:
+    paths:
+      - 'app/**'
+      - 'packages/agent/**'
+      - 'src/**'
+      - 'e2e/**'
+      - 'playwright.config.ts'
+      - 'package.json'
+      - 'app/package.json'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/e2e.yml'
+  push:
+    branches: [main]
+
+jobs:
+  component:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run app component tests
+        run: pnpm --filter @sipher/app test
+
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm exec playwright install --with-deps chromium
+
+      - name: Write E2E admin keypair
+        env:
+          E2E_ADMIN_KEYPAIR: ${{ secrets.E2E_ADMIN_KEYPAIR }}
+        run: |
+          mkdir -p e2e/fixtures
+          printf '%s' "$E2E_ADMIN_KEYPAIR" > e2e/fixtures/admin-keypair.json
+          chmod 600 e2e/fixtures/admin-keypair.json
+
+      - name: Run Playwright
+        env:
+          E2E_ADMIN_KEYPAIR_PATH: e2e/fixtures/admin-keypair.json
+          JWT_SECRET: ${{ secrets.E2E_JWT_SECRET }}
+        run: pnpm test:e2e
+
+      - if: failure() || cancelled()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14
+```
+
+Notes:
+- `continue-on-error: true` on the playwright job is intentional for the initial 2-3 PRs — flip to false once the workflow stabilizes.
+- The `component` job has no `continue-on-error` — Vitest component tests are fast and deterministic; any failure should block.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/e2e.yml
+git commit -m "ci: add Playwright E2E + app component tests workflow (path-filtered)"
+```
+
+---
+
+## Task 16: Document GitHub Secret + README section
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Manually create the GitHub Secret** (operator task, not automated)
+
+RECTOR runs locally (not CI, not code):
+
+```bash
+gh secret set E2E_ADMIN_KEYPAIR < ~/Documents/secret/cipher-admin.json --repo sip-protocol/sipher
+gh secret set E2E_JWT_SECRET --repo sip-protocol/sipher
+# Paste: any 32+ char string, e.g. `openssl rand -hex 32`
+```
+
+- [ ] **Step 2: Append "Running tests" section to `README.md`**
+
+Locate a logical spot in `README.md` (after the "Development" or "Getting Started" section). Append:
+
+```markdown
+## Running Tests
+
+### Backend + Agent (Vitest)
+
+```bash
+pnpm test -- --run                           # Root REST tests
+pnpm --filter @sipher/agent test -- --run    # Agent tests
+```
+
+### Frontend component tests (Vitest + RTL)
+
+```bash
+pnpm --filter @sipher/app test
+```
+
+### End-to-end (Playwright, Chromium)
+
+```bash
+pnpm exec playwright install chromium    # one-time browser install
+pnpm test:e2e                            # run all e2e specs
+pnpm test:e2e:ui                         # interactive UI mode
+pnpm test:e2e:headed                     # watch tests run in a visible browser
+```
+
+Playwright runs against the Vite dev server (port 5173) and the Sipher backend (port 3000), both spun up automatically via its `webServer` config. Admin flows use an ed25519-signed JWT minted at global-setup. Locally, this reads `~/Documents/secret/cipher-admin.json`; in CI, the `E2E_ADMIN_KEYPAIR` GitHub Secret supplies it.
+
+See [`docs/superpowers/specs/2026-04-18-test-infrastructure-design.md`](docs/superpowers/specs/2026-04-18-test-infrastructure-design.md) for architectural details.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): add 'Running Tests' section covering Vitest + Playwright"
+```
+
+---
+
+## Task 17: Final verification — full suite run
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Regenerate `storageState.json` for fresh run**
+
+```bash
+cd ~/local-dev/sipher
+rm -f e2e/fixtures/storageState.json e2e/test.db
+```
+
+- [ ] **Step 2: Run full E2E suite**
+
+```bash
+pnpm test:e2e
+```
+
+Expected: 6 specs pass (chat with 2 cases, auth-flow with 2, dashboard, vault, squad, herald — 8 tests total), under 90s local runtime.
+
+- [ ] **Step 3: Run component tests**
+
+```bash
+pnpm --filter @sipher/app test
+```
+
+Expected: 3 tests pass (ChatSidebar).
+
+- [ ] **Step 4: Check HTML report exists**
+
+```bash
+ls playwright-report/index.html
+```
+
+Expected: file present.
+
+- [ ] **Step 5: Push branch and open PR**
+
+```bash
+git push -u origin feat/test-infra
+gh pr create --title "feat(test-infra): Playwright E2E + Vitest+RTL component tests" --body "$(cat <<'EOF'
+## Summary
+
+Phase 1 of the audit-driven work. Lands the missing test infrastructure layers:
+
+- Playwright ^1.48 (Chromium) — 6 E2E specs, one per UI surface
+- Vitest + @testing-library/react + jsdom — component tests for `app/`
+- Path-filtered GitHub Actions workflow (`.github/workflows/e2e.yml`)
+- Ed25519-signed JWT fixture for authenticated E2E flows
+- Zustand `persist` middleware for `token`/`isAdmin` (UX bonus: session persists on refresh)
+
+All external network (Solana RPC, Jupiter, Pi SDK, X) mocked or disabled — no API keys required in CI.
+
+## Test plan
+
+- [x] All 8 Playwright tests pass locally
+- [x] All 3 Vitest component tests pass locally
+- [x] `pnpm test -- --run` still green (no existing tests broken)
+- [x] `pnpm typecheck` clean
+- [ ] CI run green on PR (manual verify after push)
+- [ ] `E2E_ADMIN_KEYPAIR` + `E2E_JWT_SECRET` GitHub Secrets set before CI run
+
+Spec: `docs/superpowers/specs/2026-04-18-test-infrastructure-design.md`
+EOF
+)"
+```
+
+Expected: PR created. Wait for CI. If green, flip `continue-on-error: true` → `false` in a follow-up PR.
+
+- [ ] **Step 6: Verify CI green** (manual — after push)
+
+Watch `gh pr checks` until green or investigate failure via artifacts.
+
+---
+
+## Success Criteria (from spec)
+
+- [ ] `pnpm test:e2e` runs locally and all 8 test cases pass on a clean checkout
+- [ ] `pnpm --filter @sipher/app test` runs locally and 3 ChatSidebar component tests pass
+- [ ] `.github/workflows/e2e.yml` triggers on a UI-touching PR and passes
+- [ ] `E2E_ADMIN_KEYPAIR` and `E2E_JWT_SECRET` secrets exist in the repo
+- [ ] Path filter correctly skips E2E on backend-only or docs-only PRs
+- [ ] No test makes real network calls to Solana RPC, LLM providers, X API, or Jupiter
+- [ ] HTML report uploaded on failure, downloadable from Actions tab
+- [ ] README has "Running tests" section linking to the spec

--- a/docs/superpowers/specs/2026-04-18-test-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-04-18-test-infrastructure-design.md
@@ -63,7 +63,7 @@ The two layers cover different concerns and do not overlap: Playwright validates
 
 ```
 sipher/
-├── playwright.config.ts              # webServer: pnpm dev on :5174
+├── playwright.config.ts              # webServer: backend on :3000 + Vite on :5173
 ├── e2e/
 │   ├── fixtures/
 │   │   ├── auth.ts                   # ed25519 JWT helper (ported from /tmp/sipher-login.mjs)
@@ -120,10 +120,14 @@ Wallet signing is impossible in a headless browser. Instead, Playwright's `globa
 
 1. `e2e/global-setup.ts` runs once before all tests.
 2. Loads the admin keypair from `E2E_ADMIN_KEYPAIR_PATH` (locally: `~/Documents/secret/cipher-admin.json`; in CI: `e2e/fixtures/admin-keypair.json`, hydrated from the `E2E_ADMIN_KEYPAIR` GitHub Secret).
-3. Fetches a nonce from `POST http://localhost:5174/api/auth/nonce`.
-4. Signs the nonce with `@noble/curves/ed25519`.
-5. Exchanges the signature for a JWT at `POST /api/auth/login`.
-6. Writes `e2e/fixtures/storageState.json` with the JWT in localStorage under Sipher's expected key.
+3. Fetches a nonce from `POST http://localhost:3000/api/auth/nonce` with `{ wallet }`.
+4. Signs the returned `message` with `@noble/curves/ed25519`.
+5. Encodes the signature as base58 and calls `POST /api/auth/verify` with `{ wallet, nonce, signature }`.
+6. Writes `e2e/fixtures/storageState.json` with the Zustand-persist payload in `localStorage['sipher-auth']`.
+
+**Enabling prerequisite — Zustand persist middleware:**
+
+The app's `useAppStore` currently holds `token` and `isAdmin` in memory only, which means Playwright cannot inject authenticated state via `storageState`. The spec adds the `zustand/middleware/persist` adapter over the `token` and `isAdmin` fields under the storage key `sipher-auth`. This is a minimal (~5 line) change with a legitimate UX bonus: real users stay logged in across page refreshes instead of losing their session. Chat state and other ephemeral store fields remain in-memory via `partialize`.
 
 **Per-test opt-in:**
 
@@ -253,7 +257,7 @@ Steps:
 
 - Port the existing `/tmp/sipher-login.mjs` ed25519 signing logic into `e2e/fixtures/auth.ts` as a reusable helper. This is the single source of truth for test-mode JWT minting; if the auth flow changes, this file is the only place to update.
 - Route interceptors live in a shared `e2e/fixtures/mocks.ts` and are attached per-test via a Playwright fixture extension. No per-test boilerplate.
-- `playwright.config.ts` sets `webServer.reuseExistingServer = !process.env.CI` so local reruns are fast but CI always gets a clean boot.
+- `playwright.config.ts` declares two `webServer` entries: the Sipher backend (`pnpm dev`, awaiting `http://localhost:3000/health`) and the Vite frontend (`pnpm --filter app dev`, awaiting `http://localhost:5173`). Both set `reuseExistingServer = !process.env.CI` so local reruns are fast but CI always gets a clean boot. Vite's built-in `/api` proxy routes frontend traffic to the backend.
 - Set `fullyParallel: true` with `workers: 2` in CI to keep under 10-minute timeout.
 
 ## Out of Scope (for later phases)

--- a/docs/superpowers/specs/2026-04-18-test-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-04-18-test-infrastructure-design.md
@@ -1,0 +1,265 @@
+# Test Infrastructure — Design Spec
+
+**Date:** 2026-04-18
+**Status:** Approved, ready for implementation plan
+**Scope:** Phase 1 of the "address all audit findings" multi-phase effort
+**Related audits:** Spec-vs-implementation gap audit, test-coverage audit (both 2026-04-18)
+
+## Summary
+
+Ship the missing test infrastructure layers that Sipher's audits revealed: end-to-end browser tests via Playwright, and React component tests via Vitest + @testing-library/react + jsdom. Land a lean scaffold — one smoke test per UI surface plus one component test — and wire it into GitHub CI with path-filtered triggering. Subsequent phases (UI gap fixes, REST service tests, tool backfills) arrive on top of this foundation already-tested.
+
+## Context
+
+The 2026-04-18 test-coverage audit found:
+
+- **Zero Playwright infrastructure.** No `playwright.config.ts`, no `@playwright/test`, no `e2e/` directory. The entire 2,079-line Command Center UI (`app/`) ships without any browser-level verification.
+- **Zero component tests in `app/`.** 23 React source files (views, hooks, components, Zustand store, API client, SSE hook) have no unit or integration tests at all.
+- **Backend coverage is strong** — 1,553 test cases across Vitest suites — but the UI layer is uncovered.
+
+Subsequent audit-driven work (UI gap fixes in Phase 2, tool unit test backfills in Phase 5) will ship code that either arrives untested or has to be back-tested later. Landing infra first eliminates that choice.
+
+## Goals
+
+- Ship a working Playwright E2E harness on Chromium, spinning up the real Vite dev server.
+- Ship a working Vitest + RTL component test harness for `app/`.
+- Land six E2E smoke tests (one per view + chat public + auth flow) and one component test.
+- Wire both harnesses into GitHub Actions with PR path filtering, failing the build on broken tests.
+- Provide an authenticated test fixture (ed25519 JWT signing) reusable across auth-gated tests.
+
+## Non-goals
+
+- Writing component tests for all 23 UI files. Further component tests arrive during Phase 2 alongside the UI gap fixes they cover.
+- Cross-browser matrix (WebKit, Firefox). Chromium only.
+- Visual regression (Percy, Chromatic, screenshot diffing).
+- Storybook.
+- Coverage reports from Playwright. Vitest already owns source coverage.
+- LLM behavior testing. Chat smoke asserts the stream opens and receives the first SSE event, nothing deeper.
+
+## Architecture
+
+**Two independent test layers, one shared stack:**
+
+```
+┌──────────────────────────────────────────────────┐
+│  Playwright (e2e/)                               │
+│  ─ Launches Vite dev server on :5174             │
+│  ─ Chromium headless                             │
+│  ─ Tests against real browser + real backend     │
+│  ─ Mocks external network (RPC, Jupiter, X)      │
+└──────────────────────────────────────────────────┘
+                       +
+┌──────────────────────────────────────────────────┐
+│  Vitest + RTL + jsdom (app/src/**/__tests__/)    │
+│  ─ Component-level unit/integration              │
+│  ─ Runs in jsdom (no browser)                    │
+│  ─ Reuses existing Vitest config patterns        │
+└──────────────────────────────────────────────────┘
+```
+
+The two layers cover different concerns and do not overlap: Playwright validates that views *render and flow* through real routing + state + SSE + middleware; RTL validates that individual components *behave* in isolation.
+
+## File Layout
+
+```
+sipher/
+├── playwright.config.ts              # webServer: pnpm dev on :5174
+├── e2e/
+│   ├── fixtures/
+│   │   ├── auth.ts                   # ed25519 JWT helper (ported from /tmp/sipher-login.mjs)
+│   │   ├── storageState.json         # gitignored; generated per run
+│   │   └── admin-keypair.json        # gitignored; hydrated from GH secret in CI
+│   ├── global-setup.ts               # mint JWT, write storageState
+│   ├── global-teardown.ts            # wipe test.db + storageState
+│   ├── dashboard.spec.ts
+│   ├── vault.spec.ts
+│   ├── squad.spec.ts
+│   ├── herald.spec.ts
+│   ├── chat-public.spec.ts
+│   └── auth-flow.spec.ts
+├── app/
+│   ├── vitest.config.ts              # jsdom env, setupFiles
+│   ├── src/
+│   │   └── setupTests.ts             # imports @testing-library/jest-dom
+│   └── src/components/__tests__/
+│       └── ChatSidebar.test.tsx      # first component smoke
+└── .github/workflows/
+    └── e2e.yml                       # Playwright PR workflow
+```
+
+**Gitignored:**
+- `e2e/fixtures/storageState.json`
+- `e2e/fixtures/admin-keypair.json`
+- `e2e/test.db`
+- `playwright-report/`
+- `test-results/`
+
+## Smoke Test Surface
+
+Six Playwright specs, each asserting a small set of visible-DOM facts and global "no console errors / pageerror" invariants.
+
+| Spec | Auth | Assertions |
+|------|------|-----------|
+| `chat-public.spec.ts` | none | Sidebar opens, send box accepts input, POST to `/api/chat/stream` fires; Playwright intercepts the request and returns a canned SSE stream so the test validates the client's stream-to-bubble render path without invoking the real agent |
+| `auth-flow.spec.ts` | both | Unauth GET to admin view returns 401/redirect; with injected JWT, admin view renders |
+| `dashboard.spec.ts` | admin | Mounts, all four metric cards render (placeholders ok), activity feed container present |
+| `vault.spec.ts` | admin | Mounts, balance field is populated (not infinite spinner), deposit list container present |
+| `squad.spec.ts` | admin | Mounts, squad grid container present |
+| `herald.spec.ts` | admin | Mounts, agent-status widget renders, budget metric visible (admin-only card actually appears) |
+
+**Global invariants enforced in every test via Playwright fixtures:**
+
+- `page.on('pageerror', ...)` collects uncaught errors — any error fails the test.
+- `page.on('console', msg => msg.type() === 'error')` collects `console.error` — fails test unless explicitly allow-listed.
+
+## Auth Strategy
+
+Wallet signing is impossible in a headless browser. Instead, Playwright's `globalSetup` mints a real JWT out-of-band and injects it into localStorage via `storageState`.
+
+**Flow:**
+
+1. `e2e/global-setup.ts` runs once before all tests.
+2. Loads the admin keypair from `E2E_ADMIN_KEYPAIR_PATH` (locally: `~/Documents/secret/cipher-admin.json`; in CI: `e2e/fixtures/admin-keypair.json`, hydrated from the `E2E_ADMIN_KEYPAIR` GitHub Secret).
+3. Fetches a nonce from `POST http://localhost:5174/api/auth/nonce`.
+4. Signs the nonce with `@noble/curves/ed25519`.
+5. Exchanges the signature for a JWT at `POST /api/auth/login`.
+6. Writes `e2e/fixtures/storageState.json` with the JWT in localStorage under Sipher's expected key.
+
+**Per-test opt-in:**
+
+```ts
+test.use({ storageState: 'e2e/fixtures/storageState.json' })  // admin tests
+test.use({ storageState: { cookies: [], origins: [] } })      // unauth tests
+```
+
+The cipher-admin pubkey (`C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N`) is added to `AUTHORIZED_WALLETS` via `.env.test`, so `isAdmin=true` on login.
+
+## External Network Strategy
+
+All external dependencies are mocked or disabled. No test depends on devnet uptime, LLM API keys, X API quota, or Jupiter liveness.
+
+| Service | Strategy |
+|---------|----------|
+| Solana RPC | Playwright route interceptor on `**/api/rpc/**` returns canned balances and signatures |
+| Pi SDK (LLM) | `chat-public.spec.ts` intercepts `POST **/api/chat/stream` at the Playwright layer and responds with a canned SSE stream. The backend agent and Pi SDK are never invoked during E2E. No `OPENROUTER_API_KEY` required in CI. |
+| X API (HERALD) | Poller disabled via `HERALD_ENABLED=false` in `.env.test` |
+| Jupiter | Route interceptor on `**/quote`, `**/swap` returns canned quotes |
+
+## Test Data
+
+- **Test DB:** `SIPHER_DB_PATH=./e2e/test.db` — isolated SQLite, recreated per run.
+- **Seed:** `global-setup` inserts one dummy deposit, one blacklist entry, and ensures the admin pubkey is in `AUTHORIZED_WALLETS`.
+- **Teardown:** `global-teardown` wipes `test.db` and `storageState.json`.
+
+## Component Test Harness
+
+**Config:** `app/vitest.config.ts`
+
+```ts
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/setupTests.ts'],
+    globals: true,
+  },
+})
+```
+
+**`src/setupTests.ts`:** `import '@testing-library/jest-dom'`
+
+**First test — `ChatSidebar.test.tsx`:**
+
+- Renders closed state, opens on trigger
+- Accepts text input, submit dispatches fetch to `/api/chat/stream`
+- Renders bubble from streamed SSE (mock `EventSource`)
+
+Further component tests land during Phase 2 UI work, not Phase 1.
+
+## CI Integration
+
+**New workflow:** `.github/workflows/e2e.yml`
+
+Triggers:
+- `pull_request` with path filter: `app/**`, `packages/agent/**`, `src/**`, `e2e/**`, `playwright.config.ts`, `package.json`, `pnpm-lock.yaml`, `.github/workflows/e2e.yml`
+- `push` to `main`
+
+Steps:
+1. Checkout, setup pnpm + Node 22
+2. `pnpm install --frozen-lockfile`
+3. `pnpm exec playwright install --with-deps chromium`
+4. Write admin keypair from `E2E_ADMIN_KEYPAIR` secret → `e2e/fixtures/admin-keypair.json` (chmod 600)
+5. `pnpm test:e2e` with env: `E2E_ADMIN_KEYPAIR_PATH`, `HERALD_ENABLED=false`, `SIPHER_DB_PATH=./e2e/test.db`, `AUTHORIZED_WALLETS=C1phr...x85N`
+6. On failure: upload `playwright-report/` as artifact (14-day retention)
+
+**Component test CI:**
+- Add `pnpm --filter app test` to the existing PR check workflow under the same path filter.
+
+**Required GitHub Secret:**
+- `E2E_ADMIN_KEYPAIR` — raw JSON content of `~/Documents/secret/cipher-admin.json`. Added manually via `gh secret set E2E_ADMIN_KEYPAIR < ~/Documents/secret/cipher-admin.json`. Rotatable.
+
+**Rollout safety:**
+- First 2-3 PRs: workflow runs with `continue-on-error: true` so infra flakiness doesn't block real work.
+- Flip to required check once stable.
+- HTML report uploaded on failure.
+
+## Package Additions
+
+**Root `package.json` devDependencies:**
+- `@playwright/test`
+- `@noble/curves` (already present — reused)
+
+**`app/package.json` devDependencies:**
+- `@testing-library/react`
+- `@testing-library/jest-dom`
+- `jsdom`
+- `vitest` (if not already in `app/`)
+- `@vitejs/plugin-react` (if not already in `app/`)
+
+**Root `package.json` scripts:**
+- `test:e2e`: `playwright test`
+- `test:e2e:ui`: `playwright test --ui` (local dev helper)
+- `test:e2e:headed`: `playwright test --headed` (local dev helper)
+
+## Success Criteria
+
+- [ ] `pnpm test:e2e` runs locally and all 6 specs pass on a clean checkout
+- [ ] `pnpm --filter app test` runs locally and the ChatSidebar component test passes
+- [ ] `.github/workflows/e2e.yml` triggers on a UI-touching PR and passes
+- [ ] `E2E_ADMIN_KEYPAIR` secret exists in the repo
+- [ ] Path filter correctly skips E2E on backend-only or docs-only PRs
+- [ ] No test makes real network calls to Solana RPC, LLM providers, X API, or Jupiter
+- [ ] HTML report uploaded on failure, downloadable from Actions tab
+- [ ] README has a short "Running tests" section linking to this spec
+
+## Risks and Alternatives
+
+**Running against the deployed VPS instead of local dev server.** Rejected — would bleed real state into a prod SQLite (blacklist entries, SENTINEL decisions, audit log). Safer to mock in hermetic local runs; prod smoke-testing belongs in a separate manual workflow, not CI.
+
+**Skipping auth and testing unauth views only.** Rejected — half the surface (admin views, vault, herald controls) would go untested forever.
+
+**Mocking the auth hook in-app during E2E mode.** Rejected — bypasses the real auth middleware, letting regressions in auth code ship silently. JWT injection via storageState is only marginally more work and exercises the real path.
+
+**Adding WebKit and Firefox now.** Rejected (YAGNI) — professional-dev audience, Chromium dominates. Easy to add later if real users hit browser-specific bugs.
+
+**Running Playwright on every PR regardless of path.** Rejected — most Sipher PRs touch docs, backend, or infra. Running a 1-2 min E2E job on every PR wastes CI minutes. Path filter gives full coverage where it matters.
+
+**Visual regression (Percy, Chromatic).** Deferred — would catch UI drift but requires third-party service, costs money, and produces noisy diffs during active UI development. Worth revisiting after Phase 2 UI work stabilizes.
+
+## Implementation Notes
+
+- Port the existing `/tmp/sipher-login.mjs` ed25519 signing logic into `e2e/fixtures/auth.ts` as a reusable helper. This is the single source of truth for test-mode JWT minting; if the auth flow changes, this file is the only place to update.
+- Route interceptors live in a shared `e2e/fixtures/mocks.ts` and are attached per-test via a Playwright fixture extension. No per-test boilerplate.
+- `playwright.config.ts` sets `webServer.reuseExistingServer = !process.env.CI` so local reruns are fast but CI always gets a clean boot.
+- Set `fullyParallel: true` with `workers: 2` in CI to keep under 10-minute timeout.
+
+## Out of Scope (for later phases)
+
+- UI gap fixes (privacy score computation, tool-use indicators, color dots, ConfirmCard wiring, HERALD queue, MetricCard gating) — Phase 2.
+- SENTINEL external-tool surface docs cleanup — Phase 3.
+- REST service tests (chain-transfer-builder, transaction-builder, private-swap-builder) — Phase 4.
+- Tool unit test backfills (29 tools) — Phase 5.
+- Chrome MCP QA against live VPS — Phase 6.

--- a/e2e/auth-flow.spec.ts
+++ b/e2e/auth-flow.spec.ts
@@ -3,10 +3,10 @@ import { test, expect } from '@playwright/test'
 const AUTH_STATE = 'e2e/fixtures/storageState.json'
 
 test.describe('auth flow', () => {
-  test('unauth user sees landing, no admin metrics', async ({ page }) => {
+  test('unauth user sees landing with connect button', async ({ page }) => {
     await page.context().addInitScript(() => window.localStorage.clear())
     await page.goto('/')
-    await expect(page.getByText(/connect wallet/i).first()).toBeVisible()
+    await expect(page.getByRole('button', { name: /connect/i })).toBeVisible()
   })
 
   test.describe('authenticated', () => {

--- a/e2e/auth-flow.spec.ts
+++ b/e2e/auth-flow.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.describe('auth flow', () => {
+  test('unauth user sees landing, no admin metrics', async ({ page }) => {
+    await page.context().addInitScript(() => window.localStorage.clear())
+    await page.goto('/')
+    await expect(page.getByText(/connect wallet/i).first()).toBeVisible()
+  })
+
+  test.describe('authenticated', () => {
+    test.use({ storageState: AUTH_STATE })
+
+    test('admin user sees dashboard', async ({ page }) => {
+      await page.goto('/')
+      await expect(page.getByText('SIPHER').first()).toBeVisible()
+      const token = await page.evaluate(() => {
+        const raw = window.localStorage.getItem('sipher-auth')
+        return raw ? (JSON.parse(raw) as { state: { token: string } }).state.token : null
+      })
+      expect(token).toBeTruthy()
+    })
+  })
+})

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.describe('chat sidebar', () => {
+  test.describe('unauthenticated', () => {
+    test.use({ storageState: { cookies: [], origins: [] } })
+
+    test('input is disabled and shows connect-wallet placeholder', async ({ page }) => {
+      const errors: string[] = []
+      page.on('pageerror', (err) => errors.push(err.message))
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') errors.push(msg.text())
+      })
+
+      await page.goto('/')
+      const input = page.getByPlaceholder('Connect wallet first')
+      await expect(input).toBeVisible()
+      await expect(input).toBeDisabled()
+      expect(errors).toEqual([])
+    })
+  })
+
+  test.describe('authenticated', () => {
+    test.use({ storageState: AUTH_STATE })
+
+    test('sends message and renders streamed reply from mocked SSE', async ({ page }) => {
+      await page.route('**/api/chat/stream', async (route) => {
+        const body =
+          'data: {"type":"content_block_delta","text":"Hello "}\n\n' +
+          'data: {"type":"content_block_delta","text":"from SIPHER."}\n\n' +
+          'data: [DONE]\n\n'
+        await route.fulfill({
+          status: 200,
+          headers: { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' },
+          body,
+        })
+      })
+
+      const errors: string[] = []
+      page.on('pageerror', (err) => errors.push(err.message))
+      page.on('console', (msg) => {
+        if (msg.type() === 'error') errors.push(msg.text())
+      })
+
+      await page.goto('/')
+      const input = page.getByPlaceholder('Message SIPHER...')
+      await expect(input).toBeEnabled()
+      await input.fill('hi')
+      await page.getByRole('button', { name: 'Send' }).click()
+
+      await expect(page.getByText('Hello from SIPHER.')).toBeVisible({ timeout: 5000 })
+      expect(errors).toEqual([])
+    })
+  })
+})

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test'
+import { mockSolanaRpc } from './fixtures/mocks'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.use({ storageState: AUTH_STATE })
+
+test('dashboard view renders without errors', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (err) => errors.push(err.message))
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text())
+  })
+
+  await mockSolanaRpc(page)
+  await page.goto('/')
+
+  await page.getByRole('button', { name: /dashboard/i }).click().catch(() => {})
+  await expect(page.locator('main, [data-testid="dashboard-view"]').first()).toBeVisible()
+  expect(errors).toEqual([])
+})

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -15,7 +15,6 @@ test('dashboard view renders without errors', async ({ page }) => {
   await mockSolanaRpc(page)
   await page.goto('/')
 
-  await page.getByRole('button', { name: /dashboard/i }).click().catch(() => {})
-  await expect(page.locator('main, [data-testid="dashboard-view"]').first()).toBeVisible()
+  await expect(page.locator('[data-testid="dashboard-view"]')).toBeVisible()
   expect(errors).toEqual([])
 })

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,0 +1,63 @@
+import fs from 'node:fs'
+import { ed25519 } from '@noble/curves/ed25519'
+
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+export function encodeBase58(bytes: Uint8Array): string {
+  let num = 0n
+  for (const b of bytes) num = num * 256n + BigInt(b)
+  let str = ''
+  while (num > 0n) {
+    str = BASE58_ALPHABET[Number(num % 58n)] + str
+    num = num / 58n
+  }
+  for (const b of bytes) {
+    if (b !== 0) break
+    str = '1' + str
+  }
+  return str || '1'
+}
+
+export interface LoginResult {
+  token: string
+  isAdmin: boolean
+  wallet: string
+}
+
+export async function mintAdminJwt(
+  keypairPath: string,
+  apiBase: string
+): Promise<LoginResult> {
+  const secretKeyArr = JSON.parse(fs.readFileSync(keypairPath, 'utf-8')) as number[]
+  const secretKey64 = Uint8Array.from(secretKeyArr)
+  const privateKey = secretKey64.slice(0, 32)
+  const publicKey = ed25519.getPublicKey(privateKey)
+  const wallet = encodeBase58(publicKey)
+
+  const nonceResp = await fetch(`${apiBase}/api/auth/nonce`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ wallet }),
+  })
+  if (!nonceResp.ok) {
+    throw new Error(`nonce failed: ${nonceResp.status} ${await nonceResp.text()}`)
+  }
+  const { nonce, message } = (await nonceResp.json()) as { nonce: string; message: string }
+
+  const sigBytes = ed25519.sign(new TextEncoder().encode(message), privateKey)
+  const signature = encodeBase58(sigBytes)
+
+  const verifyResp = await fetch(`${apiBase}/api/auth/verify`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ wallet, nonce, signature }),
+  })
+  if (!verifyResp.ok) {
+    throw new Error(`verify failed: ${verifyResp.status} ${await verifyResp.text()}`)
+  }
+  const { token, isAdmin } = (await verifyResp.json()) as {
+    token: string
+    isAdmin: boolean
+  }
+  return { token, isAdmin, wallet }
+}

--- a/e2e/fixtures/mocks.ts
+++ b/e2e/fixtures/mocks.ts
@@ -1,0 +1,35 @@
+import type { Page, Route } from '@playwright/test'
+
+export async function mockSolanaRpc(page: Page): Promise<void> {
+  await page.route('**/api/rpc/**', async (route: Route) => {
+    const body = route.request().postDataJSON() as { method?: string }
+    const method = body?.method ?? ''
+    if (method === 'getBalance') {
+      await route.fulfill({ json: { jsonrpc: '2.0', id: 1, result: { value: 1_000_000_000 } } })
+      return
+    }
+    if (method === 'getSignatureStatuses') {
+      await route.fulfill({
+        json: { jsonrpc: '2.0', id: 1, result: { value: [null] } },
+      })
+      return
+    }
+    await route.fulfill({ json: { jsonrpc: '2.0', id: 1, result: null } })
+  })
+}
+
+export async function mockJupiter(page: Page): Promise<void> {
+  await page.route('**/quote**', async (route: Route) => {
+    await route.fulfill({
+      json: {
+        inAmount: '1000000',
+        outAmount: '980000',
+        priceImpactPct: '0.1',
+        routePlan: [],
+      },
+    })
+  })
+  await page.route('**/swap**', async (route: Route) => {
+    await route.fulfill({ json: { swapTransaction: 'mock-tx-base64' } })
+  })
+}

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { mintAdminJwt } from './fixtures/auth'
+
+const FRONTEND_ORIGIN = 'http://localhost:5173'
+const BACKEND_BASE = 'http://localhost:3000'
+const STORAGE_STATE_PATH = path.resolve(__dirname, './fixtures/storageState.json')
+
+export default async function globalSetup(): Promise<void> {
+  const keypairPath =
+    process.env.E2E_ADMIN_KEYPAIR_PATH ?? '/Users/rector/Documents/secret/cipher-admin.json'
+
+  if (!fs.existsSync(keypairPath)) {
+    throw new Error(
+      `E2E admin keypair not found at ${keypairPath}. Set E2E_ADMIN_KEYPAIR_PATH env var.`
+    )
+  }
+
+  const { token, isAdmin, wallet } = await mintAdminJwt(keypairPath, BACKEND_BASE)
+  if (!isAdmin) {
+    throw new Error(`Minted JWT for ${wallet} is not admin. Check AUTHORIZED_WALLETS env.`)
+  }
+
+  const zustandPayload = {
+    state: { token, isAdmin },
+    version: 0,
+  }
+
+  const storageState = {
+    cookies: [],
+    origins: [
+      {
+        origin: FRONTEND_ORIGIN,
+        localStorage: [{ name: 'sipher-auth', value: JSON.stringify(zustandPayload) }],
+      },
+    ],
+  }
+
+  fs.writeFileSync(STORAGE_STATE_PATH, JSON.stringify(storageState, null, 2))
+  console.log(`[e2e] storageState written (wallet=${wallet}, isAdmin=${isAdmin})`)
+}

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,7 +1,9 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { mintAdminJwt } from './fixtures/auth'
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const FRONTEND_ORIGIN = 'http://localhost:5173'
 const BACKEND_BASE = 'http://localhost:3000'
 const STORAGE_STATE_PATH = path.resolve(__dirname, './fixtures/storageState.json')

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,5 +1,8 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const PATHS_TO_CLEAN = [
   path.resolve(__dirname, './fixtures/storageState.json'),

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,0 +1,14 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const PATHS_TO_CLEAN = [
+  path.resolve(__dirname, './fixtures/storageState.json'),
+  path.resolve(__dirname, './test.db'),
+  path.resolve(__dirname, './test.db-journal'),
+]
+
+export default async function globalTeardown(): Promise<void> {
+  for (const p of PATHS_TO_CLEAN) {
+    if (fs.existsSync(p)) fs.unlinkSync(p)
+  }
+}

--- a/e2e/herald.spec.ts
+++ b/e2e/herald.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.use({ storageState: AUTH_STATE })
+
+test('herald view renders with admin budget visible', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (err) => errors.push(err.message))
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text())
+  })
+
+  await page.route('**/api/herald/**', async (route) => {
+    await route.fulfill({
+      json: { budget: { used: 0, total: 1000 }, queue: [], status: 'idle' },
+    })
+  })
+
+  await page.goto('/')
+  await page.getByRole('button', { name: /herald/i }).first().click()
+  await expect(page.locator('[data-testid="herald-view"]')).toBeVisible()
+  expect(errors).toEqual([])
+})

--- a/e2e/herald.spec.ts
+++ b/e2e/herald.spec.ts
@@ -11,9 +11,14 @@ test('herald view renders with admin budget visible', async ({ page }) => {
     if (msg.type() === 'error') errors.push(msg.text())
   })
 
-  await page.route('**/api/herald/**', async (route) => {
+  await page.route('**/api/herald', async (route) => {
     await route.fulfill({
-      json: { budget: { used: 0, total: 1000 }, queue: [], status: 'idle' },
+      json: {
+        budget: { spent: 0, limit: 1000, gate: 'open', percentage: 0 },
+        queue: [],
+        dms: [],
+        recentPosts: [],
+      },
     })
   })
 

--- a/e2e/sentinel-flow.spec.ts
+++ b/e2e/sentinel-flow.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test'
+
+// Skipped pending sip-protocol/sip-protocol#1077 (SDK ESM bundle bug blocks agent startup)
+test.skip('SENTINEL pause/resume flow — full chat → override → tool runs', async ({ page }) => {
+  await page.goto('/')
+
+  // Sign in (using storageState fixture from Phase 1)
+  // Send a message that triggers a SENTINEL flag (e.g., sending to a known-blacklisted devnet address)
+  await page.getByPlaceholder('Message SIPHER...').fill('send 5 SOL to <blacklisted address>')
+  await page.getByRole('button', { name: /send/i }).click()
+
+  // SentinelConfirm card should render
+  const confirmCard = page.getByText(/risk confirm/i).first()
+  await expect(confirmCard).toBeVisible({ timeout: 10000 })
+
+  // Override → tool completes
+  await page.getByRole('button', { name: /override & send/i }).click()
+
+  // Assistant message resumes streaming
+  await expect(page.getByText(/transaction submitted/i)).toBeVisible({ timeout: 30000 })
+})
+
+test.skip('SENTINEL pause/resume flow — cancel produces graceful message', async ({ page }) => {
+  await page.goto('/')
+  await page.getByPlaceholder('Message SIPHER...').fill('send 5 SOL to <blacklisted address>')
+  await page.getByRole('button', { name: /send/i }).click()
+
+  const confirmCard = page.getByText(/risk confirm/i).first()
+  await expect(confirmCard).toBeVisible({ timeout: 10000 })
+
+  await page.getByRole('button', { name: /^cancel$/i }).click()
+
+  await expect(page.getByText(/operation cancelled/i)).toBeVisible({ timeout: 10000 })
+})

--- a/e2e/squad.spec.ts
+++ b/e2e/squad.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.use({ storageState: AUTH_STATE })
+
+test('squad view renders', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (err) => errors.push(err.message))
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text())
+  })
+
+  await page.goto('/')
+  await page.getByRole('button', { name: /squad/i }).first().click()
+  await expect(page.locator('[data-testid="squad-view"]')).toBeVisible()
+  expect(errors).toEqual([])
+})

--- a/e2e/vault.spec.ts
+++ b/e2e/vault.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test'
+import { mockSolanaRpc } from './fixtures/mocks'
+
+const AUTH_STATE = 'e2e/fixtures/storageState.json'
+
+test.use({ storageState: AUTH_STATE })
+
+test('vault view renders', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (err) => errors.push(err.message))
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text())
+  })
+
+  await mockSolanaRpc(page)
+  await page.goto('/')
+  await page.getByRole('button', { name: /vault/i }).first().click()
+  await expect(page.locator('[data-testid="vault-view"]')).toBeVisible()
+  expect(errors).toEqual([])
+})

--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
     "thanks": "bash scripts/thanks.sh",
     "openapi:export": "tsx scripts/export-openapi.ts",
     "sdks:generate": "bash sdks/generator/generate.sh",
-    "devnet-demo": "tsx scripts/devnet-shielded-transfer.ts"
+    "devnet-demo": "tsx scripts/devnet-shielded-transfer.ts",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.31",
@@ -49,6 +52,7 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/compression": "^1.8.1",
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -20,6 +20,7 @@
     "jsonwebtoken": "^9.0.3",
     "twitter-api-v2": "^1.29.0",
     "ulid": "^3.0.2",
+    "zod": "^3.24.2",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/packages/agent/src/adapters/web.ts
+++ b/packages/agent/src/adapters/web.ts
@@ -158,6 +158,9 @@ export function createWebAdapter() {
     // Track client disconnect. On disconnect we also reject any pending
     // sentinel flags for this session so the wrapped executor unblocks and
     // Pi's tool loop can wind down (instead of waiting on the 120s timeout).
+    // Note: session ids are wallet-deterministic, so clearAll affects all
+    // concurrent streams for the same wallet (e.g. multi-tab). Acceptable
+    // because a single wallet realistically has one active stream at a time.
     let aborted = false
     res.on('close', () => {
       aborted = true

--- a/packages/agent/src/adapters/web.ts
+++ b/packages/agent/src/adapters/web.ts
@@ -34,6 +34,14 @@ function chunkToSSE(chunk: ResponseChunk): Record<string, unknown> {
         id: chunk.toolId,
         success: chunk.success,
       }
+    case 'sentinel_advisory':
+      return {
+        type: 'sentinel_advisory',
+        action: chunk.advisory?.action ?? '',
+        amount: chunk.advisory?.amount ?? '',
+        severity: chunk.advisory?.severity ?? '',
+        description: chunk.advisory?.description ?? '',
+      }
     case 'error':
       return { type: 'error', message: chunk.text }
     case 'done':

--- a/packages/agent/src/adapters/web.ts
+++ b/packages/agent/src/adapters/web.ts
@@ -1,6 +1,8 @@
 import type { Request, Response } from 'express'
 import type { ResponseChunk } from '../core/types.js'
 import { AgentCore } from '../core/agent-core.js'
+import { resolveSession } from '../session.js'
+import { clearAll } from '../sentinel/pending.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Web Adapter — maps Express HTTP requests to AgentCore
@@ -34,13 +36,14 @@ function chunkToSSE(chunk: ResponseChunk): Record<string, unknown> {
         id: chunk.toolId,
         success: chunk.success,
       }
-    case 'sentinel_advisory':
+    case 'sentinel_pause':
       return {
-        type: 'sentinel_advisory',
-        action: chunk.advisory?.action ?? '',
-        amount: chunk.advisory?.amount ?? '',
-        severity: chunk.advisory?.severity ?? '',
-        description: chunk.advisory?.description ?? '',
+        type: 'sentinel_pause',
+        flagId: chunk.pause?.flagId ?? '',
+        action: chunk.pause?.action ?? '',
+        amount: chunk.pause?.amount ?? '',
+        severity: chunk.pause?.severity ?? '',
+        description: chunk.pause?.description ?? '',
       }
     case 'error':
       return { type: 'error', message: chunk.text }
@@ -140,6 +143,11 @@ export function createWebAdapter() {
       return
     }
 
+    // Resolve the session up-front so the disconnect handler has a stable id.
+    // resolveSession is deterministic by wallet, so this is the same session
+    // AgentCore.streamMessage will use internally.
+    const session = resolveSession(wallet)
+
     // Set SSE headers
     res.setHeader('Content-Type', 'text/event-stream')
     res.setHeader('Cache-Control', 'no-cache')
@@ -147,10 +155,13 @@ export function createWebAdapter() {
     res.setHeader('X-Accel-Buffering', 'no')
     res.flushHeaders()
 
-    // Track client disconnect
+    // Track client disconnect. On disconnect we also reject any pending
+    // sentinel flags for this session so the wrapped executor unblocks and
+    // Pi's tool loop can wind down (instead of waiting on the 120s timeout).
     let aborted = false
     res.on('close', () => {
       aborted = true
+      clearAll(session.id)
     })
 
     try {

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto'
 import type { AnthropicTool } from './pi/tool-adapter.js'
 import {
   depositTool,
@@ -373,7 +374,11 @@ export async function* chatStream(
   userMessage: string,
   opts: ChatOptions = {},
 ): AsyncGenerator<SSEEvent> {
-  const sessionId = opts.sessionId ?? 'unknown'
+  // Use a stable fallback UUID when no sessionId is provided so that pending
+  // flags from concurrent anonymous callers (tests, future direct callers)
+  // don't collide under a shared key. Production callers (AgentCore) always
+  // pass a real session id derived from the wallet.
+  const sessionId = opts.sessionId ?? randomUUID()
   const externalQueue: SSESentinelPause[] = []
   let externalWake: (() => void) | null = null
   const baseExecutor = opts.toolExecutor ?? executeTool

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -51,6 +51,7 @@ import { streamPiAgent } from './pi/stream-bridge.js'
 import { attachToolGuard } from './pi/tool-guard.js'
 import { runPreflightGate, type AdvisoryInfo } from './sentinel/preflight-gate.js'
 import { getSentinelConfig } from './sentinel/config.js'
+import { createPending } from './sentinel/pending.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // System prompt — Sipher's identity and behavior rules
@@ -142,14 +143,22 @@ const TOOL_EXECUTORS: Record<string, ToolExecutor> = {
  * Runs preflight gate for fund-moving tools before dispatching.
  * Throws if the tool name is not registered or SENTINEL blocks.
  *
- * `onAdvisory` is invoked synchronously (before the underlying executor) when
- * SENTINEL flagged the action without blocking AND mode === 'advisory'. The
- * callback is optional — existing callers compile unchanged.
+ * `onPause` is awaited (before the underlying executor) when SENTINEL flagged
+ * the action without blocking AND mode === 'advisory'. The callback's promise
+ * represents the user-driven approve/cancel decision:
+ *   - resolves → continue and run the tool
+ *   - rejects  → return a synthetic `{ status: 'cancelled_by_user', reason }`
+ *                result instead of running the tool. Pi treats this as the
+ *                tool's output; the LLM then communicates cancellation to the
+ *                user per its system prompt.
+ *
+ * The callback is optional — existing 2-arg callers compile unchanged and
+ * silently skip the pause (the tool runs as if no advisory existed).
  */
 export async function executeTool(
   name: string,
   input: Record<string, unknown>,
-  onAdvisory?: (info: AdvisoryInfo) => void,
+  onPause?: (info: AdvisoryInfo) => Promise<void>,
 ): Promise<unknown> {
   const executor = TOOL_EXECUTORS[name]
   if (!executor) {
@@ -160,8 +169,18 @@ export async function executeTool(
   if (!gate.allowed) {
     throw new Error(`SENTINEL blocked: ${gate.reasons.join('; ')}`)
   }
-  if (gate.advisory && onAdvisory && getSentinelConfig().mode === 'advisory') {
-    onAdvisory(gate.advisory)
+  if (gate.advisory && onPause && getSentinelConfig().mode === 'advisory') {
+    try {
+      await onPause(gate.advisory)
+    } catch (err) {
+      // User cancelled or the pending promise timed out — return a synthetic
+      // tool result so Pi's tool loop continues instead of throwing. The LLM
+      // sees this output and reports cancellation gracefully to the user.
+      return {
+        status: 'cancelled_by_user',
+        reason: err instanceof Error ? err.message : 'cancelled',
+      }
+    }
   }
   return executor(input)
 }
@@ -215,8 +234,10 @@ export interface SSEError {
   message: string
 }
 
-export interface SSESentinelAdvisory {
-  type: 'sentinel_advisory'
+export interface SSESentinelPause {
+  type: 'sentinel_pause'
+  /** Server-issued ID — client posts to /api/sentinel/override/:flagId or /cancel/:flagId */
+  flagId: string
   /** Humanized action label, e.g. "Send to Abc...123" */
   action: string
   /** Optional amount string, e.g. "5 SOL" — empty when not applicable */
@@ -233,7 +254,7 @@ export type SSEEvent =
   | SSEToolResult
   | SSEMessageComplete
   | SSEError
-  | SSESentinelAdvisory
+  | SSESentinelPause
 
 // ─── Local helpers — humanize advisory metadata for the UI ──────────────────
 
@@ -331,33 +352,54 @@ export async function chat(
  * Pi's push-based event model to a pull-based async generator of SSEEvents
  * compatible with AgentCore's SSEEvent vocabulary.
  *
- * SENTINEL advisories: When the default executor (`executeTool`) is in use
- * and SENTINEL flagged the action without blocking, the advisory is captured
- * via the optional `onAdvisory` callback and emitted as a `sentinel_advisory`
- * SSE event immediately before the corresponding `tool_result`. Custom
- * `opts.toolExecutor` overrides bypass advisory capture (no preflight gate).
+ * SENTINEL pause/resume: When the default executor (`executeTool`) is in use
+ * and SENTINEL flagged the action without blocking, a pending flag is created
+ * (sentinel/pending.ts) and a `sentinel_pause` SSE event is injected into the
+ * stream-bridge's external queue. The executor awaits the pending promise
+ * until the user POSTs to `/api/sentinel/override/:flagId` (resume) or
+ * `/cancel/:flagId` (cancel). Cancellation is surfaced as a synthetic
+ * `{ status: 'cancelled_by_user' }` tool result; the LLM reports it back.
+ *
+ * The pause event MUST go through streamPiAgent's external queue (not a
+ * chatStream-local buffer) — the wrapped executor blocks Pi between
+ * `tool_execution_start` and `tool_execution_end`, so any local drain pattern
+ * keyed on `tool_result` deadlocks: client never sees pause → never approves
+ * → executor blocks forever → bridge yields nothing. The external queue lets
+ * the bridge emit pause events while the executor is still mid-await.
+ *
+ * Custom `opts.toolExecutor` overrides bypass pause capture (no preflight gate).
  */
 export async function* chatStream(
   userMessage: string,
   opts: ChatOptions = {},
 ): AsyncGenerator<SSEEvent> {
-  const advisoryQueue: SSESentinelAdvisory[] = []
+  const sessionId = opts.sessionId ?? 'unknown'
+  const externalQueue: SSESentinelPause[] = []
+  let externalWake: (() => void) | null = null
   const baseExecutor = opts.toolExecutor ?? executeTool
 
-  // Wrap the executor so advisory callbacks are routed into a per-request queue.
-  // We keep the wrapper signature `(name, input) => Promise` to match the Pi
-  // executor contract and pass our internal `onAdvisory` only to the default
-  // `executeTool`. Custom executors are invoked unchanged.
+  // Wrap the executor so SENTINEL advisory pauses are captured and routed
+  // through the stream-bridge's external queue. We keep the wrapper signature
+  // `(name, input) => Promise` to match the Pi executor contract and only
+  // intercept calls that route through the default `executeTool`. Custom
+  // executors are invoked unchanged.
   const wrappedExecutor = (name: string, input: Record<string, unknown>): Promise<unknown> => {
     if (baseExecutor === executeTool) {
-      return executeTool(name, input, (adv) => {
-        advisoryQueue.push({
-          type: 'sentinel_advisory',
+      return executeTool(name, input, async (adv) => {
+        const { flagId, promise } = createPending(sessionId, name, input)
+        externalQueue.push({
+          type: 'sentinel_pause',
+          flagId,
           action: humanizeAction(name, input),
           amount: extractAmount(input),
           severity: adv.severity,
           description: adv.description,
         })
+        // Wake the bridge so it drains externalQueue immediately. Without this
+        // the pause event would sit until Pi emitted another event — which
+        // can't happen because Pi is blocked on this awaiting executor.
+        if (externalWake) externalWake()
+        await promise
       })
     }
     return baseExecutor(name, input)
@@ -372,15 +414,12 @@ export async function* chatStream(
     sessionId: opts.sessionId,
   })
 
-  // Drain the advisory queue before each tool_result so the client renders the
-  // warning alongside the tool's outcome. Advisories are populated synchronously
-  // inside executeTool (which Pi awaits between tool_use and tool_result), so by
-  // the time tool_result arrives the queue holds the matching advisory(ies).
-  for await (const event of streamPiAgent(agent, userMessage)) {
-    if (event.type === 'tool_result' && advisoryQueue.length > 0) {
-      const drained = advisoryQueue.splice(0, advisoryQueue.length)
-      for (const adv of drained) yield adv
-    }
+  for await (const event of streamPiAgent<SSESentinelPause>(agent, userMessage, {
+    externalQueue,
+    attachWake: (wake) => {
+      externalWake = wake
+    },
+  })) {
     yield event
   }
 }

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -49,7 +49,8 @@ import type { AgentMessage } from '@mariozechner/pi-agent-core'
 import { createPiAgent } from './pi/sipher-agent.js'
 import { streamPiAgent } from './pi/stream-bridge.js'
 import { attachToolGuard } from './pi/tool-guard.js'
-import { runPreflightGate } from './sentinel/preflight-gate.js'
+import { runPreflightGate, type AdvisoryInfo } from './sentinel/preflight-gate.js'
+import { getSentinelConfig } from './sentinel/config.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // System prompt — Sipher's identity and behavior rules
@@ -140,10 +141,15 @@ const TOOL_EXECUTORS: Record<string, ToolExecutor> = {
  * Execute a tool by name with the given input.
  * Runs preflight gate for fund-moving tools before dispatching.
  * Throws if the tool name is not registered or SENTINEL blocks.
+ *
+ * `onAdvisory` is invoked synchronously (before the underlying executor) when
+ * SENTINEL flagged the action without blocking AND mode === 'advisory'. The
+ * callback is optional — existing callers compile unchanged.
  */
 export async function executeTool(
   name: string,
   input: Record<string, unknown>,
+  onAdvisory?: (info: AdvisoryInfo) => void,
 ): Promise<unknown> {
   const executor = TOOL_EXECUTORS[name]
   if (!executor) {
@@ -153,6 +159,9 @@ export async function executeTool(
   const gate = await runPreflightGate(name, input)
   if (!gate.allowed) {
     throw new Error(`SENTINEL blocked: ${gate.reasons.join('; ')}`)
+  }
+  if (gate.advisory && onAdvisory && getSentinelConfig().mode === 'advisory') {
+    onAdvisory(gate.advisory)
   }
   return executor(input)
 }
@@ -206,12 +215,62 @@ export interface SSEError {
   message: string
 }
 
+export interface SSESentinelAdvisory {
+  type: 'sentinel_advisory'
+  /** Humanized action label, e.g. "Send to Abc...123" */
+  action: string
+  /** Optional amount string, e.g. "5 SOL" — empty when not applicable */
+  amount: string
+  /** Risk severity — low | medium | high */
+  severity: string
+  /** Concatenated reasons from the RiskReport */
+  description: string
+}
+
 export type SSEEvent =
   | SSEContentDelta
   | SSEToolUse
   | SSEToolResult
   | SSEMessageComplete
   | SSEError
+  | SSESentinelAdvisory
+
+// ─── Local helpers — humanize advisory metadata for the UI ──────────────────
+
+/**
+ * Build a short, human-readable label describing the action being taken.
+ * Best-effort — falls back to the tool name when no recipient is present.
+ */
+function humanizeAction(name: string, input: Record<string, unknown>): string {
+  const recipient = typeof input.recipient === 'string' ? input.recipient : undefined
+  const verb =
+    name === 'send' ? 'Send to' :
+    name === 'swap' ? 'Swap' :
+    name === 'deposit' ? 'Deposit' :
+    name === 'refund' ? 'Refund' :
+    name === 'sweep' ? 'Sweep' :
+    name === 'consolidate' ? 'Consolidate' :
+    name === 'splitSend' ? 'Split-send to' :
+    name === 'scheduleSend' ? 'Schedule send to' :
+    name === 'drip' ? 'Drip to' :
+    name === 'recurring' ? 'Recurring send to' :
+    name
+  if (recipient) {
+    const short = recipient.length > 8 ? `${recipient.slice(0, 4)}...${recipient.slice(-4)}` : recipient
+    return `${verb} ${short}`
+  }
+  return verb
+}
+
+/**
+ * Format the input amount + token (e.g. "5 SOL") or empty string when unset.
+ */
+function extractAmount(input: Record<string, unknown>): string {
+  const amount = input.amount
+  if (typeof amount !== 'number' || !Number.isFinite(amount)) return ''
+  const token = typeof input.token === 'string' && input.token ? input.token : 'SOL'
+  return `${amount} ${token}`
+}
 
 /**
  * Run the SIPHER agent loop to completion via Pi SDK.
@@ -271,19 +330,57 @@ export async function chat(
  * Pi SDK drives the agentic tool loop internally. The stream-bridge converts
  * Pi's push-based event model to a pull-based async generator of SSEEvents
  * compatible with AgentCore's SSEEvent vocabulary.
+ *
+ * SENTINEL advisories: When the default executor (`executeTool`) is in use
+ * and SENTINEL flagged the action without blocking, the advisory is captured
+ * via the optional `onAdvisory` callback and emitted as a `sentinel_advisory`
+ * SSE event immediately before the corresponding `tool_result`. Custom
+ * `opts.toolExecutor` overrides bypass advisory capture (no preflight gate).
  */
 export async function* chatStream(
   userMessage: string,
   opts: ChatOptions = {},
 ): AsyncGenerator<SSEEvent> {
+  const advisoryQueue: SSESentinelAdvisory[] = []
+  const baseExecutor = opts.toolExecutor ?? executeTool
+
+  // Wrap the executor so advisory callbacks are routed into a per-request queue.
+  // We keep the wrapper signature `(name, input) => Promise` to match the Pi
+  // executor contract and pass our internal `onAdvisory` only to the default
+  // `executeTool`. Custom executors are invoked unchanged.
+  const wrappedExecutor = (name: string, input: Record<string, unknown>): Promise<unknown> => {
+    if (baseExecutor === executeTool) {
+      return executeTool(name, input, (adv) => {
+        advisoryQueue.push({
+          type: 'sentinel_advisory',
+          action: humanizeAction(name, input),
+          amount: extractAmount(input),
+          severity: adv.severity,
+          description: adv.description,
+        })
+      })
+    }
+    return baseExecutor(name, input)
+  }
+
   const agent = createPiAgent({
     systemPrompt: opts.systemPrompt ?? SYSTEM_PROMPT,
     tools: opts.tools ?? TOOLS,
-    toolExecutor: opts.toolExecutor ?? executeTool,
+    toolExecutor: wrappedExecutor,
     model: opts.model,
     history: opts.history,
     sessionId: opts.sessionId,
   })
 
-  yield* streamPiAgent(agent, userMessage)
+  // Drain the advisory queue before each tool_result so the client renders the
+  // warning alongside the tool's outcome. Advisories are populated synchronously
+  // inside executeTool (which Pi awaits between tool_use and tool_result), so by
+  // the time tool_result arrives the queue holds the matching advisory(ies).
+  for await (const event of streamPiAgent(agent, userMessage)) {
+    if (event.type === 'tool_result' && advisoryQueue.length > 0) {
+      const drained = advisoryQueue.splice(0, advisoryQueue.length)
+      for (const adv of drained) yield adv
+    }
+    yield event
+  }
 }

--- a/packages/agent/src/core/agent-core.ts
+++ b/packages/agent/src/core/agent-core.ts
@@ -172,6 +172,18 @@ export class AgentCore {
           }
           break
 
+        case 'sentinel_advisory':
+          yield {
+            type: 'sentinel_advisory',
+            advisory: {
+              action: event.action,
+              amount: event.amount,
+              severity: event.severity,
+              description: event.description,
+            },
+          }
+          break
+
         case 'error':
           yield { type: 'error', text: event.message }
           break

--- a/packages/agent/src/core/agent-core.ts
+++ b/packages/agent/src/core/agent-core.ts
@@ -172,10 +172,11 @@ export class AgentCore {
           }
           break
 
-        case 'sentinel_advisory':
+        case 'sentinel_pause':
           yield {
-            type: 'sentinel_advisory',
-            advisory: {
+            type: 'sentinel_pause',
+            pause: {
+              flagId: event.flagId,
               action: event.action,
               amount: event.amount,
               severity: event.severity,

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -30,13 +30,14 @@ export interface MsgContext {
 
 /** A single response chunk for streaming */
 export interface ResponseChunk {
-  type: 'text' | 'tool_start' | 'tool_end' | 'error' | 'done' | 'sentinel_advisory'
+  type: 'text' | 'tool_start' | 'tool_end' | 'error' | 'done' | 'sentinel_pause'
   text?: string
   toolName?: string
   toolId?: string
   success?: boolean
-  /** Populated only when type === 'sentinel_advisory' */
-  advisory?: {
+  /** Populated only when type === 'sentinel_pause' */
+  pause?: {
+    flagId: string
     action: string
     amount: string
     severity: string

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -30,11 +30,18 @@ export interface MsgContext {
 
 /** A single response chunk for streaming */
 export interface ResponseChunk {
-  type: 'text' | 'tool_start' | 'tool_end' | 'error' | 'done'
+  type: 'text' | 'tool_start' | 'tool_end' | 'error' | 'done' | 'sentinel_advisory'
   text?: string
   toolName?: string
   toolId?: string
   success?: boolean
+  /** Populated only when type === 'sentinel_advisory' */
+  advisory?: {
+    action: string
+    amount: string
+    severity: string
+    description: string
+  }
 }
 
 /** Full (non-streaming) agent response */

--- a/packages/agent/src/herald/approval.ts
+++ b/packages/agent/src/herald/approval.ts
@@ -1,5 +1,55 @@
 import { getDb } from '../db.js'
 
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'NotFoundError'
+  }
+}
+
+/**
+ * Typed row from herald_queue.
+ * Note: schema has no updated_at column — created_at reflects creation time only.
+ * Last-edit timestamp tracking is deferred to a future migration.
+ */
+export interface QueueItem {
+  id: string
+  type: string
+  content: string
+  status: string
+  scheduled_at?: string | null
+  reply_to?: string | null
+  approved_by?: string | null
+  approved_at?: string | null
+  posted_at?: string | null
+  tweet_id?: string | null
+  metrics?: string | null
+  created_at: string
+}
+
+/**
+ * Fetch a single queue item by id. Returns undefined if not found.
+ */
+export function getQueueItem(id: string): QueueItem | undefined {
+  const row = getDb().prepare('SELECT * FROM herald_queue WHERE id = ?').get(id)
+  return row as QueueItem | undefined
+}
+
+/**
+ * Update the content of any queue item regardless of status (admin-level access).
+ * Unlike editQueuedPost, this has no status restriction — the route layer enforces
+ * any business rules about which statuses allow edits.
+ * Returns the canonical post-update row.
+ */
+export function updateContent(id: string, content: string): QueueItem {
+  const existing = getQueueItem(id)
+  if (!existing) throw new NotFoundError(`queue item ${id} not found`)
+  getDb().prepare('UPDATE herald_queue SET content = ? WHERE id = ?').run(content, id)
+  const updated = getQueueItem(id)
+  if (!updated) throw new NotFoundError(`queue item ${id} disappeared after update`)
+  return updated
+}
+
 /**
  * Get all pending posts from herald_queue, ordered by created_at ascending.
  */

--- a/packages/agent/src/pi/stream-bridge.ts
+++ b/packages/agent/src/pi/stream-bridge.ts
@@ -96,6 +96,31 @@ export function mapPiEventToSSE(event: AgentEvent): SSEEvent[] {
 }
 
 /**
+ * Optional injection points for external producers (e.g. the chatStream
+ * sentinel pause loop) that need to interleave events into the bridge's
+ * output stream WITHOUT waiting for a Pi event to arrive.
+ *
+ * Why this exists: when a tool executor blocks on a user-driven approval
+ * (sentinel pause), the executor is awaited inside Pi's tool loop — Pi
+ * can't emit events until the executor returns. Without this hook the
+ * pause notification can't reach the SSE client until tool_execution_end,
+ * which deadlocks the system (client never sees pause → never approves →
+ * executor never resolves).
+ *
+ * The chatStream wrapper pushes pause events onto `externalQueue` and
+ * calls the wake function (received via `attachWake`) to make the
+ * generator drain its queues.
+ *
+ * Generic `T` lets callers extend the yielded event union with their own
+ * variants (e.g. SSESentinelPause from agent.ts) without forcing this
+ * module to import them.
+ */
+export interface StreamBridgeOptions<T = SSEEvent> {
+  externalQueue?: Array<T>
+  attachWake?: (wake: () => void) => void
+}
+
+/**
  * Wrap a Pi Agent run as an async generator of SSEEvents.
  *
  * The agent must have its tools, model, and system prompt configured before
@@ -108,12 +133,18 @@ export function mapPiEventToSSE(event: AgentEvent): SSEEvent[] {
  * - They are enqueued and a pending Promise is resolved to wake the generator
  * - The generator yields from the queue and waits when empty
  * - Cleanup via unsubscribe() in finally, regardless of early return or throw
+ *
+ * Optional `options.externalQueue` + `options.attachWake` allow callers to
+ * inject events from outside the Pi event stream (used by chatStream's
+ * sentinel pause loop — see chatStream in agent.ts).
  */
-export async function* streamPiAgent(
+export async function* streamPiAgent<T = SSEEvent>(
   agent: Agent,
   userMessage: string,
-): AsyncGenerator<SSEEvent, void, unknown> {
+  options?: StreamBridgeOptions<T>,
+): AsyncGenerator<SSEEvent | T, void, unknown> {
   const queue: SSEEvent[] = []
+  const externalQueue: Array<T> = options?.externalQueue ?? []
   let resolveNext: (() => void) | null = null
   let done = false
   let errorEvent: SSEError | null = null
@@ -124,6 +155,10 @@ export async function* streamPiAgent(
       resolveNext = null
     }
   }
+
+  // Hand the wake function back to the caller so external producers can push
+  // into externalQueue and trigger a drain.
+  if (options?.attachWake) options.attachWake(wake)
 
   const guardUnsub = attachToolGuard(agent)
 
@@ -158,7 +193,13 @@ export async function* streamPiAgent(
   })
 
   try {
-    while (!done || queue.length > 0) {
+    while (!done || queue.length > 0 || externalQueue.length > 0) {
+      // Drain externally-injected events first so pause notifications reach
+      // the client BEFORE the corresponding tool_result.
+      while (externalQueue.length > 0) {
+        const evt = externalQueue.shift()
+        if (evt) yield evt
+      }
       while (queue.length > 0) {
         const evt = queue.shift()
         if (evt) yield evt

--- a/packages/agent/src/routes/herald-api.ts
+++ b/packages/agent/src/routes/herald-api.ts
@@ -1,7 +1,9 @@
 import { Router, type Request, type Response } from 'express'
-import { getPendingPosts, approvePost, rejectPost, editQueuedPost } from '../herald/approval.js'
+import { z } from 'zod'
+import { getPendingPosts, approvePost, rejectPost, getQueueItem, updateContent, NotFoundError } from '../herald/approval.js'
 import { getBudgetStatus } from '../herald/budget.js'
 import { getDb } from '../db.js'
+import { guardianBus } from '../coordination/event-bus.js'
 
 export const heraldRouter = Router()
 
@@ -18,10 +20,58 @@ heraldRouter.get('/', (_req: Request, res: Response) => {
   res.json({ queue, budget, dms, recentPosts })
 })
 
-// POST /api/herald/approve/:id — approve, reject, or edit a queued post
+// PATCH /api/herald/queue/:id — update content of any queue item (admin only via mount middleware)
+const updateSchema = z.object({
+  content: z.string().trim().min(1).max(280),
+})
+
+heraldRouter.patch('/queue/:id', (req: Request, res: Response): void => {
+  const parsed = updateSchema.safeParse(req.body)
+  if (!parsed.success) {
+    res.status(400).json({
+      error: {
+        code: 'INVALID_CONTENT',
+        message: parsed.error.issues[0]?.message ?? 'invalid content',
+      },
+    })
+    return
+  }
+
+  const id = req.params.id as string
+  const oldItem = getQueueItem(id)
+
+  try {
+    const updated = updateContent(id, parsed.data.content)
+    if (oldItem) {
+      const wallet = (req as unknown as Record<string, unknown>).wallet as string
+      guardianBus.emit({
+        source: 'herald',
+        type: 'herald:edited',
+        level: 'important',
+        data: {
+          id: updated.id,
+          oldContent: oldItem.content,
+          newContent: updated.content,
+          editedBy: wallet,
+        },
+        wallet,
+        timestamp: new Date().toISOString(),
+      })
+    }
+    res.status(200).json(updated)
+  } catch (err) {
+    if (err instanceof NotFoundError) {
+      res.status(404).json({ error: { code: 'NOT_FOUND', message: err.message } })
+      return
+    }
+    throw err
+  }
+})
+
+// POST /api/herald/approve/:id — approve or reject a queued post
 heraldRouter.post('/approve/:id', (req: Request, res: Response) => {
   const id = req.params.id as string
-  const { action, content } = req.body as { action?: string; content?: string }
+  const { action } = req.body as { action?: string }
 
   const post = getDb()
     .prepare("SELECT * FROM herald_queue WHERE id = ? AND status IN ('pending', 'approved')")
@@ -45,16 +95,7 @@ heraldRouter.post('/approve/:id', (req: Request, res: Response) => {
       res.json({ status: 'rejected', id })
       break
 
-    case 'edit':
-      if (!content) {
-        res.status(400).json({ error: 'content required for edit' })
-        return
-      }
-      editQueuedPost(id, content)
-      res.json({ status: 'edited', id })
-      break
-
     default:
-      res.status(400).json({ error: 'action must be approve, reject, or edit' })
+      res.status(400).json({ error: 'action must be approve or reject' })
   }
 })

--- a/packages/agent/src/routes/sentinel-api.ts
+++ b/packages/agent/src/routes/sentinel-api.ts
@@ -97,6 +97,10 @@ sentinelAdminRouter.get('/decisions', (req: Request, res: Response) => {
   res.json({ decisions: listDecisions({ limit, source }) })
 })
 
+// ─── Promise-gate endpoints (pause/resume for advisory mode) ────────────────
+// NOTE: distinct from /pending/:id/cancel above (circuit-breaker, SQLite-backed).
+// These act on in-memory pending promises owned by sentinel/pending.ts.
+
 sentinelAdminRouter.post('/override/:flagId', (req: Request, res: Response) => {
   const flagId = String(req.params.flagId)
   const ok = resolvePending(flagId)

--- a/packages/agent/src/routes/sentinel-api.ts
+++ b/packages/agent/src/routes/sentinel-api.ts
@@ -6,6 +6,7 @@ import {
 import { cancelCircuitBreakerAction } from '../sentinel/circuit-breaker.js'
 import { getSentinelAssessor } from '../sentinel/preflight-gate.js'
 import { getSentinelConfig } from '../sentinel/config.js'
+import { resolvePending, rejectPending } from '../sentinel/pending.js'
 
 // ─── Public endpoints (verifyJwt only) ──────────────────────────────────────
 export const sentinelPublicRouter: Router = Router()
@@ -94,6 +95,26 @@ sentinelAdminRouter.get('/decisions', (req: Request, res: Response) => {
   const limit = Number(String(req.query.limit ?? '50'))
   const source = (typeof req.query.source === 'string' ? req.query.source : undefined)
   res.json({ decisions: listDecisions({ limit, source }) })
+})
+
+sentinelAdminRouter.post('/override/:flagId', (req: Request, res: Response) => {
+  const flagId = String(req.params.flagId)
+  const ok = resolvePending(flagId)
+  if (!ok) {
+    res.status(404).json({ error: { code: 'NOT_FOUND', message: 'flag not found or expired' } })
+    return
+  }
+  res.status(204).send()
+})
+
+sentinelAdminRouter.post('/cancel/:flagId', (req: Request, res: Response) => {
+  const flagId = String(req.params.flagId)
+  const ok = rejectPending(flagId, 'cancelled_by_user')
+  if (!ok) {
+    res.status(404).json({ error: { code: 'NOT_FOUND', message: 'flag not found or expired' } })
+    return
+  }
+  res.status(204).send()
 })
 
 // ─── Combined router (backwards compatibility) ──────────────────────────────

--- a/packages/agent/src/sentinel/pending.ts
+++ b/packages/agent/src/sentinel/pending.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto'
 
-interface PendingFlag {
+export interface PendingFlag {
   sessionId: string
   toolName: string
   toolInput: unknown

--- a/packages/agent/src/sentinel/pending.ts
+++ b/packages/agent/src/sentinel/pending.ts
@@ -1,0 +1,80 @@
+import { randomUUID } from 'crypto'
+
+interface PendingFlag {
+  sessionId: string
+  toolName: string
+  toolInput: unknown
+  createdAt: number
+  resolver: (value: void) => void
+  rejecter: (reason: Error) => void
+  timeoutHandle: NodeJS.Timeout
+}
+
+let TIMEOUT_MS = 120_000
+const pending = new Map<string, PendingFlag>()
+
+export function _setTimeoutMsForTests(ms: number): void {
+  TIMEOUT_MS = ms
+}
+
+export function createPending(
+  sessionId: string,
+  toolName: string,
+  toolInput: unknown,
+): { flagId: string; promise: Promise<void> } {
+  const flagId = randomUUID()
+  let resolver!: (value: void) => void
+  let rejecter!: (reason: Error) => void
+  const promise = new Promise<void>((resolve, reject) => {
+    resolver = resolve
+    rejecter = reject
+  })
+  const timeoutHandle = setTimeout(() => {
+    if (pending.has(flagId)) {
+      pending.delete(flagId)
+      rejecter(new Error('operation timed out'))
+    }
+  }, TIMEOUT_MS)
+  pending.set(flagId, {
+    sessionId,
+    toolName,
+    toolInput,
+    createdAt: Date.now(),
+    resolver,
+    rejecter,
+    timeoutHandle,
+  })
+  return { flagId, promise }
+}
+
+export function resolvePending(flagId: string): boolean {
+  const entry = pending.get(flagId)
+  if (!entry) return false
+  clearTimeout(entry.timeoutHandle)
+  pending.delete(flagId)
+  entry.resolver()
+  return true
+}
+
+export function rejectPending(flagId: string, reason: string): boolean {
+  const entry = pending.get(flagId)
+  if (!entry) return false
+  clearTimeout(entry.timeoutHandle)
+  pending.delete(flagId)
+  entry.rejecter(new Error(reason))
+  return true
+}
+
+export function clearAll(sessionId: string): void {
+  for (const [flagId, entry] of pending.entries()) {
+    if (entry.sessionId === sessionId) {
+      clearTimeout(entry.timeoutHandle)
+      pending.delete(flagId)
+      entry.rejecter(new Error('client_disconnected'))
+    }
+  }
+}
+
+export function getPending(flagId: string): PendingFlag | undefined {
+  return pending.get(flagId)
+}

--- a/packages/agent/src/sentinel/preflight-gate.ts
+++ b/packages/agent/src/sentinel/preflight-gate.ts
@@ -16,8 +16,24 @@ export function getSentinelAssessor(): SentinelAssessor | null {
   return assessor
 }
 
+/**
+ * Advisory metadata surfaced when SENTINEL flagged an action but did not block.
+ * Populated only when the LLM analyst returned `recommendation: 'warn'` — static
+ * rules currently only allow or block, so they never produce an advisory.
+ */
+export interface AdvisoryInfo {
+  /** Risk level — low | medium | high (mirrors RiskReport.risk) */
+  severity: string
+  /** Human-readable summary built from RiskReport.reasons */
+  description: string
+  /** Original recommendation — 'warn' for advisories */
+  recommendation: string
+}
+
 export interface PreflightOutcome {
   allowed: true
+  /** Present when SENTINEL flagged but allowed the action (advisory mode) */
+  advisory?: AdvisoryInfo
 }
 
 export interface PreflightBlocked {
@@ -69,6 +85,18 @@ export async function runPreflightGate(
     })
     if (report.recommendation === 'block') {
       return { allowed: false, reasons: report.blockers ?? report.reasons }
+    }
+    // Surface advisory metadata when the LLM warned but didn't block. The caller
+    // decides whether to forward it to the client (e.g. SSE) based on mode.
+    if (report.recommendation === 'warn' && report.reasons.length > 0) {
+      return {
+        allowed: true,
+        advisory: {
+          severity: report.risk,
+          description: report.reasons.join('; '),
+          recommendation: report.recommendation,
+        },
+      }
     }
     return { allowed: true }
   } catch (err) {

--- a/packages/agent/tests/herald/queue-patch.test.ts
+++ b/packages/agent/tests/herald/queue-patch.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import express from 'express'
+import supertest from 'supertest'
+import jwt from 'jsonwebtoken'
+import { closeDb, getDb } from '../../src/db.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ADMIN_WALLET = 'admin-wallet-test'
+const NON_ADMIN_WALLET = 'random-wallet-test'
+const TEST_JWT_SECRET = 'test-secret-for-queue-patch-tests'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function signJwt(wallet: string): string {
+  return jwt.sign({ wallet }, TEST_JWT_SECRET, { expiresIn: '1h', algorithm: 'HS256' })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Module imports (top-level await — Vitest ESM)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const { heraldRouter } = await import('../../src/routes/herald-api.js')
+const { verifyJwt, requireOwner } = await import('../../src/routes/auth.js')
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test setup
+// ─────────────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  closeDb()
+  process.env.DB_PATH = ':memory:'
+  process.env.NODE_ENV = 'test'
+  process.env.JWT_SECRET = TEST_JWT_SECRET
+  process.env.AUTHORIZED_WALLETS = ADMIN_WALLET
+
+  // Seed a known queue item
+  const db = getDb()
+  db.prepare(
+    'INSERT INTO herald_queue (id, type, content, status, created_at) VALUES (?, ?, ?, ?, ?)'
+  ).run('q1', 'tweet', 'old content', 'pending', new Date().toISOString())
+})
+
+afterEach(() => {
+  closeDb()
+  delete process.env.DB_PATH
+  delete process.env.JWT_SECRET
+  delete process.env.AUTHORIZED_WALLETS
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// App factory — includes full auth chain to exercise 403 path
+// ─────────────────────────────────────────────────────────────────────────────
+
+function createApp() {
+  const app = express()
+  app.use(express.json())
+  app.use('/api/herald', verifyJwt, requireOwner, heraldRouter)
+  return app
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('PATCH /api/herald/queue/:id', () => {
+  it('updates content and returns 200 with the updated item', async () => {
+    const res = await supertest(createApp())
+      .patch('/api/herald/queue/q1')
+      .set('Authorization', `Bearer ${signJwt(ADMIN_WALLET)}`)
+      .send({ content: 'new content' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.id).toBe('q1')
+    expect(res.body.content).toBe('new content')
+    expect(res.body.status).toBe('pending')
+  })
+
+  it('returns 400 for empty content', async () => {
+    const res = await supertest(createApp())
+      .patch('/api/herald/queue/q1')
+      .set('Authorization', `Bearer ${signJwt(ADMIN_WALLET)}`)
+      .send({ content: '' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('INVALID_CONTENT')
+  })
+
+  it('returns 400 for content exceeding 280 characters', async () => {
+    const res = await supertest(createApp())
+      .patch('/api/herald/queue/q1')
+      .set('Authorization', `Bearer ${signJwt(ADMIN_WALLET)}`)
+      .send({ content: 'a'.repeat(281) })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('INVALID_CONTENT')
+  })
+
+  it('returns 404 for an unknown queue item id', async () => {
+    const res = await supertest(createApp())
+      .patch('/api/herald/queue/does-not-exist')
+      .set('Authorization', `Bearer ${signJwt(ADMIN_WALLET)}`)
+      .send({ content: 'valid content' })
+
+    expect(res.status).toBe(404)
+    expect(res.body.error.code).toBe('NOT_FOUND')
+  })
+
+  it('returns 403 for a non-admin wallet', async () => {
+    const res = await supertest(createApp())
+      .patch('/api/herald/queue/q1')
+      .set('Authorization', `Bearer ${signJwt(NON_ADMIN_WALLET)}`)
+      .send({ content: 'new content' })
+
+    expect(res.status).toBe(403)
+  })
+})

--- a/packages/agent/tests/herald/queue-update.test.ts
+++ b/packages/agent/tests/herald/queue-update.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getDb, closeDb } from '../../src/db.js'
+import {
+  getQueueItem,
+  updateContent,
+  NotFoundError,
+} from '../../src/herald/approval.js'
+
+describe('herald-queue updateContent', () => {
+  beforeEach(() => {
+    closeDb()
+    process.env.NODE_ENV = 'test'
+  })
+
+  it('updates content and returns the updated item', () => {
+    const db = getDb()
+    db.prepare(`
+      INSERT INTO herald_queue (id, type, content, status, created_at)
+      VALUES (?, ?, ?, ?, ?)
+    `).run('q1', 'tweet', 'original', 'pending', new Date().toISOString())
+
+    const updated = updateContent('q1', 'edited tweet')
+    expect(updated.content).toBe('edited tweet')
+    expect(updated.id).toBe('q1')
+    expect(updated.status).toBe('pending')
+  })
+
+  it('throws NotFoundError for unknown id', () => {
+    expect(() => updateContent('does-not-exist', 'x')).toThrow(NotFoundError)
+    expect(() => updateContent('does-not-exist', 'x')).toThrow(/not.found/i)
+  })
+
+  it('persists the change so subsequent reads see new content', () => {
+    const db = getDb()
+    db.prepare(`
+      INSERT INTO herald_queue (id, type, content, status, created_at)
+      VALUES (?, ?, ?, ?, ?)
+    `).run('q2', 'tweet', 'original', 'pending', new Date().toISOString())
+
+    updateContent('q2', 'fresh')
+    const fetched = getQueueItem('q2')
+    expect(fetched?.content).toBe('fresh')
+  })
+})

--- a/packages/agent/tests/routes/herald-api.test.ts
+++ b/packages/agent/tests/routes/herald-api.test.ts
@@ -122,7 +122,7 @@ describe('POST /api/herald/approve/:id', () => {
     expect(res.body.error).toMatch(/not found/i)
   })
 
-  it('returns 400 for edit action without content', async () => {
+  it('returns 400 for edit action (legacy — removed in favor of PATCH /queue/:id)', async () => {
     insertQueuePost('post-3', 'pending')
 
     const res = await supertest(createApp())
@@ -130,28 +130,14 @@ describe('POST /api/herald/approve/:id', () => {
       .send({ action: 'edit' })
 
     expect(res.status).toBe(400)
-    expect(res.body.error).toMatch(/content required/i)
-  })
-
-  it('edits a pending post content', async () => {
-    insertQueuePost('post-4', 'pending', 'original content')
-
-    const res = await supertest(createApp())
-      .post('/api/herald/approve/post-4')
-      .send({ action: 'edit', content: 'updated content' })
-
-    expect(res.status).toBe(200)
-    expect(res.body).toEqual({ status: 'edited', id: 'post-4' })
-
-    const row = getDb().prepare('SELECT content FROM herald_queue WHERE id = ?').get('post-4') as { content: string }
-    expect(row.content).toBe('updated content')
+    expect(res.body.error).toMatch(/action must be approve or reject/i)
   })
 
   it('returns 400 for unknown action', async () => {
-    insertQueuePost('post-5', 'pending')
+    insertQueuePost('post-4', 'pending')
 
     const res = await supertest(createApp())
-      .post('/api/herald/approve/post-5')
+      .post('/api/herald/approve/post-4')
       .send({ action: 'invalidaction' })
 
     expect(res.status).toBe(400)

--- a/packages/agent/tests/sentinel/advisory-event.test.ts
+++ b/packages/agent/tests/sentinel/advisory-event.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SENTINEL advisory SSE event — covers the path:
+//   runPreflightGate → executeTool(onAdvisory) → chatStream(SSE injection)
+//
+// Two layers of test:
+//   1. runPreflightGate populates `advisory` for warn-recommendation reports
+//   2. executeTool fires the onAdvisory callback only in advisory mode
+//
+// We don't drive a full chatStream here — the queue/injection logic is
+// exercised by integration tests in pi-smoke. The new behavior we need to
+// prove is the gate change + callback wiring.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('runPreflightGate advisory surface', () => {
+  beforeEach(() => {
+    process.env.DB_PATH = ':memory:'
+    vi.resetModules()
+  })
+  afterEach(() => {
+    delete process.env.DB_PATH
+    delete process.env.SENTINEL_MODE
+  })
+
+  async function freshDb() {
+    const { closeDb, getDb } = await import('../../src/db.js')
+    closeDb()
+    getDb()
+  }
+
+  it('returns advisory metadata when LLM recommendation === warn', async () => {
+    await freshDb()
+    const { setSentinelAssessor, runPreflightGate } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(vi.fn().mockResolvedValue({
+      risk: 'medium',
+      score: 50,
+      reasons: ['recipient is new', 'amount is large for this wallet'],
+      recommendation: 'warn',
+      decisionId: 'dec1',
+      durationMs: 200,
+    }) as never)
+
+    const result = await runPreflightGate('send', { wallet: 'w1', recipient: 'stranger', amount: 5 })
+
+    expect(result.allowed).toBe(true)
+    if (result.allowed) {
+      expect(result.advisory).toBeDefined()
+      expect(result.advisory?.severity).toBe('medium')
+      expect(result.advisory?.description).toBe('recipient is new; amount is large for this wallet')
+      expect(result.advisory?.recommendation).toBe('warn')
+    }
+  })
+
+  it('does NOT populate advisory when recommendation === allow', async () => {
+    await freshDb()
+    const { setSentinelAssessor, runPreflightGate } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(vi.fn().mockResolvedValue({
+      risk: 'low',
+      score: 5,
+      reasons: ['ok'],
+      recommendation: 'allow',
+      decisionId: 'dec2',
+      durationMs: 100,
+    }) as never)
+
+    const result = await runPreflightGate('send', { wallet: 'w1', recipient: 'stranger', amount: 5 })
+
+    expect(result.allowed).toBe(true)
+    if (result.allowed) {
+      expect(result.advisory).toBeUndefined()
+    }
+  })
+
+  it('blocks (no advisory) when recommendation === block', async () => {
+    await freshDb()
+    const { setSentinelAssessor, runPreflightGate } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(vi.fn().mockResolvedValue({
+      risk: 'high',
+      score: 90,
+      reasons: ['suspicious'],
+      recommendation: 'block',
+      blockers: ['address was reported'],
+      decisionId: 'dec3',
+      durationMs: 100,
+    }) as never)
+
+    const result = await runPreflightGate('send', { wallet: 'w1', recipient: 'stranger', amount: 5 })
+    expect(result.allowed).toBe(false)
+  })
+})
+
+describe('executeTool onAdvisory callback', () => {
+  beforeEach(() => {
+    process.env.DB_PATH = ':memory:'
+    vi.resetModules()
+  })
+  afterEach(() => {
+    delete process.env.DB_PATH
+    delete process.env.SENTINEL_MODE
+  })
+
+  async function freshDb() {
+    const { closeDb, getDb } = await import('../../src/db.js')
+    closeDb()
+    getDb()
+  }
+
+  it('fires onAdvisory when SENTINEL warns AND mode === advisory', async () => {
+    await freshDb()
+    process.env.SENTINEL_MODE = 'advisory'
+    const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(vi.fn().mockResolvedValue({
+      risk: 'medium',
+      score: 50,
+      reasons: ['unknown recipient'],
+      recommendation: 'warn',
+      decisionId: 'dec1',
+      durationMs: 100,
+    }) as never)
+
+    vi.doMock('../../src/tools/send.js', () => ({
+      executeSend: vi.fn().mockResolvedValue({ action: 'send', success: true }),
+      sendTool: { name: 'send', description: '', input_schema: { type: 'object', properties: {} } },
+    }))
+    const { executeTool } = await import('../../src/agent.js')
+    const onAdvisory = vi.fn()
+
+    const result = await executeTool(
+      'send',
+      { wallet: 'w1', recipient: 'stranger', amount: 5 },
+      onAdvisory,
+    )
+
+    expect(result).toMatchObject({ success: true })
+    expect(onAdvisory).toHaveBeenCalledTimes(1)
+    expect(onAdvisory).toHaveBeenCalledWith({
+      severity: 'medium',
+      description: 'unknown recipient',
+      recommendation: 'warn',
+    })
+    vi.doUnmock('../../src/tools/send.js')
+  })
+
+  it('does NOT fire onAdvisory when mode !== advisory (yolo allows silently)', async () => {
+    await freshDb()
+    // SENTINEL_MODE unset → defaults to 'yolo'
+    const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(vi.fn().mockResolvedValue({
+      risk: 'medium',
+      score: 50,
+      reasons: ['unknown recipient'],
+      recommendation: 'warn',
+      decisionId: 'dec1',
+      durationMs: 100,
+    }) as never)
+
+    vi.doMock('../../src/tools/send.js', () => ({
+      executeSend: vi.fn().mockResolvedValue({ action: 'send', success: true }),
+      sendTool: { name: 'send', description: '', input_schema: { type: 'object', properties: {} } },
+    }))
+    const { executeTool } = await import('../../src/agent.js')
+    const onAdvisory = vi.fn()
+
+    await executeTool(
+      'send',
+      { wallet: 'w1', recipient: 'stranger', amount: 5 },
+      onAdvisory,
+    )
+
+    expect(onAdvisory).not.toHaveBeenCalled()
+    vi.doUnmock('../../src/tools/send.js')
+  })
+
+  it('existing 2-arg callers still work (onAdvisory is optional)', async () => {
+    await freshDb()
+    process.env.SENTINEL_MODE = 'advisory'
+    const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(vi.fn().mockResolvedValue({
+      risk: 'medium',
+      score: 50,
+      reasons: ['unknown recipient'],
+      recommendation: 'warn',
+      decisionId: 'dec1',
+      durationMs: 100,
+    }) as never)
+
+    vi.doMock('../../src/tools/send.js', () => ({
+      executeSend: vi.fn().mockResolvedValue({ action: 'send', success: true }),
+      sendTool: { name: 'send', description: '', input_schema: { type: 'object', properties: {} } },
+    }))
+    const { executeTool } = await import('../../src/agent.js')
+
+    // No onAdvisory passed — must not throw
+    const result = await executeTool('send', { wallet: 'w1', recipient: 'stranger', amount: 5 })
+    expect(result).toMatchObject({ success: true })
+    vi.doUnmock('../../src/tools/send.js')
+  })
+})
+
+describe('chatStream sentinel_advisory SSE injection', () => {
+  beforeEach(() => {
+    process.env.DB_PATH = ':memory:'
+    vi.resetModules()
+  })
+  afterEach(() => {
+    delete process.env.DB_PATH
+    delete process.env.SENTINEL_MODE
+  })
+
+  async function freshDb() {
+    const { closeDb, getDb } = await import('../../src/db.js')
+    closeDb()
+    getDb()
+  }
+
+  it('injects sentinel_advisory event before tool_result in advisory mode', async () => {
+    await freshDb()
+    process.env.SENTINEL_MODE = 'advisory'
+
+    const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(vi.fn().mockResolvedValue({
+      risk: 'high',
+      score: 70,
+      reasons: ['recipient flagged in recent activity'],
+      recommendation: 'warn',
+      decisionId: 'dec1',
+      durationMs: 100,
+    }) as never)
+
+    // Stub Pi agent so we control event emission deterministically.
+    // The fake agent invokes the toolExecutor (which is the chatStream-wrapped
+    // executor) between tool_execution_start and tool_execution_end so the
+    // advisory queue is populated before the tool_result event is yielded.
+    type Subscriber = (event: unknown) => void | Promise<void>
+    vi.doMock('../../src/pi/sipher-agent.js', async (orig) => {
+      const actual = (await orig()) as Record<string, unknown>
+      return {
+        ...actual,
+        createPiAgent: vi.fn((opts: {
+          toolExecutor: (n: string, i: Record<string, unknown>) => Promise<unknown>
+        }) => {
+          const subscribers: Subscriber[] = []
+          const messages: unknown[] = []
+          return {
+            subscribe: (cb: Subscriber) => {
+              subscribers.push(cb)
+              return () => {
+                const idx = subscribers.indexOf(cb)
+                if (idx >= 0) subscribers.splice(idx, 1)
+              }
+            },
+            prompt: async () => {
+              for (const cb of [...subscribers]) {
+                await cb({ type: 'tool_execution_start', toolCallId: 'c1', toolName: 'send' })
+              }
+              try {
+                await opts.toolExecutor('send', { wallet: 'w1', recipient: 'stranger', amount: 5 })
+              } catch {
+                // executor throws if tools/send.js isn't mocked — keep going so we still emit end
+              }
+              for (const cb of [...subscribers]) {
+                await cb({
+                  type: 'tool_execution_end',
+                  toolCallId: 'c1',
+                  toolName: 'send',
+                  isError: false,
+                })
+              }
+              messages.push({ role: 'assistant', content: [{ type: 'text', text: 'done' }] })
+              for (const cb of [...subscribers]) {
+                await cb({ type: 'agent_end', messages })
+              }
+            },
+            abort: () => {},
+            state: { messages },
+          }
+        }),
+      }
+    })
+
+    vi.doMock('../../src/tools/send.js', () => ({
+      executeSend: vi.fn().mockResolvedValue({ action: 'send', success: true }),
+      sendTool: { name: 'send', description: '', input_schema: { type: 'object', properties: {} } },
+    }))
+
+    const { chatStream } = await import('../../src/agent.js')
+    const events: Array<{ type: string }> = []
+    for await (const evt of chatStream('send 5 SOL')) {
+      events.push(evt as { type: string })
+    }
+
+    const types = events.map((e) => e.type)
+    expect(types).toContain('sentinel_advisory')
+
+    const advisoryIdx = types.indexOf('sentinel_advisory')
+    const toolResultIdx = types.indexOf('tool_result')
+    const toolUseIdx = types.indexOf('tool_use')
+
+    // Order must be: tool_use → sentinel_advisory → tool_result
+    expect(toolUseIdx).toBeLessThan(advisoryIdx)
+    expect(advisoryIdx).toBeLessThan(toolResultIdx)
+
+    const advisory = events[advisoryIdx] as {
+      type: string
+      action: string
+      amount: string
+      severity: string
+      description: string
+    }
+    expect(advisory.severity).toBe('high')
+    expect(advisory.description).toBe('recipient flagged in recent activity')
+    expect(advisory.amount).toBe('5 SOL')
+    expect(advisory.action).toContain('Send to')
+
+    vi.doUnmock('../../src/tools/send.js')
+    vi.doUnmock('../../src/pi/sipher-agent.js')
+  })
+})

--- a/packages/agent/tests/sentinel/pause-event.test.ts
+++ b/packages/agent/tests/sentinel/pause-event.test.ts
@@ -1,16 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 // ─────────────────────────────────────────────────────────────────────────────
-// SENTINEL advisory SSE event — covers the path:
-//   runPreflightGate → executeTool(onAdvisory) → chatStream(SSE injection)
+// SENTINEL pause SSE event — covers the path:
+//   runPreflightGate → executeTool(onPause) → chatStream(SSE injection)
 //
-// Two layers of test:
+// Three layers of test:
 //   1. runPreflightGate populates `advisory` for warn-recommendation reports
-//   2. executeTool fires the onAdvisory callback only in advisory mode
-//
-// We don't drive a full chatStream here — the queue/injection logic is
-// exercised by integration tests in pi-smoke. The new behavior we need to
-// prove is the gate change + callback wiring.
+//      (preflight gate behavior is unchanged from the advisory-light era —
+//      the gate still emits PreflightOutcome.advisory; only the downstream
+//      executor wiring changed)
+//   2. executeTool fires the onPause callback only in advisory mode and
+//      returns a synthetic cancelled result when onPause rejects
+//   3. chatStream injects sentinel_pause events with a flagId before
+//      tool_result, via the stream-bridge external queue
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('runPreflightGate advisory surface', () => {
@@ -90,7 +92,7 @@ describe('runPreflightGate advisory surface', () => {
   })
 })
 
-describe('executeTool onAdvisory callback', () => {
+describe('executeTool onPause callback', () => {
   beforeEach(() => {
     process.env.DB_PATH = ':memory:'
     vi.resetModules()
@@ -106,7 +108,7 @@ describe('executeTool onAdvisory callback', () => {
     getDb()
   }
 
-  it('fires onAdvisory when SENTINEL warns AND mode === advisory', async () => {
+  it('awaits onPause and continues to executor when promise resolves', async () => {
     await freshDb()
     process.env.SENTINEL_MODE = 'advisory'
     const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
@@ -119,30 +121,107 @@ describe('executeTool onAdvisory callback', () => {
       durationMs: 100,
     }) as never)
 
+    const executeSendMock = vi.fn().mockResolvedValue({ action: 'send', success: true })
     vi.doMock('../../src/tools/send.js', () => ({
-      executeSend: vi.fn().mockResolvedValue({ action: 'send', success: true }),
+      executeSend: executeSendMock,
       sendTool: { name: 'send', description: '', input_schema: { type: 'object', properties: {} } },
     }))
     const { executeTool } = await import('../../src/agent.js')
-    const onAdvisory = vi.fn()
+    const onPause = vi.fn().mockResolvedValue(undefined)
 
     const result = await executeTool(
       'send',
       { wallet: 'w1', recipient: 'stranger', amount: 5 },
-      onAdvisory,
+      onPause,
     )
 
-    expect(result).toMatchObject({ success: true })
-    expect(onAdvisory).toHaveBeenCalledTimes(1)
-    expect(onAdvisory).toHaveBeenCalledWith({
+    expect(onPause).toHaveBeenCalledTimes(1)
+    expect(onPause).toHaveBeenCalledWith({
       severity: 'medium',
       description: 'unknown recipient',
       recommendation: 'warn',
     })
+    expect(executeSendMock).toHaveBeenCalledTimes(1)
+    expect(result).toMatchObject({ success: true })
     vi.doUnmock('../../src/tools/send.js')
   })
 
-  it('does NOT fire onAdvisory when mode !== advisory (yolo allows silently)', async () => {
+  it('returns synthetic cancelled result (does NOT throw) when onPause rejects', async () => {
+    await freshDb()
+    process.env.SENTINEL_MODE = 'advisory'
+    const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(vi.fn().mockResolvedValue({
+      risk: 'medium',
+      score: 50,
+      reasons: ['unknown recipient'],
+      recommendation: 'warn',
+      decisionId: 'dec1',
+      durationMs: 100,
+    }) as never)
+
+    const executeSendMock = vi.fn().mockResolvedValue({ action: 'send', success: true })
+    vi.doMock('../../src/tools/send.js', () => ({
+      executeSend: executeSendMock,
+      sendTool: { name: 'send', description: '', input_schema: { type: 'object', properties: {} } },
+    }))
+    const { executeTool } = await import('../../src/agent.js')
+    const onPause = vi.fn().mockRejectedValue(new Error('cancelled_by_user'))
+
+    const result = await executeTool(
+      'send',
+      { wallet: 'w1', recipient: 'stranger', amount: 5 },
+      onPause,
+    )
+
+    expect(onPause).toHaveBeenCalledTimes(1)
+    // Synthetic cancelled tool result — Pi treats this as the tool's output,
+    // and the LLM communicates cancellation to the user.
+    expect(result).toEqual({
+      status: 'cancelled_by_user',
+      reason: 'cancelled_by_user',
+    })
+    // The underlying executor must NOT have run when the user cancelled.
+    expect(executeSendMock).not.toHaveBeenCalled()
+    vi.doUnmock('../../src/tools/send.js')
+  })
+
+  it('returns synthetic cancelled result when onPause rejects with non-Error reason', async () => {
+    await freshDb()
+    process.env.SENTINEL_MODE = 'advisory'
+    const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(vi.fn().mockResolvedValue({
+      risk: 'medium',
+      score: 50,
+      reasons: ['unknown recipient'],
+      recommendation: 'warn',
+      decisionId: 'dec1',
+      durationMs: 100,
+    }) as never)
+
+    const executeSendMock = vi.fn().mockResolvedValue({ action: 'send', success: true })
+    vi.doMock('../../src/tools/send.js', () => ({
+      executeSend: executeSendMock,
+      sendTool: { name: 'send', description: '', input_schema: { type: 'object', properties: {} } },
+    }))
+    const { executeTool } = await import('../../src/agent.js')
+    // Reject with a non-Error to cover the fallback branch in agent.ts
+    const onPause = vi.fn().mockRejectedValue('cancelled_str')
+
+    const result = await executeTool(
+      'send',
+      { wallet: 'w1', recipient: 'stranger', amount: 5 },
+      onPause,
+    )
+
+    expect(result).toEqual({
+      status: 'cancelled_by_user',
+      reason: 'cancelled',
+    })
+    expect(executeSendMock).not.toHaveBeenCalled()
+    vi.doUnmock('../../src/tools/send.js')
+  })
+
+  it('does NOT invoke onPause when mode !== advisory (yolo allows silently)', async () => {
     await freshDb()
     // SENTINEL_MODE unset → defaults to 'yolo'
     const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
@@ -160,19 +239,19 @@ describe('executeTool onAdvisory callback', () => {
       sendTool: { name: 'send', description: '', input_schema: { type: 'object', properties: {} } },
     }))
     const { executeTool } = await import('../../src/agent.js')
-    const onAdvisory = vi.fn()
+    const onPause = vi.fn().mockResolvedValue(undefined)
 
     await executeTool(
       'send',
       { wallet: 'w1', recipient: 'stranger', amount: 5 },
-      onAdvisory,
+      onPause,
     )
 
-    expect(onAdvisory).not.toHaveBeenCalled()
+    expect(onPause).not.toHaveBeenCalled()
     vi.doUnmock('../../src/tools/send.js')
   })
 
-  it('existing 2-arg callers still work (onAdvisory is optional)', async () => {
+  it('existing 2-arg callers still work (onPause is optional)', async () => {
     await freshDb()
     process.env.SENTINEL_MODE = 'advisory'
     const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
@@ -191,14 +270,14 @@ describe('executeTool onAdvisory callback', () => {
     }))
     const { executeTool } = await import('../../src/agent.js')
 
-    // No onAdvisory passed — must not throw
+    // No onPause passed — must not throw, and the executor runs normally.
     const result = await executeTool('send', { wallet: 'w1', recipient: 'stranger', amount: 5 })
     expect(result).toMatchObject({ success: true })
     vi.doUnmock('../../src/tools/send.js')
   })
 })
 
-describe('chatStream sentinel_advisory SSE injection', () => {
+describe('chatStream sentinel_pause SSE injection', () => {
   beforeEach(() => {
     process.env.DB_PATH = ':memory:'
     vi.resetModules()
@@ -214,7 +293,7 @@ describe('chatStream sentinel_advisory SSE injection', () => {
     getDb()
   }
 
-  it('injects sentinel_advisory event before tool_result in advisory mode', async () => {
+  it('injects sentinel_pause event before tool_result with flagId in advisory mode', async () => {
     await freshDb()
     process.env.SENTINEL_MODE = 'advisory'
 
@@ -228,10 +307,19 @@ describe('chatStream sentinel_advisory SSE injection', () => {
       durationMs: 100,
     }) as never)
 
+    // Force pending flags to time out fast so the executor unblocks within
+    // the test (synthetic cancelled result → tool_execution_end fires).
+    // 50ms is generous — tests don't need to wait on real users.
+    const { _setTimeoutMsForTests } = await import('../../src/sentinel/pending.js')
+    _setTimeoutMsForTests(50)
+
     // Stub Pi agent so we control event emission deterministically.
     // The fake agent invokes the toolExecutor (which is the chatStream-wrapped
-    // executor) between tool_execution_start and tool_execution_end so the
-    // advisory queue is populated before the tool_result event is yielded.
+    // executor) between tool_execution_start and tool_execution_end. The
+    // wrapped executor pushes the pause event onto streamPiAgent's external
+    // queue and awaits the pending promise. With the fast timeout above the
+    // promise rejects after ~50ms, the executor returns a synthetic cancelled
+    // result, and Pi proceeds to tool_execution_end.
     type Subscriber = (event: unknown) => void | Promise<void>
     vi.doMock('../../src/pi/sipher-agent.js', async (orig) => {
       const actual = (await orig()) as Record<string, unknown>
@@ -257,7 +345,7 @@ describe('chatStream sentinel_advisory SSE injection', () => {
               try {
                 await opts.toolExecutor('send', { wallet: 'w1', recipient: 'stranger', amount: 5 })
               } catch {
-                // executor throws if tools/send.js isn't mocked — keep going so we still emit end
+                // executor may throw if tools/send.js isn't mocked — keep going so we still emit end
               }
               for (const cb of [...subscribers]) {
                 await cb({
@@ -291,28 +379,34 @@ describe('chatStream sentinel_advisory SSE injection', () => {
     }
 
     const types = events.map((e) => e.type)
-    expect(types).toContain('sentinel_advisory')
+    expect(types).toContain('sentinel_pause')
 
-    const advisoryIdx = types.indexOf('sentinel_advisory')
+    const pauseIdx = types.indexOf('sentinel_pause')
     const toolResultIdx = types.indexOf('tool_result')
     const toolUseIdx = types.indexOf('tool_use')
 
-    // Order must be: tool_use → sentinel_advisory → tool_result
-    expect(toolUseIdx).toBeLessThan(advisoryIdx)
-    expect(advisoryIdx).toBeLessThan(toolResultIdx)
+    // Order must be: tool_use → sentinel_pause → tool_result
+    expect(toolUseIdx).toBeGreaterThanOrEqual(0)
+    expect(pauseIdx).toBeGreaterThan(toolUseIdx)
+    expect(toolResultIdx).toBeGreaterThan(pauseIdx)
 
-    const advisory = events[advisoryIdx] as {
+    const pause = events[pauseIdx] as {
       type: string
+      flagId: string
       action: string
       amount: string
       severity: string
       description: string
     }
-    expect(advisory.severity).toBe('high')
-    expect(advisory.description).toBe('recipient flagged in recent activity')
-    expect(advisory.amount).toBe('5 SOL')
-    expect(advisory.action).toContain('Send to')
+    expect(pause.flagId).toBeTypeOf('string')
+    expect(pause.flagId.length).toBeGreaterThan(0)
+    expect(pause.severity).toBe('high')
+    expect(pause.description).toBe('recipient flagged in recent activity')
+    expect(pause.amount).toBe('5 SOL')
+    expect(pause.action).toContain('Send to')
 
+    // Reset timeout for any other tests that import the module
+    _setTimeoutMsForTests(120_000)
     vi.doUnmock('../../src/tools/send.js')
     vi.doUnmock('../../src/pi/sipher-agent.js')
   })

--- a/packages/agent/tests/sentinel/pause-resume-routes.test.ts
+++ b/packages/agent/tests/sentinel/pause-resume-routes.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import express from 'express'
+import supertest from 'supertest'
+import jwt from 'jsonwebtoken'
+import { createPending, clearAll } from '../../src/sentinel/pending.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ADMIN_WALLET = 'admin-wallet-test'
+const NON_ADMIN_WALLET = 'random-wallet-test'
+const TEST_JWT_SECRET = 'test-secret-for-sentinel-pause-tests'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function signJwt(wallet: string): string {
+  return jwt.sign({ wallet }, TEST_JWT_SECRET, { expiresIn: '1h', algorithm: 'HS256' })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Module imports (top-level await — Vitest ESM)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const { sentinelAdminRouter } = await import('../../src/routes/sentinel-api.js')
+const { verifyJwt, requireOwner } = await import('../../src/routes/auth.js')
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test setup
+// ─────────────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  process.env.NODE_ENV = 'test'
+  process.env.JWT_SECRET = TEST_JWT_SECRET
+  process.env.AUTHORIZED_WALLETS = ADMIN_WALLET
+  for (const s of ['test-session', 's1', 's2']) clearAll(s)
+})
+
+afterEach(() => {
+  delete process.env.JWT_SECRET
+  delete process.env.AUTHORIZED_WALLETS
+  for (const s of ['test-session', 's1', 's2']) clearAll(s)
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// App factory — mounts sentinelAdminRouter with full auth chain
+// ─────────────────────────────────────────────────────────────────────────────
+
+function createApp() {
+  const app = express()
+  app.use(express.json())
+  app.use('/api/sentinel', verifyJwt, requireOwner, sentinelAdminRouter)
+  return app
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('SENTINEL pause/resume routes', () => {
+  it('POST /api/sentinel/override/:flagId resolves the pending promise (204)', async () => {
+    const { flagId, promise } = createPending('test-session', 'send', { amount: 1 })
+    const res = await supertest(createApp())
+      .post(`/api/sentinel/override/${flagId}`)
+      .set('Authorization', `Bearer ${signJwt(ADMIN_WALLET)}`)
+    expect(res.status).toBe(204)
+    await expect(promise).resolves.toBeUndefined()
+  })
+
+  it('POST /api/sentinel/cancel/:flagId rejects the pending promise (204)', async () => {
+    const { flagId, promise } = createPending('test-session', 'send', { amount: 1 })
+    // attach noop catch before the HTTP call so Node doesn't flag the rejection as unhandled
+    // before our .rejects assertion consumes it
+    promise.catch(() => {})
+    const res = await supertest(createApp())
+      .post(`/api/sentinel/cancel/${flagId}`)
+      .set('Authorization', `Bearer ${signJwt(ADMIN_WALLET)}`)
+    expect(res.status).toBe(204)
+    await expect(promise).rejects.toThrow(/cancelled/i)
+  })
+
+  it('returns 404 for unknown flag id', async () => {
+    const res = await supertest(createApp())
+      .post('/api/sentinel/override/does-not-exist')
+      .set('Authorization', `Bearer ${signJwt(ADMIN_WALLET)}`)
+    expect(res.status).toBe(404)
+    expect(res.body.error.code).toBe('NOT_FOUND')
+  })
+
+  it('returns 403 for non-admin wallet', async () => {
+    // attach noop catch — afterEach clearAll rejects this promise, suppress the unhandled noise
+    const { flagId, promise } = createPending('test-session', 'send', { amount: 1 })
+    promise.catch(() => {})
+    const res = await supertest(createApp())
+      .post(`/api/sentinel/override/${flagId}`)
+      .set('Authorization', `Bearer ${signJwt(NON_ADMIN_WALLET)}`)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 401 with no Authorization header', async () => {
+    // attach noop catch — afterEach clearAll rejects this promise, suppress the unhandled noise
+    const { flagId, promise } = createPending('test-session', 'send', { amount: 1 })
+    promise.catch(() => {})
+    const res = await supertest(createApp()).post(`/api/sentinel/override/${flagId}`)
+    expect(res.status).toBe(401)
+  })
+})

--- a/packages/agent/tests/sentinel/pending.test.ts
+++ b/packages/agent/tests/sentinel/pending.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe('sentinel-pending', () => {
   beforeEach(() => {
-    clearAll('test-session')
+    for (const s of ['test-session', 's1', 's2']) clearAll(s)
     _setTimeoutMsForTests(120_000)
     vi.useRealTimers()
   })

--- a/packages/agent/tests/sentinel/pending.test.ts
+++ b/packages/agent/tests/sentinel/pending.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  createPending,
+  resolvePending,
+  rejectPending,
+  clearAll,
+  _setTimeoutMsForTests,
+} from '../../src/sentinel/pending.js'
+
+describe('sentinel-pending', () => {
+  beforeEach(() => {
+    clearAll('test-session')
+    _setTimeoutMsForTests(120_000)
+    vi.useRealTimers()
+  })
+
+  it('resolves the pending promise on resolvePending', async () => {
+    const { flagId, promise } = createPending('test-session', 'send', { amount: 1 })
+    setTimeout(() => resolvePending(flagId), 5)
+    await expect(promise).resolves.toBeUndefined()
+  })
+
+  it('rejects the pending promise on rejectPending', async () => {
+    const { flagId, promise } = createPending('test-session', 'send', { amount: 1 })
+    setTimeout(() => rejectPending(flagId, 'cancelled_by_user'), 5)
+    await expect(promise).rejects.toThrow('cancelled_by_user')
+  })
+
+  it('returns false for unknown flag id', () => {
+    expect(resolvePending('unknown-id')).toBe(false)
+    expect(rejectPending('unknown-id', 'x')).toBe(false)
+  })
+
+  it('rejects with timeout after configured duration', async () => {
+    _setTimeoutMsForTests(50)
+    const { promise } = createPending('test-session', 'send', { amount: 1 })
+    await expect(promise).rejects.toThrow(/timed out/i)
+  })
+
+  it('clearAll rejects all pending in the given session', async () => {
+    const a = createPending('s1', 'send', {})
+    const b = createPending('s1', 'swap', {})
+    const c = createPending('s2', 'send', {})
+    clearAll('s1')
+    await expect(a.promise).rejects.toThrow(/disconnected/i)
+    await expect(b.promise).rejects.toThrow(/disconnected/i)
+    setTimeout(() => resolvePending(c.flagId), 5)
+    await expect(c.promise).resolves.toBeUndefined()
+  })
+})

--- a/patches/@triton-one__yellowstone-grpc@4.0.2.patch
+++ b/patches/@triton-one__yellowstone-grpc@4.0.2.patch
@@ -1,0 +1,14 @@
+diff --git a/dist/esm/encoding/package.json b/dist/esm/encoding/package.json
+new file mode 100644
+index 0000000000000000000000000000000000000000..729ac4d93b7f2d9be36b44525f02ff6555f9383a
+--- /dev/null
++++ b/dist/esm/encoding/package.json
+@@ -0,0 +1 @@
++{"type":"commonjs"}
+diff --git a/dist/esm/package.json b/dist/esm/package.json
+new file mode 100644
+index 0000000000000000000000000000000000000000..089153bcb5adf57dc25f206a9dad3114c9cff80d
+--- /dev/null
++++ b/dist/esm/package.json
+@@ -0,0 +1 @@
++{"type":"module"}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,53 @@
+import { defineConfig, devices } from '@playwright/test'
+import path from 'node:path'
+
+const PORT_FRONTEND = 5173
+const PORT_BACKEND = 3000
+
+export default defineConfig({
+  testDir: './e2e',
+  testIgnore: ['**/fixtures/**'],
+  fullyParallel: true,
+  workers: process.env.CI ? 2 : undefined,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  timeout: 30_000,
+  reporter: process.env.CI ? [['html'], ['github']] : [['html'], ['list']],
+  globalSetup: path.resolve(__dirname, './e2e/global-setup.ts'),
+  globalTeardown: path.resolve(__dirname, './e2e/global-teardown.ts'),
+  use: {
+    baseURL: `http://localhost:${PORT_FRONTEND}`,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: [
+    {
+      command: 'pnpm --filter @sipher/agent dev',
+      url: `http://localhost:${PORT_BACKEND}/api/health`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+      env: {
+        NODE_ENV: 'test',
+        PORT: String(PORT_BACKEND),
+        HERALD_ENABLED: 'false',
+        SIPHER_DB_PATH: './e2e/test.db',
+        AUTHORIZED_WALLETS: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
+        JWT_SECRET: process.env.JWT_SECRET ?? 'e2e-test-secret-at-least-16-chars',
+        SENTINEL_MODE: 'off',
+      },
+    },
+    {
+      command: 'pnpm --filter @sipher/app dev',
+      url: `http://localhost:${PORT_FRONTEND}`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+    },
+  ],
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig, devices } from '@playwright/test'
-import path from 'node:path'
 
 const PORT_FRONTEND = 5173
 const PORT_BACKEND = 3000
@@ -13,8 +12,8 @@ export default defineConfig({
   retries: process.env.CI ? 1 : 0,
   timeout: 30_000,
   reporter: process.env.CI ? [['html'], ['github']] : [['html'], ['list']],
-  globalSetup: path.resolve(__dirname, './e2e/global-setup.ts'),
-  globalTeardown: path.resolve(__dirname, './e2e/global-teardown.ts'),
+  globalSetup: './e2e/global-setup.ts',
+  globalTeardown: './e2e/global-teardown.ts',
   use: {
     baseURL: `http://localhost:${PORT_FRONTEND}`,
     trace: 'retain-on-failure',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 1.8.0
       '@sip-protocol/sdk':
         specifier: ^0.7.4
-        version: 0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))
+        version: 0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))
       '@sip-protocol/types':
         specifier: ^0.2.2
         version: 0.2.2
@@ -177,10 +177,10 @@ importers:
     dependencies:
       '@mariozechner/pi-agent-core':
         specifier: ^0.66.1
-        version: 0.66.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
+        version: 0.66.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@mariozechner/pi-ai':
         specifier: ^0.66.1
-        version: 0.66.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
+        version: 0.66.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@noble/ciphers':
         specifier: ^2.1.1
         version: 2.1.1
@@ -211,6 +211,9 @@ importers:
       ws:
         specifier: ^8.18.0
         version: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      zod:
+        specifier: ^3.24.2
+        version: 3.25.76
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -7185,11 +7188,11 @@ snapshots:
       '@img/sharp-linuxmusl-x64': 0.33.5
       '@img/sharp-win32-x64': 0.33.5
 
-  '@anthropic-ai/sdk@0.73.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.73.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 4.3.6
+      zod: 3.25.76
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -8269,14 +8272,14 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))':
+  '@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.3.87(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      langsmith: 0.3.87(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -8309,26 +8312,26 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
 
-  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))':
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@langchain/langgraph-sdk@1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       p-queue: 9.1.0
       p-retry: 7.1.1
       uuid: 13.0.0
     optionalDependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)':
+  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
-      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 3.25.76
@@ -8338,11 +8341,11 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)':
+  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
-      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 3.25.76
@@ -8352,9 +8355,20 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      js-tiktoken: 1.0.21
+      openai: 4.104.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - encoding
+      - ws
+
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       js-tiktoken: 1.0.21
       openai: 4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       zod: 3.25.76
@@ -8408,9 +8422,9 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - utf-8-validate
 
-  '@mariozechner/pi-agent-core@0.66.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)':
+  '@mariozechner/pi-agent-core@0.66.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
-      '@mariozechner/pi-ai': 0.66.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.66.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -8420,9 +8434,9 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.66.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.66.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
-      '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.73.0(zod@3.25.76)
       '@aws-sdk/client-bedrock-runtime': 3.1027.0
       '@google/genai': 1.49.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@mistralai/mistralai': 1.14.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -8430,11 +8444,11 @@ snapshots:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       chalk: 5.6.2
-      openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
+      openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       partial-json: 0.1.7
       proxy-agent: 6.5.0
       undici: 7.24.7
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -9068,13 +9082,13 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@sip-protocol/sdk@0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))':
+  '@sip-protocol/sdk@0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
       '@aztec/bb.js': 3.0.2
       '@ethereumjs/rlp': 10.1.1
       '@jup-ag/api': 6.0.48
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@magicblock-labs/ephemeral-rollups-sdk': 0.8.5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
       '@noble/ciphers': 2.1.1
       '@noble/curves': 1.9.7
@@ -9093,7 +9107,7 @@ snapshots:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@triton-one/yellowstone-grpc': 4.0.2
-      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))
+      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))
       pino: 10.3.0
       zod: 4.3.6
     optionalDependencies:
@@ -9121,7 +9135,7 @@ snapshots:
       '@ethereumjs/rlp': 10.1.1
       '@jup-ag/api': 6.0.48
       '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@magicblock-labs/ephemeral-rollups-sdk': 0.8.5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
       '@noble/ciphers': 2.1.1
       '@noble/curves': 1.9.7
@@ -9140,7 +9154,7 @@ snapshots:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@triton-one/yellowstone-grpc': 4.0.2
-      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))
+      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))
       pino: 10.3.0
       zod: 4.3.6
     optionalDependencies:
@@ -13967,12 +13981,12 @@ snapshots:
 
   keyvaluestorage-interface@1.0.0: {}
 
-  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76)):
+  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76)):
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
-      langsmith: 0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      langsmith: 0.4.12(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       uuid: 10.0.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -13984,11 +13998,11 @@ snapshots:
       - react-dom
       - zod-to-json-schema
 
-  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6)):
+  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6)):
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
       langsmith: 0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
       uuid: 10.0.0
       zod: 3.25.76
@@ -14001,7 +14015,7 @@ snapshots:
       - react-dom
       - zod-to-json-schema
 
-  langsmith@0.3.87(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
+  langsmith@0.3.87(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -14010,7 +14024,7 @@ snapshots:
       semver: 7.7.3
       uuid: 10.0.0
     optionalDependencies:
-      openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      openai: 6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
 
   langsmith@0.3.87(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)):
     dependencies:
@@ -14023,7 +14037,7 @@ snapshots:
     optionalDependencies:
       openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
 
-  langsmith@0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
+  langsmith@0.4.12(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -14032,7 +14046,7 @@ snapshots:
       semver: 7.7.3
       uuid: 10.0.0
     optionalDependencies:
-      openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      openai: 6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
 
   langsmith@0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)):
     dependencies:
@@ -14592,6 +14606,21 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  openai@4.104.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    optionalDependencies:
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - encoding
+
   openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
@@ -14607,16 +14636,22 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
+    optionalDependencies:
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      zod: 3.25.76
+    optional: true
+
   openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
     optionalDependencies:
       ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod: 3.25.76
-    optional: true
 
   openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6):
     optionalDependencies:
       ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod: 4.3.6
+    optional: true
 
   ox@0.14.7(typescript@5.9.3)(zod@3.22.4):
     dependencies:
@@ -16292,6 +16327,7 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+    optional: true
 
   zod@3.22.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@triton-one/yellowstone-grpc@4.0.2':
+    hash: 3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a
+    path: patches/@triton-one__yellowstone-grpc@4.0.2.patch
+
 importers:
 
   .:
@@ -9106,7 +9111,7 @@ snapshots:
       '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@triton-one/yellowstone-grpc': 4.0.2
+      '@triton-one/yellowstone-grpc': 4.0.2(patch_hash=3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a)
       langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))
       pino: 10.3.0
       zod: 4.3.6
@@ -9153,7 +9158,7 @@ snapshots:
       '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@triton-one/yellowstone-grpc': 4.0.2
+      '@triton-one/yellowstone-grpc': 4.0.2(patch_hash=3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a)
       langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))
       pino: 10.3.0
       zod: 4.3.6
@@ -11463,7 +11468,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@triton-one/yellowstone-grpc@4.0.2':
+  '@triton-one/yellowstone-grpc@4.0.2(patch_hash=3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a)':
     dependencies:
       '@grpc/grpc-js': 1.14.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 1.8.0
       '@sip-protocol/sdk':
         specifier: ^0.7.4
-        version: 0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))
+        version: 0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))
       '@sip-protocol/types':
         specifier: ^0.2.2
         version: 0.2.2
@@ -66,6 +66,9 @@ importers:
         specifier: ^3.24.2
         version: 3.25.76
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@types/compression':
         specifier: ^1.8.1
         version: 1.8.1
@@ -104,7 +107,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.5
-        version: 3.2.4(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@25.2.0)(jiti@2.6.1)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   app:
     dependencies:
@@ -139,6 +142,15 @@ importers:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.2.0(react@19.2.4))
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -148,12 +160,18 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.0
         version: 4.7.0(vite@6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
       vite:
         specifier: ^6.0.0
         version: 6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@25.2.0)(jiti@2.6.1)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/agent:
     dependencies:
@@ -223,7 +241,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@25.2.0)(jiti@2.6.1)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/sdk:
     dependencies:
@@ -245,9 +263,12 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@25.2.0)(jiti@2.6.1)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
@@ -266,6 +287,9 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -590,6 +614,34 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@solana/web3.js': ^1.68.0
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@emurgo/cardano-serialization-lib-browser@13.2.1':
     resolution: {integrity: sha512-7RfX1gI16Vj2DgCp/ZoXqyLAakWo6+X95ku/rYGbVzuS/1etrlSiJmdbmdm+eYmszMlGQjrtOJQeVLXoj4L/Ag==}
@@ -1364,6 +1416,11 @@ packages:
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@project-serum/sol-wallet-adapter@0.2.6':
     resolution: {integrity: sha512-cpIb13aWPW8y4KzkZAPDgw+Kb+DXjCC6rZoH74MGm3I/6e/zKyGnfAuW5olb2zxonFqsYgnv7ev8MQnvSgJ3/g==}
@@ -3007,6 +3064,35 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
@@ -3187,6 +3273,9 @@ packages:
   '@triton-one/yellowstone-grpc@4.0.2':
     resolution: {integrity: sha512-RsHNbLz6zCU3OpQRBqKWcXqDDOKj1nxc/78LIt9kZWBU2kfYeFs7361eUpYE9Q3+BizjpCLF6BX9G1OitD76bw==}
     engines: {node: '>=20.18.0'}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -3575,6 +3664,13 @@ packages:
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
@@ -4053,6 +4149,13 @@ packages:
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -4063,6 +4166,10 @@ packages:
   data-uri-to-buffer@6.0.2:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
@@ -4090,6 +4197,9 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-uri-component@0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
@@ -4138,6 +4248,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   derive-valtio@0.1.0:
     resolution: {integrity: sha512-OCg2UsLbXK7GmmpzMXhYkdO64vhJ1ROUUGaTFyHjVwEdMEcTTRj7W1TxLbSBxdY8QLBPCcp66MTyaSy0RpO17A==}
     peerDependencies:
@@ -4171,6 +4285,12 @@ packages:
 
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -4224,6 +4344,10 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   envalid@8.1.1:
     resolution: {integrity: sha512-vOUfHxAFFvkBjbVQbBfgnCO9d3GcNfMMTtVfgqSU2rQGMFEVqWy9GBuoSfHnwGu7EqR0/GeukQcL3KjFBaga9w==}
@@ -4509,6 +4633,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4639,6 +4768,10 @@ packages:
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -4653,6 +4786,10 @@ packages:
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -4672,6 +4809,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -4747,6 +4888,9 @@ packages:
   is-plain-obj@2.1.0:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
     engines: {node: '>=8'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
@@ -4872,6 +5016,15 @@ packages:
 
   jsc-safe-url@0.2.4:
     resolution: {integrity: sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==}
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -5134,6 +5287,9 @@ packages:
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@11.2.5:
     resolution: {integrity: sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==}
     engines: {node: 20 || >=22}
@@ -5148,6 +5304,10 @@ packages:
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -5283,6 +5443,10 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
@@ -5414,6 +5578,9 @@ packages:
 
   nullthrows@1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
+
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
   ob1@0.83.5:
     resolution: {integrity: sha512-vNKPYC8L5ycVANANpF/S+WZHpfnRWKx/F3AYP4QMn6ZJTh+l2HOrId0clNkEmua58NB9vmI9Qh7YOoV/4folYg==}
@@ -5567,6 +5734,9 @@ packages:
     resolution: {integrity: sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==}
     engines: {node: '>= 0.10'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -5656,6 +5826,16 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
@@ -5691,6 +5871,10 @@ packages:
     engines: {node: '>=10'}
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
@@ -5746,6 +5930,10 @@ packages:
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   pushdata-bitcoin@1.0.1:
     resolution: {integrity: sha512-hw7rcYTJRAl4olM8Owe8x0fBuJJ+WGbMhQuLWOXEMN3PxPCKQHRkhfL+XG0+iXUmSHjkMmb3Ba55Mt21cZc9kQ==}
@@ -5813,6 +6001,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -5882,6 +6073,10 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
     engines: {node: '>=4'}
@@ -5948,6 +6143,12 @@ packages:
   rpc-websockets@9.3.3:
     resolution: {integrity: sha512-OkCsBBzrwxX4DoSv4Zlf9DgXKRB0MzVfCFg5MC+fNnf9ktr4SMWjsri0VNZQlDbCnGcImT6KNEv4ZoxktQhdpA==}
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   rtcpeerconnection-shim@1.2.15:
     resolution: {integrity: sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==}
     engines: {node: '>=6.0.0', npm: '>=3.10.0'}
@@ -5980,6 +6181,10 @@ packages:
     resolution: {integrity: sha512-28ysSzmDjx2AbotxSggqdclh9MCwlPJUldKkCph48oS5Xtwu0QOg8T9ZRHS2Mben4Y8sTq6VvxXznKssCYFBJA==}
     peerDependencies:
       '@solana/web3.js': ^1.44.3
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -6201,6 +6406,10 @@ packages:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
@@ -6251,6 +6460,9 @@ packages:
     engines: {node: '>= v0.10.32'}
     peerDependencies:
       express: '>=4.0.0 || >=5.0.0-beta'
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
@@ -6324,6 +6536,13 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
@@ -6342,8 +6561,16 @@ packages:
   toml@3.0.0:
     resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -6730,6 +6957,10 @@ packages:
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
@@ -6747,12 +6978,29 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   webrtc-adapter@7.7.1:
     resolution: {integrity: sha512-TbrbBmiQBL9n0/5bvDdORc6ZfRY/Z7JnEj+EYOD1ghseZdpJ+nF2yx14k3LgQKc7JZnG7HAcL+zHnY25So9d7A==}
     engines: {node: '>=6.0.0', npm: '>=3.10.0'}
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -6840,6 +7088,13 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xmlhttprequest-ssl@2.1.2:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
     engines: {node: '>=0.4.0'}
@@ -6913,6 +7168,8 @@ packages:
 
 snapshots:
 
+  '@adobe/css-tools@4.4.4': {}
+
   '@adraffy/ens-normalize@1.11.1': {}
 
   '@anthropic-ai/claude-agent-sdk@0.2.31(zod@3.25.76)':
@@ -6933,6 +7190,14 @@ snapshots:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.3.6
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -7553,6 +7818,26 @@ snapshots:
       bn.js: 5.2.2
       buffer-layout: 1.2.2
 
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
+
   '@emurgo/cardano-serialization-lib-browser@13.2.1': {}
 
   '@emurgo/cardano-serialization-lib-nodejs@13.2.0': {}
@@ -7984,14 +8269,14 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))':
+  '@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.3.87(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      langsmith: 0.3.87(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -8024,26 +8309,26 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
 
-  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))':
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@langchain/langgraph-sdk@1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       p-queue: 9.1.0
       p-retry: 7.1.1
       uuid: 13.0.0
     optionalDependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)':
+  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
-      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 3.25.76
@@ -8053,11 +8338,11 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)':
+  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
-      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 3.25.76
@@ -8067,20 +8352,9 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      js-tiktoken: 1.0.21
-      openai: 4.104.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
-    transitivePeerDependencies:
-      - encoding
-      - ws
-
-  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       js-tiktoken: 1.0.21
       openai: 4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       zod: 3.25.76
@@ -8307,6 +8581,10 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   '@pinojs/redact@0.4.0': {}
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@project-serum/sol-wallet-adapter@0.2.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
@@ -8790,13 +9068,13 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@sip-protocol/sdk@0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))':
+  '@sip-protocol/sdk@0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
       '@aztec/bb.js': 3.0.2
       '@ethereumjs/rlp': 10.1.1
       '@jup-ag/api': 6.0.48
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@magicblock-labs/ephemeral-rollups-sdk': 0.8.5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
       '@noble/ciphers': 2.1.1
       '@noble/curves': 1.9.7
@@ -8815,7 +9093,7 @@ snapshots:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@triton-one/yellowstone-grpc': 4.0.2
-      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))
+      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))
       pino: 10.3.0
       zod: 4.3.6
     optionalDependencies:
@@ -8843,7 +9121,7 @@ snapshots:
       '@ethereumjs/rlp': 10.1.1
       '@jup-ag/api': 6.0.48
       '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@magicblock-labs/ephemeral-rollups-sdk': 0.8.5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
       '@noble/ciphers': 2.1.1
       '@noble/curves': 1.9.7
@@ -8862,7 +9140,7 @@ snapshots:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@triton-one/yellowstone-grpc': 4.0.2
-      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))
+      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))
       pino: 10.3.0
       zod: 4.3.6
     optionalDependencies:
@@ -10762,6 +11040,40 @@ snapshots:
       tailwindcss: 4.2.2
       vite: 6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@toruslabs/base-controllers@5.11.0(@babel/runtime@7.28.6)(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
@@ -11140,6 +11452,8 @@ snapshots:
   '@triton-one/yellowstone-grpc@4.0.2':
     dependencies:
       '@grpc/grpc-js': 1.14.3
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -12017,6 +12331,12 @@ snapshots:
     dependencies:
       sprintf-js: 1.0.3
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
   asap@2.0.6: {}
 
   asn1.js@4.10.1:
@@ -12602,11 +12922,23 @@ snapshots:
 
   crypto-js@4.2.0: {}
 
+  css.escape@1.5.1: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
 
   data-uri-to-buffer@4.0.1: {}
 
   data-uri-to-buffer@6.0.2: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   dateformat@4.6.3: {}
 
@@ -12621,6 +12953,8 @@ snapshots:
       ms: 2.1.3
 
   decamelize@1.2.0: {}
+
+  decimal.js@10.6.0: {}
 
   decode-uri-component@0.2.2: {}
 
@@ -12660,6 +12994,8 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   derive-valtio@0.1.0(valtio@1.13.2(@types/react@19.2.14)(react@19.2.4)):
     dependencies:
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.4)
@@ -12691,6 +13027,10 @@ snapshots:
       randombytes: 2.1.0
 
   dijkstrajs@1.0.3: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dot-case@3.0.4:
     dependencies:
@@ -12763,6 +13103,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  entities@6.0.1: {}
 
   envalid@8.1.1:
     dependencies:
@@ -13093,6 +13435,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -13251,6 +13596,10 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -13277,6 +13626,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -13290,6 +13643,8 @@ snapshots:
       queue: 6.0.2
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -13360,6 +13715,8 @@ snapshots:
 
   is-plain-obj@2.1.0:
     optional: true
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-promise@4.0.0: {}
 
@@ -13525,6 +13882,34 @@ snapshots:
 
   jsc-safe-url@0.2.4: {}
 
+  jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   jsesc@3.1.0: {}
 
   json-bigint@1.0.0:
@@ -13582,12 +13967,12 @@ snapshots:
 
   keyvaluestorage-interface@1.0.0: {}
 
-  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76)):
+  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76)):
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
-      langsmith: 0.4.12(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      langsmith: 0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       uuid: 10.0.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -13599,11 +13984,11 @@ snapshots:
       - react-dom
       - zod-to-json-schema
 
-  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6)):
+  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6)):
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
       langsmith: 0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
       uuid: 10.0.0
       zod: 3.25.76
@@ -13616,7 +14001,7 @@ snapshots:
       - react-dom
       - zod-to-json-schema
 
-  langsmith@0.3.87(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
+  langsmith@0.3.87(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -13625,7 +14010,7 @@ snapshots:
       semver: 7.7.3
       uuid: 10.0.0
     optionalDependencies:
-      openai: 6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
 
   langsmith@0.3.87(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)):
     dependencies:
@@ -13638,7 +14023,7 @@ snapshots:
     optionalDependencies:
       openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
 
-  langsmith@0.4.12(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
+  langsmith@0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -13647,7 +14032,7 @@ snapshots:
       semver: 7.7.3
       uuid: 10.0.0
     optionalDependencies:
-      openai: 6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
 
   langsmith@0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)):
     dependencies:
@@ -13790,6 +14175,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  lru-cache@10.4.3: {}
+
   lru-cache@11.2.5: {}
 
   lru-cache@11.2.7: {}
@@ -13799,6 +14186,8 @@ snapshots:
       yallist: 3.1.1
 
   lru-cache@7.18.3: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -14035,6 +14424,8 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
+  min-indent@1.0.1: {}
+
   minimalistic-assert@1.0.1: {}
 
   minimalistic-crypto-utils@1.0.1: {}
@@ -14144,6 +14535,8 @@ snapshots:
 
   nullthrows@1.1.1: {}
 
+  nwsapi@2.2.23: {}
+
   ob1@0.83.5:
     dependencies:
       flow-enums-runtime: 0.0.6
@@ -14199,21 +14592,6 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@4.104.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
-    dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0
-    optionalDependencies:
-      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - encoding
-
   openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
@@ -14229,9 +14607,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
+  openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
     optionalDependencies:
-      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod: 3.25.76
     optional: true
 
@@ -14348,6 +14726,10 @@ snapshots:
       evp_bytestokey: 1.0.3
       pbkdf2: 3.1.5
       safe-buffer: 5.2.1
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parseurl@1.3.3: {}
 
@@ -14472,6 +14854,14 @@ snapshots:
       mlly: 1.8.0
       pathe: 2.0.3
 
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   pngjs@5.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
@@ -14505,6 +14895,12 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   pretty-format@29.7.0:
     dependencies:
@@ -14598,6 +14994,8 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
+  punycode@2.3.1: {}
+
   pushdata-bitcoin@1.0.1:
     dependencies:
       bitcoin-ops: 1.4.1
@@ -14682,6 +15080,8 @@ snapshots:
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 
@@ -14789,6 +15189,11 @@ snapshots:
   real-require@0.1.0: {}
 
   real-require@0.2.0: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   redis-errors@1.2.0: {}
 
@@ -14899,6 +15304,10 @@ snapshots:
       bufferutil: 4.1.0
       utf-8-validate: 5.0.10
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   rtcpeerconnection-shim@1.2.15:
     dependencies:
       sdp: 2.12.0
@@ -14930,6 +15339,10 @@ snapshots:
       '@project-serum/sol-wallet-adapter': 0.2.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       eventemitter3: 4.0.7
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -15188,6 +15601,10 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@5.0.3: {}
@@ -15250,6 +15667,8 @@ snapshots:
     dependencies:
       express: 5.2.1
       swagger-ui-dist: 5.31.0
+
+  symbol-tree@3.2.4: {}
 
   tailwindcss@4.2.2: {}
 
@@ -15330,6 +15749,12 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   tmpl@1.0.5: {}
 
   to-buffer@1.2.2:
@@ -15346,7 +15771,15 @@ snapshots:
 
   toml@3.0.0: {}
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tr46@0.0.3: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -15640,7 +16073,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@3.2.4(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@3.2.4(@types/node@25.2.0)(jiti@2.6.1)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
@@ -15667,6 +16100,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.2.0
+      jsdom: 25.0.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - jiti
       - less
@@ -15683,6 +16117,10 @@ snapshots:
 
   vlq@1.0.1: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
@@ -15697,12 +16135,25 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
+  webidl-conversions@7.0.0: {}
+
   webrtc-adapter@7.7.1:
     dependencies:
       rtcpeerconnection-shim: 1.2.15
       sdp: 2.12.0
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
   whatwg-fetch@3.6.20: {}
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -15772,6 +16223,10 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 5.0.10
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xmlhttprequest-ssl@2.1.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,9 @@ packages:
   - 'packages/*'
   - 'app'
   - '!sdks/**'
+patchedDependencies:
+  '@triton-one/yellowstone-grpc@4.0.2': patches/@triton-one__yellowstone-grpc@4.0.2.patch
+onlyBuiltDependencies:
+  - better-sqlite3
+  - bufferutil
+  - utf-8-validate


### PR DESCRIPTION
## Summary

Resolves sip-protocol/sip-protocol#1077 — `tsx watch src/index.ts` (agent's dev script) fails to resolve named imports of `CommitmentLevel` from `@triton-one/yellowstone-grpc`, blocking local agent dev AND the Phase 1 playwright E2E suite (PR #152).

## Root cause

`@triton-one/yellowstone-grpc@4.0.2` ships ESM-syntax files in `dist/esm/` but the root `package.json` has no `"type": "module"` field and no nested `package.json` declaring those files as ESM.

- **Native Node 22+** tolerates this via heuristic detection (sees `export` keyword in `.js` file → treats as ESM).
- **tsx (esbuild loader)** does not. It treats the file as CJS, then static linker fails with `does not provide an export named 'CommitmentLevel'`.

## Fix

`pnpm patch` adds two nested `package.json` files in the patched yellowstone-grpc package:
- `dist/esm/package.json` → `{"type": "module"}` — marks all dist/esm files as ESM
- `dist/esm/encoding/package.json` → `{"type": "commonjs"}` — opts the WASM file (uses `module.exports`) back to CJS

Also adds `onlyBuiltDependencies` allowlist to `pnpm-workspace.yaml` (better-sqlite3, bufferutil, utf-8-validate) since pnpm 10+ requires explicit approval for native build scripts.

## Verification

- ✅ `pnpm --filter @sipher/agent dev` — agent boots cleanly on port 5006
- ✅ `pnpm --filter @sipher/agent test -- --run` — 938 tests passing (no regression)
- ✅ `pnpm --filter @sipher/app test -- --run` — 45 tests passing (no regression)
- ✅ `pnpm exec playwright test` — agent + app stack starts, 4 tests pass + 2 sentinel skip + 4 fail (4 failures are CORS/port mismatch in PR #152 webServer config, separate from #1077)

## Merge order

If merged first to main, the Phase 2 stack (PR #152 → #153 → #154 → #155) auto-rebases on next merge in sequence and inherits the fix. PR #152's playwright check should go from RED → mostly green (CORS config issue is a separate cleanup).

## Upstream considerations

The proper long-term fix is for `@triton-one/yellowstone-grpc` to ship the nested `dist/esm/package.json`. This PR is a consumer-side workaround.