### PR TITLE
test(phase-4): add unit tests for 3 REST service builders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 **Live URL:** https://sipher.sip-protocol.org
 **Tagline:** "Privacy-as-a-Skill for Multi-Chain Agents"
 **Purpose:** REST API + OpenClaw skill enabling any autonomous agent to add transaction privacy via SIP Protocol
-**Stats:** 66 REST endpoints | 905 agent + 497 REST tests | 22 SIPHER tools | 14 SENTINEL tools | 9 HERALD X tools | 17 chains | Command Center UI (2,079 lines, 24 files) | 4 client SDKs (TS, Python, Rust, Go) | Eliza plugin
+**Stats:** 66 REST endpoints | 938 agent + 555 REST tests | 22 SIPHER tools | 14 SENTINEL tools | 9 HERALD X tools | 17 chains | Command Center UI (2,079 lines, 24 files) | 4 client SDKs (TS, Python, Rust, Go) | Eliza plugin
 
 ---
 
@@ -130,7 +130,7 @@ cd app && npx tsc --noEmit # Type check
 - **Logging:** Pino v9 (structured JSON, audit logs)
 - **Docs:** swagger-ui-express (OpenAPI 3.1)
 - **Cache:** Redis 7 (rate limiting, idempotency) with in-memory fallback
-- **Testing:** Vitest + Supertest (497 REST + 905 agent tests)
+- **Testing:** Vitest + Supertest (555 REST + 938 agent tests)
 - **Deployment:** Docker + GHCR → VPS (port 5006)
 - **Domain:** sipher.sip-protocol.org
 - **Frontend:** React 19, Vite 6, Tailwind CSS 4, Zustand 5, Phosphor Icons React
@@ -144,7 +144,7 @@ cd app && npx tsc --noEmit # Type check
 pnpm install                    # Install dependencies
 pnpm dev                        # Dev server (localhost:5006)
 pnpm build                      # Build for production
-pnpm test -- --run              # Run REST tests (497 tests, 32 suites) + agent tests (905 tests, 69 suites)
+pnpm test -- --run              # Run REST tests (555 tests, 35 suites) + agent tests (938 tests, 75 suites)
 pnpm typecheck                  # Type check
 pnpm demo                       # Full-flow demo (requires dev server running)
 pnpm openapi:export              # Export static OpenAPI spec to dist/openapi.json
@@ -374,8 +374,8 @@ sipher/
 │       │   │   └── tools/              # 14 SENTINEL tools (7 read + 7 action)
 │       │   ├── tools/              # 22 SIPHER agent tools (deposit, send, swap, scan, assessRisk, ...)
 │       │   └── routes/             # Agent-specific Express routes (incl. /sentinel/*)
-│       └── tests/                  # 905 agent tests (69 suites)
-├── tests/                          # 497 REST tests across 32 suites
+│       └── tests/                  # 938 agent tests (75 suites)
+├── tests/                          # 555 REST tests across 35 suites
 │   ├── health.test.ts
 │   ├── stealth.test.ts
 │   ├── commitment.test.ts
@@ -582,7 +582,7 @@ ssh sip@176.222.53.185 "docker logs sipher --tail 50"
 ## AI GUIDELINES
 
 ### DO:
-- Run `pnpm test -- --run` after code changes (497 REST tests + 905 agent tests must pass)
+- Run `pnpm test -- --run` after code changes (555 REST tests + 938 agent tests must pass)
 - Run `pnpm typecheck` before committing
 - Use @sip-protocol/sdk for all crypto operations (never roll your own)
 - Keep API responses consistent: `{ success, data?, error? }`
