### PR TITLE
fix(sentinel): normalize REST error envelope shape across all routes (#158)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 **Live URL:** https://sipher.sip-protocol.org
 **Tagline:** "Privacy-as-a-Skill for Multi-Chain Agents"
 **Purpose:** REST API + OpenClaw skill enabling any autonomous agent to add transaction privacy via SIP Protocol
-**Stats:** 66 REST endpoints | 1290 agent + 555 REST tests | 22 SIPHER tools | 14 SENTINEL tools | 9 HERALD X tools | 17 chains | Command Center UI (2,079 lines, 24 files) | 4 client SDKs (TS, Python, Rust, Go) | Eliza plugin
+**Stats:** 66 REST endpoints | 1300 agent + 555 REST tests | 22 SIPHER tools | 14 SENTINEL tools | 9 HERALD X tools | 17 chains | Command Center UI (2,079 lines, 24 files) | 4 client SDKs (TS, Python, Rust, Go) | Eliza plugin
 
 ---
 
@@ -130,7 +130,7 @@ cd app && npx tsc --noEmit # Type check
 - **Logging:** Pino v9 (structured JSON, audit logs)
 - **Docs:** swagger-ui-express (OpenAPI 3.1)
 - **Cache:** Redis 7 (rate limiting, idempotency) with in-memory fallback
-- **Testing:** Vitest + Supertest (555 REST + 1290 agent tests)
+- **Testing:** Vitest + Supertest (555 REST + 1300 agent tests)
 - **Deployment:** Docker + GHCR → VPS (port 5006)
 - **Domain:** sipher.sip-protocol.org
 - **Frontend:** React 19, Vite 6, Tailwind CSS 4, Zustand 5, Phosphor Icons React
@@ -144,7 +144,7 @@ cd app && npx tsc --noEmit # Type check
 pnpm install                    # Install dependencies
 pnpm dev                        # Dev server (localhost:5006)
 pnpm build                      # Build for production
-pnpm test -- --run              # Run REST tests (555 tests, 35 suites) + agent tests (1290 tests, 103 suites)
+pnpm test -- --run              # Run REST tests (555 tests, 35 suites) + agent tests (1300 tests, 104 suites)
 pnpm typecheck                  # Type check
 pnpm demo                       # Full-flow demo (requires dev server running)
 pnpm openapi:export              # Export static OpenAPI spec to dist/openapi.json
@@ -374,7 +374,7 @@ sipher/
 │       │   │   └── tools/              # 14 SENTINEL tools (7 read + 7 action)
 │       │   ├── tools/              # 22 SIPHER agent tools (deposit, send, swap, scan, assessRisk, ...)
 │       │   └── routes/             # Agent-specific Express routes (incl. /sentinel/*)
-│       └── tests/                  # 1290 agent tests (103 suites)
+│       └── tests/                  # 1300 agent tests (104 suites)
 ├── tests/                          # 555 REST tests across 35 suites
 │   ├── health.test.ts
 │   ├── stealth.test.ts
@@ -582,7 +582,7 @@ ssh sip@176.222.53.185 "docker logs sipher --tail 50"
 ## AI GUIDELINES
 
 ### DO:
-- Run `pnpm test -- --run` after code changes (555 REST tests + 1290 agent tests must pass)
+- Run `pnpm test -- --run` after code changes (555 REST tests + 1300 agent tests must pass)
 - Run `pnpm typecheck` before committing
 - Use @sip-protocol/sdk for all crypto operations (never roll your own)
 - Keep API responses consistent: `{ success, data?, error? }`
@@ -629,12 +629,12 @@ See [ROADMAP.md](ROADMAP.md) for the full 6-phase roadmap (38 issues across 6 mi
 | 5 | Backend Aggregation | 5 | ✅ Complete |
 | 6 | Enterprise | 6 | ✅ Complete |
 
-**Progress:** 38/38 issues complete | 555 REST tests + 1290 agent tests | 66 endpoints | 17 chains | All phases complete | Live demo at /v1/demo
+**Progress:** 38/38 issues complete | 555 REST tests + 1300 agent tests | 66 endpoints | 17 chains | All phases complete | Live demo at /v1/demo
 
 **Quick check:** `gh issue list -R sip-protocol/sipher --state open`
 
 ---
 
 **Last Updated:** 2026-04-16
-**Status:** SENTINEL Formalization Complete | 66 REST Endpoints | 555 REST + 1290 Agent Tests | 22 SIPHER Tools | 14 SENTINEL Tools | 9 HERALD X Tools | 17 Chains | Command Center UI (2,079 lines) | Platform Abstraction (AgentCore + Web/X Adapters + SentinelCore/Adapter) | Real Jupiter API | SQLite Persistence | Devnet Proof
+**Status:** SENTINEL Formalization Complete | 66 REST Endpoints | 555 REST + 1300 Agent Tests | 22 SIPHER Tools | 14 SENTINEL Tools | 9 HERALD X Tools | 17 Chains | Command Center UI (2,079 lines) | Platform Abstraction (AgentCore + Web/X Adapters + SentinelCore/Adapter) | Real Jupiter API | SQLite Persistence | Devnet Proof
 **Devnet Proof:** [Solscan](https://solscan.io/tx/4FmLGsLkC5DYJojpQeSQoGMArsJonTEnx729gnFCeYEjFsr8Z46VrDzKQXLhFrpM9Uj6ezBtCQckU28odzvjvV4a?cluster=devnet) — real 0.01 SOL shielded transfer via stealth address

--- a/app/src/components/SentinelConfirm.tsx
+++ b/app/src/components/SentinelConfirm.tsx
@@ -28,7 +28,12 @@ export default function SentinelConfirm({ flagId, token, action, amount, descrip
         headers: { Authorization: `Bearer ${token}` },
       })
       if (!res.ok) {
-        setError(`Action failed (${res.status})`)
+        let message = `Action failed (${res.status})`
+        try {
+          const body = await res.json()
+          if (body?.error?.message) message = String(body.error.message)
+        } catch { /* fall back to status */ }
+        setError(message)
         return
       }
       success = true

--- a/app/src/components/__tests__/SentinelConfirm.test.tsx
+++ b/app/src/components/__tests__/SentinelConfirm.test.tsx
@@ -84,8 +84,10 @@ describe('SentinelConfirm', () => {
     expect(onResolved).not.toHaveBeenCalled()
   })
 
-  it('surfaces error and does not resolve when fetch returns non-ok', async () => {
-    global.fetch = vi.fn().mockResolvedValue(new Response('{"error":"flag expired"}', { status: 404 })) as typeof fetch
+  it('displays envelope error message when fetch returns non-ok with envelope body', async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response('{"error":{"code":"NOT_FOUND","message":"flag not found or expired"}}', { status: 404 })
+    ) as typeof fetch
     const onResolved = vi.fn()
     render(
       <SentinelConfirm
@@ -99,6 +101,26 @@ describe('SentinelConfirm', () => {
     )
     await userEvent.click(screen.getByRole('button', { name: /override & send/i }))
     expect(onResolved).not.toHaveBeenCalled()
-    expect(screen.getByText(/failed/i)).toBeInTheDocument()
+    expect(await screen.findByText('flag not found or expired')).toBeInTheDocument()
+  })
+
+  it('falls back to status display when response body is not envelope-shaped', async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response('<html>500</html>', { status: 500 })
+    ) as typeof fetch
+    const onResolved = vi.fn()
+    render(
+      <SentinelConfirm
+        flagId="abc"
+        token="t"
+        action="Send"
+        amount="5 SOL"
+        description="x"
+        onResolved={onResolved}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /override & send/i }))
+    expect(onResolved).not.toHaveBeenCalled()
+    expect(await screen.findByText(/Action failed \(500\)/)).toBeInTheDocument()
   })
 })

--- a/docs/sentinel/rest-api.md
+++ b/docs/sentinel/rest-api.md
@@ -13,6 +13,24 @@ All endpoints live under `/api/sentinel`. JWT-based auth via `Authorization: Bea
 >
 > They operate on different state stores. A rename is tracked in [follow-up issue #1](https://github.com/sip-protocol/sipher/issues/157).
 
+## Error Envelope
+
+All SENTINEL routes that emit errors return a structured envelope:
+
+```json
+{ "error": { "code": "<CODE>", "message": "<human-readable>" } }
+```
+
+| Code | HTTP status | Meaning |
+|---|---|---|
+| `VALIDATION_FAILED` | 400 | Required fields missing or malformed |
+| `NOT_FOUND` | 404 | Resource ID does not exist |
+| `FORBIDDEN` | 403 | Reserved (auth middleware emits its own legacy shape today) |
+| `UNAVAILABLE` | 503 | Server up but a dependency is unconfigured |
+| `INTERNAL` | 500 | Unexpected server-side failure |
+
+**Note on auth errors:** 401/403 responses from `verifyJwt` and `requireOwner` middleware still use the legacy `{error: "string"}` shape. Normalizing those is tracked separately as a future API-wide cleanup.
+
 ---
 
 ## Public Endpoints
@@ -60,7 +78,7 @@ All endpoints live under `/api/sentinel`. JWT-based auth via `Authorization: Bea
 **Response 400:**
 
 ```json
-{ "error": "action and wallet are required strings" }
+{ "error": { "code": "VALIDATION_FAILED", "message": "action and wallet are required strings" } }
 ```
 
 Returned when `action` or `wallet` is missing or not a string.
@@ -68,7 +86,7 @@ Returned when `action` or `wallet` is missing or not a string.
 **Response 500:**
 
 ```json
-{ "error": "<error message from assessor>" }
+{ "error": { "code": "INTERNAL", "message": "<error message from assessor>" } }
 ```
 
 Returned when the assessor throws an unexpected error.
@@ -76,7 +94,7 @@ Returned when the assessor throws an unexpected error.
 **Response 503:**
 
 ```json
-{ "error": "SENTINEL assessor not configured" }
+{ "error": { "code": "UNAVAILABLE", "message": "SENTINEL assessor not configured" } }
 ```
 
 Only returned when no assessor is registered at startup. Production agents always register one via `setSentinelAssessor`, so this path is rarely hit in deployed environments.
@@ -234,7 +252,7 @@ Admin routes require both `verifyJwt` AND `requireOwner` middleware. The calling
 **Response 400:**
 
 ```json
-{ "error": "address, reason, severity required" }
+{ "error": { "code": "VALIDATION_FAILED", "message": "address, reason, severity required" } }
 ```
 
 **Example:**
@@ -307,16 +325,21 @@ curl -X DELETE http://localhost:5006/api/sentinel/blacklist/01KQP25BM8RVZJ92CTAN
 { "reason": "string (default: 'manual cancel')" }
 ```
 
-**Response 200:** Always 200. The `success` boolean signals whether the ID was found and cancelled.
+**Response 200:**
 
 ```json
