### PR TITLE
fix(docker): copy patches/ before pnpm install in builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN corepack enable && corepack prepare pnpm@latest --activate && \
 
 # Copy workspace config and all package.json files first (cache deps layer)
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY patches/ patches/
 COPY packages/sdk/package.json packages/sdk/
 COPY packages/agent/package.json packages/agent/
 COPY app/package.json app/


### PR DESCRIPTION
## Summary

Repairs the `build-and-push` Docker job that has been failing on every push to `main` since 2026-04-27, blocking VPS auto-deploy at `sipher.sip-protocol.org`.

## Root cause

The Dockerfile builder stage copies `pnpm-workspace.yaml` early to cache the install layer, but never copies `patches/` until `COPY . .` further down. Since [3e07c9c](https://github.com/sip-protocol/sipher/commit/3e07c9c) (2026-04-27) added a `patchedDependencies` entry pointing at `patches/@triton-one__yellowstone-grpc@4.0.2.patch` (the tsx ESM-marker fix for #1077), `pnpm install --frozen-lockfile` now reads `pnpm-workspace.yaml`, tries to open `/app/patches/...patch`, hits ENOENT, and exits 254 — before the chained `node-gyp rebuild` step ever runs.

**The exit-254 framing as a `better-sqlite3` problem was a red herring** caused by the two commands being chained in one `RUN`. The actual failure is in `pnpm install`.

Failed log excerpt from run [25273147682](https://github.com/sip-protocol/sipher/actions/runs/25273147682):

```
#17 0.771  ENOENT  ENOENT: no such file or directory, open '/app/patches/@triton-one__yellowstone-grpc@4.0.2.patch'
#17 ERROR: process "/bin/sh -c pnpm install --frozen-lockfile && ... npx --yes node-gyp rebuild" did not complete successfully: exit code: 254
```

## Fix

Add a single `COPY patches/ patches/` line right after the workspace-config copy so the patch file is present in the build context when pnpm resolves `patchedDependencies`. One-line diff. Layer caching for `pnpm install` is preserved.

## Deferred follow-up (not part of this PR)

`pnpm-workspace.yaml` already declares `onlyBuiltDependencies: [better-sqlite3, ...]`, which means pnpm 10 runs `better-sqlite3`'s install scripts (and therefore `prebuild-install || node-gyp rebuild`) during the normal `pnpm install`. The manual `npx --yes node-gyp rebuild` step in the same `RUN` is now redundant and can probably be dropped in a separate cleanup PR. Out of scope here — keeping the change minimal.

## Test plan

- [ ] `build-and-push` succeeds on this PR's CI run (pre-merge gate)
- [ ] After merge to main, `build-and-push` succeeds on the merge commit and produces `ghcr.io/sip-protocol/sipher:latest`
- [ ] `deploy` job runs (was being skipped due to `needs: build-and-push` failing)
- [ ] VPS at `sipher.sip-protocol.org` picks up the new image