@@ -629,12 +629,12 @@ See [ROADMAP.md](ROADMAP.md) for the full 6-phase roadmap (38 issues across 6 mi
 | 5 | Backend Aggregation | 5 | ✅ Complete |
 | 6 | Enterprise | 6 | ✅ Complete |
 
-**Progress:** 38/38 issues complete | 497 REST tests + 905 agent tests | 66 endpoints | 17 chains | All phases complete | Live demo at /v1/demo
+**Progress:** 38/38 issues complete | 555 REST tests + 938 agent tests | 66 endpoints | 17 chains | All phases complete | Live demo at /v1/demo
 
 **Quick check:** `gh issue list -R sip-protocol/sipher --state open`
 
 ---
 
 **Last Updated:** 2026-04-16
-**Status:** SENTINEL Formalization Complete | 66 REST Endpoints | 497 REST + 905 Agent Tests | 22 SIPHER Tools | 14 SENTINEL Tools | 9 HERALD X Tools | 17 Chains | Command Center UI (2,079 lines) | Platform Abstraction (AgentCore + Web/X Adapters + SentinelCore/Adapter) | Real Jupiter API | SQLite Persistence | Devnet Proof
+**Status:** SENTINEL Formalization Complete | 66 REST Endpoints | 555 REST + 938 Agent Tests | 22 SIPHER Tools | 14 SENTINEL Tools | 9 HERALD X Tools | 17 Chains | Command Center UI (2,079 lines) | Platform Abstraction (AgentCore + Web/X Adapters + SentinelCore/Adapter) | Real Jupiter API | SQLite Persistence | Devnet Proof
 **Devnet Proof:** [Solscan](https://solscan.io/tx/4FmLGsLkC5DYJojpQeSQoGMArsJonTEnx729gnFCeYEjFsr8Z46VrDzKQXLhFrpM9Uj6ezBtCQckU28odzvjvV4a?cluster=devnet) — real 0.01 SOL shielded transfer via stealth address

--- a/docs/superpowers/plans/2026-05-03-rest-service-tests.md
+++ b/docs/superpowers/plans/2026-05-03-rest-service-tests.md
@@ -1,0 +1,1742 @@
+# Phase 4 — REST Service Tests Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add isolated unit-level test coverage for the 3 builder modules under `src/services/` (transaction-builder, chain-transfer-builder, private-swap-builder), per the approved spec at `docs/superpowers/specs/2026-05-03-rest-service-tests-design.md`.
+
+**Architecture:** 3 new test files in root `tests/` + 1 shared fixture file at `tests/fixtures/builder-mocks.ts`. Real `@sip-protocol/sdk` (no mocks); mock `@solana/web3.js` Connection, `./jupiter-provider.js`, `./cspl.js` at module boundaries via `vi.mock` + `vi.importActual` pattern from existing `tests/private-swap.test.ts`.
+
+**Tech Stack:** Vitest, @solana/web3.js, @solana/spl-token, @sip-protocol/sdk, @noble/hashes.
+
+**Branch:** `feat/phase-4-rest-service-tests` (already created, spec already committed).
+
+**Test count target:** ~37 tests across 3 files. Root suite goes 33 → 36 files. Agent (938) + app (45) baselines unchanged.
+
+---
+
+## Task 1: Commit this plan
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-05-03-rest-service-tests.md` (this file)
+
+- [ ] **Step 1: Verify file exists and is staged**
+
+```bash
+cd ~/local-dev/sipher
+git status
+```
+
+Expected: `docs/superpowers/plans/2026-05-03-rest-service-tests.md` listed as untracked or staged.
+
+- [ ] **Step 2: Stage and commit**
+
+```bash
+git add docs/superpowers/plans/2026-05-03-rest-service-tests.md
+git commit -m "docs(phase-4): add rest service tests plan"
+```
+
+Expected: 1 file changed, commit succeeds.
+
+---
+
+## Task 2: Create shared fixture file `tests/fixtures/builder-mocks.ts`
+
+**Files:**
+- Create: `tests/fixtures/builder-mocks.ts`
+
+- [ ] **Step 1: Create directory if it does not exist**
+
+```bash
+cd ~/local-dev/sipher
+mkdir -p tests/fixtures
+```
+
+Expected: directory exists (idempotent).
+
+- [ ] **Step 2: Write the fixture file**
+
+Create `tests/fixtures/builder-mocks.ts` with the following content:
+
+```typescript
+import { vi } from 'vitest'
+
+/**
+ * Generates CONFIG_PDA bytes for buildAnchorShieldedSolTransfer tests.
+ * The function reads total_transfers at byte offset 43 as u64 LE.
+ * See src/services/transaction-builder.ts:155-159
+ */
+export function makeConfigPDABytes(counter: bigint): Buffer {
+  const buf = Buffer.alloc(51)
+  buf.writeBigUInt64LE(counter, 43)
+  return buf
+}
+
+interface SolanaConnectionMockOverrides {
+  getAccountInfo?: ReturnType<typeof vi.fn>
+  getLatestBlockhash?: ReturnType<typeof vi.fn>
+  getSlot?: ReturnType<typeof vi.fn>
+}
+
+/**
+ * Returns a vi.mock factory for @solana/web3.js Connection.
+ * Spreads vi.importActual to preserve PublicKey/Transaction/SystemProgram constructors.
+ * Use: vi.mock('@solana/web3.js', mockSolanaConnection({...}))
+ */
+export function mockSolanaConnection(overrides: SolanaConnectionMockOverrides = {}) {
+  return async () => {
+    const actual = await vi.importActual<typeof import('@solana/web3.js')>('@solana/web3.js')
+    return {
+      ...(actual as object),
+      Connection: vi.fn().mockImplementation(() => ({
+        rpcEndpoint: 'https://api.mainnet-beta.solana.com',
+        getSlot: overrides.getSlot ?? vi.fn().mockResolvedValue(300_000_000),
+        getLatestBlockhash: overrides.getLatestBlockhash ?? vi.fn().mockResolvedValue({
+          blockhash: '4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM',
+          lastValidBlockHeight: 300_000_100,
+        }),
+        getAccountInfo: overrides.getAccountInfo ?? vi.fn().mockResolvedValue(null),
+      })),
+    }
+  }
+}
+
+type CSPLBehavior = 'success' | 'fail' | 'throws'
+
+/**
+ * Returns a mock CSPL service object for private-swap-builder tests.
+ * Used inside vi.mock('./cspl.js', () => ({ getCSPLService: () => mockCSPLService(...) }))
+ */
+export function mockCSPLService(behavior: CSPLBehavior) {
+  if (behavior === 'success') {
+    return {
+      wrap: vi.fn().mockResolvedValue({
+        success: true,
+        signature: 'csplwrapsig000000000000000000000000000000000000000000000000000',
+      }),
+    }
+  }
+  if (behavior === 'fail') {
+    return {
+      wrap: vi.fn().mockResolvedValue({ success: false }),
+    }
+  }
+  return {
+    wrap: vi.fn().mockRejectedValue(new Error('CSPL wrap failed')),
+  }
+}
+
+interface JupiterQuoteOptions {
+  inAmount?: string
+  outAmount?: string
+  slippageBps?: number
+  quoteId?: string
+  priceImpactPct?: string
+}
+
+/**
+ * Builds a canned Jupiter quote response shape for tests.
+ * Mock jupiter-provider.getQuote to return this.
+ */
+export function makeJupiterQuote(opts: JupiterQuoteOptions = {}) {
+  const inAmount = opts.inAmount ?? '1000000000'
+  const outAmount = opts.outAmount ?? '150000000'
+  const slippageBps = opts.slippageBps ?? 50
+  return {
+    quoteId: opts.quoteId ?? 'jup_test_quote_001',
+    inAmount,
+    outAmount,
+    outAmountMin: String(Math.floor(Number(outAmount) * (10000 - slippageBps) / 10000)),
+    priceImpactPct: opts.priceImpactPct ?? '0.05',
+    slippageBps,
+  }
+}
+
+/**
+ * Builds a canned Jupiter swap-tx response.
+ * Mock jupiter-provider.buildSwapTransaction to return this.
+ */
+export function makeJupiterSwapTx(swapTransaction = 'mockedJupiterSwapTxBase64String===') {
+  return { swapTransaction }
+}
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+cd ~/local-dev/sipher
+pnpm typecheck
+```
+
+Expected: no errors related to `tests/fixtures/builder-mocks.ts`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/fixtures/builder-mocks.ts
+git commit -m "test(fixtures): add shared builder-mocks helper"
+```
+
+---
+
+## Task 3: Add `buildShieldedSolTransfer` tests (3 tests)
+
+**Files:**
+- Create: `tests/transaction-builder.test.ts`
+- Reference (read-only): `src/services/transaction-builder.ts:235-259`
+
+- [ ] **Step 1: Write the test file with the first test group**
+
+Create `tests/transaction-builder.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest'
+import { Keypair, Transaction, SystemProgram } from '@solana/web3.js'
+import { mockSolanaConnection } from './fixtures/builder-mocks.js'
+
+vi.mock('@solana/web3.js', mockSolanaConnection())
+
+const { buildShieldedSolTransfer } = await import('../src/services/transaction-builder.js')
+
+const sender = Keypair.generate()
+const stealth = Keypair.generate()
+const senderAddress = sender.publicKey.toBase58()
+const stealthAddress = stealth.publicKey.toBase58()
+
+describe('buildShieldedSolTransfer', () => {
+  it('builds SystemProgram.transfer with correct fromPubkey/toPubkey/lamports', async () => {
+    const amount = 1_000_000n
+    const txBase64 = await buildShieldedSolTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      amount,
+    })
+
+    const tx = Transaction.from(Buffer.from(txBase64, 'base64'))
+
+    expect(tx.instructions).toHaveLength(1)
+    const ix = tx.instructions[0]
+    expect(ix.programId.equals(SystemProgram.programId)).toBe(true)
+
+    const decoded = SystemProgram.decodeTransfer(ix)
+    expect(decoded.fromPubkey.toBase58()).toBe(senderAddress)
+    expect(decoded.toPubkey.toBase58()).toBe(stealthAddress)
+    expect(decoded.lamports).toBe(Number(amount))
+  })
+
+  it('sets recentBlockhash, lastValidBlockHeight, and feePayer', async () => {
+    const txBase64 = await buildShieldedSolTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      amount: 100_000n,
+    })
+
+    const tx = Transaction.from(Buffer.from(txBase64, 'base64'))
+    expect(tx.recentBlockhash).toBe('4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM')
+    expect(tx.lastValidBlockHeight).toBe(300_000_100)
+    expect(tx.feePayer?.toBase58()).toBe(senderAddress)
+  })
+
+  it('returns base64 string that deserializes to a valid Transaction', async () => {
+    const txBase64 = await buildShieldedSolTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      amount: 50_000n,
+    })
+
+    expect(typeof txBase64).toBe('string')
+    expect(() => Transaction.from(Buffer.from(txBase64, 'base64'))).not.toThrow()
+  })
+})
+```
+
+- [ ] **Step 2: Run the new tests**
+
+```bash
+cd ~/local-dev/sipher
+pnpm test tests/transaction-builder -- --run
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 3: Verify typecheck passes**
+
+```bash
+pnpm typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Verify no regression in full root suite**
+
+```bash
+pnpm test -- --run 2>&1 | tail -10
+```
+
+Expected: all root tests pass (was 33 files / N tests, now +1 file with 3 new tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/transaction-builder.test.ts
+git commit -m "test(transaction-builder): add buildShieldedSolTransfer tests (3)"
+```
+
+---
+
+## Task 4: Add `buildShieldedSplTransfer` tests (4 tests)
+
+**Files:**
+- Modify: `tests/transaction-builder.test.ts`
+- Reference (read-only): `src/services/transaction-builder.ts:264-308`
+
+- [ ] **Step 1: Add SPL test group below existing describe block**
+
+Append the following to `tests/transaction-builder.test.ts` (after the `buildShieldedSolTransfer` describe, before EOF). Update imports at top to include the new bits:
+
+Update the import line near the top:
+
+```typescript
+import { Keypair, Transaction, SystemProgram, PublicKey } from '@solana/web3.js'
+import {
+  TOKEN_PROGRAM_ID,
+  getAssociatedTokenAddress,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+} from '@solana/spl-token'
+```
+
+Update the `vi.mock` call to support per-test ATA-existence overrides. Replace the mock setup line:
+
+```typescript
+const mockGetAccountInfo = vi.fn().mockResolvedValue(null)
+vi.mock('@solana/web3.js', mockSolanaConnection({ getAccountInfo: mockGetAccountInfo }))
+
+const { buildShieldedSolTransfer, buildShieldedSplTransfer } = await import('../src/services/transaction-builder.js')
+```
+
+Add a fixed mint constant near the other constants:
+
+```typescript
+const mintPubkey = Keypair.generate().publicKey
+const mintAddress = mintPubkey.toBase58()
+```
+
+Append the new describe block at the end of the file:
+
+```typescript
+describe('buildShieldedSplTransfer', () => {
+  beforeEach(() => {
+    mockGetAccountInfo.mockReset()
+  })
+
+  it('creates ATA when stealth ATA does not exist', async () => {
+    mockGetAccountInfo.mockResolvedValue(null)
+
+    const txBase64 = await buildShieldedSplTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      mint: mintAddress,
+      amount: 1_000_000n,
+    })
+
+    const tx = Transaction.from(Buffer.from(txBase64, 'base64'))
+    expect(tx.instructions).toHaveLength(2)
+    expect(tx.instructions[0].programId.equals(ASSOCIATED_TOKEN_PROGRAM_ID)).toBe(true)
+    expect(tx.instructions[1].programId.equals(TOKEN_PROGRAM_ID)).toBe(true)
+  })
+
+  it('skips ATA creation when stealth ATA already exists', async () => {
+    mockGetAccountInfo.mockResolvedValue({ data: Buffer.alloc(0), executable: false, lamports: 1, owner: TOKEN_PROGRAM_ID })
+
+    const txBase64 = await buildShieldedSplTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      mint: mintAddress,
+      amount: 1_000_000n,
+    })
+
+    const tx = Transaction.from(Buffer.from(txBase64, 'base64'))
+    expect(tx.instructions).toHaveLength(1)
+    expect(tx.instructions[0].programId.equals(TOKEN_PROGRAM_ID)).toBe(true)
+  })
+
+  it('derives sender ATA via getAssociatedTokenAddress(mint, sender)', async () => {
+    mockGetAccountInfo.mockResolvedValue(null)
+
+    const expectedSenderATA = await getAssociatedTokenAddress(mintPubkey, sender.publicKey)
+
+    const txBase64 = await buildShieldedSplTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      mint: mintAddress,
+      amount: 500_000n,
+    })
+
+    const tx = Transaction.from(Buffer.from(txBase64, 'base64'))
+    const transferIx = tx.instructions.find(ix => ix.programId.equals(TOKEN_PROGRAM_ID))!
+    expect(transferIx.keys[0].pubkey.equals(expectedSenderATA)).toBe(true)
+  })
+
+  it('uses allowOwnerOffCurve=true for stealth ATA derivation', async () => {
+    mockGetAccountInfo.mockResolvedValue(null)
+
+    const expectedStealthATA = await getAssociatedTokenAddress(
+      mintPubkey,
+      stealth.publicKey,
+      true,
+    )
+
+    const txBase64 = await buildShieldedSplTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      mint: mintAddress,
+      amount: 750_000n,
+    })
+
+    const tx = Transaction.from(Buffer.from(txBase64, 'base64'))
+    const transferIx = tx.instructions.find(ix => ix.programId.equals(TOKEN_PROGRAM_ID))!
+    expect(transferIx.keys[1].pubkey.equals(expectedStealthATA)).toBe(true)
+  })
+})
+```
+
+Add `beforeEach` to the import line at the top:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+```
+
+- [ ] **Step 2: Run the new tests**
+
+```bash
+cd ~/local-dev/sipher
+pnpm test tests/transaction-builder -- --run
+```
+
+Expected: 7 tests pass (3 SOL + 4 SPL).
+
+- [ ] **Step 3: Verify typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/transaction-builder.test.ts
+git commit -m "test(transaction-builder): add buildShieldedSplTransfer tests (4)"
+```
+
+---
+
+## Task 5: Add `buildAnchorShieldedSolTransfer` tests (7 tests)
+
+**Files:**
+- Modify: `tests/transaction-builder.test.ts`
+- Reference (read-only): `src/services/transaction-builder.ts:143-230`
+
+- [ ] **Step 1: Append the Anchor test group**
+
+Add the following describe block at the end of `tests/transaction-builder.test.ts`. Also update the import to include `makeConfigPDABytes`:
+
+Update the imports near the top:
+
+```typescript
+import { mockSolanaConnection, makeConfigPDABytes } from './fixtures/builder-mocks.js'
+```
+
+Update the named imports from transaction-builder:
+
+```typescript
+const { buildShieldedSolTransfer, buildShieldedSplTransfer, buildAnchorShieldedSolTransfer } = await import('../src/services/transaction-builder.js')
+```
+
+Add a constant near other constants for the program/config IDs (these are public, hard-coded into source):
+
+```typescript
+const SIP_PRIVACY_PROGRAM_ID = new PublicKey('S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at')
+const CONFIG_PDA = new PublicKey('BVawZkppFewygA5nxdrLma4ThKx8Th7bW4KTCkcWTZwZ')
+const FEE_COLLECTOR = new PublicKey('S1P6j1yeTm6zkewQVeihrTZvmfoHABRkHDhabWTuWMd')
+const SHIELDED_TRANSFER_DISCRIMINATOR = Buffer.from([0x9d, 0x2a, 0x42, 0x93, 0xee, 0x75, 0x61, 0x5c])
+
+// Realistic hex inputs (sized to source's expected lengths)
+const COMMITMENT_HEX_NO_PREFIX = '02' + 'a'.repeat(64) // 33 bytes = 66 hex chars
+const BLINDING_HEX_NO_PREFIX = 'b'.repeat(64) // 32 bytes = 64 hex chars
+const EPHEMERAL_HEX_NO_PREFIX = 'c'.repeat(64) // 32 bytes
+const VKHASH_HEX_NO_PREFIX = 'd'.repeat(64) // 32 bytes
+```
+
+Append the test group:
+
+```typescript
+describe('buildAnchorShieldedSolTransfer', () => {
+  beforeEach(() => {
+    mockGetAccountInfo.mockReset()
+  })
+
+  it('throws when CONFIG_PDA account is not found', async () => {
+    mockGetAccountInfo.mockResolvedValue(null)
+
+    await expect(
+      buildAnchorShieldedSolTransfer({
+        sender: senderAddress,
+        stealthAddress,
+        amount: 1_000_000n,
+        commitment: '0x' + COMMITMENT_HEX_NO_PREFIX,
+        blindingFactor: '0x' + BLINDING_HEX_NO_PREFIX,
+        ephemeralPublicKey: '0x' + EPHEMERAL_HEX_NO_PREFIX,
+        viewingKeyHash: '0x' + VKHASH_HEX_NO_PREFIX,
+      })
+    ).rejects.toThrow(/CONFIG_PDA account not found/)
+  })
+
+  it('parses total_transfers correctly when counter = 0', async () => {
+    mockGetAccountInfo.mockResolvedValue({ data: makeConfigPDABytes(0n) })
+
+    const result = await buildAnchorShieldedSolTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      amount: 1_000_000n,
+      commitment: '0x' + COMMITMENT_HEX_NO_PREFIX,
+      blindingFactor: '0x' + BLINDING_HEX_NO_PREFIX,
+      ephemeralPublicKey: '0x' + EPHEMERAL_HEX_NO_PREFIX,
+      viewingKeyHash: '0x' + VKHASH_HEX_NO_PREFIX,
+    })
+
+    expect(result.instructionType).toBe('anchor')
+    expect(typeof result.noteId).toBe('string')
+    expect(result.noteId.length).toBeGreaterThan(0) // base58 PDA
+  })
+
+  it('parses total_transfers correctly when counter = 42', async () => {
+    mockGetAccountInfo.mockResolvedValue({ data: makeConfigPDABytes(42n) })
+
+    const result = await buildAnchorShieldedSolTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      amount: 1_000_000n,
+      commitment: '0x' + COMMITMENT_HEX_NO_PREFIX,
+      blindingFactor: '0x' + BLINDING_HEX_NO_PREFIX,
+      ephemeralPublicKey: '0x' + EPHEMERAL_HEX_NO_PREFIX,
+      viewingKeyHash: '0x' + VKHASH_HEX_NO_PREFIX,
+    })
+
+    expect(result.instructionType).toBe('anchor')
+    expect(result.noteId.length).toBeGreaterThan(0)
+  })
+
+  it('parses total_transfers correctly when counter near MAX_SAFE_INTEGER', async () => {
+    const maxCounter = (2n ** 53n) - 1n
+    mockGetAccountInfo.mockResolvedValue({ data: makeConfigPDABytes(maxCounter) })
+
+    const result = await buildAnchorShieldedSolTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      amount: 1_000_000n,
+      commitment: '0x' + COMMITMENT_HEX_NO_PREFIX,
+      blindingFactor: '0x' + BLINDING_HEX_NO_PREFIX,
+      ephemeralPublicKey: '0x' + EPHEMERAL_HEX_NO_PREFIX,
+      viewingKeyHash: '0x' + VKHASH_HEX_NO_PREFIX,
+    })
+
+    expect(result.instructionType).toBe('anchor')
+  })
+
+  it('derives transferRecordPDA from [TRANSFER_RECORD_SEED, sender, counter_le_bytes]', async () => {
+    const counter = 7n
+    mockGetAccountInfo.mockResolvedValue({ data: makeConfigPDABytes(counter) })
+
+    const TRANSFER_RECORD_SEED = Buffer.from('transfer_record')
+    const counterLeBytes = Buffer.alloc(8)
+    counterLeBytes.writeBigUInt64LE(counter, 0)
+
+    const [expectedPDA] = PublicKey.findProgramAddressSync(
+      [TRANSFER_RECORD_SEED, sender.publicKey.toBuffer(), counterLeBytes],
+      SIP_PRIVACY_PROGRAM_ID,
+    )
+
+    const result = await buildAnchorShieldedSolTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      amount: 1_000_000n,
+      commitment: '0x' + COMMITMENT_HEX_NO_PREFIX,
+      blindingFactor: '0x' + BLINDING_HEX_NO_PREFIX,
+      ephemeralPublicKey: '0x' + EPHEMERAL_HEX_NO_PREFIX,
+      viewingKeyHash: '0x' + VKHASH_HEX_NO_PREFIX,
+    })
+
+    expect(result.noteId).toBe(expectedPDA.toBase58())
+  })
+
+  it('packs instruction data with correct byte layout at exact offsets', async () => {
+    mockGetAccountInfo.mockResolvedValue({ data: makeConfigPDABytes(0n) })
+
+    const amount = 12345n
+    const result = await buildAnchorShieldedSolTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      amount,
+      commitment: '0x' + COMMITMENT_HEX_NO_PREFIX,
+      blindingFactor: '0x' + BLINDING_HEX_NO_PREFIX,
+      ephemeralPublicKey: '0x' + EPHEMERAL_HEX_NO_PREFIX,
+      viewingKeyHash: '0x' + VKHASH_HEX_NO_PREFIX,
+    })
+
+    const tx = Transaction.from(Buffer.from(result.transaction, 'base64'))
+    expect(tx.instructions).toHaveLength(1)
+    const ix = tx.instructions[0]
+    expect(ix.programId.equals(SIP_PRIVACY_PROGRAM_ID)).toBe(true)
+
+    const data = ix.data
+    expect(data.length).toBe(8 + 33 + 32 + 32 + 32 + 8 + 128 + 8)
+
+    // Byte-precise offset checks
+    expect(data.subarray(0, 8).equals(SHIELDED_TRANSFER_DISCRIMINATOR)).toBe(true)
+    expect(data.subarray(8, 41).toString('hex')).toBe(COMMITMENT_HEX_NO_PREFIX)
+    expect(data.subarray(41, 73).equals(stealth.publicKey.toBytes())).toBe(true)
+    expect(data.subarray(73, 105).toString('hex')).toBe(EPHEMERAL_HEX_NO_PREFIX)
+    expect(data.subarray(105, 137).toString('hex')).toBe(VKHASH_HEX_NO_PREFIX)
+    // amount at end (8 bytes LE)
+    const amountBytes = data.subarray(273, 281)
+    const amountReadback = amountBytes.readBigUInt64LE(0)
+    expect(amountReadback).toBe(amount)
+
+    // Verify accounts
+    expect(ix.keys[0].pubkey.equals(CONFIG_PDA)).toBe(true)
+    expect(ix.keys[2].pubkey.equals(sender.publicKey)).toBe(true)
+    expect(ix.keys[3].pubkey.equals(stealth.publicKey)).toBe(true)
+    expect(ix.keys[4].pubkey.equals(FEE_COLLECTOR)).toBe(true)
+    expect(ix.keys[5].pubkey.equals(SystemProgram.programId)).toBe(true)
+  })
+
+  it.each([
+    ['with 0x prefix', true],
+    ['without 0x prefix', false],
+  ])('handles hex inputs %s consistently', async (_label, withPrefix) => {
+    mockGetAccountInfo.mockResolvedValue({ data: makeConfigPDABytes(0n) })
+
+    const prefix = withPrefix ? '0x' : ''
+    const result = await buildAnchorShieldedSolTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      amount: 1_000_000n,
+      commitment: prefix + COMMITMENT_HEX_NO_PREFIX,
+      blindingFactor: prefix + BLINDING_HEX_NO_PREFIX,
+      ephemeralPublicKey: prefix + EPHEMERAL_HEX_NO_PREFIX,
+      viewingKeyHash: prefix + VKHASH_HEX_NO_PREFIX,
+    })
+
+    const tx = Transaction.from(Buffer.from(result.transaction, 'base64'))
+    const data = tx.instructions[0].data
+
+    // Byte content should be identical regardless of prefix presence
+    expect(data.subarray(8, 41).toString('hex')).toBe(COMMITMENT_HEX_NO_PREFIX)
+    expect(data.subarray(73, 105).toString('hex')).toBe(EPHEMERAL_HEX_NO_PREFIX)
+    expect(data.subarray(105, 137).toString('hex')).toBe(VKHASH_HEX_NO_PREFIX)
+  })
+})
+```
+
+- [ ] **Step 2: Run the new tests**
+
+```bash
+cd ~/local-dev/sipher
+pnpm test tests/transaction-builder -- --run
+```
+
+Expected: 14 tests pass total (3 SOL + 4 SPL + 7 Anchor).
+
+- [ ] **Step 3: Verify typecheck and full root suite**
+
+```bash
+pnpm typecheck
+pnpm test -- --run 2>&1 | tail -10
+```
+
+Expected: typecheck clean; root suite green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/transaction-builder.test.ts
+git commit -m "test(transaction-builder): add buildAnchorShieldedSolTransfer tests (7)"
+```
+
+---
+
+## Task 6: Add `chain-transfer-builder` helper tests (3 tests)
+
+**Files:**
+- Create: `tests/chain-transfer-builder.test.ts`
+- Reference (read-only): `src/services/chain-transfer-builder.ts:92-98`
+
+- [ ] **Step 1: Create the test file with helper tests**
+
+Create `tests/chain-transfer-builder.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock transaction-builder.js BEFORE importing chain-transfer-builder
+vi.mock('../src/services/transaction-builder.js', () => ({
+  buildShieldedSolTransfer: vi.fn().mockResolvedValue('mockedSolTxBase64'),
+  buildShieldedSplTransfer: vi.fn().mockResolvedValue('mockedSplTxBase64'),
+  buildAnchorShieldedSolTransfer: vi.fn().mockResolvedValue({
+    transaction: 'mockedAnchorTxBase64',
+    noteId: 'mockedNoteIdPDA',
+    encryptedAmount: '0xdeadbeefcafebabe',
+    instructionType: 'anchor' as const,
+  }),
+}))
+
+const {
+  isTransferSupported,
+  getSupportedTransferChains,
+} = await import('../src/services/chain-transfer-builder.js')
+
+describe('isTransferSupported', () => {
+  it.each([
+    'solana',
+    'ethereum',
+    'polygon',
+    'arbitrum',
+    'optimism',
+    'base',
+    'near',
+  ])('returns true for supported chain: %s', (chain) => {
+    expect(isTransferSupported(chain)).toBe(true)
+  })
+
+  it('returns false for unsupported chain', () => {
+    expect(isTransferSupported('bitcoin')).toBe(false)
+  })
+})
+
+describe('getSupportedTransferChains', () => {
+  it('returns array containing all 7 supported chains', () => {
+    const chains = getSupportedTransferChains()
+    expect(chains).toHaveLength(7)
+    expect(chains).toEqual(
+      expect.arrayContaining([
+        'solana',
+        'ethereum',
+        'polygon',
+        'arbitrum',
+        'optimism',
+        'base',
+        'near',
+      ])
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cd ~/local-dev/sipher
+pnpm test tests/chain-transfer-builder -- --run
+```
+
+Expected: 3 tests pass (1 parameterized for 7 chains + 1 negative + 1 array check). Note: `it.each` with 7 entries counts as 7 individual `it` runs.
+
+- [ ] **Step 3: Verify typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/chain-transfer-builder.test.ts
+git commit -m "test(chain-transfer-builder): add isTransferSupported + getSupportedTransferChains tests (3)"
+```
+
+---
+
+## Task 7: Add `chain-transfer-builder` Solana branch tests (3 tests)
+
+**Files:**
+- Modify: `tests/chain-transfer-builder.test.ts`
+- Reference (read-only): `src/services/chain-transfer-builder.ts:131-141, 176-223`
+
+- [ ] **Step 1: Append the Solana branch test group**
+
+First, update the imports at the top of `tests/chain-transfer-builder.test.ts` to include the additional symbols and a vi-mocked reference:
+
+Replace the import block at top with:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock transaction-builder.js BEFORE importing chain-transfer-builder
+vi.mock('../src/services/transaction-builder.js', () => ({
+  buildShieldedSolTransfer: vi.fn().mockResolvedValue('mockedSolTxBase64'),
+  buildShieldedSplTransfer: vi.fn().mockResolvedValue('mockedSplTxBase64'),
+  buildAnchorShieldedSolTransfer: vi.fn().mockResolvedValue({
+    transaction: 'mockedAnchorTxBase64',
+    noteId: 'mockedNoteIdPDA',
+    encryptedAmount: '0xdeadbeefcafebabe',
+    instructionType: 'anchor' as const,
+  }),
+}))
+
+const txBuilder = await import('../src/services/transaction-builder.js')
+
+const {
+  isTransferSupported,
+  getSupportedTransferChains,
+  buildPrivateTransfer,
+} = await import('../src/services/chain-transfer-builder.js')
+
+// Realistic test recipient meta-address (use real ed25519/secp256k1 hex)
+// 32-byte ed25519 pubkey for solana/near
+const SOLANA_SPENDING_KEY = '0x' + 'a'.repeat(64)
+const SOLANA_VIEWING_KEY = '0x' + 'b'.repeat(64)
+
+// 33-byte secp256k1 compressed pubkey for evm
+const EVM_SPENDING_KEY = '0x02' + 'c'.repeat(64)
+const EVM_VIEWING_KEY = '0x02' + 'd'.repeat(64)
+
+const sender = 'SenderAddrXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+```
+
+Append the new describe block at the end of the file:
+
+```typescript
+describe('buildPrivateTransfer — Solana branch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('native SOL → calls buildAnchorShieldedSolTransfer with anchor instructionType', async () => {
+    const result = await buildPrivateTransfer({
+      sender,
+      recipientMetaAddress: {
+        spendingKey: SOLANA_SPENDING_KEY,
+        viewingKey: SOLANA_VIEWING_KEY,
+        chain: 'solana',
+      },
+      amount: '1000000',
+    })
+
+    expect(txBuilder.buildAnchorShieldedSolTransfer).toHaveBeenCalledOnce()
+    expect(result.instructionType).toBe('anchor')
+    expect(result.chain).toBe('solana')
+    expect(result.curve).toBe('ed25519')
+  })
+
+  it('native SOL → falls back to system transfer when Anchor throws', async () => {
+    vi.mocked(txBuilder.buildAnchorShieldedSolTransfer).mockRejectedValueOnce(
+      new Error('CONFIG_PDA account not found')
+    )
+
+    const result = await buildPrivateTransfer({
+      sender,
+      recipientMetaAddress: {
+        spendingKey: SOLANA_SPENDING_KEY,
+        viewingKey: SOLANA_VIEWING_KEY,
+        chain: 'solana',
+      },
+      amount: '1000000',
+    })
+
+    expect(txBuilder.buildShieldedSolTransfer).toHaveBeenCalledOnce()
+    expect(result.instructionType).toBe('system')
+  })
+
+  it('SPL token (mint provided) → calls buildShieldedSplTransfer', async () => {
+    const result = await buildPrivateTransfer({
+      sender,
+      recipientMetaAddress: {
+        spendingKey: SOLANA_SPENDING_KEY,
+        viewingKey: SOLANA_VIEWING_KEY,
+        chain: 'solana',
+      },
+      amount: '500000',
+      token: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', // USDC mint
+    })
+
+    expect(txBuilder.buildShieldedSplTransfer).toHaveBeenCalledOnce()
+    expect(result.chain).toBe('solana')
+    if (result.chainData.type === 'solana') {
+      expect(result.chainData.mint).toBe('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')
+    }
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cd ~/local-dev/sipher
+pnpm test tests/chain-transfer-builder -- --run
+```
+
+Expected: 6 tests total now (3 helper + 3 Solana branch).
+
+- [ ] **Step 3: Verify typecheck**
+
+```bash
+pnpm typecheck
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/chain-transfer-builder.test.ts
+git commit -m "test(chain-transfer-builder): add Solana branch tests (3)"
+```
+
+---
+
+## Task 8: Add `chain-transfer-builder` EVM branch tests (3 tests)
+
+**Files:**
+- Modify: `tests/chain-transfer-builder.test.ts`
+- Reference (read-only): `src/services/chain-transfer-builder.ts:225-256`
+
+- [ ] **Step 1: Append the EVM branch test group**
+
+Append the following describe block at the end of `tests/chain-transfer-builder.test.ts`:
+
+```typescript
+describe('buildPrivateTransfer — EVM branch', () => {
+  const evmChainsWithIds: Array<[string, number]> = [
+    ['ethereum', 1],
+    ['polygon', 137],
+    ['arbitrum', 42161],
+    ['optimism', 10],
+    ['base', 8453],
+  ]
+
+  it.each(evmChainsWithIds)('native ETH on %s returns {to, value, data:0x}', async (chain, _chainId) => {
+    const result = await buildPrivateTransfer({
+      sender,
+      recipientMetaAddress: {
+        spendingKey: EVM_SPENDING_KEY,
+        viewingKey: EVM_VIEWING_KEY,
+        chain,
+      },
+      amount: '1000000000000000000', // 1 ETH in wei
+    })
+
+    expect(result.chainData.type).toBe('evm')
+    if (result.chainData.type === 'evm') {
+      expect(result.chainData.to.toLowerCase()).toMatch(/^0x[0-9a-f]{40}$/)
+      expect(result.chainData.value).toBe('1000000000000000000')
+      expect(result.chainData.data).toBe('0x')
+    }
+  })
+
+  it('ERC20 → data starts with 0xa9059cbb + padded address + padded amount', async () => {
+    const tokenContract = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' // USDC on ETH
+    const amount = '1000000' // 1 USDC
+
+    const result = await buildPrivateTransfer({
+      sender,
+      recipientMetaAddress: {
+        spendingKey: EVM_SPENDING_KEY,
+        viewingKey: EVM_VIEWING_KEY,
+        chain: 'ethereum',
+      },
+      amount,
+      token: tokenContract,
+    })
+
+    expect(result.chainData.type).toBe('evm')
+    if (result.chainData.type === 'evm') {
+      expect(result.chainData.to).toBe(tokenContract)
+      expect(result.chainData.tokenContract).toBe(tokenContract)
+      expect(result.chainData.value).toBe('0')
+      // data: 0xa9059cbb + 64-char-padded-stealth + 64-char-padded-amount
+      expect(result.chainData.data.startsWith('0xa9059cbb')).toBe(true)
+      expect(result.chainData.data.length).toBe(2 + 8 + 64 + 64)
+
+      const amountHex = result.chainData.data.slice(2 + 8 + 64)
+      const amountReadback = BigInt('0x' + amountHex)
+      expect(amountReadback).toBe(BigInt(amount))
+    }
+  })
+
+  it.each(evmChainsWithIds)('sets correct chainId for %s → %i', async (chain, chainId) => {
+    const result = await buildPrivateTransfer({
+      sender,
+      recipientMetaAddress: {
+        spendingKey: EVM_SPENDING_KEY,
+        viewingKey: EVM_VIEWING_KEY,
+        chain,
+      },
+      amount: '1000',
+    })
+
+    if (result.chainData.type === 'evm') {
+      expect(result.chainData.chainId).toBe(chainId)
+    }
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cd ~/local-dev/sipher
+pnpm test tests/chain-transfer-builder -- --run
+```
+
+Expected: more tests now (5 EVM native + 1 ERC20 + 5 chainId via parameterization).
+
+- [ ] **Step 3: Verify typecheck**
+
+```bash
+pnpm typecheck
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/chain-transfer-builder.test.ts
+git commit -m "test(chain-transfer-builder): add EVM branch tests (3, parameterized)"
+```
+
+---
+
+## Task 9: Add `chain-transfer-builder` NEAR branch tests (2 tests)
+
+**Files:**
+- Modify: `tests/chain-transfer-builder.test.ts`
+- Reference (read-only): `src/services/chain-transfer-builder.ts:258-290`
+
+- [ ] **Step 1: Append the NEAR branch test group**
+
+Append at the end of `tests/chain-transfer-builder.test.ts`:
+
+```typescript
+describe('buildPrivateTransfer — NEAR branch', () => {
+  it('native NEAR → returns Transfer action with amount', async () => {
+    const result = await buildPrivateTransfer({
+      sender,
+      recipientMetaAddress: {
+        spendingKey: SOLANA_SPENDING_KEY, // ed25519 reused for NEAR
+        viewingKey: SOLANA_VIEWING_KEY,
+        chain: 'near',
+      },
+      amount: '1000000000000000000000000', // 1 NEAR (24 decimals)
+    })
+
+    expect(result.chainData.type).toBe('near')
+    if (result.chainData.type === 'near') {
+      expect(result.chainData.actions).toHaveLength(1)
+      expect(result.chainData.actions[0]).toEqual({
+        type: 'Transfer',
+        amount: '1000000000000000000000000',
+      })
+      expect(result.chainData.tokenContract).toBeUndefined()
+    }
+  })
+
+  it('NEP-141 FT → FunctionCall with ft_transfer + base64 args', async () => {
+    const tokenContract = 'usdc.fakes.testnet'
+    const amount = '1000000' // 1 USDC
+
+    const result = await buildPrivateTransfer({
+      sender,
+      recipientMetaAddress: {
+        spendingKey: SOLANA_SPENDING_KEY,
+        viewingKey: SOLANA_VIEWING_KEY,
+        chain: 'near',
+      },
+      amount,
+      token: tokenContract,
+    })
+
+    expect(result.chainData.type).toBe('near')
+    if (result.chainData.type === 'near') {
+      expect(result.chainData.receiverId).toBe(tokenContract)
+      expect(result.chainData.tokenContract).toBe(tokenContract)
+      expect(result.chainData.actions).toHaveLength(1)
+
+      const action = result.chainData.actions[0]
+      if (action.type === 'FunctionCall') {
+        expect(action.methodName).toBe('ft_transfer')
+        expect(action.gas).toBe('30000000000000')
+        expect(action.deposit).toBe('1')
+
+        const decoded = JSON.parse(Buffer.from(action.args, 'base64').toString())
+        expect(decoded.amount).toBe(amount)
+        expect(decoded.memo).toBe('SIP private transfer')
+        expect(typeof decoded.receiver_id).toBe('string')
+      }
+    }
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cd ~/local-dev/sipher
+pnpm test tests/chain-transfer-builder -- --run
+```
+
+Expected: 2 NEAR tests pass on top of previous tests.
+
+- [ ] **Step 3: Verify typecheck**
+
+```bash
+pnpm typecheck
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/chain-transfer-builder.test.ts
+git commit -m "test(chain-transfer-builder): add NEAR branch tests (2)"
+```
+
+---
+
+## Task 10: Add `chain-transfer-builder` error + curve detection tests (2 tests)
+
+**Files:**
+- Modify: `tests/chain-transfer-builder.test.ts`
+- Reference (read-only): `src/services/chain-transfer-builder.ts:122, 147-149`
+
+- [ ] **Step 1: Append the error / curve test group**
+
+Append at the end of `tests/chain-transfer-builder.test.ts`:
+
+```typescript
+describe('buildPrivateTransfer — error + curve detection', () => {
+  it('throws on unsupported chain', async () => {
+    await expect(
+      buildPrivateTransfer({
+        sender,
+        recipientMetaAddress: {
+          spendingKey: SOLANA_SPENDING_KEY,
+          viewingKey: SOLANA_VIEWING_KEY,
+          chain: 'bitcoin',
+        },
+        amount: '1000',
+      })
+    ).rejects.toThrow(/Unsupported transfer chain/)
+  })
+
+  it.each([
+    ['solana', 'ed25519' as const, SOLANA_SPENDING_KEY, SOLANA_VIEWING_KEY],
+    ['near', 'ed25519' as const, SOLANA_SPENDING_KEY, SOLANA_VIEWING_KEY],
+    ['ethereum', 'secp256k1' as const, EVM_SPENDING_KEY, EVM_VIEWING_KEY],
+    ['polygon', 'secp256k1' as const, EVM_SPENDING_KEY, EVM_VIEWING_KEY],
+    ['arbitrum', 'secp256k1' as const, EVM_SPENDING_KEY, EVM_VIEWING_KEY],
+    ['optimism', 'secp256k1' as const, EVM_SPENDING_KEY, EVM_VIEWING_KEY],
+    ['base', 'secp256k1' as const, EVM_SPENDING_KEY, EVM_VIEWING_KEY],
+  ])('returns curve=%s for chain=%s', async (chain, expectedCurve, spendingKey, viewingKey) => {
+    const result = await buildPrivateTransfer({
+      sender,
+      recipientMetaAddress: {
+        spendingKey,
+        viewingKey,
+        chain,
+      },
+      amount: '1000',
+    })
+
+    expect(result.curve).toBe(expectedCurve)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cd ~/local-dev/sipher
+pnpm test tests/chain-transfer-builder -- --run
+```
+
+Expected: 1 error test + 7 parameterized curve tests pass on top of previous tests.
+
+- [ ] **Step 3: Verify typecheck and full root suite**
+
+```bash
+pnpm typecheck
+pnpm test -- --run 2>&1 | tail -10
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/chain-transfer-builder.test.ts
+git commit -m "test(chain-transfer-builder): add error + curve detection tests (2)"
+```
+
+---
+
+## Task 11: Add `private-swap-builder` happy path tests (3 tests)
+
+**Files:**
+- Create: `tests/private-swap-builder.test.ts`
+- Reference (read-only): `src/services/private-swap-builder.ts:66-172`
+
+- [ ] **Step 1: Create the test file with happy path tests**
+
+Create `tests/private-swap-builder.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { makeJupiterQuote, makeJupiterSwapTx, mockCSPLService } from './fixtures/builder-mocks.js'
+
+// Mock jupiter-provider — must be hoisted before importing the builder
+vi.mock('../src/services/jupiter-provider.js', () => ({
+  getQuote: vi.fn(),
+  buildSwapTransaction: vi.fn(),
+}))
+
+// Mock cspl — default to success
+vi.mock('../src/services/cspl.js', () => ({
+  getCSPLService: vi.fn().mockResolvedValue({
+    wrap: vi.fn().mockResolvedValue({ success: false }),
+  }),
+}))
+
+const jupiterProvider = await import('../src/services/jupiter-provider.js')
+const csplModule = await import('../src/services/cspl.js')
+
+const { buildPrivateSwap } = await import('../src/services/private-swap-builder.js')
+
+const sender = 'SenderAddrXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+const SOL_MINT = 'So11111111111111111111111111111111111111112'
+const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+
+// Realistic 32-byte ed25519 hex pubkey for Solana
+const PROVIDED_SPENDING_KEY = '0x' + 'a'.repeat(64)
+const PROVIDED_VIEWING_KEY = '0x' + 'b'.repeat(64)
+
+describe('buildPrivateSwap — happy path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jupiterProvider.getQuote).mockResolvedValue(makeJupiterQuote())
+    vi.mocked(jupiterProvider.buildSwapTransaction).mockResolvedValue(makeJupiterSwapTx())
+    vi.mocked(csplModule.getCSPLService).mockResolvedValue(mockCSPLService('fail') as never)
+  })
+
+  it('with provided meta-address → uses it (not ephemeral)', async () => {
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+      recipientMetaAddress: {
+        spendingKey: PROVIDED_SPENDING_KEY,
+        viewingKey: PROVIDED_VIEWING_KEY,
+        chain: 'solana',
+      },
+    })
+
+    // viewingKeyHash should derive from PROVIDED_VIEWING_KEY (not ephemeral)
+    expect(result.viewingKeyHash).toMatch(/^0x[0-9a-f]{64}$/)
+    // ephemeral viewing key hash uses input "ephemeral-" + address
+    // we verify by recomputing what provided-key hash should be in Task 14
+    expect(result.outputStealthAddress).toMatch(/^[1-9A-HJ-NP-Za-km-z]{32,44}$/) // base58
+  })
+
+  it('without meta-address → generates ephemeral meta-address', async () => {
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+    })
+
+    expect(result.outputStealthAddress).toMatch(/^[1-9A-HJ-NP-Za-km-z]{32,44}$/)
+    expect(result.viewingKeyHash).toMatch(/^0x[0-9a-f]{64}$/)
+  })
+
+  it('returns expected PrivateSwapResult shape', async () => {
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+    })
+
+    // Privacy artifacts
+    expect(result).toHaveProperty('outputStealthAddress')
+    expect(result).toHaveProperty('ephemeralPublicKey')
+    expect(result).toHaveProperty('viewTag')
+    expect(result).toHaveProperty('commitment')
+    expect(result).toHaveProperty('blindingFactor')
+    expect(result).toHaveProperty('viewingKeyHash')
+    expect(result).toHaveProperty('sharedSecret')
+
+    // Swap details
+    expect(result.inputMint).toBe(SOL_MINT)
+    expect(result.outputMint).toBe(USDC_MINT)
+    expect(result.inputAmount).toBe('1000000000')
+    expect(result.outputAmount).toBe('150000000')
+    expect(result.quoteId).toBe('jup_test_quote_001')
+    expect(result.slippageBps).toBe(50)
+
+    // Transaction bundle
+    expect(Array.isArray(result.transactions)).toBe(true)
+    expect(Array.isArray(result.executionOrder)).toBe(true)
+    expect(typeof result.estimatedComputeUnits).toBe('number')
+
+    // C-SPL status
+    expect(typeof result.csplWrapped).toBe('boolean')
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cd ~/local-dev/sipher
+pnpm test tests/private-swap-builder -- --run
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 3: Verify typecheck**
+
+```bash
+pnpm typecheck
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/private-swap-builder.test.ts
+git commit -m "test(private-swap-builder): add happy path tests (3)"
+```
+
+---
+
+## Task 12: Add `private-swap-builder` C-SPL branch tests (3 tests)
+
+**Files:**
+- Modify: `tests/private-swap-builder.test.ts`
+- Reference (read-only): `src/services/private-swap-builder.ts:108-131, 147`
+
+- [ ] **Step 1: Append the C-SPL branch test group**
+
+Append at the end of `tests/private-swap-builder.test.ts`:
+
+```typescript
+describe('buildPrivateSwap — C-SPL branches', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jupiterProvider.getQuote).mockResolvedValue(makeJupiterQuote())
+    vi.mocked(jupiterProvider.buildSwapTransaction).mockResolvedValue(makeJupiterSwapTx())
+  })
+
+  it('CSPL wrap succeeds → wrap tx in bundle, csplWrapped=true, computeUnits=400_000', async () => {
+    vi.mocked(csplModule.getCSPLService).mockResolvedValue(mockCSPLService('success') as never)
+
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+    })
+
+    expect(result.csplWrapped).toBe(true)
+    expect(result.estimatedComputeUnits).toBe(400_000)
+    expect(result.transactions[0].type).toBe('wrap')
+    expect(result.executionOrder).toContain('wrap')
+    expect(result.executionOrder).toContain('swap')
+  })
+
+  it('CSPL returns {success: false} → no wrap tx, csplWrapped=false, computeUnits=200_000', async () => {
+    vi.mocked(csplModule.getCSPLService).mockResolvedValue(mockCSPLService('fail') as never)
+
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+    })
+
+    expect(result.csplWrapped).toBe(false)
+    expect(result.estimatedComputeUnits).toBe(200_000)
+    expect(result.executionOrder).not.toContain('wrap')
+    expect(result.transactions.every(tx => tx.type !== 'wrap')).toBe(true)
+  })
+
+  it('CSPL throws → silently caught, no wrap tx, csplWrapped=false, computeUnits=200_000', async () => {
+    vi.mocked(csplModule.getCSPLService).mockRejectedValue(new Error('CSPL service down'))
+
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+    })
+
+    expect(result.csplWrapped).toBe(false)
+    expect(result.estimatedComputeUnits).toBe(200_000)
+    expect(result.executionOrder).not.toContain('wrap')
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cd ~/local-dev/sipher
+pnpm test tests/private-swap-builder -- --run
+```
+
+Expected: 6 tests pass total (3 happy + 3 CSPL).
+
+- [ ] **Step 3: Verify typecheck**
+
+```bash
+pnpm typecheck
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/private-swap-builder.test.ts
+git commit -m "test(private-swap-builder): add C-SPL branch tests (3)"
+```
+
+---
+
+## Task 13: Add `private-swap-builder` stealth + commitment invariant tests (2 tests)
+
+**Files:**
+- Modify: `tests/private-swap-builder.test.ts`
+- Reference (read-only): `src/services/private-swap-builder.ts:84-97`
+
+- [ ] **Step 1: Append the stealth + commitment test group**
+
+Append at the end of `tests/private-swap-builder.test.ts`:
+
+```typescript
+describe('buildPrivateSwap — stealth + commitment invariants', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jupiterProvider.getQuote).mockResolvedValue(makeJupiterQuote())
+    vi.mocked(jupiterProvider.buildSwapTransaction).mockResolvedValue(makeJupiterSwapTx())
+    vi.mocked(csplModule.getCSPLService).mockResolvedValue(mockCSPLService('fail') as never)
+  })
+
+  it('outputStealthAddress is a valid base58 Solana address (32 bytes)', async () => {
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+    })
+
+    // base58 Solana addresses are 32-44 chars
+    expect(result.outputStealthAddress).toMatch(/^[1-9A-HJ-NP-Za-km-z]{32,44}$/)
+
+    // Validate by reconstructing PublicKey (will throw if invalid)
+    const { PublicKey } = await import('@solana/web3.js')
+    expect(() => new PublicKey(result.outputStealthAddress)).not.toThrow()
+    expect(new PublicKey(result.outputStealthAddress).toBytes()).toHaveLength(32)
+  })
+
+  it('commitment is 33-byte compressed point hex; blindingFactor is 32-byte hex', async () => {
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+    })
+
+    // commitment: 0x + 66 hex chars (33 bytes)
+    expect(result.commitment).toMatch(/^0x[0-9a-f]{66}$/)
+
+    // First byte after 0x must be 02 or 03 (compressed point prefix)
+    const prefix = result.commitment.slice(2, 4)
+    expect(['02', '03']).toContain(prefix)
+
+    // blindingFactor: 0x + 64 hex chars (32 bytes)
+    expect(result.blindingFactor).toMatch(/^0x[0-9a-f]{64}$/)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cd ~/local-dev/sipher
+pnpm test tests/private-swap-builder -- --run
+```
+
+Expected: 8 tests pass total (3 happy + 3 CSPL + 2 stealth/commitment).
+
+- [ ] **Step 3: Verify typecheck**
+
+```bash
+pnpm typecheck
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/private-swap-builder.test.ts
+git commit -m "test(private-swap-builder): add stealth + commitment invariant tests (2)"
+```
+
+---
+
+## Task 14: Add `private-swap-builder` viewing key hash tests (2 tests)
+
+**Files:**
+- Modify: `tests/private-swap-builder.test.ts`
+- Reference (read-only): `src/services/private-swap-builder.ts:99-106`
+
+- [ ] **Step 1: Append the viewing key hash test group**
+
+Append at the end of `tests/private-swap-builder.test.ts`:
+
+```typescript
+describe('buildPrivateSwap — viewing key hash', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jupiterProvider.getQuote).mockResolvedValue(makeJupiterQuote())
+    vi.mocked(jupiterProvider.buildSwapTransaction).mockResolvedValue(makeJupiterSwapTx())
+    vi.mocked(csplModule.getCSPLService).mockResolvedValue(mockCSPLService('fail') as never)
+  })
+
+  it('with provided meta-address → vkHash = 0x + sha256(viewingKey bytes)', async () => {
+    const { sha256 } = await import('@noble/hashes/sha256')
+    const { hexToBytes, bytesToHex } = await import('@noble/hashes/utils')
+
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+      recipientMetaAddress: {
+        spendingKey: PROVIDED_SPENDING_KEY,
+        viewingKey: PROVIDED_VIEWING_KEY,
+        chain: 'solana',
+      },
+    })
+
+    const viewingKeyBytes = hexToBytes(PROVIDED_VIEWING_KEY.slice(2))
+    const expectedHash = `0x${bytesToHex(sha256(viewingKeyBytes))}`
+
+    expect(result.viewingKeyHash).toBe(expectedHash)
+  })
+
+  it('without meta-address → vkHash = 0x + sha256("ephemeral-" + outputStealthAddress)', async () => {
+    const { sha256 } = await import('@noble/hashes/sha256')
+    const { bytesToHex } = await import('@noble/hashes/utils')
+
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+    })
+
+    const expectedHash = `0x${bytesToHex(sha256(new TextEncoder().encode('ephemeral-' + result.outputStealthAddress)))}`
+
+    expect(result.viewingKeyHash).toBe(expectedHash)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cd ~/local-dev/sipher
+pnpm test tests/private-swap-builder -- --run
+```
+
+Expected: 10 tests pass total.
+
+- [ ] **Step 3: Verify typecheck and full root suite**
+
+```bash
+pnpm typecheck
+pnpm test -- --run 2>&1 | tail -10
+```
+
+Expected: typecheck clean; root suite green (33 + 3 = 36 files).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/private-swap-builder.test.ts
+git commit -m "test(private-swap-builder): add viewing key hash tests (2)"
+```
+
+---
+
+## Task 15: Bump test count baseline in CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md` (find the "Test Suite" section, update the per-package counts)
+
+- [ ] **Step 1: Locate the test count line**
+
+```bash
+cd ~/local-dev/sipher
+grep -n "REST" CLAUDE.md | head -10
+```
+
+Expected: shows the line(s) referencing REST test counts.
+
+- [ ] **Step 2: Get the current and new test counts**
+
+```bash
+pnpm test -- --run 2>&1 | grep -E "Tests|Test Files"
+```
+
+Expected: shows actual file count (should be 36) and total test count.
+
+Record these numbers — they go into the diff in the next step.
+
+- [ ] **Step 3: Update CLAUDE.md**
+
+Edit `CLAUDE.md` to bump the REST test count. Find the line that currently says something like:
+
+```
+**Stats:** 58 REST + 22 agent tools + 9 HERALD tools + 14 SENTINEL tools + Command Center UI | 497 REST + 912 agent tests | 17 chains
+```
+
+Update the REST test count to the new number from Step 2 (e.g., 497 → 497+37 ≈ 534, exact number depends on actual `pnpm test` output).
+
+- [ ] **Step 4: Run typecheck (no impact, but sanity check)**
+
+```bash
+pnpm typecheck
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "chore: bump test count baseline in CLAUDE.md"
+```
+
+---
+
+## Task 16: Final verification + open PR
+
+**Files:** None modified — pre-PR checklist + PR open
+
+- [ ] **Step 1: Full pre-PR verification**
+
+```bash
+cd ~/local-dev/sipher
+pnpm test -- --run                          # full root suite
+pnpm --filter @sipher/agent test -- --run   # agent baseline 938 unchanged
+pnpm --filter @sipher/app test -- --run     # app baseline 45 unchanged
+pnpm typecheck                              # workspace
+```
+
+Expected:
+- Root suite: 36 files pass, ~37 new tests
+- Agent: 938 tests pass (unchanged)
+- App: 45 tests pass (unchanged)
+- Typecheck: no errors
+
+- [ ] **Step 2: Run Playwright E2E (if cipher-admin keypair available)**
+
+```bash
+pnpm exec playwright test
+```
+
+Expected: 8/8 + 2 skipped (cipher-admin gate).
+
+- [ ] **Step 3: Sanity-check scope**
+
+```bash
+git diff main --stat
+```
+
+Expected: only test files + spec + plan + CLAUDE.md baseline. No source changes to `src/services/*.ts`.
+
+- [ ] **Step 4: Push branch**
+
+```bash
+git push -u origin feat/phase-4-rest-service-tests
+```
+
+- [ ] **Step 5: Open PR**
+
+```bash
+gh pr create --title "test(phase-4): add unit tests for 3 REST service builders" --body "$(cat <<'EOF'
+## Summary
+
+Phase 4 of the audit-driven plan — adds isolated unit-level test coverage for the 3 builder modules under `src/services/`:
+
+- `transaction-builder.ts` (14 tests covering buildShieldedSolTransfer, buildShieldedSplTransfer, buildAnchorShieldedSolTransfer)
+- `chain-transfer-builder.ts` (13 tests across helpers + 4 chain branches + error/curve detection)
+- `private-swap-builder.ts` (10 tests across happy path, C-SPL fallback, stealth/commitment invariants, viewing key hash)
+
+## Architecture
+
+- 3 new test files in root `tests/`
+- 1 shared fixture file at `tests/fixtures/builder-mocks.ts`
+- Real `@sip-protocol/sdk` (no mocks)
+- Mocks at module boundaries: `@solana/web3.js` Connection, `./jupiter-provider.js`, `./cspl.js`
+- Dealer strategy by layer: fixed-byte inputs for `transaction-builder` (no randomness inside), invariants for the two orchestrators
+
+## Spec / plan
+
+- Spec: `docs/superpowers/specs/2026-05-03-rest-service-tests-design.md`
+- Plan: `docs/superpowers/plans/2026-05-03-rest-service-tests.md`
+
+## Test plan
+
+- [x] Root suite: 33 → 36 files, ~37 new tests, all green via `pnpm test -- --run`
+- [x] Agent baseline (938) unchanged
+- [x] App baseline (45) unchanged
+- [x] `pnpm typecheck` clean
+- [x] No source changes to `src/services/*.ts` (test-only PR)
+
+## Out of scope (per spec)
+
+- Tests for other `src/services/*.ts` files (jupiter-provider, cspl, redis, etc.)
+- Modifying existing route tests (`tests/private-swap.test.ts`, `tests/transfer-shield.test.ts`)
+- Source-code refactors
+
+## Follow-up issues (if any discovered during execution)
+
+To be filled in after the implementing subagent runs.
+EOF
+)"
+```
+
+Expected: PR opened against `main`.
+
+- [ ] **Step 6: Mark plan complete**
+
+Update `docs/superpowers/specs/2026-05-03-rest-service-tests-design.md` "Phase 4 Lessons to Carry Forward" section with any lessons learned during execution.
+
+---
+
+## Summary
+
+**Tasks:** 16 (1 plan commit + 1 fixture + 12 test groups + 1 baseline bump + 1 PR)
+**Estimated test count:** 37 tests (3 + 4 + 7 + 3 + 3 + 3 + 2 + 2 + 3 + 3 + 2 + 2 = 37)
+**Files created:** 4 (1 spec, 1 plan, 1 fixture, 3 test files — total 6 files; spec + plan committed in Tasks 1 + already done)
+**Files modified:** 1 (CLAUDE.md)
+**Commits:** ~16 (matches spec's commit cadence)
+**PR:** 1 vs `main`
+
+**Verification commands (final):**
+```bash
+pnpm test -- --run                          # 36 files green
+pnpm --filter @sipher/agent test -- --run   # 938 unchanged
+pnpm --filter @sipher/app test -- --run     # 45 unchanged
+pnpm typecheck                              # clean
+```
+
+---
+
+**Plan status:** Ready for execution via `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans`.

--- a/docs/superpowers/specs/2026-05-03-rest-service-tests-design.md
+++ b/docs/superpowers/specs/2026-05-03-rest-service-tests-design.md
@@ -64,7 +64,8 @@ Why a shared `fixtures/builder-mocks.ts`: all 3 test files need the same `vi.moc
 
 - `mockSolanaConnection(overrides?)` — returns the Connection mock factory
 - `makeConfigPDABytes(counter: bigint)` — produces a `Buffer.alloc(51)` with `total_transfers` written at offset 43 as u64 LE
-- `mockJupiterFetch(quoteOverrides?, swapOverrides?)` — returns a `vi.fn()` for `vi.stubGlobal('fetch', ...)`
+- `makeJupiterQuote(opts?)` — returns a typed `QuoteEntry` shape for use with `vi.mock('./jupiter-provider.js')` (preferred over fetch-global stubbing — mocks at module boundary so the builder gets the same shape it would receive in production)
+- `makeJupiterSwapTx(swapTransaction?)` — returns a typed `SwapTransactionResult` shape for `buildSwapTransaction` mock
 - `mockCSPLService(behavior: 'success' | 'fail' | 'throws')` — returns the CSPL service mock
 
 ### Mocking strategy per file (Q1 = real-kitchen / service-integration)

--- a/docs/superpowers/specs/2026-05-03-rest-service-tests-design.md
+++ b/docs/superpowers/specs/2026-05-03-rest-service-tests-design.md
@@ -1,0 +1,292 @@
+# Phase 4 — REST Service Tests Design Spec
+
+**Date:** 2026-05-03
+**Status:** Approved scope, ready for implementation plan
+**Scope:** Phase 4 of the "address all audit findings" multi-phase effort
+**Related audits:** Spec-vs-implementation gap audit (2026-04-18); test-infrastructure spec line 267 lists this phase
+**Predecessor specs:** `2026-04-18-test-infrastructure-design.md` (Phase 1), `2026-04-26-ui-gaps-design.md` (Phase 2), `2026-04-27-sentinel-surface-docs-design.md` (Phase 3)
+
+## Summary
+
+Add isolated unit-level test coverage for the three REST API service-layer modules under `src/services/` that compose Solana transactions for SIPHER's stealth-transfer and private-swap flows: `transaction-builder.ts`, `chain-transfer-builder.ts`, and `private-swap-builder.ts`. Currently uncovered as units (one of the three has partial transitive coverage via `tests/private-swap.test.ts`). Phase 4 adds **~37 new tests** across **3 new test files** in root `tests/`, plus **1 shared fixture file** at `tests/fixtures/builder-mocks.ts`. Tests follow the same real-SDK + mocked-network pattern as the existing `tests/private-swap.test.ts`. Zero source-code changes to the builders. Single PR.
+
+## Context
+
+The 2026-04-18 test-infrastructure audit listed Phase 4 as: *"REST service tests (chain-transfer-builder, transaction-builder, private-swap-builder) — Phase 4."* The audit located these files at `packages/agent/src/services/`, but verification on 2026-05-03 found them at root `src/services/`:
+
+- `src/services/transaction-builder.ts` (308 lines) — Solana transaction builders: `buildShieldedSolTransfer`, `buildShieldedSplTransfer`, `buildAnchorShieldedSolTransfer`. The Anchor builder reads `CONFIG_PDA` bytes from RPC, parses the `total_transfers` counter at byte offset 43, derives a `transfer_record` PDA, and packs an 8+33+32+32+32+8+128+8 byte instruction-data buffer for the live `S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at` program.
+- `src/services/chain-transfer-builder.ts` (290 lines) — Multi-chain orchestrator: `buildPrivateTransfer`, `isTransferSupported`, `getSupportedTransferChains`. Branches across 7 chains (Solana with Anchor / system / SPL fallbacks; Ethereum, Polygon, Arbitrum, Optimism, Base via EVM family with ERC20 calldata; NEAR with native Transfer or NEP-141 FunctionCall).
+- `src/services/private-swap-builder.ts` (173 lines) — Jupiter-routed private-swap orchestrator: `buildPrivateSwap`. Calls Jupiter for quote + swap tx, generates stealth output address, optionally wraps via C-SPL with try/catch fallback, computes Pedersen commitment.
+
+**Existing coverage map:**
+
+| File | Existing route-level coverage | Existing unit-level coverage |
+|------|------------------------------|------------------------------|
+| `transaction-builder.ts` | None directly; called via `chain-transfer-builder` from `transfer-shield.test.ts` | None |
+| `chain-transfer-builder.ts` | Partial via `transfer-shield.test.ts` (Solana branch only) | None |
+| `private-swap-builder.ts` | `tests/private-swap.test.ts` — 18 supertest tests (happy, validation, idempotency, beta, E2E) | None |
+
+The existing tests are restaurant-review-style: order at the route, kitchen cooks, plate goes out. Phase 4 adds chef-interview-style: import the builder, call it directly, assert its branches and contracts. Both styles have value (Phase 4 lesson Q2 = option A: add alongside, not replace).
+
+## Goals
+
+1. Land **3 new test files** in root `tests/` covering the 3 builders directly.
+2. **~37 tests** total (full-branch coverage, see Test Categories section). Numbers may flex ±2 during TDD.
+3. **Zero regression** in existing root suite (33 files), agent suite (938 tests), app suite (45 tests).
+4. **Zero source-code changes** to the 3 builders — Phase 4 is test-only.
+5. **Single PR** vs `main` (avoid Phase 2's stacked-spec-branch orphan trap).
+6. **Spec + plan + impl** all bundled in one PR.
+
+## Non-goals
+
+- Tests for other services in `src/services/*.ts` (jupiter-provider, cspl, redis, helius-provider, solana, etc.) — not in audit scope, future phase.
+- Modifying `tests/private-swap.test.ts` or `tests/transfer-shield.test.ts` — Q2 chose to add alongside, not replace.
+- Testing CSPL service internals (`cspl.ts` itself) — we mock at the boundary.
+- E2E tests against devnet/mainnet — already covered by existing `private-swap.test.ts` E2E section.
+- Refactoring builders to be more testable — Phase 4 tests them as-is. If a test reveals a real bug, file a follow-up issue and pause; do not fix in this PR.
+- Performance / load tests, snapshot tests.
+- Migrating existing tests to a new pattern.
+
+## Architecture
+
+### File layout
+
+```
+tests/
+  private-swap-builder.test.ts     (NEW — sits next to existing private-swap.test.ts)
+  chain-transfer-builder.test.ts   (NEW)
+  transaction-builder.test.ts      (NEW)
+  fixtures/
+    builder-mocks.ts               (NEW — shared mocks)
+```
+
+Why a shared `fixtures/builder-mocks.ts`: all 3 test files need the same `vi.mock('@solana/web3.js')` pattern (faked `Connection` returning `getLatestBlockhash` + `getAccountInfo`). Inlining 3 copies is duplication. The shared module exports:
+
+- `mockSolanaConnection(overrides?)` — returns the Connection mock factory
+- `makeConfigPDABytes(counter: bigint)` — produces a `Buffer.alloc(51)` with `total_transfers` written at offset 43 as u64 LE
+- `mockJupiterFetch(quoteOverrides?, swapOverrides?)` — returns a `vi.fn()` for `vi.stubGlobal('fetch', ...)`
+- `mockCSPLService(behavior: 'success' | 'fail' | 'throws')` — returns the CSPL service mock
+
+### Mocking strategy per file (Q1 = real-kitchen / service-integration)
+
+#### `transaction-builder.test.ts` — the prep cook
+
+**Faked:**
+- `@solana/web3.js` `Connection` via `vi.mock` with `vi.importActual` spread (matches existing `tests/private-swap.test.ts:7-22` pattern)
+- `./solana.js` `getConnection` returns the mocked Connection
+
+**Real:**
+- `@noble/hashes/sha256`, `@solana/spl-token` instruction builders (pure crypto / byte helpers, no I/O)
+- All inputs are fixed deterministic values (no SDK randomness inside this file — Q4 dealer strategy: fixed bytes since the prep cook doesn't roll dice)
+
+**Anchor mocking trick:** `buildAnchorShieldedSolTransfer` reads `total_transfers` from CONFIG_PDA bytes at offset 43. Tests use `makeConfigPDABytes(counter)` to generate `Buffer.alloc(51)` with `writeBigUInt64LE(counter, 43)`. This lets us test counter=0, counter=42, counter=2^53-1 cases without touching the chain.
+
+#### `chain-transfer-builder.test.ts` — the head chef
+
+**Faked:**
+- `./transaction-builder.js` — mock all 3 exports (`buildShieldedSolTransfer`, `buildShieldedSplTransfer`, `buildAnchorShieldedSolTransfer`) to return predictable strings. Lets us test "did the head chef call the right prep cook with the right args?" in isolation.
+
+**Real:**
+- `@sip-protocol/sdk` — real `generateStealthAddress`, real `commit()`, real `isEd25519Chain`, real curve detection. Q4 dealer strategy: invariants (assert "stealth address is a valid 32-byte ed25519 pubkey for solana/near", "valid 0x-prefixed hex secp256k1 pubkey for evm").
+
+#### `private-swap-builder.test.ts` — the specialty chef
+
+**Faked:**
+- `./jupiter-provider.js` `getQuote` and `buildSwapTransaction` — return canned quote + canned swap tx
+- `./cspl.js` `getCSPLService` — three configurable behaviors via `mockCSPLService(behavior)`: `'success'` (returns wrap result with signature), `'fail'` (returns `{success: false}`), `'throws'` (rejects)
+
+**Real:**
+- `@sip-protocol/sdk` — real stealth gen + real commit (same as chain-transfer-builder)
+
+### Dealer strategy by layer (Q4 = match strategy to layer)
+
+| Layer | File | Strategy | Why |
+|-------|------|----------|-----|
+| Prep cook | `transaction-builder.ts` | Fixed-byte inputs, byte-precise assertions | No randomness inside this file — receives stealth addresses as parameters. Byte layout matters (instruction data has specific offsets). |
+| Orchestrator | `chain-transfer-builder.ts` | Real SDK randomness, invariant assertions | Calls SDK's `generateStealthAddress` which uses `crypto.getRandomValues`. Asserting specific addresses would freeze SDK internals. |
+| Orchestrator | `private-swap-builder.ts` | Real SDK randomness, invariant assertions | Same reason. |
+
+This is not "two patterns" — it is matching the test to the layer.
+
+## Test Categories (the menu)
+
+Per Q3 = full chef's table. ~37 tests total. Each test sentence becomes one task in the implementation plan (some grouped via `it.each` parameterization).
+
+### `transaction-builder.test.ts` — 14 tests
+
+**`buildShieldedSolTransfer` (3)**
+1. Builds `SystemProgram.transfer` instruction with correct `fromPubkey` / `toPubkey` / `lamports`
+2. Tx has `recentBlockhash`, `lastValidBlockHeight`, `feePayer` set
+3. Returned base64 deserializes back to a valid unsigned tx
+
+**`buildShieldedSplTransfer` (4)**
+1. When stealth ATA does **not** exist → tx contains `createAssociatedTokenAccountInstruction` + `createTransferInstruction`
+2. When stealth ATA **exists** → tx contains only `createTransferInstruction` (no ATA creation)
+3. Uses correct sender-ATA derivation (`getAssociatedTokenAddress(mint, sender)`)
+4. Uses `allowOwnerOffCurve=true` for stealth-ATA derivation (critical — stealth addresses can be off-curve)
+
+**`buildAnchorShieldedSolTransfer` (7)**
+1. Throws `"CONFIG_PDA account not found"` when RPC returns `null`
+2. Parses `total_transfers` correctly when counter = 0
+3. Parses correctly when counter = 42
+4. Parses correctly when counter = `2n ** 53n - 1n` (near `Number.MAX_SAFE_INTEGER`)
+5. Derives `transferRecordPDA` from `[TRANSFER_RECORD_SEED, senderPubkey, counter_le_bytes]`
+6. Instruction data byte layout assertion at exact offsets: discriminator(0-7), commitment(8-40), stealth(41-72), ephemeral(73-104), vkHash(105-136), encryptedAmount(137-144), proof(145-272), amount(273-280)
+7. Handles hex inputs with AND without `0x` prefix (parameterized via `it.each([true, false])` over each hex field)
+
+### `chain-transfer-builder.test.ts` — 13 tests
+
+**`isTransferSupported` (2)**
+1. Returns `true` for all 7 supported chains (parameterized: solana, ethereum, polygon, arbitrum, optimism, base, near)
+2. Returns `false` for unsupported chain (`'bitcoin'`)
+
+**`getSupportedTransferChains` (1)**
+1. Returns array containing all 7 chains
+
+**`buildPrivateTransfer` — Solana branch (3)**
+1. Native SOL → calls `buildAnchorShieldedSolTransfer` (Anchor path), returned `instructionType === 'anchor'`
+2. Native SOL → if Anchor mock throws, falls back to `buildShieldedSolTransfer`, returned `instructionType === 'system'`
+3. SPL token (mint provided) → calls `buildShieldedSplTransfer` with mint
+
+**`buildPrivateTransfer` — EVM branch (3)**
+1. Native ETH → returns `{type:'evm', to: stealth, value: amount, data: '0x'}` for all 5 EVM chains (parameterized over `[ethereum, polygon, arbitrum, optimism, base]`)
+2. ERC20 (token contract provided) → `data` starts with `0xa9059cbb` + 32-byte-padded stealth address + 32-byte-padded amount
+3. Correct `chainId` per chain (parameterized — defends against per-chain encoding regression)
+
+**`buildPrivateTransfer` — NEAR branch (2)**
+1. Native NEAR → `actions: [{type: 'Transfer', amount}]`
+2. NEP-141 FT (token contract provided) → `FunctionCall` with `methodName: 'ft_transfer'`, base64-encoded args containing `receiver_id`, `amount`, `memo`, gas `30000000000000`, deposit `'1'`
+
+**`buildPrivateTransfer` — error / curve detection (2)**
+1. Throws on unsupported chain (e.g., `'bitcoin'`)
+2. Returns correct `curve` (`'ed25519'` for solana/near, `'secp256k1'` for evm) — parameterized over all 7 chains
+
+### `private-swap-builder.test.ts` — 10 tests
+
+**Happy path (3)**
+1. With provided meta-address → uses it (not ephemeral)
+2. Without meta-address → generates ephemeral meta-address
+3. Returns expected `PrivateSwapResult` shape (all documented fields populated)
+
+**C-SPL branches (3)**
+1. CSPL wrap **succeeds** → `transactions[0].type === 'wrap'`, `csplWrapped === true`, `estimatedComputeUnits === 400_000`, `executionOrder` includes `'wrap'`
+2. CSPL returns `{success: false}` → no wrap tx, `csplWrapped === false`, `estimatedComputeUnits === 200_000`
+3. CSPL **throws** → silently caught, no wrap tx, `csplWrapped === false`, `estimatedComputeUnits === 200_000`
+
+**Stealth + commitment (2)**
+1. `outputStealthAddress` is a valid 32-byte ed25519 Solana address (invariant)
+2. `commitment` is a 33-byte compressed point (66 hex chars after `0x`), `blindingFactor` is 32-byte hex
+
+**Viewing key hash (2)**
+1. With provided meta-address → `viewingKeyHash === '0x' + sha256(viewingKey bytes)`
+2. Without meta-address (ephemeral) → `viewingKeyHash === '0x' + sha256("ephemeral-" + outputStealthAddress)`
+
+## Implementation Notes
+
+- **`vi.mock('@solana/web3.js')` pattern:** Use `vi.importActual<typeof import('@solana/web3.js')>('@solana/web3.js')` and spread, only override `Connection`. Copy verbatim from `tests/private-swap.test.ts:7-22`. Without `importActual`, `PublicKey`, `Transaction`, `SystemProgram` constructors break.
+- **`makeConfigPDABytes(counter: bigint): Buffer`** lives in `tests/fixtures/builder-mocks.ts`. Returns `Buffer.alloc(51)` with `buf.writeBigUInt64LE(counter, 43)`. Document the offset reference in a comment pointing at `transaction-builder.ts:155-159`.
+- **Parameterized EVM tests** use `it.each([['ethereum', 1], ['polygon', 137], ['arbitrum', 42161], ['optimism', 10], ['base', 8453]])` — keeps the test code single-source and asserts the exact `chainId` mapping.
+- **Hex prefix parameterization** uses `it.each([['with prefix', true], ['without prefix', false]])` — wraps each Anchor input field through both forms in a single test definition.
+- **Test inputs:** Reuse fixed `Keypair.generate()` once per test file at top, store in `const`, reuse across tests. Avoids regenerating identities per test (faster + deterministic).
+- **No source-code changes** to the 3 builders — if a test reveals a bug, file as a separate issue and pause Phase 4 to discuss. Phase 4 PR ships only tests.
+
+## Acceptance Criteria
+
+- [ ] 3 new test files committed under `tests/`: `transaction-builder.test.ts`, `chain-transfer-builder.test.ts`, `private-swap-builder.test.ts`
+- [ ] 1 new shared fixture file at `tests/fixtures/builder-mocks.ts`
+- [ ] ~37 tests added (±2 acceptable)
+- [ ] Root suite goes 33 → 36 files, all green: `pnpm test -- --run`
+- [ ] Zero regression in agent (938) and app (45) test suites
+- [ ] `pnpm typecheck` clean across workspace
+- [ ] Single PR vs `main` (no stacked spec branch)
+- [ ] Spec + plan files committed alongside test code in same PR
+- [ ] PR description lists what was tested and what was deferred (with links to follow-up issues, if any filed)
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Anchor instruction byte layout shifts when `sip_privacy` program is updated | Test file header comment references `programs/sip_privacy/src/lib.rs` so future devs know which source to update |
+| SDK upgrades change stealth function return shape | Q4 invariants are resilient. If SDK breaks invariants intentionally, our tests catch it (correct behavior). |
+| `crypto.getRandomValues` flake from accidentally pinning specific values | Q4 forbids specific-value assertions in orchestrator tests; PR reviewer must scan for `expect(addr).toBe('...')` patterns |
+| `vi.mock('@solana/web3.js')` over-mocks and breaks unrelated tests | Use `vi.importActual` + spread pattern (existing `private-swap.test.ts:7-22`). Verify via `pnpm test -- --run` after every test added. |
+| Discovering real bugs in builders during test writing expands scope | **Hard rule:** file as separate follow-up issue, pause Phase 4, do not fix in this PR. Tests prove the bug exists; the fix is a separate PR. |
+| Mock factory drift between 3 test files | Single shared `tests/fixtures/builder-mocks.ts` is the only source of truth; lint review catches inline duplication. |
+
+## PR + Commit Strategy
+
+**Branch:** `feat/phase-4-rest-service-tests` (single branch off `main`)
+
+**Why single PR (no stacked spec branch):** Phase 3 lesson #4 — the stacked-spec-branch pattern leaves orphans. Phase 2's spec was orphaned and required a rescue PR (#161). Phase 4 lands as one combined PR with spec + plan + tests bundled.
+
+**Commit cadence (TDD-style, one commit per task):**
+
+```
+docs(phase-4): add rest service tests spec
+docs(phase-4): add rest service tests plan
+test(fixtures): add shared builder-mocks helper
+test(transaction-builder): add buildShieldedSolTransfer tests (3)
+test(transaction-builder): add buildShieldedSplTransfer tests (4)
+test(transaction-builder): add buildAnchorShieldedSolTransfer tests (7)
+test(chain-transfer-builder): add isTransferSupported + getSupportedTransferChains tests (3)
+test(chain-transfer-builder): add Solana branch tests (3)
+test(chain-transfer-builder): add EVM branch tests (3, parameterized)
+test(chain-transfer-builder): add NEAR branch tests (2)
+test(chain-transfer-builder): add error + curve detection tests (2)
+test(private-swap-builder): add happy path tests (3)
+test(private-swap-builder): add C-SPL branch tests (3)
+test(private-swap-builder): add stealth + commitment invariant tests (2)
+test(private-swap-builder): add viewing key hash tests (2)
+chore: bump test count baseline in CLAUDE.md
+```
+
+~16 commits / ~14-15 plan tasks (some commits group small related tests).
+
+**Verification before opening PR:**
+
+```bash
+# Per-task TDD loop (during execution)
+pnpm test tests/transaction-builder -- --run
+pnpm typecheck
+
+# Final pre-PR checklist
+pnpm test -- --run                          # full root suite, expect 33→36 files green
+pnpm --filter @sipher/agent test -- --run   # agent baseline 938 unchanged
+pnpm --filter @sipher/app test -- --run     # app baseline 45 unchanged
+pnpm typecheck                              # workspace
+pnpm exec playwright test                   # E2E: 8/8 + 2 skipped (cipher-admin keypair)
+git diff main --stat                        # sanity check scope
+```
+
+## Naming Conventions
+
+- **Test file naming:** `{builder-name}.test.ts` (kebab-case, exactly matches source file basename)
+- **Test description style:** `describe('buildShieldedSolTransfer', () => { it('builds System.transfer with correct from/to/lamports', ...) })` — function name as describe, behavior phrase as it
+- **Fixture file:** `tests/fixtures/builder-mocks.ts` (one helper per public mock, named after what it mocks)
+- **Mock variable convention:** `mockGetAccountInfo`, `mockGetLatestBlockhash` (prefix with `mock`, follow with method name being mocked)
+
+## Out of Scope (deferred or explicitly excluded)
+
+- Source-code changes to the 3 builders — test-only PR.
+- Tests for other `src/services/*.ts` files (jupiter-provider, cspl, redis, helius-provider, solana, etc.).
+- Modifying `tests/private-swap.test.ts` or `tests/transfer-shield.test.ts`.
+- Testing CSPL service internals.
+- E2E tests against devnet/mainnet.
+- Performance / load tests.
+- Snapshot testing.
+- Migrating existing tests to a new pattern.
+- Refactoring `transaction-builder.ts` to extract CONFIG_PDA reader (would simplify testing — file as follow-up issue if testing turns out painful, do not do in this PR).
+
+## Follow-up Issues (filed during PR open if discovered)
+
+- Bugs surfaced by tests during execution
+- Refactor opportunities noted but not pursued (e.g., CONFIG_PDA reader extraction)
+- Test coverage gaps for adjacent uncovered files (other `src/services/`)
+
+## Phase 4 Lessons to Carry Forward (post-execution)
+
+To be filled in during PR open / session handoff.
+
+---
+
+**Spec status:** Approved sections 1-5 in brainstorming dialogue 2026-05-03 with RECTOR. Ready for `superpowers:writing-plans` to convert into TDD task list.

--- a/tests/chain-transfer-builder.test.ts
+++ b/tests/chain-transfer-builder.test.ts
@@ -295,7 +295,7 @@ describe('buildPrivateTransfer — error + curve detection', () => {
     ['arbitrum', 'secp256k1' as const, EVM_SPENDING_KEY, EVM_VIEWING_KEY],
     ['optimism', 'secp256k1' as const, EVM_SPENDING_KEY, EVM_VIEWING_KEY],
     ['base', 'secp256k1' as const, EVM_SPENDING_KEY, EVM_VIEWING_KEY],
-  ])('returns curve=%s for chain=%s', async (chain, expectedCurve, spendingKey, viewingKey) => {
+  ])('chain=%s returns curve=%s', async (chain, expectedCurve, spendingKey, viewingKey) => {
     const result = await buildPrivateTransfer({
       sender,
       recipientMetaAddress: {

--- a/tests/chain-transfer-builder.test.ts
+++ b/tests/chain-transfer-builder.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock transaction-builder.js BEFORE importing chain-transfer-builder
+vi.mock('../src/services/transaction-builder.js', () => ({
+  buildShieldedSolTransfer: vi.fn().mockResolvedValue('mockedSolTxBase64'),
+  buildShieldedSplTransfer: vi.fn().mockResolvedValue('mockedSplTxBase64'),
+  buildAnchorShieldedSolTransfer: vi.fn().mockResolvedValue({
+    transaction: 'mockedAnchorTxBase64',
+    noteId: 'mockedNoteIdPDA',
+    encryptedAmount: '0xdeadbeefcafebabe',
+    instructionType: 'anchor' as const,
+  }),
+}))
+
+const {
+  isTransferSupported,
+  getSupportedTransferChains,
+} = await import('../src/services/chain-transfer-builder.js')
+
+describe('isTransferSupported', () => {
+  it.each([
+    'solana',
+    'ethereum',
+    'polygon',
+    'arbitrum',
+    'optimism',
+    'base',
+    'near',
+  ])('returns true for supported chain: %s', (chain) => {
+    expect(isTransferSupported(chain)).toBe(true)
+  })
+
+  it('returns false for unsupported chain', () => {
+    expect(isTransferSupported('bitcoin')).toBe(false)
+  })
+})
+
+describe('getSupportedTransferChains', () => {
+  it('returns array containing all 7 supported chains', () => {
+    const chains = getSupportedTransferChains()
+    expect(chains).toHaveLength(7)
+    expect(chains).toEqual(
+      expect.arrayContaining([
+        'solana',
+        'ethereum',
+        'polygon',
+        'arbitrum',
+        'optimism',
+        'base',
+        'near',
+      ])
+    )
+  })
+})

--- a/tests/chain-transfer-builder.test.ts
+++ b/tests/chain-transfer-builder.test.ts
@@ -255,6 +255,7 @@ describe('buildPrivateTransfer — NEAR branch', () => {
       expect(result.chainData.actions).toHaveLength(1)
 
       const action = result.chainData.actions[0]
+      expect(action.type).toBe('FunctionCall')
       if (action.type === 'FunctionCall') {
         expect(action.methodName).toBe('ft_transfer')
         expect(action.gas).toBe('30000000000000')
@@ -263,7 +264,7 @@ describe('buildPrivateTransfer — NEAR branch', () => {
         const decoded = JSON.parse(Buffer.from(action.args, 'base64').toString())
         expect(decoded.amount).toBe(amount)
         expect(decoded.memo).toBe('SIP private transfer')
-        expect(typeof decoded.receiver_id).toBe('string')
+        expect(decoded.receiver_id).toBe(result.stealthAddress)
       }
     }
   })

--- a/tests/chain-transfer-builder.test.ts
+++ b/tests/chain-transfer-builder.test.ts
@@ -209,3 +209,62 @@ describe('buildPrivateTransfer — EVM branch', () => {
     }
   })
 })
+
+describe('buildPrivateTransfer — NEAR branch', () => {
+  it('native NEAR → returns Transfer action with amount', async () => {
+    const result = await buildPrivateTransfer({
+      sender,
+      recipientMetaAddress: {
+        spendingKey: SOLANA_SPENDING_KEY, // ed25519 reused for NEAR
+        viewingKey: SOLANA_VIEWING_KEY,
+        chain: 'near',
+      },
+      amount: '1000000000000000000000000', // 1 NEAR (24 decimals)
+    })
+
+    expect(result.chainData.type).toBe('near')
+    if (result.chainData.type === 'near') {
+      expect(result.chainData.actions).toHaveLength(1)
+      expect(result.chainData.actions[0]).toEqual({
+        type: 'Transfer',
+        amount: '1000000000000000000000000',
+      })
+      expect(result.chainData.tokenContract).toBeUndefined()
+    }
+  })
+
+  it('NEP-141 FT → FunctionCall with ft_transfer + base64 args', async () => {
+    const tokenContract = 'usdc.fakes.testnet'
+    const amount = '1000000' // 1 USDC
+
+    const result = await buildPrivateTransfer({
+      sender,
+      recipientMetaAddress: {
+        spendingKey: SOLANA_SPENDING_KEY,
+        viewingKey: SOLANA_VIEWING_KEY,
+        chain: 'near',
+      },
+      amount,
+      token: tokenContract,
+    })
+
+    expect(result.chainData.type).toBe('near')
+    if (result.chainData.type === 'near') {
+      expect(result.chainData.receiverId).toBe(tokenContract)
+      expect(result.chainData.tokenContract).toBe(tokenContract)
+      expect(result.chainData.actions).toHaveLength(1)
+
+      const action = result.chainData.actions[0]
+      if (action.type === 'FunctionCall') {
+        expect(action.methodName).toBe('ft_transfer')
+        expect(action.gas).toBe('30000000000000')
+        expect(action.deposit).toBe('1')
+
+        const decoded = JSON.parse(Buffer.from(action.args, 'base64').toString())
+        expect(decoded.amount).toBe(amount)
+        expect(decoded.memo).toBe('SIP private transfer')
+        expect(typeof decoded.receiver_id).toBe('string')
+      }
+    }
+  })
+})

--- a/tests/chain-transfer-builder.test.ts
+++ b/tests/chain-transfer-builder.test.ts
@@ -25,9 +25,9 @@ const {
 const SOLANA_SPENDING_KEY = '0x' + 'a'.repeat(64)
 const SOLANA_VIEWING_KEY = '0x' + 'b'.repeat(64)
 
-// 33-byte secp256k1 compressed pubkey for evm
-const EVM_SPENDING_KEY = '0x02' + 'c'.repeat(64)
-const EVM_VIEWING_KEY = '0x02' + 'd'.repeat(64)
+// 33-byte secp256k1 compressed pubkeys for evm (valid curve points)
+const EVM_SPENDING_KEY = '0x02acf11ab16a2ff3306993b16294b9885e721758656537728a4d46d7721828bb56'
+const EVM_VIEWING_KEY = '0x0264c15fa5af8fd6cea8c3450871a907cb4ae531fb18c69c8598f58226b1754379'
 
 const sender = 'SenderAddrXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 
@@ -127,6 +127,85 @@ describe('buildPrivateTransfer — Solana branch', () => {
     expect(result.chainData.type).toBe('solana')
     if (result.chainData.type === 'solana') {
       expect(result.chainData.mint).toBe('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')
+    }
+  })
+})
+
+describe('buildPrivateTransfer — EVM branch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const evmChainsWithIds: Array<[string, number]> = [
+    ['ethereum', 1],
+    ['polygon', 137],
+    ['arbitrum', 42161],
+    ['optimism', 10],
+    ['base', 8453],
+  ]
+
+  it.each(evmChainsWithIds)('native ETH on %s returns {to, value, data:0x}', async (chain, _chainId) => {
+    const result = await buildPrivateTransfer({
+      sender,
+      recipientMetaAddress: {
+        spendingKey: EVM_SPENDING_KEY,
+        viewingKey: EVM_VIEWING_KEY,
+        chain,
+      },
+      amount: '1000000000000000000', // 1 ETH in wei
+    })
+
+    expect(result.chainData.type).toBe('evm')
+    if (result.chainData.type === 'evm') {
+      expect(result.chainData.to.toLowerCase()).toMatch(/^0x[0-9a-f]{40}$/)
+      expect(result.chainData.value).toBe('1000000000000000000')
+      expect(result.chainData.data).toBe('0x')
+    }
+  })
+
+  it('ERC20 → data starts with 0xa9059cbb + padded address + padded amount', async () => {
+    const tokenContract = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' // USDC on ETH
+    const amount = '1000000' // 1 USDC
+
+    const result = await buildPrivateTransfer({
+      sender,
+      recipientMetaAddress: {
+        spendingKey: EVM_SPENDING_KEY,
+        viewingKey: EVM_VIEWING_KEY,
+        chain: 'ethereum',
+      },
+      amount,
+      token: tokenContract,
+    })
+
+    expect(result.chainData.type).toBe('evm')
+    if (result.chainData.type === 'evm') {
+      expect(result.chainData.to).toBe(tokenContract)
+      expect(result.chainData.tokenContract).toBe(tokenContract)
+      expect(result.chainData.value).toBe('0')
+      expect(result.chainData.data.startsWith('0xa9059cbb')).toBe(true)
+      expect(result.chainData.data.length).toBe(2 + 8 + 64 + 64)
+
+      const amountHex = result.chainData.data.slice(2 + 8 + 64)
+      const amountReadback = BigInt('0x' + amountHex)
+      expect(amountReadback).toBe(BigInt(amount))
+    }
+  })
+
+  it.each(evmChainsWithIds)('sets correct chainId for %s → %i', async (chain, chainId) => {
+    const result = await buildPrivateTransfer({
+      sender,
+      recipientMetaAddress: {
+        spendingKey: EVM_SPENDING_KEY,
+        viewingKey: EVM_VIEWING_KEY,
+        chain,
+      },
+      amount: '1000',
+    })
+
+    expect(result.chainData.type).toBe('evm')
+    if (result.chainData.type === 'evm') {
+      expect(result.chainData.chainId).toBe(chainId)
     }
   })
 })

--- a/tests/chain-transfer-builder.test.ts
+++ b/tests/chain-transfer-builder.test.ts
@@ -269,3 +269,43 @@ describe('buildPrivateTransfer — NEAR branch', () => {
     }
   })
 })
+
+describe('buildPrivateTransfer — error + curve detection', () => {
+  it('throws on unsupported chain', async () => {
+    // bitcoin is a valid SDK chain (secp256k1) but not in our transfer builder's dispatch
+    // so use valid secp256k1 keys to pass SDK validation and hit our Unsupported guard
+    await expect(
+      buildPrivateTransfer({
+        sender,
+        recipientMetaAddress: {
+          spendingKey: EVM_SPENDING_KEY,
+          viewingKey: EVM_VIEWING_KEY,
+          chain: 'bitcoin',
+        },
+        amount: '1000',
+      })
+    ).rejects.toThrow(/Unsupported transfer chain/)
+  })
+
+  it.each([
+    ['solana', 'ed25519' as const, SOLANA_SPENDING_KEY, SOLANA_VIEWING_KEY],
+    ['near', 'ed25519' as const, SOLANA_SPENDING_KEY, SOLANA_VIEWING_KEY],
+    ['ethereum', 'secp256k1' as const, EVM_SPENDING_KEY, EVM_VIEWING_KEY],
+    ['polygon', 'secp256k1' as const, EVM_SPENDING_KEY, EVM_VIEWING_KEY],
+    ['arbitrum', 'secp256k1' as const, EVM_SPENDING_KEY, EVM_VIEWING_KEY],
+    ['optimism', 'secp256k1' as const, EVM_SPENDING_KEY, EVM_VIEWING_KEY],
+    ['base', 'secp256k1' as const, EVM_SPENDING_KEY, EVM_VIEWING_KEY],
+  ])('returns curve=%s for chain=%s', async (chain, expectedCurve, spendingKey, viewingKey) => {
+    const result = await buildPrivateTransfer({
+      sender,
+      recipientMetaAddress: {
+        spendingKey,
+        viewingKey,
+        chain,
+      },
+      amount: '1000',
+    })
+
+    expect(result.curve).toBe(expectedCurve)
+  })
+})

--- a/tests/chain-transfer-builder.test.ts
+++ b/tests/chain-transfer-builder.test.ts
@@ -124,6 +124,7 @@ describe('buildPrivateTransfer — Solana branch', () => {
 
     expect(txBuilder.buildShieldedSplTransfer).toHaveBeenCalledOnce()
     expect(result.chain).toBe('solana')
+    expect(result.chainData.type).toBe('solana')
     if (result.chainData.type === 'solana') {
       expect(result.chainData.mint).toBe('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')
     }

--- a/tests/chain-transfer-builder.test.ts
+++ b/tests/chain-transfer-builder.test.ts
@@ -50,5 +50,7 @@ describe('getSupportedTransferChains', () => {
         'near',
       ])
     )
+    expect(chains).not.toContain('bitcoin')  // Symmetry with isTransferSupported negative test
+    expect(chains).not.toBe(getSupportedTransferChains())  // Returns a fresh array (immutability guard)
   })
 })

--- a/tests/chain-transfer-builder.test.ts
+++ b/tests/chain-transfer-builder.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // Mock transaction-builder.js BEFORE importing chain-transfer-builder
 vi.mock('../src/services/transaction-builder.js', () => ({
@@ -12,10 +12,24 @@ vi.mock('../src/services/transaction-builder.js', () => ({
   }),
 }))
 
+const txBuilder = await import('../src/services/transaction-builder.js')
+
 const {
   isTransferSupported,
   getSupportedTransferChains,
+  buildPrivateTransfer,
 } = await import('../src/services/chain-transfer-builder.js')
+
+// Realistic test recipient meta-address (use real ed25519/secp256k1 hex)
+// 32-byte ed25519 pubkey for solana/near
+const SOLANA_SPENDING_KEY = '0x' + 'a'.repeat(64)
+const SOLANA_VIEWING_KEY = '0x' + 'b'.repeat(64)
+
+// 33-byte secp256k1 compressed pubkey for evm
+const EVM_SPENDING_KEY = '0x02' + 'c'.repeat(64)
+const EVM_VIEWING_KEY = '0x02' + 'd'.repeat(64)
+
+const sender = 'SenderAddrXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 
 describe('isTransferSupported', () => {
   it.each([
@@ -52,5 +66,66 @@ describe('getSupportedTransferChains', () => {
     )
     expect(chains).not.toContain('bitcoin')  // Symmetry with isTransferSupported negative test
     expect(chains).not.toBe(getSupportedTransferChains())  // Returns a fresh array (immutability guard)
+  })
+})
+
+describe('buildPrivateTransfer — Solana branch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('native SOL → calls buildAnchorShieldedSolTransfer with anchor instructionType', async () => {
+    const result = await buildPrivateTransfer({
+      sender,
+      recipientMetaAddress: {
+        spendingKey: SOLANA_SPENDING_KEY,
+        viewingKey: SOLANA_VIEWING_KEY,
+        chain: 'solana',
+      },
+      amount: '1000000',
+    })
+
+    expect(txBuilder.buildAnchorShieldedSolTransfer).toHaveBeenCalledOnce()
+    expect(result.instructionType).toBe('anchor')
+    expect(result.chain).toBe('solana')
+    expect(result.curve).toBe('ed25519')
+  })
+
+  it('native SOL → falls back to system transfer when Anchor throws', async () => {
+    vi.mocked(txBuilder.buildAnchorShieldedSolTransfer).mockRejectedValueOnce(
+      new Error('CONFIG_PDA account not found')
+    )
+
+    const result = await buildPrivateTransfer({
+      sender,
+      recipientMetaAddress: {
+        spendingKey: SOLANA_SPENDING_KEY,
+        viewingKey: SOLANA_VIEWING_KEY,
+        chain: 'solana',
+      },
+      amount: '1000000',
+    })
+
+    expect(txBuilder.buildShieldedSolTransfer).toHaveBeenCalledOnce()
+    expect(result.instructionType).toBe('system')
+  })
+
+  it('SPL token (mint provided) → calls buildShieldedSplTransfer', async () => {
+    const result = await buildPrivateTransfer({
+      sender,
+      recipientMetaAddress: {
+        spendingKey: SOLANA_SPENDING_KEY,
+        viewingKey: SOLANA_VIEWING_KEY,
+        chain: 'solana',
+      },
+      amount: '500000',
+      token: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', // USDC mint
+    })
+
+    expect(txBuilder.buildShieldedSplTransfer).toHaveBeenCalledOnce()
+    expect(result.chain).toBe('solana')
+    if (result.chainData.type === 'solana') {
+      expect(result.chainData.mint).toBe('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')
+    }
   })
 })

--- a/tests/fixtures/builder-mocks.ts
+++ b/tests/fixtures/builder-mocks.ts
@@ -1,0 +1,100 @@
+import { vi } from 'vitest'
+
+/**
+ * Generates CONFIG_PDA bytes for buildAnchorShieldedSolTransfer tests.
+ * The function reads total_transfers at byte offset 43 as u64 LE.
+ * See src/services/transaction-builder.ts:155-159
+ */
+export function makeConfigPDABytes(counter: bigint): Buffer {
+  const buf = Buffer.alloc(51)
+  buf.writeBigUInt64LE(counter, 43)
+  return buf
+}
+
+interface SolanaConnectionMockOverrides {
+  getAccountInfo?: ReturnType<typeof vi.fn>
+  getLatestBlockhash?: ReturnType<typeof vi.fn>
+  getSlot?: ReturnType<typeof vi.fn>
+}
+
+/**
+ * Returns a vi.mock factory for @solana/web3.js Connection.
+ * Spreads vi.importActual to preserve PublicKey/Transaction/SystemProgram constructors.
+ * Use: vi.mock('@solana/web3.js', mockSolanaConnection({...}))
+ */
+export function mockSolanaConnection(overrides: SolanaConnectionMockOverrides = {}) {
+  return async () => {
+    const actual = await vi.importActual<typeof import('@solana/web3.js')>('@solana/web3.js')
+    return {
+      ...(actual as object),
+      Connection: vi.fn().mockImplementation(() => ({
+        rpcEndpoint: 'https://api.mainnet-beta.solana.com',
+        getSlot: overrides.getSlot ?? vi.fn().mockResolvedValue(300_000_000),
+        getLatestBlockhash: overrides.getLatestBlockhash ?? vi.fn().mockResolvedValue({
+          blockhash: '4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM',
+          lastValidBlockHeight: 300_000_100,
+        }),
+        getAccountInfo: overrides.getAccountInfo ?? vi.fn().mockResolvedValue(null),
+      })),
+    }
+  }
+}
+
+type CSPLBehavior = 'success' | 'fail' | 'throws'
+
+/**
+ * Returns a mock CSPL service object for private-swap-builder tests.
+ * Used inside vi.mock('./cspl.js', () => ({ getCSPLService: () => mockCSPLService(...) }))
+ */
+export function mockCSPLService(behavior: CSPLBehavior) {
+  if (behavior === 'success') {
+    return {
+      wrap: vi.fn().mockResolvedValue({
+        success: true,
+        signature: 'csplwrapsig000000000000000000000000000000000000000000000000000',
+      }),
+    }
+  }
+  if (behavior === 'fail') {
+    return {
+      wrap: vi.fn().mockResolvedValue({ success: false }),
+    }
+  }
+  return {
+    wrap: vi.fn().mockRejectedValue(new Error('CSPL wrap failed')),
+  }
+}
+
+interface JupiterQuoteOptions {
+  inAmount?: string
+  outAmount?: string
+  slippageBps?: number
+  quoteId?: string
+  priceImpactPct?: string
+}
+
+/**
+ * Builds a canned Jupiter quote response shape for tests.
+ * Mock jupiter-provider.getQuote to return this.
+ */
+export function makeJupiterQuote(opts: JupiterQuoteOptions = {}) {
+  const inAmount = opts.inAmount ?? '1000000000'
+  const outAmount = opts.outAmount ?? '150000000'
+  const slippageBps = opts.slippageBps ?? 50
+  return {
+    quoteId: opts.quoteId ?? 'jup_test_quote_001',
+    inAmount,
+    outAmount,
+    outAmountMin: String(Math.floor(Number(outAmount) * (10000 - slippageBps) / 10000)),
+    priceImpactPct: opts.priceImpactPct ?? '0.05',
+    slippageBps,
+  }
+}
+
+/**
+ * Builds a canned Jupiter swap-tx response.
+ * Mock jupiter-provider.buildSwapTransaction to return this.
+ */
+export function makeJupiterSwapTx(swapTransaction = 'mockedJupiterSwapTxBase64String===') {
+  return { swapTransaction }
+}