-{ "success": false }
+{ "success": true }
 ```
 
-When the action ID exists and is in a cancellable state, `success` is `true`. When the ID is not found or already settled, `success` is `false` (as shown above — captured against a missing ID in a fresh DB).
+Returned when the action ID exists and was cancelled.
 
-> [!NOTE]
-> Unlike the promise-gate routes (`/override/:flagId` and `/cancel/:flagId`), this endpoint does **not** return 404 for missing IDs. The `success` boolean carries that signal instead. See [follow-up issue #1](https://github.com/sip-protocol/sipher/issues/157) for the rename plan.
+**Response 404:**
+
+```json
+{ "error": { "code": "NOT_FOUND", "message": "pending action not found or already resolved" } }
+```
+
+Returned when the action ID does not exist or is already settled. (Behavior changed in this PR — previously this path returned `200 + {success: false}`.)
 
 **Example:**
 
@@ -427,4 +450,4 @@ curl -X POST http://localhost:5006/api/sentinel/cancel/flag_01KQP24PG0KZCJVWJDQM
 
 ---
 
-*Last verified: 2026-04-27 | Source: `packages/agent/src/routes/sentinel-api.ts`*
+*Last verified: 2026-05-04 | Source: `packages/agent/src/routes/sentinel-api.ts`*

--- a/docs/sentinel/rest-api.md
+++ b/docs/sentinel/rest-api.md
@@ -8,8 +8,8 @@ All endpoints live under `/api/sentinel`. JWT-based auth via `Authorization: Bea
 > [!WARNING]
 > Two distinct cancel routes exist on the admin router and look nearly identical by name:
 >