--- a/tests/fixtures/builder-mocks.ts
+++ b/tests/fixtures/builder-mocks.ts
@@ -11,7 +11,7 @@ export function makeConfigPDABytes(counter: bigint): Buffer {
   return buf
 }
 
-interface SolanaConnectionMockOverrides {
+export interface SolanaConnectionMockOverrides {
   getAccountInfo?: ReturnType<typeof vi.fn>
   getLatestBlockhash?: ReturnType<typeof vi.fn>
   getSlot?: ReturnType<typeof vi.fn>
@@ -66,16 +66,20 @@ export function mockCSPLService(behavior: CSPLBehavior) {
 }
 
 interface JupiterQuoteOptions {
+  inputMint?: string
+  outputMint?: string
   inAmount?: string
   outAmount?: string
   slippageBps?: number
   quoteId?: string
   priceImpactPct?: string
+  expiresAt?: number
 }
 
 /**
- * Builds a canned Jupiter quote response shape for tests.
+ * Builds a canned Jupiter QuoteEntry shape for tests.
  * Mock jupiter-provider.getQuote to return this.
+ * Matches the QuoteEntry interface in src/services/jupiter-provider.ts:26-36.
  */
 export function makeJupiterQuote(opts: JupiterQuoteOptions = {}) {
   const inAmount = opts.inAmount ?? '1000000000'
@@ -83,18 +87,34 @@ export function makeJupiterQuote(opts: JupiterQuoteOptions = {}) {
   const slippageBps = opts.slippageBps ?? 50
   return {
     quoteId: opts.quoteId ?? 'jup_test_quote_001',
+    inputMint: opts.inputMint ?? 'So11111111111111111111111111111111111111112',
+    outputMint: opts.outputMint ?? 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
     inAmount,
     outAmount,
     outAmountMin: String(Math.floor(Number(outAmount) * (10000 - slippageBps) / 10000)),
     priceImpactPct: opts.priceImpactPct ?? '0.05',
     slippageBps,
+    expiresAt: opts.expiresAt ?? Date.now() + 30_000,
   }
 }
 
+interface JupiterSwapTxOptions {
+  swapTransaction?: string
+  quoteId?: string
+  computeUnitPrice?: number
+  priorityFee?: number
+}
+
 /**
- * Builds a canned Jupiter swap-tx response.
+ * Builds a canned Jupiter SwapTransactionResult shape for tests.
  * Mock jupiter-provider.buildSwapTransaction to return this.
+ * Matches the SwapTransactionResult interface in src/services/jupiter-provider.ts:44-49.
  */
-export function makeJupiterSwapTx(swapTransaction = 'mockedJupiterSwapTxBase64String===') {
-  return { swapTransaction }
+export function makeJupiterSwapTx(opts: JupiterSwapTxOptions = {}) {
+  return {
+    swapTransaction: opts.swapTransaction ?? 'mockedJupiterSwapTxBase64String===',
+    quoteId: opts.quoteId ?? 'jup_test_quote_001',
+    computeUnitPrice: opts.computeUnitPrice ?? 1000,
+    priorityFee: opts.priorityFee ?? 5000,
+  }
 }

--- a/tests/private-swap-builder.test.ts
+++ b/tests/private-swap-builder.test.ts
@@ -200,3 +200,50 @@ describe('buildPrivateSwap — stealth + commitment invariants', () => {
     expect(result.blindingFactor).toMatch(/^0x[0-9a-f]{64}$/)
   })
 })
+
+describe('buildPrivateSwap — viewing key hash', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jupiterProvider.getQuote).mockResolvedValue(makeJupiterQuote())
+    vi.mocked(jupiterProvider.buildSwapTransaction).mockResolvedValue(makeJupiterSwapTx())
+    vi.mocked(csplModule.getCSPLService).mockResolvedValue(mockCSPLService('fail') as never)
+  })
+
+  it('with provided meta-address → vkHash = 0x + sha256(viewingKey bytes)', async () => {
+    const { sha256 } = await import('@noble/hashes/sha256')
+    const { hexToBytes, bytesToHex } = await import('@noble/hashes/utils')
+
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+      recipientMetaAddress: {
+        spendingKey: PROVIDED_SPENDING_KEY,
+        viewingKey: PROVIDED_VIEWING_KEY,
+        chain: 'solana',
+      },
+    })
+
+    const viewingKeyBytes = hexToBytes(PROVIDED_VIEWING_KEY.slice(2))
+    const expectedHash = `0x${bytesToHex(sha256(viewingKeyBytes))}`
+
+    expect(result.viewingKeyHash).toBe(expectedHash)
+  })
+
+  it('without meta-address → vkHash = 0x + sha256("ephemeral-" + outputStealthAddress)', async () => {
+    const { sha256 } = await import('@noble/hashes/sha256')
+    const { bytesToHex } = await import('@noble/hashes/utils')
+
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+    })
+
+    const expectedHash = `0x${bytesToHex(sha256(new TextEncoder().encode('ephemeral-' + result.outputStealthAddress)))}`
+
+    expect(result.viewingKeyHash).toBe(expectedHash)
+  })
+})

--- a/tests/private-swap-builder.test.ts
+++ b/tests/private-swap-builder.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { makeJupiterQuote, makeJupiterSwapTx, mockCSPLService } from './fixtures/builder-mocks.js'
+
+// Mock jupiter-provider — must be hoisted before importing the builder
+vi.mock('../src/services/jupiter-provider.js', () => ({
+  getQuote: vi.fn(),
+  buildSwapTransaction: vi.fn(),
+}))
+
+// Mock cspl — default to "fail" (no wrap) so tests don't accidentally wrap
+vi.mock('../src/services/cspl.js', () => ({
+  getCSPLService: vi.fn().mockResolvedValue({
+    wrap: vi.fn().mockResolvedValue({ success: false }),
+  }),
+}))
+
+const jupiterProvider = await import('../src/services/jupiter-provider.js')
+const csplModule = await import('../src/services/cspl.js')
+
+const { buildPrivateSwap } = await import('../src/services/private-swap-builder.js')
+
+const sender = 'SenderAddrXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+const SOL_MINT = 'So11111111111111111111111111111111111111112'
+const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+
+// Realistic 32-byte ed25519 hex pubkey for Solana (using all-a/b for spending/viewing — same convention as other tests)
+const PROVIDED_SPENDING_KEY = '0x' + 'a'.repeat(64)
+const PROVIDED_VIEWING_KEY = '0x' + 'b'.repeat(64)
+
+describe('buildPrivateSwap — happy path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jupiterProvider.getQuote).mockResolvedValue(makeJupiterQuote())
+    vi.mocked(jupiterProvider.buildSwapTransaction).mockResolvedValue(makeJupiterSwapTx())
+    vi.mocked(csplModule.getCSPLService).mockResolvedValue(mockCSPLService('fail') as never)
+  })
+
+  it('with provided meta-address → uses it (not ephemeral)', async () => {
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+      recipientMetaAddress: {
+        spendingKey: PROVIDED_SPENDING_KEY,
+        viewingKey: PROVIDED_VIEWING_KEY,
+        chain: 'solana',
+      },
+    })
+
+    // viewingKeyHash should derive from PROVIDED_VIEWING_KEY (not ephemeral)
+    expect(result.viewingKeyHash).toMatch(/^0x[0-9a-f]{64}$/)
+    expect(result.outputStealthAddress).toMatch(/^[1-9A-HJ-NP-Za-km-z]{32,44}$/) // base58
+  })
+
+  it('without meta-address → generates ephemeral meta-address', async () => {
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+    })
+
+    expect(result.outputStealthAddress).toMatch(/^[1-9A-HJ-NP-Za-km-z]{32,44}$/)
+    expect(result.viewingKeyHash).toMatch(/^0x[0-9a-f]{64}$/)
+  })
+
+  it('returns expected PrivateSwapResult shape', async () => {
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+    })
+
+    // Privacy artifacts
+    expect(result).toHaveProperty('outputStealthAddress')
+    expect(result).toHaveProperty('ephemeralPublicKey')
+    expect(result).toHaveProperty('viewTag')
+    expect(result).toHaveProperty('commitment')
+    expect(result).toHaveProperty('blindingFactor')
+    expect(result).toHaveProperty('viewingKeyHash')
+    expect(result).toHaveProperty('sharedSecret')
+
+    // Swap details
+    expect(result.inputMint).toBe(SOL_MINT)
+    expect(result.outputMint).toBe(USDC_MINT)
+    expect(result.inputAmount).toBe('1000000000')
+    expect(result.outputAmount).toBe('150000000')
+    expect(result.quoteId).toBe('jup_test_quote_001')
+    expect(result.slippageBps).toBe(50)
+
+    // Transaction bundle
+    expect(Array.isArray(result.transactions)).toBe(true)
+    expect(Array.isArray(result.executionOrder)).toBe(true)
+    expect(typeof result.estimatedComputeUnits).toBe('number')
+
+    // C-SPL status
+    expect(typeof result.csplWrapped).toBe('boolean')
+  })
+})