-> - `POST /api/sentinel/pending/:id/cancel` — cancels a circuit-breaker pending action (SQLite-backed, always returns 200 + `{"success": bool}`)
-> - `POST /api/sentinel/cancel/:flagId` — rejects an in-memory promise-gate flag (returns 204 on success, 404 on missing)
+> - `POST /api/sentinel/pending/:id/cancel` — cancels a circuit-breaker pending action (SQLite-backed, returns 200 + `{"success": true}` on success, 404 + `NOT_FOUND` envelope on missing)
+> - `POST /api/sentinel/cancel/:flagId` — rejects an in-memory promise-gate flag (returns 204 on success, 404 + `NOT_FOUND` envelope on missing)
 >
 > They operate on different state stores. A rename is tracked in [follow-up issue #1](https://github.com/sip-protocol/sipher/issues/157).
 

--- a/docs/superpowers/plans/2026-05-04-sentinel-error-envelope.md
+++ b/docs/superpowers/plans/2026-05-04-sentinel-error-envelope.md
@@ -1,0 +1,897 @@
+# SENTINEL REST Error Envelope Normalization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Standardize SENTINEL REST error responses on `{error: {code, message}}` via a typed helper, plus a behavior change to `POST /pending/:id/cancel` (404 + NOT_FOUND when missing) and a frontend upgrade so SentinelConfirm.tsx surfaces the envelope message.
+
+**Architecture:** New file `packages/agent/src/routes/sentinel-errors.ts` exports a `SentinelErrorCode` union and `sendSentinelError(res, code, message)` helper that centralizes the status-code-to-error-code mapping. Five-code taxonomy: `VALIDATION_FAILED | NOT_FOUND | FORBIDDEN | UNAVAILABLE | INTERNAL`. Clean cut migration — no compatibility layer. Eight focused commits.
+
+**Tech Stack:** Express 5, TypeScript, Vitest, supertest, React 19 + Testing Library
+
+**Spec:** `docs/superpowers/specs/2026-05-04-sentinel-error-envelope-design.md`
+
+---
+
+## File Structure
+
+```
+packages/agent/src/routes/
+├── sentinel-errors.ts          # NEW (Task 1) — SentinelErrorCode union + sendSentinelError helper
+└── sentinel-api.ts             # MODIFY (Tasks 2-5) — 7 error sites + 5 JSDoc updates
+
+packages/agent/tests/sentinel/
+├── sentinel-errors.test.ts     # NEW (Task 1) — 6 unit tests
+└── sentinel-api.test.ts        # MODIFY (Tasks 2-4) — modify 1 test + add 4 tests
+
+app/src/components/
+├── SentinelConfirm.tsx         # MODIFY (Task 6) — parse error envelope on failure
+└── __tests__/
+    └── SentinelConfirm.test.tsx # MODIFY (Task 6) — refactor 1 test + add 1 test
+
+docs/sentinel/
+└── rest-api.md                 # MODIFY (Task 7) — add envelope section, update examples
+
+CLAUDE.md                       # MODIFY (Task 8) — bump test counts
+```
+
+**Per-task commits.** Each task ends with a single commit. Eight commits total.
+
+**Branch:** `fix/sentinel-error-envelope` (already created from main).
+
+---
+
+## Task 1: Helper file + unit tests (TDD)
+
+**Files:**
+- Create: `packages/agent/src/routes/sentinel-errors.ts`
+- Create: `packages/agent/tests/sentinel/sentinel-errors.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/agent/tests/sentinel/sentinel-errors.test.ts`:
+
+```ts
+// packages/agent/tests/sentinel/sentinel-errors.test.ts
+import { describe, it, expect, vi } from 'vitest'
+import type { Response } from 'express'
+import { sendSentinelError } from '../../src/routes/sentinel-errors.js'
+
+function mockResponse() {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn(),
+  } as unknown as Response
+}
+
+function jsonCall(res: Response): unknown {
+  return (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0]
+}
+
+describe('sendSentinelError', () => {
+  it('VALIDATION_FAILED maps to status 400', () => {
+    const res = mockResponse()
+    sendSentinelError(res, 'VALIDATION_FAILED', 'bad input')
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(jsonCall(res)).toStrictEqual({
+      error: { code: 'VALIDATION_FAILED', message: 'bad input' },
+    })
+  })
+
+  it('NOT_FOUND maps to status 404', () => {
+    const res = mockResponse()
+    sendSentinelError(res, 'NOT_FOUND', 'missing')
+    expect(res.status).toHaveBeenCalledWith(404)
+    expect(jsonCall(res)).toStrictEqual({
+      error: { code: 'NOT_FOUND', message: 'missing' },
+    })
+  })
+
+  it('FORBIDDEN maps to status 403', () => {
+    const res = mockResponse()
+    sendSentinelError(res, 'FORBIDDEN', 'denied')
+    expect(res.status).toHaveBeenCalledWith(403)
+    expect(jsonCall(res)).toStrictEqual({
+      error: { code: 'FORBIDDEN', message: 'denied' },
+    })
+  })
+
+  it('UNAVAILABLE maps to status 503', () => {
+    const res = mockResponse()
+    sendSentinelError(res, 'UNAVAILABLE', 'not configured')
+    expect(res.status).toHaveBeenCalledWith(503)
+    expect(jsonCall(res)).toStrictEqual({
+      error: { code: 'UNAVAILABLE', message: 'not configured' },
+    })
+  })
+
+  it('INTERNAL maps to status 500', () => {
+    const res = mockResponse()
+    sendSentinelError(res, 'INTERNAL', 'crash')
+    expect(res.status).toHaveBeenCalledWith(500)
+    expect(jsonCall(res)).toStrictEqual({
+      error: { code: 'INTERNAL', message: 'crash' },
+    })
+  })
+
+  it('preserves message verbatim including special characters and newlines', () => {
+    const res = mockResponse()
+    const message = 'Error: "value" failed validation\nat line 42'
+    sendSentinelError(res, 'VALIDATION_FAILED', message)
+    expect(jsonCall(res)).toStrictEqual({
+      error: { code: 'VALIDATION_FAILED', message },
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @sipher/agent test packages/agent/tests/sentinel/sentinel-errors.test.ts -- --run`
+Expected: FAIL with module-not-found error (`Cannot find module '../../src/routes/sentinel-errors.js'`)
+
+- [ ] **Step 3: Create the helper file**
+
+Create `packages/agent/src/routes/sentinel-errors.ts`:
+
+```ts
+// packages/agent/src/routes/sentinel-errors.ts
+// Reference: docs/sentinel/rest-api.md#error-envelope
+
+import type { Response } from 'express'
+
+export type SentinelErrorCode =
+  | 'VALIDATION_FAILED'
+  | 'NOT_FOUND'
+  | 'FORBIDDEN'
+  | 'UNAVAILABLE'
+  | 'INTERNAL'
+
+const STATUS: Record<SentinelErrorCode, number> = {
+  VALIDATION_FAILED: 400,
+  NOT_FOUND: 404,
+  FORBIDDEN: 403,
+  UNAVAILABLE: 503,
+  INTERNAL: 500,
+}
+
+/**
+ * Send a SENTINEL error envelope: { error: { code, message } }.
+ * Status code derived from the SENTINEL code per the design doc.
+ * @see docs/sentinel/rest-api.md#error-envelope
+ */
+export function sendSentinelError(
+  res: Response,
+  code: SentinelErrorCode,
+  message: string,
+): void {
+  res.status(STATUS[code]).json({ error: { code, message } })
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @sipher/agent test packages/agent/tests/sentinel/sentinel-errors.test.ts -- --run`
+Expected: PASS — all 6 tests green
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: clean (no errors)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/agent/src/routes/sentinel-errors.ts packages/agent/tests/sentinel/sentinel-errors.test.ts
+git commit -m "feat(sentinel): add sendSentinelError helper with 5-code taxonomy"
+```
+
+---
+
+## Task 2: Migrate `POST /assess` (3 error paths) — TDD
+
+**Files:**
+- Modify: `packages/agent/tests/sentinel/sentinel-api.test.ts` (existing test on lines 45-49 + add 2 new tests)
+- Modify: `packages/agent/src/routes/sentinel-api.ts` (lines 26, 31, 38 + JSDoc lines 16-22)
+
+- [ ] **Step 1: Update existing 400 test + add 503 and 500 tests (failing)**
+
+In `packages/agent/tests/sentinel/sentinel-api.test.ts`, **replace** the existing 400 test (lines 45-49):
+
+```ts
+  it('POST /assess returns 400 + VALIDATION_FAILED envelope on missing required fields', async () => {
+    const app = await buildApp(vi.fn())
+    const res = await request(app).post('/api/sentinel/assess').send({})
+    expect(res.status).toBe(400)
+    expect(res.body).toStrictEqual({
+      error: { code: 'VALIDATION_FAILED', message: 'action and wallet are required strings' },
+    })
+  })
+```
+
+Add **two new tests** immediately after (before the next `it` block):
+
+```ts
+  it('POST /assess returns 503 + UNAVAILABLE when assessor is not configured', async () => {
+    await freshDb()
+    const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(null)
+    const { sentinelPublicRouter } = await import('../../src/routes/sentinel-api.js')
+    const app = express()
+    app.use(express.json())
+    app.use('/api/sentinel', sentinelPublicRouter)
+    const res = await request(app).post('/api/sentinel/assess').send({
+      action: 'send', wallet: 'w1',
+    })
+    expect(res.status).toBe(503)
+    expect(res.body).toStrictEqual({
+      error: { code: 'UNAVAILABLE', message: 'SENTINEL assessor not configured' },
+    })
+  })
+
+  it('POST /assess returns 500 + INTERNAL envelope when assessor throws', async () => {
+    const assess = vi.fn().mockRejectedValue(new Error('boom'))
+    const app = await buildApp(assess as never)
+    const res = await request(app).post('/api/sentinel/assess').send({
+      action: 'send', wallet: 'w1',
+    })
+    expect(res.status).toBe(500)
+    expect(res.body).toStrictEqual({
+      error: { code: 'INTERNAL', message: 'boom' },
+    })
+  })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @sipher/agent test packages/agent/tests/sentinel/sentinel-api.test.ts -- --run`
+Expected: 3 failures — all three new/modified tests fail body assertions (status assertions still pass; body still has `{error: 'string'}` shape)
+
+- [ ] **Step 3: Migrate the `POST /assess` handler**
+
+In `packages/agent/src/routes/sentinel-api.ts`, **add the import** at the top of the file (after the existing imports, before line 11):
+
+```ts
+import { sendSentinelError } from './sentinel-errors.js'
+```
+
+**Replace lines 23-40** (the entire `POST /assess` handler) with:
+
+```ts
+/**
+ * One-shot risk assessment for a proposed action.
+ * @auth verifyJwt
+ * @body { action, wallet, recipient?, amount?, token?, metadata? }
+ * @returns 200 RiskReport | 400 ErrorEnvelope | 500 ErrorEnvelope | 503 ErrorEnvelope
+ * @see docs/sentinel/rest-api.md#post-apisentinelassess
+ * @see docs/sentinel/rest-api.md#error-envelope
+ */
+sentinelPublicRouter.post('/assess', async (req: Request, res: Response) => {
+  const { action, wallet, recipient, amount, token, metadata } = req.body ?? {}
+  if (typeof action !== 'string' || typeof wallet !== 'string') {
+    sendSentinelError(res, 'VALIDATION_FAILED', 'action and wallet are required strings')
+    return
+  }
+  const assessor = getSentinelAssessor()
+  if (!assessor) {
+    sendSentinelError(res, 'UNAVAILABLE', 'SENTINEL assessor not configured')
+    return
+  }
+  try {
+    const report = await assessor({ action, wallet, recipient, amount, token, metadata })
+    res.json(report)
+  } catch (e) {
+    sendSentinelError(res, 'INTERNAL', e instanceof Error ? e.message : 'assess failed')
+  }
+})
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @sipher/agent test packages/agent/tests/sentinel/sentinel-api.test.ts -- --run`
+Expected: PASS — all 3 modified/new tests green; existing happy-path test (`POST /assess returns a RiskReport from the assessor`) still passes
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: clean
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/agent/src/routes/sentinel-api.ts packages/agent/tests/sentinel/sentinel-api.test.ts
+git commit -m "fix(sentinel): migrate POST /assess to error envelope (#158)"
+```
+
+---
+
+## Task 3: Migrate `POST /blacklist` 400 — TDD
+
+**Files:**
+- Modify: `packages/agent/tests/sentinel/sentinel-api.test.ts` (add 1 new test)
+- Modify: `packages/agent/src/routes/sentinel-api.ts` (line 98 + JSDoc lines 88-94)
+
+- [ ] **Step 1: Add the failing test**
+
+In `packages/agent/tests/sentinel/sentinel-api.test.ts`, immediately after the existing `POST /blacklist adds an entry` test (lines 60-69), add:
+
+```ts
+  it('POST /blacklist returns 400 + VALIDATION_FAILED envelope on missing fields', async () => {
+    const app = await buildApp(vi.fn())
+    const res = await request(app).post('/api/sentinel/blacklist').send({ address: 'only-address' })
+    expect(res.status).toBe(400)
+    expect(res.body).toStrictEqual({
+      error: { code: 'VALIDATION_FAILED', message: 'address, reason, severity required' },
+    })
+  })
+```
+
+- [ ] **Step 2: Run tests to verify it fails**
+
+Run: `pnpm --filter @sipher/agent test packages/agent/tests/sentinel/sentinel-api.test.ts -- --run`
+Expected: 1 failure — body assertion fails because handler still emits string error
+
+- [ ] **Step 3: Migrate the `POST /blacklist` handler**
+
+In `packages/agent/src/routes/sentinel-api.ts`, **replace the JSDoc + handler** (lines 88-108) with:
+
+```ts
+/**
+ * Add an address to the blacklist.
+ * @auth verifyJwt + requireOwner
+ * @body { address, reason, severity, expiresAt?, sourceEventId? }
+ * @returns 200 { success: true, entryId } | 400 ErrorEnvelope
+ * @see docs/sentinel/rest-api.md#post-apisentinelblacklist
+ * @see docs/sentinel/rest-api.md#error-envelope
+ */
+sentinelAdminRouter.post('/blacklist', (req: Request, res: Response) => {
+  const { address, reason, severity, expiresAt, sourceEventId } = req.body ?? {}
+  if (!address || !reason || !severity) {
+    sendSentinelError(res, 'VALIDATION_FAILED', 'address, reason, severity required')
+    return
+  }
+  const wallet = (req as unknown as Record<string, unknown>).wallet as string | undefined
+  const id = insertBlacklist({
+    address, reason, severity,
+    addedBy: wallet ? `admin:${wallet}` : 'admin',
+    expiresAt, sourceEventId,
+  })
+  res.json({ success: true, entryId: id })
+})
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @sipher/agent test packages/agent/tests/sentinel/sentinel-api.test.ts -- --run`
+Expected: PASS — new test green; happy-path `POST /blacklist adds an entry` still passes
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: clean
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/agent/src/routes/sentinel-api.ts packages/agent/tests/sentinel/sentinel-api.test.ts
+git commit -m "fix(sentinel): migrate POST /blacklist to error envelope (#158)"
+```
+
+---
+
+## Task 4: Migrate `POST /pending/:id/cancel` (BEHAVIOR CHANGE) — TDD
+
+**Files:**
+- Modify: `packages/agent/tests/sentinel/sentinel-api.test.ts` (add 1 new test for the 404 behavior)
+- Modify: `packages/agent/src/routes/sentinel-api.ts` (lines 137-145 + JSDoc lines 128-136)
+
+- [ ] **Step 1: Add the failing test for the new 404 behavior**
+
+In `packages/agent/tests/sentinel/sentinel-api.test.ts`, immediately after the existing `POST /pending/:id/cancel cancels an action` test (lines 89-101), add:
+
+```ts
+  it('POST /pending/:id/cancel returns 404 + NOT_FOUND when ID does not exist', async () => {
+    const app = await buildApp(vi.fn())
+    const res = await request(app).post('/api/sentinel/pending/does-not-exist/cancel').send({
+      reason: 'attempted cancel',
+    })
+    expect(res.status).toBe(404)
+    expect(res.body).toStrictEqual({
+      error: { code: 'NOT_FOUND', message: 'pending action not found or already resolved' },
+    })
+  })
+```
+
+- [ ] **Step 2: Run tests to verify it fails**
+
+Run: `pnpm --filter @sipher/agent test packages/agent/tests/sentinel/sentinel-api.test.ts -- --run`
+Expected: 1 failure — current handler returns 200 with `{success: false}`, not 404
+
+- [ ] **Step 3: Migrate the `POST /pending/:id/cancel` handler**
+
+In `packages/agent/src/routes/sentinel-api.ts`, **replace the JSDoc + handler** (lines 128-145) with:
+
+```ts
+/**
+ * Circuit-breaker cancel — mark a pending action cancelled in SQLite.
+ * Circuit-breaker cancel — distinct from the promise-gate `/cancel/:flagId`.
+ * @auth verifyJwt + requireOwner
+ * @param id pending action id
+ * @body { reason? string }
+ * @returns 200 { success: true } | 404 ErrorEnvelope
+ * @see docs/sentinel/rest-api.md#post-apisentinelpendingidcancel
+ * @see docs/sentinel/rest-api.md#error-envelope
+ */
+sentinelAdminRouter.post('/pending/:id/cancel', (req: Request, res: Response) => {
+  const reason = (req.body?.reason as string) ?? 'manual cancel'
+  const w = (req as unknown as Record<string, unknown>).wallet
+  const wallet = (typeof w === 'string' ? w : undefined)
+  const by = typeof wallet === 'string' ? `user:${wallet}` : 'admin'
+  const id = (typeof req.params.id === 'string' ? req.params.id : String(req.params.id))
+  const ok = cancelCircuitBreakerAction(id, by, reason)
+  if (!ok) {
+    sendSentinelError(res, 'NOT_FOUND', 'pending action not found or already resolved')
+    return
+  }
+  res.json({ success: true })
+})
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @sipher/agent test packages/agent/tests/sentinel/sentinel-api.test.ts -- --run`
+Expected: PASS — both new test (404 path) and existing happy-path test (success → 200 + `{success: true}`) green
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: clean
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/agent/src/routes/sentinel-api.ts packages/agent/tests/sentinel/sentinel-api.test.ts
+git commit -m "fix(sentinel): POST /pending/:id/cancel returns 404 + NOT_FOUND on missing (#158)"
+```
+
+---
+
+## Task 5: Refactor promise-gate routes to helper (no new tests)
+
+These two routes already emit `{error: {code, message}}` — refactoring them to use the helper produces identical wire output. The existing `pause-resume-routes.test.ts` asserts `res.body.error.code === 'NOT_FOUND'` (line 89) and is the regression guard.
+
+**Files:**
+- Modify: `packages/agent/src/routes/sentinel-api.ts` (lines 172-198 + JSDoc lines 164-188)
+
+- [ ] **Step 1: Refactor both handlers to the helper**
+
+In `packages/agent/src/routes/sentinel-api.ts`, **replace the JSDoc + both handlers** (lines 164-198) with:
+
+```ts
+/**
+ * Promise-gate resolve — approve a paused advisory-mode action.
+ * Promise-gate resolve — see also `/cancel/:flagId` reject.
+ * @auth verifyJwt + requireOwner
+ * @param flagId in-memory promise flag id
+ * @returns 204 | 404 ErrorEnvelope
+ * @see docs/sentinel/rest-api.md#post-apisentineloverrideflagid
+ * @see docs/sentinel/rest-api.md#error-envelope
+ */
+sentinelAdminRouter.post('/override/:flagId', (req: Request, res: Response) => {
+  const flagId = String(req.params.flagId)
+  const ok = resolvePending(flagId)
+  if (!ok) {
+    sendSentinelError(res, 'NOT_FOUND', 'flag not found or expired')
+    return
+  }
+  res.status(204).send()
+})
+
+/**
+ * Promise-gate reject — deny a paused advisory-mode action.
+ * Promise-gate reject — distinct from the circuit-breaker `/pending/:id/cancel`.
+ * @auth verifyJwt + requireOwner
+ * @param flagId in-memory promise flag id
+ * @returns 204 | 404 ErrorEnvelope
+ * @see docs/sentinel/rest-api.md#post-apisentinelcancelflagid
+ * @see docs/sentinel/rest-api.md#error-envelope
+ */
+sentinelAdminRouter.post('/cancel/:flagId', (req: Request, res: Response) => {
+  const flagId = String(req.params.flagId)
+  const ok = rejectPending(flagId, 'cancelled_by_user')
+  if (!ok) {
+    sendSentinelError(res, 'NOT_FOUND', 'flag not found or expired')
+    return
+  }
+  res.status(204).send()
+})
+```
+
+- [ ] **Step 2: Run all SENTINEL tests to confirm zero regressions**
+
+Run: `pnpm --filter @sipher/agent test packages/agent/tests/sentinel -- --run`
+Expected: PASS — all SENTINEL test files green, including `pause-resume-routes.test.ts` (which asserts `res.body.error.code === 'NOT_FOUND'`)
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: clean
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/agent/src/routes/sentinel-api.ts
+git commit -m "refactor(sentinel): route promise-gate 404s through sendSentinelError (#158)"
+```
+
+---
+
+## Task 6: Frontend `SentinelConfirm.tsx` envelope parsing — TDD
+
+**Files:**
+- Modify: `app/src/components/__tests__/SentinelConfirm.test.tsx` (modify existing test on lines 87-103, add 1 new fallback test)
+- Modify: `app/src/components/SentinelConfirm.tsx` (lines 24-41)
+
+- [ ] **Step 1: Modify existing test + add fallback test (failing)**
+
+In `app/src/components/__tests__/SentinelConfirm.test.tsx`, **replace the existing test** on lines 87-103:
+
+```tsx
+  it('displays envelope error message when fetch returns non-ok with envelope body', async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response('{"error":{"code":"NOT_FOUND","message":"flag not found or expired"}}', { status: 404 })
+    ) as typeof fetch
+    const onResolved = vi.fn()
+    render(
+      <SentinelConfirm
+        flagId="abc"
+        token="t"
+        action="Send"
+        amount="5 SOL"
+        description="x"
+        onResolved={onResolved}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /override & send/i }))
+    expect(onResolved).not.toHaveBeenCalled()
+    expect(await screen.findByText('flag not found or expired')).toBeInTheDocument()
+  })
+
+  it('falls back to status display when response body is not envelope-shaped', async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response('<html>500</html>', { status: 500 })
+    ) as typeof fetch
+    const onResolved = vi.fn()
+    render(
+      <SentinelConfirm
+        flagId="abc"
+        token="t"
+        action="Send"
+        amount="5 SOL"
+        description="x"
+        onResolved={onResolved}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /override & send/i }))
+    expect(onResolved).not.toHaveBeenCalled()
+    expect(await screen.findByText(/Action failed \(500\)/)).toBeInTheDocument()
+  })
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @sipher/app test src/components/__tests__/SentinelConfirm.test.tsx -- --run`
+Expected: 2 failures — both new/modified tests fail because component still shows generic `Action failed (404)` for envelope case
+
+- [ ] **Step 3: Update the component to parse the envelope**
+
+In `app/src/components/SentinelConfirm.tsx`, **replace the `dispatch` function** (lines 20-41) with:
+
+```tsx
+  const dispatch = async (kind: 'override' | 'cancel') => {
+    if (busy) return
+    setBusy(true)
+    setError(null)
+    let success = false
+    try {
+      const res = await fetch(`${API_URL}/api/sentinel/${kind}/${encodeURIComponent(flagId)}`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) {
+        let message = `Action failed (${res.status})`
+        try {
+          const body = await res.json()
+          if (body?.error?.message) message = String(body.error.message)
+        } catch { /* fall back to status */ }
+        setError(message)
+        return
+      }
+      success = true
+    } catch {
+      setError('Network error — try again')
+    } finally {
+      setBusy(false)
+    }
+    if (success) onResolved(kind)
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @sipher/app test src/components/__tests__/SentinelConfirm.test.tsx -- --run`
+Expected: PASS — both new tests green; the 4 unchanged tests (rendering, override POST, cancel POST, double-dispatch prevention) still pass
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: clean
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/components/SentinelConfirm.tsx app/src/components/__tests__/SentinelConfirm.test.tsx
+git commit -m "feat(app): SentinelConfirm parses error envelope message (#158)"
+```
+
+---
+
+## Task 7: Update `docs/sentinel/rest-api.md`
+
+No tests for this task — documentation only.
+
+**Files:**
+- Modify: `docs/sentinel/rest-api.md`
+
+- [ ] **Step 1: Add top-level "Error Envelope" section**
+
+In `docs/sentinel/rest-api.md`, **insert** the following section between the auth intro line `> They operate on different state stores. A rename is tracked in [follow-up issue #1](https://github.com/sip-protocol/sipher/issues/157).` and the `---` separator on line 16:
+
+```markdown
+
+## Error Envelope
+
+All SENTINEL routes that emit errors return a structured envelope:
+
+```json
+{ "error": { "code": "<CODE>", "message": "<human-readable>" } }
+```
+
+| Code | HTTP status | Meaning |
+|---|---|---|
+| `VALIDATION_FAILED` | 400 | Required fields missing or malformed |
+| `NOT_FOUND` | 404 | Resource ID does not exist |
+| `FORBIDDEN` | 403 | Reserved (auth middleware emits its own legacy shape today) |
+| `UNAVAILABLE` | 503 | Server up but a dependency is unconfigured |
+| `INTERNAL` | 500 | Unexpected server-side failure |
+
+**Note on auth errors:** 401/403 responses from `verifyJwt` and `requireOwner` middleware still use the legacy `{error: "string"}` shape. Normalizing those is tracked separately as a future API-wide cleanup.
+
+```
+
+(The leading and trailing blank lines preserve markdown spacing around the existing surrounding content.)
+
+- [ ] **Step 2: Update `POST /assess` Response 400 / 500 / 503 examples**
+
+In the `POST /api/sentinel/assess` section, **replace** the three response examples (lines ~60-82):
+
+```markdown
+**Response 400:**
+
+```json
+{ "error": { "code": "VALIDATION_FAILED", "message": "action and wallet are required strings" } }
+```
+
+Returned when `action` or `wallet` is missing or not a string.
+
+**Response 500:**
+
+```json
+{ "error": { "code": "INTERNAL", "message": "<error message from assessor>" } }
+```
+
+Returned when the assessor throws an unexpected error.
+
+**Response 503:**
+
+```json
+{ "error": { "code": "UNAVAILABLE", "message": "SENTINEL assessor not configured" } }
+```
+
+Only returned when no assessor is registered at startup. Production agents always register one via `setSentinelAssessor`, so this path is rarely hit in deployed environments.
+```
+
+- [ ] **Step 3: Update `POST /blacklist` Response 400 example**
+
+In the `POST /api/sentinel/blacklist` section, **replace** the Response 400 example (lines ~234-238):
+
+```markdown
+**Response 400:**
+
+```json
+{ "error": { "code": "VALIDATION_FAILED", "message": "address, reason, severity required" } }
+```
+```
+
+- [ ] **Step 4: Rewrite `POST /pending/:id/cancel` Response section**
+
+In the `POST /api/sentinel/pending/:id/cancel` section, **replace** the entire Response 200 block (lines ~310-319) with:
+
+```markdown
+**Response 200:**
+
+```json
+{ "success": true }
+```
+
+Returned when the action ID exists and was cancelled.
+
+**Response 404:**
+
+```json
+{ "error": { "code": "NOT_FOUND", "message": "pending action not found or already resolved" } }
+```
+
+Returned when the action ID does not exist or is already settled. (Behavior changed in this PR — previously this path returned `200 + {success: false}`.)
+```
+
+**Also remove** the stale `> [!NOTE]` callout immediately following (the note that begins "Unlike the promise-gate routes (`/override/:flagId` and `/cancel/:flagId`), this endpoint does **not** return 404 for missing IDs."). It is no longer accurate.
+
+- [ ] **Step 5: Update `Last verified:` footer**
+
+At the bottom of `docs/sentinel/rest-api.md`, replace:
+
+```
+*Last verified: 2026-04-27 | Source: `packages/agent/src/routes/sentinel-api.ts`*
+```
+
+With:
+
+```
+*Last verified: 2026-05-04 | Source: `packages/agent/src/routes/sentinel-api.ts`*
+```
+
+- [ ] **Step 6: Verify the markdown renders without breakage**
+
+Run: `git diff docs/sentinel/rest-api.md | head -150`
+Expected: Visual confirmation that envelope examples replaced string examples; envelope section added; stale note removed; footer updated.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/sentinel/rest-api.md
+git commit -m "docs(sentinel): document error envelope contract + update affected examples (#158)"
+```
+
+---
+
+## Task 8: CLAUDE.md test count bump + final verification
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Run full agent + app test suites + typecheck (baseline check)**
+
+Run all three in parallel:
+```bash
+pnpm --filter @sipher/agent test -- --run
+pnpm --filter @sipher/app test -- --run
+pnpm typecheck
+```
+Expected counts:
+- Agent: **1300 tests**, **104 suites** (1290 → 1300, 103 → 104)
+- App: **46 tests**, 12 suites (45 → 46)
+- Typecheck: clean
+
+If counts differ, investigate before proceeding.
+
+- [ ] **Step 2: Update CLAUDE.md test counts**
+
+In `CLAUDE.md`, find every occurrence of `1290` (agent test count) and replace with `1300`. Find every occurrence of `103` paired with `suites` (agent suite count) and replace with `104`. Find every occurrence of `45` paired with `app` and replace with `46`.
+
+Use this command to scope the search precisely:
+```bash
+grep -n "1290\|103 suites\|105 suites\|45 (12 suites)\|45 tests" CLAUDE.md
+```
+
+For each match, update via Edit tool with sufficient surrounding context for uniqueness. Common locations include:
+- Test count summary at the top of the SIP Core section
+- Sipher project status section in MEMORY.md (if applicable — note that MEMORY.md is in the user's private memory dir, NOT in the repo, so this only updates `CLAUDE.md`)
+- Status footer line at the bottom
+
+- [ ] **Step 3: Re-run all suites one more time as final verification**
+
+```bash
+pnpm --filter @sipher/agent test -- --run
+pnpm --filter @sipher/app test -- --run
+pnpm typecheck
+```
+Expected: same counts as Step 1, all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: bump test counts after error envelope normalization (1290 → 1300, 103 → 104 suites)"
+```
+
+---
+
+## Verification before PR
+
+After all 8 tasks complete:
+
+```bash
+# Confirm 8 commits on the branch
+git log main..HEAD --oneline
+
+# Confirm test counts
+pnpm --filter @sipher/agent test -- --run 2>&1 | tail -10
+pnpm --filter @sipher/app test -- --run 2>&1 | tail -10
+pnpm typecheck
+
+# Confirm spec + plan are committed (the spec was committed before plan execution)
+git log main..HEAD -- docs/superpowers/
+
+# Diff against main for PR description
+git diff main..HEAD --stat
+```
+
+**Expected diff stat (approximate):**
+```
+ CLAUDE.md                                                   |  ~10 ++--
+ app/src/components/SentinelConfirm.tsx                      |   ~7 ++-
+ app/src/components/__tests__/SentinelConfirm.test.tsx       |  ~30 +++++++--
+ docs/sentinel/rest-api.md                                   |  ~50 +++++++++--
+ docs/superpowers/plans/2026-05-04-sentinel-error-envelope.md| +600 (NEW)
+ docs/superpowers/specs/2026-05-04-sentinel-error-envelope-design.md | +296 (NEW, already committed)
+ packages/agent/src/routes/sentinel-api.ts                   |  ~30 ++++--
+ packages/agent/src/routes/sentinel-errors.ts                |  +25 (NEW)
+ packages/agent/tests/sentinel/sentinel-api.test.ts          |  ~50 ++++++--
+ packages/agent/tests/sentinel/sentinel-errors.test.ts       |  +75 (NEW)
+```
+
+**PR title:** `fix(sentinel): normalize REST error envelope shape across all routes (#158)`
+
+**PR body sections:** Summary | Behavior changes | Test count delta | Closes #158 | Notes (mentions #157 will apply this contract; #159 will mirror docs)
+
+---
+
+## Self-review
+
+**1. Spec coverage check:**
+
+| Spec section / requirement | Plan task |
+|---|---|
+| Helper file with `SentinelErrorCode` union | Task 1 |
+| 5-code taxonomy (VALIDATION_FAILED, NOT_FOUND, FORBIDDEN, UNAVAILABLE, INTERNAL) | Task 1 (helper), Task 2-4 (used in handlers) |
+| `sendSentinelError` function signature | Task 1 |
+| `POST /assess` 400/500/503 envelope migration | Task 2 |
+| `POST /blacklist` 400 envelope migration | Task 3 |
+| `POST /pending/:id/cancel` BEHAVIOR CHANGE (200→404 on missing) | Task 4 |
+| `POST /override/:flagId` 404 refactor to helper | Task 5 |
+| `POST /cancel/:flagId` 404 refactor to helper | Task 5 |
+| Frontend SentinelConfirm.tsx envelope parsing | Task 6 |
+| Frontend test for envelope display + fallback | Task 6 |
+| Helper unit tests (6 tests, all 5 codes + verbatim message) | Task 1 |
+| New error-path tests in sentinel-api.test.ts (assess 503/500, blacklist 400, pending 404) | Tasks 2-4 |
+| `pause-resume-routes.test.ts` zero changes (regression guard) | Task 5 (verified in Step 2) |
+| `docs/sentinel/rest-api.md` Error Envelope section | Task 7 Step 1 |
+| `docs/sentinel/rest-api.md` updated response examples | Task 7 Steps 2-4 |
+| Stale `/pending/:id/cancel` note removal | Task 7 Step 4 |
+| `Last verified:` footer date bump | Task 7 Step 5 |
+| JSDoc `@returns` updates on 5 affected handlers | Tasks 2-5 (each handler's JSDoc updated alongside the code change) |
+| `@see docs/sentinel/rest-api.md#error-envelope` cross-link on each handler | Tasks 2-5 |
+| CLAUDE.md test count bump (1290→1300, 103→104) | Task 8 |
+| `pnpm typecheck` clean | Tasks 1-6 (every implementation task), 8 (final) |
+| Test count target: agent 1300, app 46 | Task 8 final verification |
+
+All spec requirements mapped to plan tasks. ✓
+
+**2. Placeholder scan:** No "TBD", "TODO", "implement later", "similar to Task N", or vague "add error handling" patterns. Every step contains the actual code or command to run. ✓
+
+**3. Type consistency:**
+- `SentinelErrorCode` union spelled identically in helper file (Task 1), used by string literals only in handlers (Tasks 2-5)
+- `sendSentinelError` signature `(res, code, message)` consistent across every callsite
+- Test assertion uses `toStrictEqual({error: {code, message}})` consistently ✓
+
+**4. Bite-sized check:** Largest task is Task 7 (docs, 7 steps); other tasks are 4-6 steps. Each step is one action (write code, run test, commit). ✓

--- a/docs/superpowers/specs/2026-05-04-sentinel-error-envelope-design.md
+++ b/docs/superpowers/specs/2026-05-04-sentinel-error-envelope-design.md
@@ -1,0 +1,296 @@
+# SENTINEL REST Error Envelope Normalization — Design Spec
+
+**Date:** 2026-05-04
+**Status:** Approved scope, ready for implementation plan
+**Issue:** [#158 — SENTINEL: normalize REST error envelope shape across all routes](https://github.com/sip-protocol/sipher/issues/158)
+**Predecessor specs:** `2026-04-27-sentinel-surface-docs-design.md` (Phase 3 — surface docs that exposed the envelope inconsistency)
+**Related follow-ups:** #157 (rename dual-cancel routes — applies this contract), #159 (mirror docs — captures this contract)
+
+## Summary
+
+Standardize SENTINEL REST error responses on a single structured envelope: `{ error: { code, message } }`. Replace the four heterogeneous shapes that exist today (plain string `{error:"..."}`, partially-structured `{error:{code,message}}`, no-envelope `{success:false}`, no-error-path) with one consistent contract. Introduce a small typed helper `sendSentinelError(res, code, message)` that centralizes the status-code-to-error-code mapping. Five-code taxonomy: `VALIDATION_FAILED | NOT_FOUND | FORBIDDEN | UNAVAILABLE | INTERNAL`. Clean cut migration — no compatibility layer. Single PR. Behavior change: `POST /pending/:id/cancel` switches from "always 200" to "404 + NOT_FOUND" when the ID does not exist.
+
+## Context
+
+The 2026-04-27 SENTINEL surface-docs cleanup (PR #160) exposed inconsistent error envelopes across the 10 SENTINEL REST routes:
+
+- `POST /assess` (400, 500, 503), `POST /blacklist` (400) → `{ error: "string message" }`
+- `POST /override/:flagId` (404), `POST /cancel/:flagId` (404) → `{ error: { code: "NOT_FOUND", message: "..." } }`
+- `POST /pending/:id/cancel` → returns 200 with `{ success: false }` even when the ID does not exist (no error envelope at all)
+
+These shapes are documented honestly in `docs/sentinel/rest-api.md` but are confusing for any external integrator. The Phase 3 spec deferred normalization as follow-up issue #158.
+
+The frontend caller `app/src/components/SentinelConfirm.tsx` only inspects `res.ok` and `res.status` — it never reads the response body. So the wire-shape change is backwards-compatible by accident for the existing UI, but the structured envelope is currently demonstrated by zero consumers.
+
+With Superteam grant tranches landing and the dApp Store / Solana Foundation work ahead, integrators reading the surface docs will eventually call these routes and need a predictable error contract.
+
+## Goals
+
+1. **One envelope shape** for every SENTINEL REST error: `{ error: { code, message } }`.
+2. **One status-code mapping** centralized in a helper, preventing `400 + NOT_FOUND` mismatches.
+3. **One concrete consumer** of the envelope: `SentinelConfirm.tsx` displays `error.message` instead of generic `Action failed (404)`.
+4. **No compatibility layer** — clean cut, single release.
+5. **Surface docs reflect reality** — `docs/sentinel/rest-api.md` documents the new envelope at the top and updates each affected response example.
+6. Land as **one PR**, with passing tests and clean typecheck.
+
+## Non-goals
+
+- Auth middleware (`verifyJwt`, `requireOwner`) envelope normalization. Those middlewares emit their own legacy `{error:"string"}` shape on 401/403 and protect the entire authenticated API (`/api/sentinel/*`, `/api/vault/*`, etc.). Renormalizing them is a broader, separate concern.
+- `details?` field on the envelope. Omitted from v1; can be added later as a non-breaking optional field if a concrete consumer need arises.
+- Additional error codes (`RATE_LIMITED`, `CONFLICT`, etc.). YAGNI — current SENTINEL routes have no error paths that need them.
+- Issue #157 route renames (`/cancel/:flagId` → `/promise-gate/:flagId/reject`, etc.). Separate PR; this PR defines the error contract that #157 will then apply.
+- Issue #159 mirror to `docs.sip-protocol.org`. Separate cross-repo PRs.
+- OpenAPI schema. Out of scope until first SDK consumer.
+
+## Architecture
+
+### The helper file
+
+**New file:** `packages/agent/src/routes/sentinel-errors.ts` (~25 lines)
+
+```ts
+import type { Response } from 'express'
+
+export type SentinelErrorCode =
+  | 'VALIDATION_FAILED'
+  | 'NOT_FOUND'
+  | 'FORBIDDEN'
+  | 'UNAVAILABLE'
+  | 'INTERNAL'
+
+const STATUS: Record<SentinelErrorCode, number> = {
+  VALIDATION_FAILED: 400,
+  NOT_FOUND: 404,
+  FORBIDDEN: 403,
+  UNAVAILABLE: 503,
+  INTERNAL: 500,
+}
+
+/**
+ * Send a SENTINEL error envelope: { error: { code, message } }.
+ * Status code derived from the SENTINEL code per the design doc.
+ * @see docs/sentinel/rest-api.md#error-envelope
+ */
+export function sendSentinelError(
+  res: Response,
+  code: SentinelErrorCode,
+  message: string,
+): void {
+  res.status(STATUS[code]).json({ error: { code, message } })
+}
+```
+
+**Design rationale:**
+
+- **Single source of truth:** the status mapping lives in one place. Impossible to send `404 + VALIDATION_FAILED`.
+- **Type-safe:** TypeScript catches typos in code names at compile time.
+- **Tests import the type:** the union type is exported so test files can assert against it.
+- **Co-located:** lives next to `sentinel-api.ts` and is named `sentinel-errors.ts` so the SENTINEL scope is explicit. Function is named `sendSentinelError` (not just `sendError`) for the same reason.
+- **No middleware:** rejected the Express error-middleware approach because it requires polyfills for async-error handling and touches router-mount setup. The helper is the smallest viable abstraction.
+
+### Error code taxonomy
+
+| Code | HTTP status | Meaning | Triggered by (current SENTINEL routes) |
+|---|---|---|---|
+| `VALIDATION_FAILED` | 400 | Required fields missing or malformed | `POST /assess` missing `action`/`wallet`; `POST /blacklist` missing `address`/`reason`/`severity` |
+| `NOT_FOUND` | 404 | Resource ID does not exist | `POST /override/:flagId`, `POST /cancel/:flagId`, `POST /pending/:id/cancel` |
+| `FORBIDDEN` | 403 | Authenticated but not allowed | Reserved (auth middleware emits own legacy shape) |
+| `UNAVAILABLE` | 503 | Server up, dependency unconfigured | `POST /assess` when no assessor registered |
+| `INTERNAL` | 500 | Unexpected server-side failure | `POST /assess` when assessor throws |
+
+`FORBIDDEN` is reserved-but-unused by SENTINEL handlers today. Keeping it in the taxonomy from v1 means we don't have to widen the union later if/when middleware normalization happens.
+
+## Per-handler migration
+
+Every error response in `packages/agent/src/routes/sentinel-api.ts`:
+
+| # | Route | Line | Change | Type |
+|---|---|---:|---|---|
+| 1 | `POST /assess` 400 | 26 | `sendSentinelError(res, 'VALIDATION_FAILED', 'action and wallet are required strings')` | shape only |
+| 2 | `POST /assess` 503 | 31 | `sendSentinelError(res, 'UNAVAILABLE', 'SENTINEL assessor not configured')` | shape only |
+| 3 | `POST /assess` 500 | 38 | `sendSentinelError(res, 'INTERNAL', e instanceof Error ? e.message : 'assess failed')` | shape only |
+| 4 | `POST /blacklist` 400 | 98 | `sendSentinelError(res, 'VALIDATION_FAILED', 'address, reason, severity required')` | shape only |
+| 5 | `POST /pending/:id/cancel` | 137-145 | If `cancelCircuitBreakerAction` returns `false`: `sendSentinelError(res, 'NOT_FOUND', 'pending action not found or already resolved')`. If `true`: `res.json({ success: true })` | **BEHAVIOR CHANGE** |
+| 6 | `POST /override/:flagId` 404 | 176 | `sendSentinelError(res, 'NOT_FOUND', 'flag not found or expired')` | refactor to helper |
+| 7 | `POST /cancel/:flagId` 404 | 194 | `sendSentinelError(res, 'NOT_FOUND', 'flag not found or expired')` | refactor to helper |
+
+Routes that don't change (no error paths exist today): `GET /blacklist`, `GET /pending`, `GET /status`, `GET /decisions`, `DELETE /blacklist/:id`.
+
+### Notes on the behavior change (#5)
+
+`cancelCircuitBreakerAction` returns `false` for two cases: (a) the ID does not exist, OR (b) the ID exists but is already settled/cancelled. Both collapse into `NOT_FOUND` with the message `"pending action not found or already resolved"`. The message disambiguates well enough; adding a `CONFLICT` code to differentiate would bloat the taxonomy with no concrete consumer benefit.
+
+The success path stays `200 + { success: true }` — unchanged response body so any future caller relying on truthiness isn't broken. The shape difference is only on the failure branch.
+
+### JSDoc updates
+
+Per-handler `@returns` updates in `packages/agent/src/routes/sentinel-api.ts`:
+
+| Handler | Before | After |
+|---|---|---|
+| `POST /assess` | `@returns 200 RiskReport \| 400 { error } \| 503 { error }` (500 unmentioned) | `@returns 200 RiskReport \| 400 ErrorEnvelope \| 500 ErrorEnvelope \| 503 ErrorEnvelope` |
+| `POST /blacklist` | `@returns 200 { success: true, entryId } \| 400 { error }` | `@returns 200 { success: true, entryId } \| 400 ErrorEnvelope` |
+| `POST /pending/:id/cancel` | `@returns 200 { success: boolean }` | `@returns 200 { success: true } \| 404 ErrorEnvelope` |
+| `POST /override/:flagId` | `@returns 204 \| 404 { error }` | `@returns 204 \| 404 ErrorEnvelope` |
+| `POST /cancel/:flagId` | `@returns 204 \| 404 { error }` | `@returns 204 \| 404 ErrorEnvelope` |
+
+Add `@see docs/sentinel/rest-api.md#error-envelope` cross-link on each of the 5 handlers above.
+
+Routes that emit no errors (`GET /blacklist`, `GET /pending`, `GET /status`, `GET /decisions`, `DELETE /blacklist/:id`) get no JSDoc changes.
+
+## Frontend implications
+
+**File:** `app/src/components/SentinelConfirm.tsx`
+
+Today the component only checks `res.ok` and displays `Action failed (${res.status})`. With the new envelope it can display the `message` field instead, providing a real UX win.
+
+```ts
+if (!res.ok) {
+  let message = `Action failed (${res.status})`
+  try {
+    const body = await res.json()
+    if (body?.error?.message) message = body.error.message
+  } catch { /* fall back to status */ }
+  setError(message)
+  return
+}
+```
+
+Wired in this PR (not deferred) because:
+
+- It demonstrates the envelope is consumed end-to-end — proves the contract works.
+- It's the sole frontend caller of these admin endpoints.
+- ~5 lines of code + 1 new test.
+
+## Testing
+
+### New file: `packages/agent/tests/sentinel/sentinel-errors.test.ts` (~50 lines, 6 tests)
+
+Unit tests for the helper. Mock Express `Response` via `{ status: vi.fn().mockReturnThis(), json: vi.fn() }`.
+
+| Test | Asserts |
+|---|---|
+| `VALIDATION_FAILED → 400` | status + `toStrictEqual({error:{code:'VALIDATION_FAILED', message:'msg'}})` |
+| `NOT_FOUND → 404` | same shape |
+| `FORBIDDEN → 403` | same shape |
+| `UNAVAILABLE → 503` | same shape |
+| `INTERNAL → 500` | same shape |
+| `message field is preserved verbatim` | passes a long string with quotes/special chars |
+
+### Modify: `packages/agent/tests/sentinel/sentinel-api.test.ts`
+
+| Test | Change |
+|---|---|
+| `POST /assess returns 400 on missing required fields` | Add `expect(res.body).toStrictEqual({error:{code:'VALIDATION_FAILED', message:'action and wallet are required strings'}})` |
+| **NEW:** `POST /assess returns 503 + UNAVAILABLE when assessor not configured` | Build app without calling `setSentinelAssessor`; assert 503 + envelope |
+| **NEW:** `POST /assess returns 500 + INTERNAL when assessor throws` | Mock assessor `mockRejectedValue(new Error('boom'))`; assert 500 + envelope with `message:'boom'` |
+| `POST /blacklist` add 400 case | Currently only happy path. Add: missing fields → 400 + VALIDATION_FAILED envelope |
+| **NEW:** `POST /pending/:id/cancel returns 404 + NOT_FOUND when ID does not exist` | Post to non-existent ID; assert 404 + envelope `code:'NOT_FOUND', message:'pending action not found or already resolved'` |
+
+The existing `POST /pending/:id/cancel cancels an action` test stays as-is — regression guard for the success path.
+
+### Unchanged: `packages/agent/tests/sentinel/pause-resume-routes.test.ts`
+
+Already asserts `res.body.error.code === 'NOT_FOUND'` (line 89). Refactoring the routes to use the helper produces an identical wire response. Zero changes — proves backward-compat of the refactor.
+
+### Modify: `app/src/components/__tests__/SentinelConfirm.test.tsx`
+
+| Change | Detail |
+|---|---|
+| Update fixture on line 88 | `new Response('{"error":{"code":"NOT_FOUND","message":"flag not found or expired"}}', { status: 404 })` |
+| **NEW test:** `displays error envelope message instead of generic status` | Mock 404 with envelope; assert "flag not found or expired" appears in the rendered output |
+
+### Test count delta
+
+- Agent: **+10** (1290 → 1300) — 6 helper + 4 new error-path
+- App: **+1** (45 → 46)
+
+## Documentation
+
+### `docs/sentinel/rest-api.md`
+
+1. **Add a top-level "Error Envelope" section** after the auth intro (around line 16):
+
+   ```markdown
+   ## Error Envelope
+
+   All SENTINEL routes that emit errors return a structured envelope:
+
+   { "error": { "code": "<CODE>", "message": "<human-readable>" } }
+
+   | Code | HTTP status | Meaning |
+   |---|---|---|
+   | VALIDATION_FAILED | 400 | Required fields missing or malformed |
+   | NOT_FOUND | 404 | Resource ID does not exist |
+   | FORBIDDEN | 403 | Reserved (auth middleware emits its own legacy shape today) |
+   | UNAVAILABLE | 503 | Server up but a dependency is unconfigured |
+   | INTERNAL | 500 | Unexpected server-side failure |
+
+   **Note on auth errors:** 401/403 responses from `verifyJwt` and `requireOwner` middleware still use the legacy `{error: "string"}` shape. Normalizing those is tracked separately as a future API-wide cleanup.
+   ```
+
+2. **Update Response sections** for affected routes:
+   - `POST /assess` 400, 500, 503 (lines 60-82) — replace string examples with envelope
+   - `POST /blacklist` 400 (lines 234-238)
+   - `POST /pending/:id/cancel` (lines 290-328) — **rewrite**: now 200 `{success: true}` on success, 404 `NOT_FOUND` envelope on missing. **Remove the stale `> [!NOTE]` callout** about "does not return 404 for missing IDs"
+   - `POST /override/:flagId` 404 (line 380-384) — confirm shape (already aligned)
+   - `POST /cancel/:flagId` 404 (line 414-418) — confirm shape (already aligned)
+
+3. **Update `Last verified: YYYY-MM-DD` footer** to today's date.
+
+### `CLAUDE.md`
+
+- Bump test counts: agent 1290 → 1300, suite 103 → 104 (only the new helper file `sentinel-errors.test.ts` adds a suite; new tests inside `sentinel-api.test.ts` and `SentinelConfirm.test.tsx` go into existing suites)
+- (No description changes needed — error envelope is a contract detail, not a CLAUDE.md-tier fact)
+
+## Files touched
+
+| File | Status | Approximate LOC |
+|---|---|---:|
+| `packages/agent/src/routes/sentinel-errors.ts` | NEW | +25 |
+| `packages/agent/src/routes/sentinel-api.ts` | MODIFY | ~10 changes |
+| `packages/agent/tests/sentinel/sentinel-errors.test.ts` | NEW | +50 (6 tests) |
+| `packages/agent/tests/sentinel/sentinel-api.test.ts` | MODIFY | +4 tests, ~5 mods |
+| `app/src/components/SentinelConfirm.tsx` | MODIFY | +5 |
+| `app/src/components/__tests__/SentinelConfirm.test.tsx` | MODIFY | +1 test, 1 fixture update |
+| `docs/sentinel/rest-api.md` | MODIFY | +20 envelope section, ~30 line replacements |
+| `CLAUDE.md` | MODIFY | Test counts |
+
+## Success criteria
+
+- [ ] `packages/agent/src/routes/sentinel-errors.ts` exists with `SentinelErrorCode` union and `sendSentinelError` helper
+- [ ] All 5 codes have unit tests asserting status + envelope shape via `toStrictEqual`
+- [ ] All 4 error paths in `sentinel-api.ts` (assess 400/500/503, blacklist 400) have integration tests asserting envelope
+- [ ] `POST /pending/:id/cancel` returns 404 + NOT_FOUND when ID does not exist (new behavior, tested)
+- [ ] `pause-resume-routes.test.ts` still passes with zero modifications (backward-compat proof)
+- [ ] `SentinelConfirm.tsx` displays `error.message` from envelope on failure (tested)
+- [ ] `docs/sentinel/rest-api.md` has a top-level Error Envelope section, all examples updated, stale `/pending/:id/cancel` note removed, `Last verified` footer updated
+- [ ] JSDoc `@returns` annotations updated on all 5 affected handlers (assess, blacklist POST, pending cancel, override, cancel); `@see` links point at the new envelope section
+- [ ] CLAUDE.md test counts updated (agent 1290→1300, suite 103→104)
+- [ ] `pnpm typecheck` clean (workspace + agent)
+- [ ] `pnpm --filter @sipher/agent test -- --run` shows 1300 green
+- [ ] `pnpm --filter @sipher/app test -- --run` shows 46 green
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| External integrator scraping the old string error format breaks | No known external consumers. Frontend reads HTTP status, not body. Surface-docs documented as "two shapes" so the contract was never authoritative. Acceptable to break. |
+| `POST /pending/:id/cancel` consumer relying on `{success: false}` breaks | No frontend caller exists for this admin endpoint. Backend itself does not call it. Risk ≈ 0. |
+| Helper file becomes a god-object as more codes are added | Codes are explicit additions to a TypeScript union; cannot grow accidentally. Status-mapping table forces a deliberate update. YAGNI keeps the surface tight. |
+| Confusion between SENTINEL handler envelope and auth-middleware legacy shape | Documented explicitly in the new Error Envelope section ("Note on auth errors") |
+| Status-code/error-code drift if helper is bypassed | Code review catches direct `res.status(N).json({error:...})` calls. Could add a lint rule later if drift becomes real. |
+
+## Rollback
+
+Single PR, single revert. No DB migrations, no env changes, no route changes. The behavior change to `POST /pending/:id/cancel` (200 → 404 on missing) is the only thing that affects the wire contract; rolling back restores the prior "always 200" behavior.
+
+## Out of scope (deferred)
+
+- Auth middleware envelope (separate API-wide concern)
+- `details?` field (non-breaking add later)
+- `RATE_LIMITED`, `CONFLICT` codes (YAGNI)
+- Issue #157 dual-cancel route renames (separate PR; this PR defines the contract that #157 applies)
+- Issue #159 docs mirror to `docs.sip-protocol.org` (separate cross-repo PRs; this PR's docs are the source of truth)
+- OpenAPI / Swagger spec (until first SDK consumer)
+- Lint rule enforcing helper usage (add later if drift becomes real)

--- a/packages/agent/src/routes/sentinel-api.ts
+++ b/packages/agent/src/routes/sentinel-api.ts
@@ -134,8 +134,9 @@ sentinelAdminRouter.delete('/blacklist/:id', (req: Request, res: Response) => {
  * @auth verifyJwt + requireOwner
  * @param id pending action id
  * @body { reason? string }
- * @returns 200 { success: boolean }
+ * @returns 200 { success: true } | 404 ErrorEnvelope
  * @see docs/sentinel/rest-api.md#post-apisentinelpendingidcancel
+ * @see docs/sentinel/rest-api.md#error-envelope
  */
 sentinelAdminRouter.post('/pending/:id/cancel', (req: Request, res: Response) => {
   const reason = (req.body?.reason as string) ?? 'manual cancel'
@@ -144,7 +145,11 @@ sentinelAdminRouter.post('/pending/:id/cancel', (req: Request, res: Response) =>
   const by = typeof wallet === 'string' ? `user:${wallet}` : 'admin'
   const id = (typeof req.params.id === 'string' ? req.params.id : String(req.params.id))
   const ok = cancelCircuitBreakerAction(id, by, reason)
-  res.json({ success: ok })
+  if (!ok) {
+    sendSentinelError(res, 'NOT_FOUND', 'pending action not found or already resolved')
+    return
+  }
+  res.json({ success: true })
 })
 
 /**

--- a/packages/agent/src/routes/sentinel-api.ts
+++ b/packages/agent/src/routes/sentinel-api.ts
@@ -91,13 +91,14 @@ export const sentinelAdminRouter: Router = Router()
  * Add an address to the blacklist.
  * @auth verifyJwt + requireOwner
  * @body { address, reason, severity, expiresAt?, sourceEventId? }
- * @returns 200 { success: true, entryId } | 400 { error }
+ * @returns 200 { success: true, entryId } | 400 ErrorEnvelope
  * @see docs/sentinel/rest-api.md#post-apisentinelblacklist
+ * @see docs/sentinel/rest-api.md#error-envelope
  */
 sentinelAdminRouter.post('/blacklist', (req: Request, res: Response) => {
   const { address, reason, severity, expiresAt, sourceEventId } = req.body ?? {}
   if (!address || !reason || !severity) {
-    res.status(400).json({ error: 'address, reason, severity required' })
+    sendSentinelError(res, 'VALIDATION_FAILED', 'address, reason, severity required')
     return
   }
   const wallet = (req as unknown as Record<string, unknown>).wallet as string | undefined

--- a/packages/agent/src/routes/sentinel-api.ts
+++ b/packages/agent/src/routes/sentinel-api.ts
@@ -7,6 +7,7 @@ import { cancelCircuitBreakerAction } from '../sentinel/circuit-breaker.js'
 import { getSentinelAssessor } from '../sentinel/preflight-gate.js'
 import { getSentinelConfig } from '../sentinel/config.js'
 import { resolvePending, rejectPending } from '../sentinel/pending.js'
+import { sendSentinelError } from './sentinel-errors.js'
 
 // Reference: docs/sentinel/rest-api.md
 
@@ -17,25 +18,26 @@ export const sentinelPublicRouter: Router = Router()
  * One-shot risk assessment for a proposed action.
  * @auth verifyJwt
  * @body { action, wallet, recipient?, amount?, token?, metadata? }
- * @returns 200 RiskReport | 400 { error } | 503 { error }
+ * @returns 200 RiskReport | 400 ErrorEnvelope | 500 ErrorEnvelope | 503 ErrorEnvelope
  * @see docs/sentinel/rest-api.md#post-apisentinelassess
+ * @see docs/sentinel/rest-api.md#error-envelope
  */
 sentinelPublicRouter.post('/assess', async (req: Request, res: Response) => {
   const { action, wallet, recipient, amount, token, metadata } = req.body ?? {}
   if (typeof action !== 'string' || typeof wallet !== 'string') {
-    res.status(400).json({ error: 'action and wallet are required strings' })
+    sendSentinelError(res, 'VALIDATION_FAILED', 'action and wallet are required strings')
     return
   }
   const assessor = getSentinelAssessor()
   if (!assessor) {
-    res.status(503).json({ error: 'SENTINEL assessor not configured' })
+    sendSentinelError(res, 'UNAVAILABLE', 'SENTINEL assessor not configured')
     return
   }
   try {
     const report = await assessor({ action, wallet, recipient, amount, token, metadata })
     res.json(report)
   } catch (e) {
-    res.status(500).json({ error: e instanceof Error ? e.message : 'assess failed' })
+    sendSentinelError(res, 'INTERNAL', e instanceof Error ? e.message : 'assess failed')
   }
 })
 

--- a/packages/agent/src/routes/sentinel-api.ts
+++ b/packages/agent/src/routes/sentinel-api.ts
@@ -174,14 +174,15 @@ sentinelAdminRouter.get('/decisions', (req: Request, res: Response) => {
  * Promise-gate resolve — see also `/cancel/:flagId` reject.
  * @auth verifyJwt + requireOwner
  * @param flagId in-memory promise flag id
- * @returns 204 | 404 { error }
+ * @returns 204 | 404 ErrorEnvelope
  * @see docs/sentinel/rest-api.md#post-apisentineloverrideflagid
+ * @see docs/sentinel/rest-api.md#error-envelope
  */
 sentinelAdminRouter.post('/override/:flagId', (req: Request, res: Response) => {
   const flagId = String(req.params.flagId)
   const ok = resolvePending(flagId)
   if (!ok) {
-    res.status(404).json({ error: { code: 'NOT_FOUND', message: 'flag not found or expired' } })
+    sendSentinelError(res, 'NOT_FOUND', 'flag not found or expired')
     return
   }
   res.status(204).send()
@@ -192,14 +193,15 @@ sentinelAdminRouter.post('/override/:flagId', (req: Request, res: Response) => {
  * Promise-gate reject — distinct from the circuit-breaker `/pending/:id/cancel`.
  * @auth verifyJwt + requireOwner
  * @param flagId in-memory promise flag id
- * @returns 204 | 404 { error }
+ * @returns 204 | 404 ErrorEnvelope
  * @see docs/sentinel/rest-api.md#post-apisentinelcancelflagid
+ * @see docs/sentinel/rest-api.md#error-envelope
  */
 sentinelAdminRouter.post('/cancel/:flagId', (req: Request, res: Response) => {
   const flagId = String(req.params.flagId)
   const ok = rejectPending(flagId, 'cancelled_by_user')
   if (!ok) {
-    res.status(404).json({ error: { code: 'NOT_FOUND', message: 'flag not found or expired' } })
+    sendSentinelError(res, 'NOT_FOUND', 'flag not found or expired')
     return
   }
   res.status(204).send()

--- a/packages/agent/src/routes/sentinel-errors.ts
+++ b/packages/agent/src/routes/sentinel-errors.ts
@@ -1,0 +1,32 @@
+// packages/agent/src/routes/sentinel-errors.ts
+// Reference: docs/sentinel/rest-api.md#error-envelope
+
+import type { Response } from 'express'
+
+export type SentinelErrorCode =
+  | 'VALIDATION_FAILED'
+  | 'NOT_FOUND'
+  | 'FORBIDDEN'
+  | 'UNAVAILABLE'
+  | 'INTERNAL'
+
+const STATUS: Record<SentinelErrorCode, number> = {
+  VALIDATION_FAILED: 400,
+  NOT_FOUND: 404,
+  FORBIDDEN: 403,
+  UNAVAILABLE: 503,
+  INTERNAL: 500,
+}
+
+/**
+ * Send a SENTINEL error envelope: { error: { code, message } }.
+ * Status code derived from the SENTINEL code per the design doc.
+ * @see docs/sentinel/rest-api.md#error-envelope
+ */
+export function sendSentinelError(
+  res: Response,
+  code: SentinelErrorCode,
+  message: string,
+): void {
+  res.status(STATUS[code]).json({ error: { code, message } })
+}

--- a/packages/agent/tests/sentinel/sentinel-api.test.ts
+++ b/packages/agent/tests/sentinel/sentinel-api.test.ts
@@ -141,6 +141,17 @@ describe('sentinel REST endpoints', () => {
     cb.clearAllTimers()
   })
 
+  it('POST /pending/:id/cancel returns 404 + NOT_FOUND when ID does not exist', async () => {
+    const app = await buildApp(vi.fn())
+    const res = await request(app).post('/api/sentinel/pending/does-not-exist/cancel').send({
+      reason: 'attempted cancel',
+    })
+    expect(res.status).toBe(404)
+    expect(res.body).toStrictEqual({
+      error: { code: 'NOT_FOUND', message: 'pending action not found or already resolved' },
+    })
+  })
+
   it('GET /decisions lists audit log', async () => {
     const app = await buildApp(vi.fn())
     const { insertDecisionDraft, finalizeDecision } = await import('../../src/db.js')

--- a/packages/agent/tests/sentinel/sentinel-api.test.ts
+++ b/packages/agent/tests/sentinel/sentinel-api.test.ts
@@ -100,6 +100,15 @@ describe('sentinel REST endpoints', () => {
     expect(getActiveBlacklistEntry('bad')).not.toBeNull()
   })
 
+  it('POST /blacklist returns 400 + VALIDATION_FAILED envelope on missing fields', async () => {
+    const app = await buildApp(vi.fn())
+    const res = await request(app).post('/api/sentinel/blacklist').send({ address: 'only-address' })
+    expect(res.status).toBe(400)
+    expect(res.body).toStrictEqual({
+      error: { code: 'VALIDATION_FAILED', message: 'address, reason, severity required' },
+    })
+  })
+
   it('DELETE /blacklist/:id soft-removes entry', async () => {
     const app = await buildApp(vi.fn())
     const { insertBlacklist, getActiveBlacklistEntry } = await import('../../src/db.js')

--- a/packages/agent/tests/sentinel/sentinel-api.test.ts
+++ b/packages/agent/tests/sentinel/sentinel-api.test.ts
@@ -42,10 +42,42 @@ describe('sentinel REST endpoints', () => {
     expect(res.body).toMatchObject({ risk: 'low', recommendation: 'allow' })
   })
 
-  it('POST /assess returns 400 on missing required fields', async () => {
+  it('POST /assess returns 400 + VALIDATION_FAILED envelope on missing required fields', async () => {
     const app = await buildApp(vi.fn())
     const res = await request(app).post('/api/sentinel/assess').send({})
     expect(res.status).toBe(400)
+    expect(res.body).toStrictEqual({
+      error: { code: 'VALIDATION_FAILED', message: 'action and wallet are required strings' },
+    })
+  })
+
+  it('POST /assess returns 503 + UNAVAILABLE when assessor is not configured', async () => {
+    await freshDb()
+    const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
+    setSentinelAssessor(null)
+    const { sentinelPublicRouter } = await import('../../src/routes/sentinel-api.js')
+    const app = express()
+    app.use(express.json())
+    app.use('/api/sentinel', sentinelPublicRouter)
+    const res = await request(app).post('/api/sentinel/assess').send({
+      action: 'send', wallet: 'w1',
+    })
+    expect(res.status).toBe(503)
+    expect(res.body).toStrictEqual({
+      error: { code: 'UNAVAILABLE', message: 'SENTINEL assessor not configured' },
+    })
+  })
+
+  it('POST /assess returns 500 + INTERNAL envelope when assessor throws', async () => {
+    const assess = vi.fn().mockRejectedValue(new Error('boom'))
+    const app = await buildApp(assess as never)
+    const res = await request(app).post('/api/sentinel/assess').send({
+      action: 'send', wallet: 'w1',
+    })
+    expect(res.status).toBe(500)
+    expect(res.body).toStrictEqual({
+      error: { code: 'INTERNAL', message: 'boom' },
+    })
   })
 
   it('GET /blacklist returns active entries', async () => {

--- a/packages/agent/tests/sentinel/sentinel-errors.test.ts
+++ b/packages/agent/tests/sentinel/sentinel-errors.test.ts
@@ -1,0 +1,71 @@
+// packages/agent/tests/sentinel/sentinel-errors.test.ts
+import { describe, it, expect, vi } from 'vitest'
+import type { Response } from 'express'
+import { sendSentinelError } from '../../src/routes/sentinel-errors.js'
+
+function mockResponse() {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn(),
+  } as unknown as Response
+}
+
+function jsonCall(res: Response): unknown {
+  return (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0]
+}
+
+describe('sendSentinelError', () => {
+  it('VALIDATION_FAILED maps to status 400', () => {
+    const res = mockResponse()
+    sendSentinelError(res, 'VALIDATION_FAILED', 'bad input')
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(jsonCall(res)).toStrictEqual({
+      error: { code: 'VALIDATION_FAILED', message: 'bad input' },
+    })
+  })
+
+  it('NOT_FOUND maps to status 404', () => {
+    const res = mockResponse()
+    sendSentinelError(res, 'NOT_FOUND', 'missing')
+    expect(res.status).toHaveBeenCalledWith(404)
+    expect(jsonCall(res)).toStrictEqual({
+      error: { code: 'NOT_FOUND', message: 'missing' },
+    })
+  })
+
+  it('FORBIDDEN maps to status 403', () => {
+    const res = mockResponse()
+    sendSentinelError(res, 'FORBIDDEN', 'denied')
+    expect(res.status).toHaveBeenCalledWith(403)
+    expect(jsonCall(res)).toStrictEqual({
+      error: { code: 'FORBIDDEN', message: 'denied' },
+    })
+  })
+
+  it('UNAVAILABLE maps to status 503', () => {
+    const res = mockResponse()
+    sendSentinelError(res, 'UNAVAILABLE', 'not configured')
+    expect(res.status).toHaveBeenCalledWith(503)
+    expect(jsonCall(res)).toStrictEqual({
+      error: { code: 'UNAVAILABLE', message: 'not configured' },
+    })
+  })
+
+  it('INTERNAL maps to status 500', () => {
+    const res = mockResponse()
+    sendSentinelError(res, 'INTERNAL', 'crash')
+    expect(res.status).toHaveBeenCalledWith(500)
+    expect(jsonCall(res)).toStrictEqual({
+      error: { code: 'INTERNAL', message: 'crash' },
+    })
+  })
+
+  it('preserves message verbatim including special characters and newlines', () => {
+    const res = mockResponse()
+    const message = 'Error: "value" failed validation\nat line 42'
+    sendSentinelError(res, 'VALIDATION_FAILED', message)
+    expect(jsonCall(res)).toStrictEqual({
+      error: { code: 'VALIDATION_FAILED', message },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Standardize SENTINEL REST error responses on a single structured envelope `{error: {code, message}}` via a typed `sendSentinelError(res, code, message)` helper. Replaces 4 heterogeneous error shapes with one consistent contract across all 10 routes. Five-code taxonomy: `VALIDATION_FAILED | NOT_FOUND | FORBIDDEN | UNAVAILABLE | INTERNAL`.

Spec: [`docs/superpowers/specs/2026-05-04-sentinel-error-envelope-design.md`](docs/superpowers/specs/2026-05-04-sentinel-error-envelope-design.md)
Plan: [`docs/superpowers/plans/2026-05-04-sentinel-error-envelope.md`](docs/superpowers/plans/2026-05-04-sentinel-error-envelope.md)

Closes #158.

## Behavior change (one wire-contract change)

`POST /api/sentinel/pending/:id/cancel` now returns:
- `200 + {success: true}` on successful cancellation (unchanged)
- **`404 + {error: {code: 'NOT_FOUND', message: 'pending action not found or already resolved'}}`** when the ID does not exist or is already settled (was previously: `200 + {success: false}`)

No frontend caller relies on the previous `{success: false}` path, so blast radius is local. Documented inline in the route's response section.

## What's in this PR

- **New helper** (`packages/agent/src/routes/sentinel-errors.ts`): `SentinelErrorCode` union + `sendSentinelError` function. Centralizes the status-code-to-error-code mapping so it's impossible to send `400 + NOT_FOUND` mismatches.
- **Migrated 7 error sites** in `packages/agent/src/routes/sentinel-api.ts` (POST `/assess` ×3, POST `/blacklist`, POST `/pending/:id/cancel` (behavior change), POST `/override/:flagId`, POST `/cancel/:flagId`)
- **Updated JSDoc** on all 5 affected handlers with new `@returns ErrorEnvelope` shape and `@see docs/sentinel/rest-api.md#error-envelope` cross-link
- **Frontend wired up** (`app/src/components/SentinelConfirm.tsx`): now parses `error.message` from the envelope and surfaces it (instead of generic `Action failed (404)`). Falls back to status display on non-JSON bodies.
- **Surface docs updated** (`docs/sentinel/rest-api.md`): top-level Error Envelope section + 4 affected response examples + stale `[!NOTE]` callout removed + `Last verified` bumped to 2026-05-04
- **Auth middleware unchanged** — out of scope; the auth middleware's legacy `{error: 'string'}` shape is documented as a known wider concern, separate from this PR

## Test count delta

| Suite | Before | After | Delta |
|---|---:|---:|---:|
| Agent | 1290 / 103 suites | **1300 / 104 suites** | +10 / +1 |
| App | 45 / 12 suites | **46 / 12 suites** | +1 / +0 |
| `pause-resume-routes.test.ts` | (unchanged) | (unchanged) | — |

`pause-resume-routes.test.ts` was deliberately left untouched — it asserts `res.body.error.code === 'NOT_FOUND'` and serves as the regression guard proving the promise-gate refactor preserves the wire format.

## Test plan

- [ ] CI green (agent + app + typecheck)
- [ ] `pnpm --filter @sipher/agent test -- --run` shows 1300 passing
- [ ] `pnpm --filter @sipher/app test -- --run` shows 46 passing
- [ ] `pnpm typecheck` clean
- [ ] Manual smoke test: POST `/api/sentinel/assess` with empty body → expect `{error: {code: 'VALIDATION_FAILED', message: 'action and wallet are required strings'}}`
- [ ] Manual smoke test: POST `/api/sentinel/pending/<missing-id>/cancel` → expect `404 + {error: {code: 'NOT_FOUND', message: 'pending action not found or already resolved'}}`

## Follow-ups

- #157 — rename dual-cancel routes (this PR defines the contract that #157 will apply when renaming `/cancel/:flagId` → `/promise-gate/:flagId/reject` etc.)
- #159 — mirror SENTINEL docs to `docs.sip-protocol.org` (cross-repo; this PR's docs become the source of truth)

## Out of scope (explicitly deferred)

- Auth middleware envelope normalization (broader API concern)
- `details?` field on the envelope (non-breaking add later if a concrete consumer need arises)
- Additional error codes (`RATE_LIMITED`, `CONFLICT`) — YAGNI
- OpenAPI schema (until first SDK consumer)