--- a/tests/private-swap-builder.test.ts
+++ b/tests/private-swap-builder.test.ts
@@ -99,3 +99,59 @@ describe('buildPrivateSwap — happy path', () => {
     expect(typeof result.csplWrapped).toBe('boolean')
   })
 })
+
+describe('buildPrivateSwap — C-SPL branches', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jupiterProvider.getQuote).mockResolvedValue(makeJupiterQuote())
+    vi.mocked(jupiterProvider.buildSwapTransaction).mockResolvedValue(makeJupiterSwapTx())
+  })
+
+  it('CSPL wrap succeeds → wrap tx in bundle, csplWrapped=true, computeUnits=400_000', async () => {
+    vi.mocked(csplModule.getCSPLService).mockResolvedValue(mockCSPLService('success') as never)
+
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+    })
+
+    expect(result.csplWrapped).toBe(true)
+    expect(result.estimatedComputeUnits).toBe(400_000)
+    expect(result.transactions[0].type).toBe('wrap')
+    expect(result.executionOrder).toContain('wrap')
+    expect(result.executionOrder).toContain('swap')
+  })
+
+  it('CSPL returns {success: false} → no wrap tx, csplWrapped=false, computeUnits=200_000', async () => {
+    vi.mocked(csplModule.getCSPLService).mockResolvedValue(mockCSPLService('fail') as never)
+
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+    })
+
+    expect(result.csplWrapped).toBe(false)
+    expect(result.estimatedComputeUnits).toBe(200_000)
+    expect(result.executionOrder).not.toContain('wrap')
+    expect(result.transactions.every(tx => tx.type !== 'wrap')).toBe(true)
+  })
+
+  it('CSPL throws → silently caught, no wrap tx, csplWrapped=false, computeUnits=200_000', async () => {
+    vi.mocked(csplModule.getCSPLService).mockRejectedValue(new Error('CSPL service down'))
+
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+    })
+
+    expect(result.csplWrapped).toBe(false)
+    expect(result.estimatedComputeUnits).toBe(200_000)
+    expect(result.executionOrder).not.toContain('wrap')
+  })
+})

--- a/tests/private-swap-builder.test.ts
+++ b/tests/private-swap-builder.test.ts
@@ -155,3 +155,48 @@ describe('buildPrivateSwap — C-SPL branches', () => {
     expect(result.executionOrder).not.toContain('wrap')
   })
 })
+
+describe('buildPrivateSwap — stealth + commitment invariants', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(jupiterProvider.getQuote).mockResolvedValue(makeJupiterQuote())
+    vi.mocked(jupiterProvider.buildSwapTransaction).mockResolvedValue(makeJupiterSwapTx())
+    vi.mocked(csplModule.getCSPLService).mockResolvedValue(mockCSPLService('fail') as never)
+  })
+
+  it('outputStealthAddress is a valid base58 Solana address (32 bytes)', async () => {
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+    })
+
+    // base58 Solana addresses are 32-44 chars
+    expect(result.outputStealthAddress).toMatch(/^[1-9A-HJ-NP-Za-km-z]{32,44}$/)
+
+    // Validate by reconstructing PublicKey (will throw if invalid)
+    const { PublicKey } = await import('@solana/web3.js')
+    expect(() => new PublicKey(result.outputStealthAddress)).not.toThrow()
+    expect(new PublicKey(result.outputStealthAddress).toBytes()).toHaveLength(32)
+  })
+
+  it('commitment is 33-byte compressed point hex; blindingFactor is 32-byte hex', async () => {
+    const result = await buildPrivateSwap({
+      sender,
+      inputMint: SOL_MINT,
+      inputAmount: '1000000000',
+      outputMint: USDC_MINT,
+    })
+
+    // commitment: 0x + 66 hex chars (33 bytes)
+    expect(result.commitment).toMatch(/^0x[0-9a-f]{66}$/)
+
+    // First byte after 0x must be 02 or 03 (compressed point prefix)
+    const prefix = result.commitment.slice(2, 4)
+    expect(['02', '03']).toContain(prefix)
+
+    // blindingFactor: 0x + 64 hex chars (32 bytes)
+    expect(result.blindingFactor).toMatch(/^0x[0-9a-f]{64}$/)
+  })
+})

--- a/tests/transaction-builder.test.ts
+++ b/tests/transaction-builder.test.ts
@@ -1,5 +1,14 @@
-import { describe, it, expect, vi } from 'vitest'
-import { Keypair, Transaction, SystemProgram } from '@solana/web3.js'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Keypair, Transaction, SystemProgram, PublicKey } from '@solana/web3.js'
+import {
+  TOKEN_PROGRAM_ID,
+  getAssociatedTokenAddress,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+} from '@solana/spl-token'
+
+// External controllable mock — Vitest hoists vi.mock above imports, but closures
+// resolve at factory-invocation time (after this const is initialized)
+const mockGetAccountInfo = vi.fn().mockResolvedValue(null)
 
 vi.mock('@solana/web3.js', async () => {
   const actual = await vi.importActual<typeof import('@solana/web3.js')>('@solana/web3.js')
@@ -12,17 +21,20 @@ vi.mock('@solana/web3.js', async () => {
         blockhash: '4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM',
         lastValidBlockHeight: 300_000_100,
       }),
-      getAccountInfo: vi.fn().mockResolvedValue(null),
+      getAccountInfo: mockGetAccountInfo,
     })),
   }
 })
 
-const { buildShieldedSolTransfer } = await import('../src/services/transaction-builder.js')
+const { buildShieldedSolTransfer, buildShieldedSplTransfer } = await import('../src/services/transaction-builder.js')
 
 const sender = Keypair.generate()
 const stealth = Keypair.generate()
 const senderAddress = sender.publicKey.toBase58()
 const stealthAddress = stealth.publicKey.toBase58()
+
+const mintPubkey = Keypair.generate().publicKey
+const mintAddress = mintPubkey.toBase58()
 
 describe('buildShieldedSolTransfer', () => {
   it('builds SystemProgram.transfer with correct fromPubkey/toPubkey/lamports', async () => {
@@ -68,5 +80,85 @@ describe('buildShieldedSolTransfer', () => {
 
     expect(typeof txBase64).toBe('string')
     expect(() => Transaction.from(Buffer.from(txBase64, 'base64'))).not.toThrow()
+  })
+})
+
+describe('buildShieldedSplTransfer', () => {
+  beforeEach(() => {
+    mockGetAccountInfo.mockReset()
+  })
+
+  it('creates ATA when stealth ATA does not exist', async () => {
+    mockGetAccountInfo.mockResolvedValue(null)
+
+    const txBase64 = await buildShieldedSplTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      mint: mintAddress,
+      amount: 1_000_000n,
+    })
+
+    const tx = Transaction.from(Buffer.from(txBase64, 'base64'))
+    expect(tx.instructions).toHaveLength(2)
+    expect(tx.instructions[0].programId.equals(ASSOCIATED_TOKEN_PROGRAM_ID)).toBe(true)
+    expect(tx.instructions[1].programId.equals(TOKEN_PROGRAM_ID)).toBe(true)
+  })
+
+  it('skips ATA creation when stealth ATA already exists', async () => {
+    mockGetAccountInfo.mockResolvedValue({
+      data: Buffer.alloc(0),
+      executable: false,
+      lamports: 1,
+      owner: TOKEN_PROGRAM_ID,
+    })
+
+    const txBase64 = await buildShieldedSplTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      mint: mintAddress,
+      amount: 1_000_000n,
+    })
+
+    const tx = Transaction.from(Buffer.from(txBase64, 'base64'))
+    expect(tx.instructions).toHaveLength(1)
+    expect(tx.instructions[0].programId.equals(TOKEN_PROGRAM_ID)).toBe(true)
+  })
+
+  it('derives sender ATA via getAssociatedTokenAddress(mint, sender)', async () => {
+    mockGetAccountInfo.mockResolvedValue(null)
+
+    const expectedSenderATA = await getAssociatedTokenAddress(mintPubkey, sender.publicKey)
+
+    const txBase64 = await buildShieldedSplTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      mint: mintAddress,
+      amount: 500_000n,
+    })
+
+    const tx = Transaction.from(Buffer.from(txBase64, 'base64'))
+    const transferIx = tx.instructions.find(ix => ix.programId.equals(TOKEN_PROGRAM_ID))!
+    expect(transferIx.keys[0].pubkey.equals(expectedSenderATA)).toBe(true)
+  })
+
+  it('uses allowOwnerOffCurve=true for stealth ATA derivation', async () => {
+    mockGetAccountInfo.mockResolvedValue(null)
+
+    const expectedStealthATA = await getAssociatedTokenAddress(
+      mintPubkey,
+      stealth.publicKey,
+      true,
+    )
+
+    const txBase64 = await buildShieldedSplTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      mint: mintAddress,
+      amount: 750_000n,
+    })
+
+    const tx = Transaction.from(Buffer.from(txBase64, 'base64'))
+    const transferIx = tx.instructions.find(ix => ix.programId.equals(TOKEN_PROGRAM_ID))!
+    expect(transferIx.keys[1].pubkey.equals(expectedStealthATA)).toBe(true)
   })
 })

--- a/tests/transaction-builder.test.ts
+++ b/tests/transaction-builder.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest'
+import { Keypair, Transaction, SystemProgram } from '@solana/web3.js'
+
+vi.mock('@solana/web3.js', async () => {
+  const actual = await vi.importActual<typeof import('@solana/web3.js')>('@solana/web3.js')
+  return {
+    ...(actual as object),
+    Connection: vi.fn().mockImplementation(() => ({
+      rpcEndpoint: 'https://api.mainnet-beta.solana.com',
+      getSlot: vi.fn().mockResolvedValue(300_000_000),
+      getLatestBlockhash: vi.fn().mockResolvedValue({
+        blockhash: '4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM',
+        lastValidBlockHeight: 300_000_100,
+      }),
+      getAccountInfo: vi.fn().mockResolvedValue(null),
+    })),
+  }
+})
+
+const { buildShieldedSolTransfer } = await import('../src/services/transaction-builder.js')
+
+const sender = Keypair.generate()
+const stealth = Keypair.generate()
+const senderAddress = sender.publicKey.toBase58()
+const stealthAddress = stealth.publicKey.toBase58()
+
+describe('buildShieldedSolTransfer', () => {
+  it('builds SystemProgram.transfer with correct fromPubkey/toPubkey/lamports', async () => {
+    const amount = 1_000_000n
+    const txBase64 = await buildShieldedSolTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      amount,
+    })
+
+    const tx = Transaction.from(Buffer.from(txBase64, 'base64'))
+
+    expect(tx.instructions).toHaveLength(1)
+    const ix = tx.instructions[0]
+    expect(ix.programId.equals(SystemProgram.programId)).toBe(true)
+
+    // SystemProgram.transfer layout: [type u32LE=2][lamports u64LE]
+    // ix.keys[0]=fromPubkey (writable, signer), ix.keys[1]=toPubkey (writable)
+    expect(ix.data.readUInt32LE(0)).toBe(2) // SystemInstruction.Transfer = 2
+    expect(ix.data.readBigUInt64LE(4)).toBe(amount)
+    expect(ix.keys[0].pubkey.toBase58()).toBe(senderAddress)
+    expect(ix.keys[1].pubkey.toBase58()).toBe(stealthAddress)
+  })
+
+  it('sets recentBlockhash and feePayer', async () => {
+    const txBase64 = await buildShieldedSolTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      amount: 100_000n,
+    })
+
+    const tx = Transaction.from(Buffer.from(txBase64, 'base64'))
+    expect(tx.recentBlockhash).toBe('4uQeVj5tqViQh7yWWGStvkEG1Zmhx6uasJtWCJziofM')
+    expect(tx.feePayer?.toBase58()).toBe(senderAddress)
+  })
+
+  it('returns base64 string that deserializes to a valid Transaction', async () => {
+    const txBase64 = await buildShieldedSolTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      amount: 50_000n,
+    })
+
+    expect(typeof txBase64).toBe('string')
+    expect(() => Transaction.from(Buffer.from(txBase64, 'base64'))).not.toThrow()
+  })
+})

--- a/tests/transaction-builder.test.ts
+++ b/tests/transaction-builder.test.ts
@@ -5,6 +5,7 @@ import {
   getAssociatedTokenAddress,
   ASSOCIATED_TOKEN_PROGRAM_ID,
 } from '@solana/spl-token'
+import { makeConfigPDABytes } from './fixtures/builder-mocks.js'
 
 // External controllable mock — Vitest hoists vi.mock above imports, but closures
 // resolve at factory-invocation time (after this const is initialized)
@@ -26,7 +27,7 @@ vi.mock('@solana/web3.js', async () => {
   }
 })
 
-const { buildShieldedSolTransfer, buildShieldedSplTransfer } = await import('../src/services/transaction-builder.js')
+const { buildShieldedSolTransfer, buildShieldedSplTransfer, buildAnchorShieldedSolTransfer } = await import('../src/services/transaction-builder.js')
 
 const sender = Keypair.generate()
 const stealth = Keypair.generate()
@@ -35,6 +36,17 @@ const stealthAddress = stealth.publicKey.toBase58()
 
 const mintPubkey = Keypair.generate().publicKey
 const mintAddress = mintPubkey.toBase58()
+
+const SIP_PRIVACY_PROGRAM_ID = new PublicKey('S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at')
+const CONFIG_PDA = new PublicKey('BVawZkppFewygA5nxdrLma4ThKx8Th7bW4KTCkcWTZwZ')
+const FEE_COLLECTOR = new PublicKey('S1P6j1yeTm6zkewQVeihrTZvmfoHABRkHDhabWTuWMd')
+const SHIELDED_TRANSFER_DISCRIMINATOR = Buffer.from([0x9d, 0x2a, 0x42, 0x93, 0xee, 0x75, 0x61, 0x5c])
+
+// Realistic hex inputs (sized to source's expected lengths)
+const COMMITMENT_HEX_NO_PREFIX = '02' + 'a'.repeat(64) // 33 bytes = 66 hex chars
+const BLINDING_HEX_NO_PREFIX = 'b'.repeat(64) // 32 bytes = 64 hex chars
+const EPHEMERAL_HEX_NO_PREFIX = 'c'.repeat(64) // 32 bytes
+const VKHASH_HEX_NO_PREFIX = 'd'.repeat(64) // 32 bytes
 
 describe('buildShieldedSolTransfer', () => {
   it('builds SystemProgram.transfer with correct fromPubkey/toPubkey/lamports', async () => {
@@ -160,5 +172,172 @@ describe('buildShieldedSplTransfer', () => {
     const tx = Transaction.from(Buffer.from(txBase64, 'base64'))
     const transferIx = tx.instructions.find(ix => ix.programId.equals(TOKEN_PROGRAM_ID))!
     expect(transferIx.keys[1].pubkey.equals(expectedStealthATA)).toBe(true)
+  })
+})
+
+describe('buildAnchorShieldedSolTransfer', () => {
+  beforeEach(() => {
+    mockGetAccountInfo.mockClear()
+  })
+
+  it('throws when CONFIG_PDA account is not found', async () => {
+    mockGetAccountInfo.mockResolvedValue(null)
+
+    await expect(
+      buildAnchorShieldedSolTransfer({
+        sender: senderAddress,
+        stealthAddress,
+        amount: 1_000_000n,
+        commitment: '0x' + COMMITMENT_HEX_NO_PREFIX,
+        blindingFactor: '0x' + BLINDING_HEX_NO_PREFIX,
+        ephemeralPublicKey: '0x' + EPHEMERAL_HEX_NO_PREFIX,
+        viewingKeyHash: '0x' + VKHASH_HEX_NO_PREFIX,
+      })
+    ).rejects.toThrow(/CONFIG_PDA account not found/)
+  })
+
+  it('parses total_transfers correctly when counter = 0', async () => {
+    mockGetAccountInfo.mockResolvedValue({ data: makeConfigPDABytes(0n) })
+
+    const result = await buildAnchorShieldedSolTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      amount: 1_000_000n,
+      commitment: '0x' + COMMITMENT_HEX_NO_PREFIX,
+      blindingFactor: '0x' + BLINDING_HEX_NO_PREFIX,
+      ephemeralPublicKey: '0x' + EPHEMERAL_HEX_NO_PREFIX,
+      viewingKeyHash: '0x' + VKHASH_HEX_NO_PREFIX,
+    })
+
+    expect(result.instructionType).toBe('anchor')
+    expect(typeof result.noteId).toBe('string')
+    expect(result.noteId.length).toBeGreaterThan(0)
+  })
+
+  it('parses total_transfers correctly when counter = 42', async () => {
+    mockGetAccountInfo.mockResolvedValue({ data: makeConfigPDABytes(42n) })
+
+    const result = await buildAnchorShieldedSolTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      amount: 1_000_000n,
+      commitment: '0x' + COMMITMENT_HEX_NO_PREFIX,
+      blindingFactor: '0x' + BLINDING_HEX_NO_PREFIX,
+      ephemeralPublicKey: '0x' + EPHEMERAL_HEX_NO_PREFIX,
+      viewingKeyHash: '0x' + VKHASH_HEX_NO_PREFIX,
+    })
+
+    expect(result.instructionType).toBe('anchor')
+    expect(result.noteId.length).toBeGreaterThan(0)
+  })
+
+  it('parses total_transfers correctly when counter near MAX_SAFE_INTEGER', async () => {
+    const maxCounter = (2n ** 53n) - 1n
+    mockGetAccountInfo.mockResolvedValue({ data: makeConfigPDABytes(maxCounter) })
+
+    const result = await buildAnchorShieldedSolTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      amount: 1_000_000n,
+      commitment: '0x' + COMMITMENT_HEX_NO_PREFIX,
+      blindingFactor: '0x' + BLINDING_HEX_NO_PREFIX,
+      ephemeralPublicKey: '0x' + EPHEMERAL_HEX_NO_PREFIX,
+      viewingKeyHash: '0x' + VKHASH_HEX_NO_PREFIX,
+    })
+
+    expect(result.instructionType).toBe('anchor')
+  })
+
+  it('derives transferRecordPDA from [TRANSFER_RECORD_SEED, sender, counter_le_bytes]', async () => {
+    const counter = 7n
+    mockGetAccountInfo.mockResolvedValue({ data: makeConfigPDABytes(counter) })
+
+    const TRANSFER_RECORD_SEED = Buffer.from('transfer_record')
+    const counterLeBytes = Buffer.alloc(8)
+    counterLeBytes.writeBigUInt64LE(counter, 0)
+
+    const [expectedPDA] = PublicKey.findProgramAddressSync(
+      [TRANSFER_RECORD_SEED, sender.publicKey.toBuffer(), counterLeBytes],
+      SIP_PRIVACY_PROGRAM_ID,
+    )
+
+    const result = await buildAnchorShieldedSolTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      amount: 1_000_000n,
+      commitment: '0x' + COMMITMENT_HEX_NO_PREFIX,
+      blindingFactor: '0x' + BLINDING_HEX_NO_PREFIX,
+      ephemeralPublicKey: '0x' + EPHEMERAL_HEX_NO_PREFIX,
+      viewingKeyHash: '0x' + VKHASH_HEX_NO_PREFIX,
+    })
+
+    expect(result.noteId).toBe(expectedPDA.toBase58())
+  })
+
+  it('packs instruction data with correct byte layout at exact offsets', async () => {
+    mockGetAccountInfo.mockResolvedValue({ data: makeConfigPDABytes(0n) })
+
+    const amount = 12345n
+    const result = await buildAnchorShieldedSolTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      amount,
+      commitment: '0x' + COMMITMENT_HEX_NO_PREFIX,
+      blindingFactor: '0x' + BLINDING_HEX_NO_PREFIX,
+      ephemeralPublicKey: '0x' + EPHEMERAL_HEX_NO_PREFIX,
+      viewingKeyHash: '0x' + VKHASH_HEX_NO_PREFIX,
+    })
+
+    const tx = Transaction.from(Buffer.from(result.transaction, 'base64'))
+    expect(tx.instructions).toHaveLength(1)
+    const ix = tx.instructions[0]
+    expect(ix.programId.equals(SIP_PRIVACY_PROGRAM_ID)).toBe(true)
+
+    const data = ix.data
+    expect(data.length).toBe(8 + 33 + 32 + 32 + 32 + 8 + 128 + 8) // 281
+
+    // Byte-precise offset checks
+    expect(data.subarray(0, 8).equals(SHIELDED_TRANSFER_DISCRIMINATOR)).toBe(true)
+    expect(data.subarray(8, 41).toString('hex')).toBe(COMMITMENT_HEX_NO_PREFIX)
+    expect(data.subarray(41, 73).equals(stealth.publicKey.toBytes())).toBe(true)
+    expect(data.subarray(73, 105).toString('hex')).toBe(EPHEMERAL_HEX_NO_PREFIX)
+    expect(data.subarray(105, 137).toString('hex')).toBe(VKHASH_HEX_NO_PREFIX)
+    // amount at end (8 bytes LE)
+    const amountBytes = data.subarray(273, 281)
+    const amountReadback = amountBytes.readBigUInt64LE(0)
+    expect(amountReadback).toBe(amount)
+
+    // Verify accounts
+    expect(ix.keys[0].pubkey.equals(CONFIG_PDA)).toBe(true)
+    expect(ix.keys[2].pubkey.equals(sender.publicKey)).toBe(true)
+    expect(ix.keys[3].pubkey.equals(stealth.publicKey)).toBe(true)
+    expect(ix.keys[4].pubkey.equals(FEE_COLLECTOR)).toBe(true)
+    expect(ix.keys[5].pubkey.equals(SystemProgram.programId)).toBe(true)
+  })
+
+  it.each([
+    ['with 0x prefix', true],
+    ['without 0x prefix', false],
+  ])('handles hex inputs %s consistently', async (_label, withPrefix) => {
+    mockGetAccountInfo.mockResolvedValue({ data: makeConfigPDABytes(0n) })
+
+    const prefix = withPrefix ? '0x' : ''
+    const result = await buildAnchorShieldedSolTransfer({
+      sender: senderAddress,
+      stealthAddress,
+      amount: 1_000_000n,
+      commitment: prefix + COMMITMENT_HEX_NO_PREFIX,
+      blindingFactor: prefix + BLINDING_HEX_NO_PREFIX,
+      ephemeralPublicKey: prefix + EPHEMERAL_HEX_NO_PREFIX,
+      viewingKeyHash: prefix + VKHASH_HEX_NO_PREFIX,
+    })
+
+    const tx = Transaction.from(Buffer.from(result.transaction, 'base64'))
+    const data = tx.instructions[0].data
+
+    // Byte content should be identical regardless of prefix presence
+    expect(data.subarray(8, 41).toString('hex')).toBe(COMMITMENT_HEX_NO_PREFIX)
+    expect(data.subarray(73, 105).toString('hex')).toBe(EPHEMERAL_HEX_NO_PREFIX)
+    expect(data.subarray(105, 137).toString('hex')).toBe(VKHASH_HEX_NO_PREFIX)
   })
 })


### PR DESCRIPTION
## Summary

Phase 4 of the audit-driven plan from the 2026-04-18 test-infrastructure spec. Adds isolated unit-level test coverage for the 3 builder modules under `src/services/` that compose Solana transactions for SIPHER's stealth-transfer and private-swap flows.

- `transaction-builder.ts` — 15 tests covering `buildShieldedSolTransfer`, `buildShieldedSplTransfer`, `buildAnchorShieldedSolTransfer` (incl. byte-precise instruction layout assertions for the live `S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at` Anchor program)
- `chain-transfer-builder.ts` — 33 tests across helpers + Solana/EVM/NEAR branches + error/curve detection (parameterized over 7 chains)
- `private-swap-builder.ts` — 10 tests across happy path, C-SPL fallback (success/fail/throws), stealth/commitment invariants, viewing key hash derivation

## Architecture

- 3 new test files in root `tests/`
- 1 shared fixture file: `tests/fixtures/builder-mocks.ts`
- Real `@sip-protocol/sdk` (Q1 = real-kitchen / service-integration strategy)
- Mocks at module boundaries: `@solana/web3.js` Connection, `./jupiter-provider.js`, `./cspl.js`
- Dealer strategy by layer (Q4): byte-precise inputs for `transaction-builder`, invariant assertions for the two orchestrators

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-05-03-rest-service-tests-design.md`
- Plan: `docs/superpowers/plans/2026-05-03-rest-service-tests.md`

## Stats

| Metric | Before | After | Delta |
|---|---|---|---|
| Root test files | 32 | 35 | +3 |
| Root tests | 497 | 555 | +58 |
| Agent tests | 938 | 938 | 0 (preserved) |
| App tests | 45 | 45 | 0 (preserved) |
| Source code lines | — | 0 | (test-only PR) |

## Test plan

- [x] `pnpm test -- --run` → 35 files, 555 passed
- [x] `pnpm --filter @sipher/agent test -- --run` → 75 files, 938 passed (unchanged)
- [x] `pnpm --filter @sipher/app test -- --run` → 12 files, 45 passed (unchanged)
- [x] `pnpm typecheck` → clean
- [x] No source-code changes to `src/services/*.ts` (test-only PR)
- [ ] Reviewer to manually verify test names/coverage match the audit's intent

## Out of scope (per spec)

- Tests for other `src/services/*.ts` files (jupiter-provider, cspl, redis, helius-provider, solana, etc.) — separate phases
- Modifying existing route tests (`tests/private-swap.test.ts`, `tests/transfer-shield.test.ts`) — Q2 chose to add alongside, not replace
- Source-code refactors to make builders more testable
- E2E tests against devnet/mainnet (already covered transitively)

## Deferred minor improvements (non-blocking, can land in cleanup PR)

- Document the `mockSolanaConnection` fixture export as inline-pattern reference (TDZ prevents direct vi.mock call-site use)
- Add `encryptedAmount` byte assertion in `buildAnchorShieldedSolTransfer` byte-layout test (offsets 137-144 currently unasserted)
- Harmonize `mockGetAccountInfo.mockReset()` (SPL suite) vs `mockClear()` (Anchor suite) — pick one for consistency

## Notable execution notes

- `SystemProgram.decodeTransfer` doesn't exist in @solana/web3.js@1.98.4 — tests adapted to direct byte decoding
- `lastValidBlockHeight` doesn't survive `Transaction.from()` round-trip — assertions adjusted
- `vi.mock` + import-binding TDZ: the inline factory + external-closure pattern is what works
- Plan's placeholder EVM keys weren't valid secp256k1 points — implementer regenerated via `secp256k1.getPublicKey`
- Bitcoin reaches the dispatch error guard only when fed secp256k1-shaped keys (ed25519 fails SDK validation first)