### PR TITLE
refactor(sentinel): rename dual-cancel routes (#157)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,7 +484,7 @@ All return `ApiResponse<T>`: `{ success, data?, error? }`
 | POST | `/v1/sentinel/blacklist` | Add address to blacklist (admin) | Yes | — |
 | DELETE | `/v1/sentinel/blacklist/:address` | Remove address from blacklist (admin) | Yes | — |
 | GET | `/v1/sentinel/pending` | List pending cancellable actions | Yes | — |
-| POST | `/v1/sentinel/pending/:id/cancel` | Cancel a pending action | Yes | — |
+| POST | `/v1/sentinel/circuit-breaker/:id/cancel` | Cancel a pending action | Yes | — |
 | GET | `/v1/sentinel/decisions` | Recent SENTINEL risk decisions | Yes | — |
 | GET | `/v1/sentinel/status` | SENTINEL mode + health status | Yes | — |
 

--- a/app/src/components/SentinelConfirm.tsx
+++ b/app/src/components/SentinelConfirm.tsx
@@ -10,20 +10,20 @@ interface Props {
   action: string
   amount: string
   description?: string
-  onResolved: (decision: 'override' | 'cancel') => void
+  onResolved: (decision: 'resolve' | 'reject') => void
 }
 
 export default function SentinelConfirm({ flagId, token, action, amount, description, onResolved }: Props) {
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const dispatch = async (kind: 'override' | 'cancel') => {
+  const dispatch = async (verb: 'resolve' | 'reject') => {
     if (busy) return
     setBusy(true)
     setError(null)
     let success = false
     try {
-      const res = await fetch(`${API_URL}/api/sentinel/${kind}/${encodeURIComponent(flagId)}`, {
+      const res = await fetch(`${API_URL}/api/sentinel/promise-gate/${encodeURIComponent(flagId)}/${verb}`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
       })
@@ -42,7 +42,7 @@ export default function SentinelConfirm({ flagId, token, action, amount, descrip
     } finally {
       setBusy(false)
     }
-    if (success) onResolved(kind)
+    if (success) onResolved(verb)
   }
 
   return (
@@ -53,8 +53,8 @@ export default function SentinelConfirm({ flagId, token, action, amount, descrip
         amount={amount}
         description={description}
         disabled={busy}
-        onConfirm={() => dispatch('override')}
-        onCancel={() => dispatch('cancel')}
+        onConfirm={() => dispatch('resolve')}
+        onCancel={() => dispatch('reject')}
       />
       {error && <div className="text-[12px] text-red px-1">{error}</div>}
     </div>

--- a/app/src/components/__tests__/SentinelConfirm.test.tsx
+++ b/app/src/components/__tests__/SentinelConfirm.test.tsx
@@ -23,7 +23,7 @@ describe('SentinelConfirm', () => {
     expect(screen.getByRole('button', { name: /override & send/i })).toBeInTheDocument()
   })
 
-  it('POSTs to override endpoint on Override click', async () => {
+  it('POSTs to promise-gate resolve endpoint on Override click', async () => {
     const onResolved = vi.fn()
     render(
       <SentinelConfirm
@@ -37,13 +37,13 @@ describe('SentinelConfirm', () => {
     )
     await userEvent.click(screen.getByRole('button', { name: /override & send/i }))
     expect(global.fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/api/sentinel/override/abc'),
+      expect.stringContaining('/api/sentinel/promise-gate/abc/resolve'),
       expect.objectContaining({ method: 'POST' }),
     )
-    expect(onResolved).toHaveBeenCalledWith('override')
+    expect(onResolved).toHaveBeenCalledWith('resolve')
   })
 
-  it('POSTs to cancel endpoint on Cancel click', async () => {
+  it('POSTs to promise-gate reject endpoint on Cancel click', async () => {
     const onResolved = vi.fn()
     render(
       <SentinelConfirm
@@ -57,10 +57,10 @@ describe('SentinelConfirm', () => {
     )
     await userEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
     expect(global.fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/api/sentinel/cancel/abc'),
+      expect.stringContaining('/api/sentinel/promise-gate/abc/reject'),
       expect.objectContaining({ method: 'POST' }),
     )
-    expect(onResolved).toHaveBeenCalledWith('cancel')
+    expect(onResolved).toHaveBeenCalledWith('reject')
   })
 
   it('prevents double-dispatch when busy', async () => {

--- a/docs/sentinel/audit-log.md
+++ b/docs/sentinel/audit-log.md
@@ -69,7 +69,7 @@ CREATE INDEX IF NOT EXISTS idx_risk_history
 
 ### sentinel_pending_actions
 
-Circuit-breaker queue. Populated when an action is scheduled to fire after a cancellation window (see [`SENTINEL_CANCEL_WINDOW_MS`](./config.md#autonomy)). Cancel via [`POST /api/sentinel/pending/:id/cancel`](./rest-api.md#post-apisentinelpendingidcancel). The `status` column transitions through `pending` → `executed` or `cancelled`.
+Circuit-breaker queue. Populated when an action is scheduled to fire after a cancellation window (see [`SENTINEL_CANCEL_WINDOW_MS`](./config.md#autonomy)). Cancel via [`POST /api/sentinel/circuit-breaker/:id/cancel`](./rest-api.md#post-apisentinelcircuit-breakeridcancel). The `status` column transitions through `pending` → `executed` or `cancelled`.
 
 ```sql
 CREATE TABLE IF NOT EXISTS sentinel_pending_actions (

--- a/docs/sentinel/rest-api.md
+++ b/docs/sentinel/rest-api.md
@@ -5,14 +5,6 @@ All endpoints live under `/api/sentinel`. JWT-based auth via `Authorization: Bea
 - **Public** routes require `verifyJwt` only.
 - **Admin** routes require `verifyJwt + requireOwner` — wallet must appear in `AUTHORIZED_WALLETS` env var.
 
-> [!WARNING]
-> Two distinct cancel routes exist on the admin router and look nearly identical by name:
->
-> - `POST /api/sentinel/pending/:id/cancel` — cancels a circuit-breaker pending action (SQLite-backed, returns 200 + `{"success": true}` on success, 404 + `NOT_FOUND` envelope on missing)
-> - `POST /api/sentinel/cancel/:flagId` — rejects an in-memory promise-gate flag (returns 204 on success, 404 + `NOT_FOUND` envelope on missing)
->
-> They operate on different state stores. A rename is tracked in [follow-up issue #1](https://github.com/sip-protocol/sipher/issues/157).
-
 ## Error Envelope
 
 All SENTINEL routes that emit errors return a structured envelope:
@@ -307,7 +299,7 @@ curl -X DELETE http://localhost:5006/api/sentinel/blacklist/01KQP25BM8RVZJ92CTAN
 
 ---
 
-### POST /api/sentinel/pending/:id/cancel
+### POST /api/sentinel/circuit-breaker/:id/cancel
 
 **Auth:** `verifyJwt + requireOwner`
 
@@ -344,7 +336,7 @@ Returned when the action ID does not exist or is already settled. (Behavior chan
 **Example:**
 
 ```bash
-curl -X POST http://localhost:5006/api/sentinel/pending/01KQP25BM8RVZJ92CTANFDNTMG/cancel \
+curl -X POST http://localhost:5006/api/sentinel/circuit-breaker/01KQP25BM8RVZJ92CTANFDNTMG/cancel \
   -H "Authorization: Bearer $JWT" \
   -H "Content-Type: application/json" \
   -d '{ "reason": "admin override, action no longer needed" }'
@@ -385,7 +377,7 @@ curl -H "Authorization: Bearer $JWT" \
 
 ---
 
-### POST /api/sentinel/override/:flagId
+### POST /api/sentinel/promise-gate/:flagId/resolve
 
 **Auth:** `verifyJwt + requireOwner`
 
@@ -410,20 +402,17 @@ Returned when no in-memory flag exists for the given `flagId`. Flags expire when
 **Example:**
 
 ```bash
-curl -X POST http://localhost:5006/api/sentinel/override/flag_01KQP24PG0KZCJVWJDQM8H3JAY \
+curl -X POST http://localhost:5006/api/sentinel/promise-gate/flag_01KQP24PG0KZCJVWJDQM8H3JAY/resolve \
   -H "Authorization: Bearer $JWT"
 ```
 
 ---
 
-### POST /api/sentinel/cancel/:flagId
+### POST /api/sentinel/promise-gate/:flagId/reject
 
 **Auth:** `verifyJwt + requireOwner`
 
 **Description:** Reject a pending in-memory promise-gate flag — the admin denial path when SENTINEL is in `advisory` mode and has paused an action. Calls `rejectPending(flagId, 'cancelled_by_user')` in `packages/agent/src/sentinel/pending.ts`. The paused tool call receives a rejection and the agent aborts the action.
-
-> [!WARNING]
-> See the top-of-file warning about dual-cancel route ambiguity. This route operates on **in-memory promise-gate flags**. For cancelling SQLite-backed circuit-breaker actions, use `POST /api/sentinel/pending/:id/cancel`.
 
 **Path params:**
 
@@ -444,7 +433,7 @@ Returned when no in-memory flag exists for the given `flagId`.
 **Example:**
 
 ```bash
-curl -X POST http://localhost:5006/api/sentinel/cancel/flag_01KQP24PG0KZCJVWJDQM8H3JAY \
+curl -X POST http://localhost:5006/api/sentinel/promise-gate/flag_01KQP24PG0KZCJVWJDQM8H3JAY/reject \
   -H "Authorization: Bearer $JWT"
 ```
 

--- a/docs/superpowers/plans/2026-05-04-sentinel-route-rename.md
+++ b/docs/superpowers/plans/2026-05-04-sentinel-route-rename.md
@@ -1,0 +1,1086 @@
+# SENTINEL Dual-Cancel Route Rename Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename three SENTINEL admin routes so URL names announce which state store they touch, eliminating the dual-cancel ambiguity that PR #160 documented with a `WARNING` callout.
+
+**Architecture:** Pure URL rename, clean cut, single PR. Eight tasks, eight commits. Tasks 1-3 each pair a route handler change with its supertest update (TDD-friendly, every commit lands green). Task 4 `git mv`s the promise-gate test file. Task 5 updates internal JSDoc cross-links. Task 6 updates the lone frontend caller (`SentinelConfirm.tsx`). Tasks 7-8 sweep surface docs and CLAUDE.md.
+
+**Tech Stack:** TypeScript, Express 5 (routing), Vitest (unit), Supertest (HTTP), React 19 + Testing Library (frontend), pnpm + Turborepo workspace.
+
+**Spec:** `docs/superpowers/specs/2026-05-04-sentinel-route-rename-design.md`
+
+> **Note on line numbers:** Line numbers throughout this plan reference the pre-task baseline state of each file. As you commit Tasks 1-8 in order, line numbers in subsequent tasks may shift (e.g., Task 1 shrinks `sentinel-api.ts` by ~2 lines, so Task 2's "lines 172-189" land at roughly "lines 170-187" post-Task-1). Use the code blocks and surrounding context (function names, route paths, JSDoc text) as the source of truth — the line numbers are advisory only.
+
+---
+
+## Pre-Flight
+
+You are working on branch `refactor/sentinel-route-rename` (already created from `main` at commit `00e5933`; the spec was committed as `4207286`).
+
+Confirm before starting:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+# Expected: refactor/sentinel-route-rename
+
+git log --oneline -1
+# Expected: 4207286 docs(sentinel): design spec for dual-cancel route rename (#157)
+
+pnpm --filter @sipher/agent test -- --run 2>&1 | tail -5
+# Expected: Tests 1300 passed | Test Files 104 passed
+```
+
+If counts differ, stop and investigate — baseline drifted.
+
+---
+
+## Task 1: Rename `POST /pending/:id/cancel` → `POST /circuit-breaker/:id/cancel`
+
+**Files:**
+- Modify: `packages/agent/tests/sentinel/sentinel-api.test.ts:130-153`
+- Modify: `packages/agent/src/routes/sentinel-api.ts:131-153,168-170`
+
+**Goal of this task:** The circuit-breaker cancel route exposes new URL `/circuit-breaker/:id/cancel`. Old URL returns 404 (Express has no handler for it). Behavior, status codes, error envelope unchanged. Inline `// NOTE:` comment at lines 168-170 is deleted (it referenced the soon-to-be-renamed old URL).
+
+- [ ] **Step 1: Update the failing tests in `sentinel-api.test.ts`**
+
+In `packages/agent/tests/sentinel/sentinel-api.test.ts`, replace the two cancel-route tests (lines 130-153) with these new versions. Note: only `it(...)` text and URL strings change; assertions are identical.
+
+Replace lines 130-153 with:
+
+```ts
+  it('POST /circuit-breaker/:id/cancel cancels an action', async () => {
+    const app = await buildApp(vi.fn())
+    const cb = await import('../../src/sentinel/circuit-breaker.js')
+    const id = cb.scheduleCancellableAction({
+      actionType: 'refund', payload: {}, reasoning: 'r', wallet: 'w1', delayMs: 60000,
+    })
+    const res = await request(app).post(`/api/sentinel/circuit-breaker/${id}/cancel`).send({ reason: 'user cancelled' })
+    expect(res.status).toBe(200)
+    expect(res.body.success).toBe(true)
+    const { getPendingAction } = await import('../../src/db.js')
+    expect(getPendingAction(id)!.status).toBe('cancelled')
+    cb.clearAllTimers()
+  })
+
+  it('POST /circuit-breaker/:id/cancel returns 404 + NOT_FOUND when ID does not exist', async () => {
+    const app = await buildApp(vi.fn())
+    const res = await request(app).post('/api/sentinel/circuit-breaker/does-not-exist/cancel').send({
+      reason: 'attempted cancel',
+    })
+    expect(res.status).toBe(404)
+    expect(res.body).toStrictEqual({
+      error: { code: 'NOT_FOUND', message: 'pending action not found or already resolved' },
+    })
+  })
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+```bash
+pnpm --filter @sipher/agent test packages/agent/tests/sentinel/sentinel-api.test.ts -- --run 2>&1 | tail -20
+```
+
+Expected: both new tests FAIL with status 404 (no handler at new URL yet — Express returns default 404 with no envelope, so `res.body` won't match `{error:{code,message}}` either).
+
+- [ ] **Step 3: Update the route handler in `sentinel-api.ts`**
+
+In `packages/agent/src/routes/sentinel-api.ts`, replace the JSDoc + handler at lines 131-153 with:
+
+```ts
+/**
+ * Circuit-breaker cancel — mark a pending action cancelled in SQLite.
+ * Operates on the durable circuit-breaker queue (distinct from the in-memory promise-gate routes).
+ * @auth verifyJwt + requireOwner
+ * @param id pending action id
+ * @body { reason? string }
+ * @returns 200 { success: true } | 404 ErrorEnvelope
+ * @see docs/sentinel/rest-api.md#post-apisentinelcircuit-breakeridcancel
+ * @see docs/sentinel/rest-api.md#error-envelope
+ */
+sentinelAdminRouter.post('/circuit-breaker/:id/cancel', (req: Request, res: Response) => {
+  const reason = (req.body?.reason as string) ?? 'manual cancel'
+  const w = (req as unknown as Record<string, unknown>).wallet
+  const wallet = (typeof w === 'string' ? w : undefined)
+  const by = typeof wallet === 'string' ? `user:${wallet}` : 'admin'
+  const id = (typeof req.params.id === 'string' ? req.params.id : String(req.params.id))
+  const ok = cancelCircuitBreakerAction(id, by, reason)
+  if (!ok) {
+    sendSentinelError(res, 'NOT_FOUND', 'pending action not found or already resolved')
+    return
+  }
+  res.json({ success: true })
+})
+```
+
+Two diffs vs. existing code:
+- Route path: `/pending/:id/cancel` → `/circuit-breaker/:id/cancel`
+- JSDoc cross-references: removed two prose lines (`Circuit-breaker cancel — distinct from...`) since the new URL is self-explanatory; updated `@see` anchor; tightened opening line
+
+- [ ] **Step 4: Delete the inline NOTE comment at lines 168-170**
+
+In `packages/agent/src/routes/sentinel-api.ts`, the section header above the promise-gate handlers currently reads:
+
+```ts
+// ─── Promise-gate endpoints (pause/resume for advisory mode) ────────────────
+// NOTE: distinct from /pending/:id/cancel above (circuit-breaker, SQLite-backed).
+// These act on in-memory pending promises owned by sentinel/pending.ts.
+```
+
+Replace with:
+
+```ts
+// ─── Promise-gate endpoints (pause/resume for advisory mode) ────────────────
+// These act on in-memory pending promises owned by sentinel/pending.ts.
+```
+
+The middle line (`NOTE: distinct from /pending/:id/cancel...`) is dead weight after the rename — the URL namespaces (`circuit-breaker/*` vs `promise-gate/*`) make the distinction visible.
+
+- [ ] **Step 5: Run tests, verify they pass**
+
+```bash
+pnpm --filter @sipher/agent test packages/agent/tests/sentinel/sentinel-api.test.ts -- --run 2>&1 | tail -10
+```
+
+Expected: all `sentinel-api.test.ts` tests PASS.
+
+- [ ] **Step 6: Run typecheck**
+
+```bash
+pnpm typecheck 2>&1 | tail -5
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/agent/src/routes/sentinel-api.ts packages/agent/tests/sentinel/sentinel-api.test.ts
+git commit -m "refactor(sentinel): rename POST /pending/:id/cancel → /circuit-breaker/:id/cancel (#157)"
+```
+
+---
+
+## Task 2: Rename `POST /override/:flagId` → `POST /promise-gate/:flagId/resolve`
+
+**Files:**
+- Modify: `packages/agent/tests/sentinel/pause-resume-routes.test.ts:63-70,84-90,92-100,102-108`
+- Modify: `packages/agent/src/routes/sentinel-api.ts:172-189`
+
+**Goal of this task:** Promise-gate resolve route exposes new URL `/promise-gate/:flagId/resolve`. The pause-resume-routes test file's four `/override`-using tests are updated to the new URL. Note: this test file will be `git mv`d to `promise-gate-routes.test.ts` in Task 4 — for now, it stays at its current name.
+
+- [ ] **Step 1: Update the failing tests in `pause-resume-routes.test.ts`**
+
+In `packages/agent/tests/sentinel/pause-resume-routes.test.ts`, replace four occurrences of `/api/sentinel/override/` with `/api/sentinel/promise-gate/<flagId>/resolve` shape. The `it(...)` text on line 63 also changes.
+
+Replace line 63 (the `it(...)` opening line):
+
+Old:
+```ts
+  it('POST /api/sentinel/override/:flagId resolves the pending promise (204)', async () => {
+```
+
+New:
+```ts
+  it('POST /api/sentinel/promise-gate/:flagId/resolve resolves the pending promise (204)', async () => {
+```
+
+Replace line 66 URL:
+
+Old:
+```ts
+      .post(`/api/sentinel/override/${flagId}`)
+```
+
+New:
+```ts
+      .post(`/api/sentinel/promise-gate/${flagId}/resolve`)
+```
+
+Replace line 86 URL (404 test):
+
+Old:
+```ts
+      .post('/api/sentinel/override/does-not-exist')
+```
+
+New:
+```ts
+      .post('/api/sentinel/promise-gate/does-not-exist/resolve')
+```
+
+Replace line 97 URL (403 test):
+
+Old:
+```ts
+      .post(`/api/sentinel/override/${flagId}`)
+```
+
+New:
+```ts
+      .post(`/api/sentinel/promise-gate/${flagId}/resolve`)
+```
+
+Replace line 106 URL (401 test):
+
+Old:
+```ts
+    const res = await supertest(createApp()).post(`/api/sentinel/override/${flagId}`)
+```
+
+New:
+```ts
+    const res = await supertest(createApp()).post(`/api/sentinel/promise-gate/${flagId}/resolve`)
+```
+
+- [ ] **Step 2: Run tests, verify the four affected tests fail**
+
+```bash
+pnpm --filter @sipher/agent test packages/agent/tests/sentinel/pause-resume-routes.test.ts -- --run 2>&1 | tail -20
+```
+
+Expected: tests on lines 63-108 that hit the new URL FAIL with 404 (no handler yet). The cancel test at line 72 still passes because its URL is unchanged in this task.
+
+- [ ] **Step 3: Update the route handler in `sentinel-api.ts`**
+
+In `packages/agent/src/routes/sentinel-api.ts`, replace the JSDoc + handler at lines 172-189 with:
+
+```ts
+/**
+ * Promise-gate resolve — approve a paused advisory-mode action.
+ * Operates on the in-memory pending-promise registry owned by `sentinel/pending.ts`.
+ * @auth verifyJwt + requireOwner
+ * @param flagId in-memory promise flag id
+ * @returns 204 | 404 ErrorEnvelope
+ * @see docs/sentinel/rest-api.md#post-apisentinelpromise-gateflagidresolve
+ * @see docs/sentinel/rest-api.md#error-envelope
+ */
+sentinelAdminRouter.post('/promise-gate/:flagId/resolve', (req: Request, res: Response) => {
+  const flagId = String(req.params.flagId)
+  const ok = resolvePending(flagId)
+  if (!ok) {
+    sendSentinelError(res, 'NOT_FOUND', 'flag not found or expired')
+    return
+  }
+  res.status(204).send()
+})
+```
+
+Three diffs vs. existing code:
+- Route path: `/override/:flagId` → `/promise-gate/:flagId/resolve`
+- JSDoc cross-reference line (`Promise-gate resolve — see also \`/cancel/:flagId\` reject.`) removed (Task 3 will add a similar removal for the reject handler; the URL namespaces are self-explanatory now)
+- `@see` anchor updated to new heading
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+pnpm --filter @sipher/agent test packages/agent/tests/sentinel/pause-resume-routes.test.ts -- --run 2>&1 | tail -10
+```
+
+Expected: all 5 tests in this file PASS.
+
+- [ ] **Step 5: Run typecheck**
+
+```bash
+pnpm typecheck 2>&1 | tail -5
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/agent/src/routes/sentinel-api.ts packages/agent/tests/sentinel/pause-resume-routes.test.ts
+git commit -m "refactor(sentinel): rename POST /override/:flagId → /promise-gate/:flagId/resolve (#157)"
+```
+
+---
+
+## Task 3: Rename `POST /cancel/:flagId` → `POST /promise-gate/:flagId/reject`
+
+**Files:**
+- Modify: `packages/agent/tests/sentinel/pause-resume-routes.test.ts:72-82`
+- Modify: `packages/agent/src/routes/sentinel-api.ts:191-208`
+
+**Goal of this task:** Promise-gate reject route exposes new URL `/promise-gate/:flagId/reject`. Only the one cancel test in this file updates URLs (the override-related tests in Task 2 already moved).
+
+- [ ] **Step 1: Update the failing test in `pause-resume-routes.test.ts`**
+
+In `packages/agent/tests/sentinel/pause-resume-routes.test.ts`, replace lines 72-82 (the cancel/reject test) with:
+
+```ts
+  it('POST /api/sentinel/promise-gate/:flagId/reject rejects the pending promise (204)', async () => {
+    const { flagId, promise } = createPending('test-session', 'send', { amount: 1 })
+    // attach noop catch before the HTTP call so Node doesn't flag the rejection as unhandled
+    // before our .rejects assertion consumes it
+    promise.catch(() => {})
+    const res = await supertest(createApp())
+      .post(`/api/sentinel/promise-gate/${flagId}/reject`)
+      .set('Authorization', `Bearer ${signJwt(ADMIN_WALLET)}`)
+    expect(res.status).toBe(204)
+    await expect(promise).rejects.toThrow(/cancelled/i)
+  })
+```
+
+Two diffs:
+- `it(...)` text URL: `/api/sentinel/cancel/:flagId` → `/api/sentinel/promise-gate/:flagId/reject`
+- Supertest URL: `/api/sentinel/cancel/${flagId}` → `/api/sentinel/promise-gate/${flagId}/reject`
+
+- [ ] **Step 2: Run test, verify it fails**
+
+```bash
+pnpm --filter @sipher/agent test packages/agent/tests/sentinel/pause-resume-routes.test.ts -- --run 2>&1 | tail -15
+```
+
+Expected: the reject test FAILS with 404 (no handler yet).
+
+- [ ] **Step 3: Update the route handler in `sentinel-api.ts`**
+
+In `packages/agent/src/routes/sentinel-api.ts`, replace the JSDoc + handler at lines 191-208 with:
+
+```ts
+/**
+ * Promise-gate reject — deny a paused advisory-mode action.
+ * Operates on the in-memory pending-promise registry owned by `sentinel/pending.ts`.
+ * @auth verifyJwt + requireOwner
+ * @param flagId in-memory promise flag id
+ * @returns 204 | 404 ErrorEnvelope
+ * @see docs/sentinel/rest-api.md#post-apisentinelpromise-gateflagidreject
+ * @see docs/sentinel/rest-api.md#error-envelope
+ */
+sentinelAdminRouter.post('/promise-gate/:flagId/reject', (req: Request, res: Response) => {
+  const flagId = String(req.params.flagId)
+  const ok = rejectPending(flagId, 'cancelled_by_user')
+  if (!ok) {
+    sendSentinelError(res, 'NOT_FOUND', 'flag not found or expired')
+    return
+  }
+  res.status(204).send()
+})
+```
+
+Three diffs vs. existing code:
+- Route path: `/cancel/:flagId` → `/promise-gate/:flagId/reject`
+- JSDoc cross-reference line (`Promise-gate reject — distinct from the circuit-breaker \`/pending/:id/cancel\`.`) removed
+- `@see` anchor updated to new heading
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+```bash
+pnpm --filter @sipher/agent test packages/agent/tests/sentinel/pause-resume-routes.test.ts -- --run 2>&1 | tail -10
+```
+
+Expected: all 5 tests PASS.
+
+- [ ] **Step 5: Run typecheck**
+
+```bash
+pnpm typecheck 2>&1 | tail -5
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/agent/src/routes/sentinel-api.ts packages/agent/tests/sentinel/pause-resume-routes.test.ts
+git commit -m "refactor(sentinel): rename POST /cancel/:flagId → /promise-gate/:flagId/reject (#157)"
+```
+
+---
+
+## Task 4: `git mv` test file → `promise-gate-routes.test.ts`
+
+**Files:**
+- Rename: `packages/agent/tests/sentinel/pause-resume-routes.test.ts` → `packages/agent/tests/sentinel/promise-gate-routes.test.ts`
+- Modify (1 line): the `describe(...)` block inside
+
+**Goal of this task:** File name now matches the route namespace it exercises (`promise-gate`). All URL strings inside have already moved (Tasks 2 & 3) so this is a clean rename plus a 1-line `describe` text update. Git rename detection should report 100% similarity.
+
+- [ ] **Step 1: Run `git mv`**
+
+```bash
+git mv packages/agent/tests/sentinel/pause-resume-routes.test.ts packages/agent/tests/sentinel/promise-gate-routes.test.ts
+```
+
+- [ ] **Step 2: Update the `describe` block**
+
+In `packages/agent/tests/sentinel/promise-gate-routes.test.ts` line 62, replace:
+
+Old:
+```ts
+describe('SENTINEL pause/resume routes', () => {
+```
+
+New:
+```ts
+describe('SENTINEL promise-gate routes', () => {
+```
+
+- [ ] **Step 3: Run the renamed test file to confirm it still works**
+
+```bash
+pnpm --filter @sipher/agent test packages/agent/tests/sentinel/promise-gate-routes.test.ts -- --run 2>&1 | tail -10
+```
+
+Expected: all 5 tests PASS, suite name reads `SENTINEL promise-gate routes`.
+
+- [ ] **Step 4: Run typecheck**
+
+```bash
+pnpm typecheck 2>&1 | tail -5
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/agent/tests/sentinel/promise-gate-routes.test.ts
+git commit -m "test(sentinel): rename pause-resume-routes.test.ts → promise-gate-routes.test.ts (#157)"
+```
+
+After committing, verify rename detection:
+
+```bash
+git log -1 --stat --diff-filter=R 2>&1 | head -5
+# Expected: a `R100` (100% rename) entry, not separate add+delete
+```
+
+If the diff shows below 100% similarity, that's still acceptable — the only content change was the `describe` line. Do not split this commit.
+
+---
+
+## Task 5: Update internal JSDoc cross-links in `pending.ts` and `agent.ts`
+
+**Files:**
+- Modify: `packages/agent/src/sentinel/pending.ts:42,76,80,93,98`
+- Modify: `packages/agent/src/agent.ts:240,360-361`
+
+**Goal of this task:** Source-of-truth JSDoc inside the modules that own promise-gate state now references the new URLs and anchors. Documentation only — no behavioral change, no test required (typecheck verifies the comments don't break parser; the `@see` anchors will be visually validated when rest-api.md is rendered in Task 7).
+
+- [ ] **Step 1: Update `pending.ts` line 42 (createPending JSDoc `@see`)**
+
+In `packages/agent/src/sentinel/pending.ts`, replace line 42:
+
+Old:
+```ts
+ * @see docs/sentinel/rest-api.md#post-apisentineloverrideflagid
+```
+
+New:
+```ts
+ * @see docs/sentinel/rest-api.md#post-apisentinelpromise-gateflagidresolve
+```
+
+- [ ] **Step 2: Update `pending.ts` lines 75-80 (resolvePending JSDoc)**
+
+In `packages/agent/src/sentinel/pending.ts`, replace lines 74-81 (the `resolvePending` JSDoc block + signature line):
+
+Old:
+```ts
+/**
+ * Resolve a pending flag — admin override path.
+ * Mapped to `POST /api/sentinel/override/:flagId`.
+ * Clears the auto-timeout, removes the flag from the Map, and calls the promise resolver.
+ * @param flagId - flag identifier returned by `createPending`
+ * @returns `true` if the flag existed and was resolved; `false` if not found or already settled.
+ * @see docs/sentinel/rest-api.md#post-apisentineloverrideflagid
+ */
+```
+
+New:
+```ts
+/**
+ * Resolve a pending flag — admin approval path.
+ * Mapped to `POST /api/sentinel/promise-gate/:flagId/resolve`.
+ * Clears the auto-timeout, removes the flag from the Map, and calls the promise resolver.
+ * @param flagId - flag identifier returned by `createPending`
+ * @returns `true` if the flag existed and was resolved; `false` if not found or already settled.
+ * @see docs/sentinel/rest-api.md#post-apisentinelpromise-gateflagidresolve
+ */
+```
+
+Two diffs:
+- Prose: `admin override path` → `admin approval path` (clearer with the new URL verb)
+- Prose: `POST /api/sentinel/override/:flagId` → `POST /api/sentinel/promise-gate/:flagId/resolve`
+- `@see` anchor updated
+
+- [ ] **Step 3: Update `pending.ts` lines 91-98 (rejectPending JSDoc)**
+
+In `packages/agent/src/sentinel/pending.ts`, replace lines 91-99 (the `rejectPending` JSDoc block):
+
+Old:
+```ts
+/**
+ * Reject a pending flag — admin cancel path.
+ * Mapped to `POST /api/sentinel/cancel/:flagId`.
+ * Clears the auto-timeout, removes the flag from the Map, and rejects the promise with `reason`.
+ * @param flagId - flag identifier returned by `createPending`
+ * @param reason - rejection reason string (e.g. `'cancelled_by_user'`), wrapped in an Error
+ * @returns `true` if the flag existed and was rejected; `false` if not found or already settled.
+ * @see docs/sentinel/rest-api.md#post-apisentinelcancelflagid
+ */
+```
+
+New:
+```ts
+/**
+ * Reject a pending flag — admin denial path.
+ * Mapped to `POST /api/sentinel/promise-gate/:flagId/reject`.
+ * Clears the auto-timeout, removes the flag from the Map, and rejects the promise with `reason`.
+ * @param flagId - flag identifier returned by `createPending`
+ * @param reason - rejection reason string (e.g. `'cancelled_by_user'`), wrapped in an Error
+ * @returns `true` if the flag existed and was rejected; `false` if not found or already settled.
+ * @see docs/sentinel/rest-api.md#post-apisentinelpromise-gateflagidreject
+ */
+```
+
+Three diffs:
+- Prose: `admin cancel path` → `admin denial path` (clearer with the new URL verb)
+- Prose: `POST /api/sentinel/cancel/:flagId` → `POST /api/sentinel/promise-gate/:flagId/reject`
+- `@see` anchor updated
+
+- [ ] **Step 4: Update `agent.ts` line 240 (SSESentinelPause comment)**
+
+In `packages/agent/src/agent.ts`, replace line 240:
+
+Old:
+```ts
+  /** Server-issued ID — client posts to /api/sentinel/override/:flagId or /cancel/:flagId */
+```
+
+New:
+```ts
+  /** Server-issued ID — client posts to /api/sentinel/promise-gate/:flagId/resolve or /reject */
+```
+
+- [ ] **Step 5: Update `agent.ts` lines 360-361 (architecture comment)**
+
+In `packages/agent/src/agent.ts`, replace lines 360-361:
+
+Old:
+```ts
+ * until the user POSTs to `/api/sentinel/override/:flagId` (resume) or
+ * `/cancel/:flagId` (cancel). Cancellation is surfaced as a synthetic
+```
+
+New:
+```ts
+ * until the user POSTs to `/api/sentinel/promise-gate/:flagId/resolve` (resume) or
+ * `/promise-gate/:flagId/reject` (cancel). Cancellation is surfaced as a synthetic
+```
+
+- [ ] **Step 6: Run typecheck**
+
+```bash
+pnpm typecheck 2>&1 | tail -5
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Run agent test suite to confirm nothing accidentally broke**
+
+```bash
+pnpm --filter @sipher/agent test -- --run 2>&1 | tail -5
+```
+
+Expected: 1300 tests / 104 suites pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/agent/src/sentinel/pending.ts packages/agent/src/agent.ts
+git commit -m "docs(sentinel): update internal JSDoc for renamed routes (#157)"
+```
+
+---
+
+## Task 6: Frontend caller — `SentinelConfirm.tsx` + test
+
+**Files:**
+- Modify: `app/src/components/SentinelConfirm.tsx:13,20,26,45,56-57`
+- Modify: `app/src/components/__tests__/SentinelConfirm.test.tsx:38-43,58-63`
+
+**Goal of this task:** The lone consumer of the renamed routes uses the new URL template. Internal vocabulary moves from `kind: 'override' | 'cancel'` to `verb: 'resolve' | 'reject'` to match the new URL verb segment. The public `onResolved` callback signature changes from `(decision: 'override' | 'cancel') => void` to `(decision: 'resolve' | 'reject') => void`. The lone parent (`ChatSidebar.tsx:164`) ignores the decision arg, so this rename is invisible to callers. Button copy ("Override & Send", "Cancel") stays unchanged — that's user-facing UX.
+
+- [ ] **Step 1: Update the failing assertions in `SentinelConfirm.test.tsx`**
+
+In `app/src/components/__tests__/SentinelConfirm.test.tsx`, replace lines 38-43 (the override test fetch + onResolved assertions):
+
+Old:
+```tsx
+    await userEvent.click(screen.getByRole('button', { name: /override & send/i }))
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/sentinel/override/abc'),
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(onResolved).toHaveBeenCalledWith('override')
+```
+
+New:
+```tsx
+    await userEvent.click(screen.getByRole('button', { name: /override & send/i }))
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/sentinel/promise-gate/abc/resolve'),
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(onResolved).toHaveBeenCalledWith('resolve')
+```
+
+Replace lines 58-63 (the cancel test fetch + onResolved assertions):
+
+Old:
+```tsx
+    await userEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/sentinel/cancel/abc'),
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(onResolved).toHaveBeenCalledWith('cancel')
+```
+
+New:
+```tsx
+    await userEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/sentinel/promise-gate/abc/reject'),
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(onResolved).toHaveBeenCalledWith('reject')
+```
+
+Also update the `it(...)` text on lines 26 and 46 to match the new vocabulary:
+
+Line 26 — old:
+```tsx
+  it('POSTs to override endpoint on Override click', async () => {
+```
+
+Line 26 — new:
+```tsx
+  it('POSTs to promise-gate resolve endpoint on Override click', async () => {
+```
+
+Line 46 — old:
+```tsx
+  it('POSTs to cancel endpoint on Cancel click', async () => {
+```
+
+Line 46 — new:
+```tsx
+  it('POSTs to promise-gate reject endpoint on Cancel click', async () => {
+```
+
+- [ ] **Step 2: Run app tests, verify the four affected assertions fail**
+
+```bash
+pnpm --filter @sipher/app test app/src/components/__tests__/SentinelConfirm.test.tsx -- --run 2>&1 | tail -20
+```
+
+Expected: 4 of the 6 tests FAIL — the two URL-shape assertions and the two `onResolved` arg assertions. The other 4 tests (render, double-dispatch, envelope error display, fallback) should still pass.
+
+- [ ] **Step 3: Update `SentinelConfirm.tsx`**
+
+Replace the entire file (`app/src/components/SentinelConfirm.tsx`) with:
+
+```tsx
+import { useState } from 'react'
+import ConfirmCard from './ConfirmCard'
+
+const API_URL = import.meta.env.VITE_API_URL ?? ''
+
+interface Props {
+  flagId: string
+  /** Owner JWT — endpoints require requireOwner middleware on the server. */
+  token: string
+  action: string
+  amount: string
+  description?: string
+  onResolved: (decision: 'resolve' | 'reject') => void
+}
+
+export default function SentinelConfirm({ flagId, token, action, amount, description, onResolved }: Props) {
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const dispatch = async (verb: 'resolve' | 'reject') => {
+    if (busy) return
+    setBusy(true)
+    setError(null)
+    let success = false
+    try {
+      const res = await fetch(`${API_URL}/api/sentinel/promise-gate/${encodeURIComponent(flagId)}/${verb}`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) {
+        let message = `Action failed (${res.status})`
+        try {
+          const body = await res.json()
+          if (body?.error?.message) message = String(body.error.message)
+        } catch { /* fall back to status */ }
+        setError(message)
+        return
+      }
+      success = true
+    } catch {
+      setError('Network error — try again')
+    } finally {
+      setBusy(false)
+    }
+    if (success) onResolved(verb)
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <ConfirmCard
+        variant="warning"
+        action={action}
+        amount={amount}
+        description={description}
+        disabled={busy}
+        onConfirm={() => dispatch('resolve')}
+        onCancel={() => dispatch('reject')}
+      />
+      {error && <div className="text-[12px] text-red px-1">{error}</div>}
+    </div>
+  )
+}
+```
+
+Five vocabulary-only diffs vs. existing code:
+- `Props.onResolved` type union: `'override' | 'cancel'` → `'resolve' | 'reject'`
+- `dispatch` arg name: `kind` → `verb`
+- `dispatch` arg type: `'override' | 'cancel'` → `'resolve' | 'reject'`
+- Fetch URL template: `/api/sentinel/${kind}/${encodeURIComponent(flagId)}` → `/api/sentinel/promise-gate/${encodeURIComponent(flagId)}/${verb}`
+- Button handlers: `dispatch('override')` → `dispatch('resolve')`, `dispatch('cancel')` → `dispatch('reject')`
+
+- [ ] **Step 4: Run app tests, verify all pass**
+
+```bash
+pnpm --filter @sipher/app test app/src/components/__tests__/SentinelConfirm.test.tsx -- --run 2>&1 | tail -10
+```
+
+Expected: all 6 tests PASS.
+
+- [ ] **Step 5: Run typecheck**
+
+```bash
+pnpm typecheck 2>&1 | tail -10
+```
+
+Expected: no errors. The `ChatSidebar.tsx:164` caller passes an arrow function that ignores the decision arg (`onResolved={() => dismissMessage(msg.id)}`), so the type union change is invisible there.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/components/SentinelConfirm.tsx app/src/components/__tests__/SentinelConfirm.test.tsx
+git commit -m "refactor(app): SentinelConfirm uses promise-gate route shape (#157)"
+```
+
+---
+
+## Task 7: Surface docs — `docs/sentinel/rest-api.md`
+
+**Files:**
+- Modify: `docs/sentinel/rest-api.md:8-14,310-352,388-415,419-449`
+
+**Goal of this task:** Surface docs reflect the new routes. Delete the dual-cancel `WARNING` (top of file). Rename three section headings + their curl examples. Delete the second WARNING block inside the cancel section (now obsolete). The `Last verified: 2026-05-04` footer is already today's date and stays.
+
+- [ ] **Step 1: Delete the top-of-file WARNING block**
+
+In `docs/sentinel/rest-api.md`, delete lines 8-14:
+
+```markdown
+> [!WARNING]
+> Two distinct cancel routes exist on the admin router and look nearly identical by name:
+>
+> - `POST /api/sentinel/pending/:id/cancel` — cancels a circuit-breaker pending action (SQLite-backed, returns 200 + `{"success": true}` on success, 404 + `NOT_FOUND` envelope on missing)
+> - `POST /api/sentinel/cancel/:flagId` — rejects an in-memory promise-gate flag (returns 204 on success, 404 + `NOT_FOUND` envelope on missing)
+>
+> They operate on different state stores. A rename is tracked in [follow-up issue #1](https://github.com/sip-protocol/sipher/issues/157).
+```
+
+The result: line 7 (the public/admin route description bullets) is followed directly by line 16 (`## Error Envelope` heading). Verify there is exactly one blank line between them.
+
+- [ ] **Step 2: Rename `### POST /api/sentinel/pending/:id/cancel` section heading + curl**
+
+In `docs/sentinel/rest-api.md`, replace line 310:
+
+Old:
+```markdown
+### POST /api/sentinel/pending/:id/cancel
+```
+
+New:
+```markdown
+### POST /api/sentinel/circuit-breaker/:id/cancel
+```
+
+Replace line 347 (curl in this section):
+
+Old:
+```bash
+curl -X POST http://localhost:5006/api/sentinel/pending/01KQP25BM8RVZJ92CTANFDNTMG/cancel \
+```
+
+New:
+```bash
+curl -X POST http://localhost:5006/api/sentinel/circuit-breaker/01KQP25BM8RVZJ92CTANFDNTMG/cancel \
+```
+
+Leave everything else in this section unchanged — including the existing 200/404 documentation and the parenthetical `(Behavior changed in this PR — previously this path returned \`200 + {success: false}\`.)` note on line 342, which describes the #158 behavior change and remains accurate.
+
+- [ ] **Step 3: Rename `### POST /api/sentinel/override/:flagId` section heading + curl**
+
+In `docs/sentinel/rest-api.md`, replace line 388:
+
+Old:
+```markdown
+### POST /api/sentinel/override/:flagId
+```
+
+New:
+```markdown
+### POST /api/sentinel/promise-gate/:flagId/resolve
+```
+
+Replace line 413 (curl):
+
+Old:
+```bash
+curl -X POST http://localhost:5006/api/sentinel/override/flag_01KQP24PG0KZCJVWJDQM8H3JAY \
+```
+
+New:
+```bash
+curl -X POST http://localhost:5006/api/sentinel/promise-gate/flag_01KQP24PG0KZCJVWJDQM8H3JAY/resolve \
+```
+
+- [ ] **Step 4: Rename `### POST /api/sentinel/cancel/:flagId` section heading + curl + delete inner WARNING block**
+
+In `docs/sentinel/rest-api.md`, replace line 419:
+
+Old:
+```markdown
+### POST /api/sentinel/cancel/:flagId
+```
+
+New:
+```markdown
+### POST /api/sentinel/promise-gate/:flagId/reject
+```
+
+Delete lines 425-426 (the inner WARNING block, now obsolete):
+
+```markdown
+> [!WARNING]
+> See the top-of-file warning about dual-cancel route ambiguity. This route operates on **in-memory promise-gate flags**. For cancelling SQLite-backed circuit-breaker actions, use `POST /api/sentinel/pending/:id/cancel`.
+```
+
+After deletion, the **Description** paragraph (line 423) should be followed directly by the **Path params:** heading (was line 428). Verify there is exactly one blank line between them.
+
+Replace line 447 (curl):
+
+Old:
+```bash
+curl -X POST http://localhost:5006/api/sentinel/cancel/flag_01KQP24PG0KZCJVWJDQM8H3JAY \
+```
+
+New:
+```bash
+curl -X POST http://localhost:5006/api/sentinel/promise-gate/flag_01KQP24PG0KZCJVWJDQM8H3JAY/reject \
+```
+
+- [ ] **Step 5: Verify the doc renders cleanly**
+
+```bash
+grep -n "^### POST" docs/sentinel/rest-api.md
+# Expected: lines for /assess, /blacklist, /circuit-breaker/:id/cancel, /promise-gate/:flagId/resolve, /promise-gate/:flagId/reject
+# Should NOT see: /pending/:id/cancel, /override/:flagId, /cancel/:flagId
+
+grep -c "WARNING" docs/sentinel/rest-api.md
+# Expected: 0
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/sentinel/rest-api.md
+git commit -m "docs(sentinel): rename routes in rest-api.md + remove dual-cancel WARNING (#157)"
+```
+
+---
+
+## Task 8: Cross-doc cleanup — `audit-log.md` + `CLAUDE.md`
+
+**Files:**
+- Modify: `docs/sentinel/audit-log.md:72`
+- Modify: `CLAUDE.md:487`
+
+**Goal of this task:** Mop up the two remaining stale references in adjacent docs. Both are single-line edits.
+
+- [ ] **Step 1: Update `docs/sentinel/audit-log.md` line 72**
+
+In `docs/sentinel/audit-log.md`, replace line 72:
+
+Old:
+```markdown
+Circuit-breaker queue. Populated when an action is scheduled to fire after a cancellation window (see [`SENTINEL_CANCEL_WINDOW_MS`](./config.md#autonomy)). Cancel via [`POST /api/sentinel/pending/:id/cancel`](./rest-api.md#post-apisentinelpendingidcancel). The `status` column transitions through `pending` → `executed` or `cancelled`.
+```
+
+New:
+```markdown
+Circuit-breaker queue. Populated when an action is scheduled to fire after a cancellation window (see [`SENTINEL_CANCEL_WINDOW_MS`](./config.md#autonomy)). Cancel via [`POST /api/sentinel/circuit-breaker/:id/cancel`](./rest-api.md#post-apisentinelcircuit-breakeridcancel). The `status` column transitions through `pending` → `executed` or `cancelled`.
+```
+
+Two changes on the same line:
+- Visible link text URL: `/api/sentinel/pending/:id/cancel` → `/api/sentinel/circuit-breaker/:id/cancel`
+- Anchor target: `#post-apisentinelpendingidcancel` → `#post-apisentinelcircuit-breakeridcancel`
+
+- [ ] **Step 2: Update `CLAUDE.md` line 487**
+
+In `CLAUDE.md`, replace line 487:
+
+Old:
+```markdown
+| POST | `/v1/sentinel/pending/:id/cancel` | Cancel a pending action | Yes | — |
+```
+
+New:
+```markdown
+| POST | `/v1/sentinel/circuit-breaker/:id/cancel` | Cancel a pending action | Yes | — |
+```
+
+Path segment update only. The `/v1/` prefix is a pre-existing inconsistency with the actual code path `/api/`, but auditing the prefix is out of scope (every other entry in this table uses `/v1/` too).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/sentinel/audit-log.md CLAUDE.md
+git commit -m "docs(sentinel): update audit-log + CLAUDE.md route references (#157)"
+```
+
+---
+
+## Final Verification
+
+Before pushing the branch and opening a PR, run the full verification sweep.
+
+- [ ] **Step 1: Full agent test suite**
+
+```bash
+pnpm --filter @sipher/agent test -- --run 2>&1 | tail -5
+```
+
+Expected: `Tests 1300 passed | Test Files 104 passed`. Counts unchanged from baseline (rename, not behavior change).
+
+- [ ] **Step 2: Full app test suite**
+
+```bash
+pnpm --filter @sipher/app test -- --run 2>&1 | tail -5
+```
+
+Expected: `Tests 46 passed | Test Files 12 passed`.
+
+- [ ] **Step 3: Workspace typecheck**
+
+```bash
+pnpm typecheck 2>&1 | tail -5
+```
+
+Expected: no errors anywhere in the workspace.
+
+- [ ] **Step 4: Stale-reference grep**
+
+```bash
+grep -rn "pending/:id/cancel\|cancel/:flagId\|override/:flagId\|/api/sentinel/pending/[^\"]*cancel\|/api/sentinel/cancel/\|/api/sentinel/override/\|sentinelpendingidcancel\|sentinelcancelflagid\|sentineloverrideflagid" \
+  --include="*.ts" --include="*.tsx" --include="*.md" \
+  --exclude-dir=docs/superpowers --exclude-dir=node_modules .
+```
+
+Expected: zero hits. The `--exclude-dir=docs/superpowers` flag excludes historical specs and plans (which describe the world at the time written and should not be edited).
+
+If any hits surface, address them before pushing — they indicate either (a) a missed call site or (b) a doc that needs updating, and either way the rename is incomplete.
+
+- [ ] **Step 5: Render `rest-api.md` in GitHub preview**
+
+After pushing the branch, open `docs/sentinel/rest-api.md` on the GitHub UI for this branch and click each TOC entry / each `@see` anchor target:
+
+- `#post-apisentinelcircuit-breakeridcancel`
+- `#post-apisentinelpromise-gateflagidresolve`
+- `#post-apisentinelpromise-gateflagidreject`
+
+If any anchor fails to scroll to its heading, GitHub generated a different anchor than expected — record what GitHub generated, update the JSDoc `@see` references in `pending.ts` and `agent.ts` (and `audit-log.md` line 72) to match, and commit as a fix-up.
+
+- [ ] **Step 6: Final whole-branch review**
+
+Dispatch a code-quality review subagent with the full branch diff. Same pattern as #158 — the per-task review pass caught zero issues until the final whole-branch sweep, which found a stale WARNING line. This PR has more cross-cutting doc surface (3 source JSDoc files, 2 doc files, CLAUDE.md), so the final review is essential. Brief the reviewer: "Verify no stale URL references remain, all `@see` anchors point to existing headings, behavior is unchanged."
+
+- [ ] **Step 7: Push and open PR**
+
+```bash
+git push -u origin refactor/sentinel-route-rename
+gh pr create --title "refactor(sentinel): rename dual-cancel routes (#157)" --body "$(cat <<'EOF'
+## Summary
+
+- Rename three SENTINEL admin routes so URL names announce which state store they touch (closes #157)
+- Delete the dual-cancel `WARNING` block in `docs/sentinel/rest-api.md` — the URL namespaces (`circuit-breaker/*` vs `promise-gate/*`) make the architectural distinction self-documenting
+- `git mv` `pause-resume-routes.test.ts` → `promise-gate-routes.test.ts` to match the route namespace it exercises
+
+## Route map
+
+| Old | New |
+|---|---|
+| `POST /api/sentinel/pending/:id/cancel` | `POST /api/sentinel/circuit-breaker/:id/cancel` |
+| `POST /api/sentinel/override/:flagId` | `POST /api/sentinel/promise-gate/:flagId/resolve` |
+| `POST /api/sentinel/cancel/:flagId` | `POST /api/sentinel/promise-gate/:flagId/reject` |
+
+Clean cut migration — no compatibility layer (same precedent as #158/PR #167). Behavior, status codes, error envelope, auth requirements all preserved. Frontend caller `SentinelConfirm.tsx` updated in the same PR.
+
+## Test plan
+
+- [x] `pnpm --filter @sipher/agent test -- --run` — 1300/104 passing (unchanged)
+- [x] `pnpm --filter @sipher/app test -- --run` — 46/12 passing (unchanged)
+- [x] `pnpm typecheck` — clean
+- [x] Stale-reference grep returns zero hits across `*.ts`, `*.tsx`, `*.md` (excluding historical specs/plans)
+- [x] Final whole-branch review (subagent dispatch) — no remaining drift
+EOF
+)"
+```
+
+---
+
+## Test Count Summary
+
+| Suite | Before | After | Delta |
+|---|---|---|---|
+| Agent (`@sipher/agent`) tests | 1300 | 1300 | 0 |
+| Agent suites | 104 | 104 | 0 |
+| App (`@sipher/app`) tests | 46 | 46 | 0 |
+| App suites | 12 | 12 | 0 |
+
+No new tests added. No tests removed. URL string changes only. CLAUDE.md test-count line stays at 1300/104.
+
+---
+
+## Files-Touched Summary
+
+| Path | Type | Touched in task |
+|---|---|---|
+| `packages/agent/src/routes/sentinel-api.ts` | Modify | 1, 2, 3 |
+| `packages/agent/src/sentinel/pending.ts` | Modify | 5 |
+| `packages/agent/src/agent.ts` | Modify | 5 |
+| `packages/agent/tests/sentinel/sentinel-api.test.ts` | Modify | 1 |
+| `packages/agent/tests/sentinel/pause-resume-routes.test.ts` | Rename → `promise-gate-routes.test.ts` | 2, 3, 4 |
+| `app/src/components/SentinelConfirm.tsx` | Modify | 6 |
+| `app/src/components/__tests__/SentinelConfirm.test.tsx` | Modify | 6 |
+| `docs/sentinel/rest-api.md` | Modify | 7 |
+| `docs/sentinel/audit-log.md` | Modify | 8 |
+| `CLAUDE.md` | Modify | 8 |
+| `docs/superpowers/specs/2026-05-04-sentinel-route-rename-design.md` | Created on branch | (pre-existing in `4207286`) |
+| `docs/superpowers/plans/2026-05-04-sentinel-route-rename.md` | This file | (committed alongside the spec or separately) |
+
+10 source/doc files modified + 1 file renamed + 2 spec/plan docs.

--- a/docs/superpowers/specs/2026-05-04-sentinel-route-rename-design.md
+++ b/docs/superpowers/specs/2026-05-04-sentinel-route-rename-design.md
@@ -1,0 +1,216 @@
+# SENTINEL Dual-Cancel Route Rename — Design Spec
+
+**Date:** 2026-05-04
+**Status:** Approved scope, ready for implementation plan
+**Issue:** [#157 — SENTINEL: rename dual-cancel routes to disambiguate circuit-breaker vs promise-gate](https://github.com/sip-protocol/sipher/issues/157)
+**Predecessor specs:** `2026-04-27-sentinel-surface-docs-design.md` (which surfaced the dual-cancel ambiguity), `2026-05-04-sentinel-error-envelope-design.md` (#158, sets the error-envelope contract this rename inherits)
+**Related follow-ups:** #159 (mirror SENTINEL docs to docs.sip-protocol.org — captures the post-rename surface)
+
+## Summary
+
+Rename three SENTINEL admin routes so URL names announce which state store they touch. Today, two routes named `/cancel` sit on the same router and operate on different state stores (SQLite-backed circuit-breaker vs in-memory promise-gate). Rename:
+
+- `POST /api/sentinel/pending/:id/cancel` → `POST /api/sentinel/circuit-breaker/:id/cancel`
+- `POST /api/sentinel/override/:flagId` → `POST /api/sentinel/promise-gate/:flagId/resolve`
+- `POST /api/sentinel/cancel/:flagId` → `POST /api/sentinel/promise-gate/:flagId/reject`
+
+Clean cut migration — no compatibility layer, no redirects, single PR. Behavior, status codes, request/response bodies, and auth requirements unchanged. The error envelope contract from #158 carries over verbatim. Test count delta is zero (URL strings change, behavior does not).
+
+## Context
+
+The 2026-04-27 surface-docs cleanup (PR #160) had to ship a `WARNING` callout at the top of `docs/sentinel/rest-api.md` explaining that two routes named `/cancel` mean different things:
+
+- `POST /api/sentinel/pending/:id/cancel` — circuit-breaker, SQLite-backed, durable
+- `POST /api/sentinel/cancel/:flagId` — promise-gate, in-memory, process-local
+
+The `WARNING` was a bandaid for a confusing API surface. #157 fixes the surface itself by renaming so the URLs encode the architectural distinction:
+
+- `circuit-breaker/*` clearly means the durable SQLite-backed action queue
+- `promise-gate/*` clearly means the in-memory pending-promise registry
+- `resolve` vs `reject` matches the underlying `pending.ts` API verbs (`resolvePending`, `rejectPending`) and Promise lifecycle vocabulary
+
+After the rename, the URL itself is self-documenting, and the `WARNING` becomes obsolete.
+
+## Goals
+
+1. **URL names mirror state stores** — `circuit-breaker/*` and `promise-gate/*` namespaces make the architectural distinction visible in the route.
+2. **No behavior change** — handlers, status codes, response bodies, auth, error envelope from #158 all preserved.
+3. **No compatibility layer** — clean cut, single release.
+4. **Surface docs reflect reality** — delete the dual-cancel `WARNING`, update headings + curl examples.
+5. **Test file naming follows the route namespace** — rename `pause-resume-routes.test.ts` to `promise-gate-routes.test.ts` so the file matches the namespace it exercises.
+6. Land as **one PR**, with passing tests and clean typecheck.
+
+## Non-goals
+
+- Renaming `GET /api/sentinel/pending` (the listing route). Issue #157 names only the cancel routes; symmetric rename of the GET expands scope without solving the dual-cancel ambiguity, and the GET serves a different audience (anyone authed) than the admin POST routes.
+- Fixing the `/v1/` vs `/api/` prefix mismatch in `CLAUDE.md`'s endpoint table. Pre-existing inconsistency; auditing the whole table is out of scope.
+- Renaming user-facing button copy in `SentinelConfirm.tsx` ("Override & Send", "Cancel"). The rename is a backend/URL change; UX wording is a separate UX decision.
+- E2E test updates beyond URL changes. `e2e/sentinel-flow.spec.ts` is `test.skip` (blocked on sip-protocol/sip-protocol#1077) and contains only user-facing button-label regex, no URLs.
+
+## Decisions Locked
+
+### Migration strategy: clean cut
+
+Single PR ships the new routes, removes the old ones, updates the lone frontend caller and all internal callers in the same atomic change. No 308 redirects, no 410 Gone, no `Deprecation` header window.
+
+**Justification:** No external SDK consumers. Single internal monorepo. Frontend caller (`SentinelConfirm.tsx`) is updated in the same PR. Same precedent set by #158 — keeping a compatibility layer means committing to deleting it next week, which is wasted work.
+
+### `WARNING` block disposition: delete entirely
+
+Remove `docs/sentinel/rest-api.md` lines 8-14 (the dual-cancel `WARNING`). No migration note, no slimmed-down architecture note.
+
+**Justification:** The `WARNING` exists to disambiguate a confusing API surface. The rename fixes the surface, so the disambiguator is dead weight. The architectural distinction (durable vs in-memory) is already documented inline in each section's body and JSDoc; duplicating it at the top adds no value. Git history preserves the story for any reader curious about the path here.
+
+### Test file rename: `pause-resume-routes.test.ts` → `promise-gate-routes.test.ts`
+
+`git mv` the file. Update the inline `describe` block from `'SENTINEL pause/resume routes'` to `'SENTINEL promise-gate routes'`. Update URL strings inside.
+
+**Justification:** Convention in `packages/agent/tests/sentinel/` is "test file matches what it tests" (`sentinel-api.test.ts`, `pending.test.ts`, `circuit-breaker.test.ts`). After the rename, both routes in this file live under the `promise-gate` namespace, so the file name should mirror that namespace. `git mv` preserves history at 100% similarity since only URL strings and the `describe` text change.
+
+## Architecture
+
+### Route map
+
+| Old route | New route | Backed by | State store | Verb meaning |
+|---|---|---|---|---|
+| `POST /api/sentinel/pending/:id/cancel` | `POST /api/sentinel/circuit-breaker/:id/cancel` | `cancelCircuitBreakerAction` | SQLite, durable | Cancel a queued action before its scheduled fire time |
+| `POST /api/sentinel/override/:flagId` | `POST /api/sentinel/promise-gate/:flagId/resolve` | `resolvePending` | In-memory `Map`, process-local | Resolve a paused promise (override the SENTINEL flag, allow the action to continue) |
+| `POST /api/sentinel/cancel/:flagId` | `POST /api/sentinel/promise-gate/:flagId/reject` | `rejectPending` | In-memory `Map`, process-local | Reject a paused promise (honour the SENTINEL flag, surface a synthetic cancellation error) |
+
+### Behavior preservation
+
+- **Status codes**: 200/204/400/403/404 mappings unchanged per route.
+- **Error envelope**: `{ error: { code, message } }` from #158 carries over. `circuit-breaker/:id/cancel` still returns 404 + `NOT_FOUND` on missing ID; `promise-gate/:flagId/{resolve,reject}` still return 404 + `NOT_FOUND` on missing flag.
+- **Auth**: all three routes still require `verifyJwt + requireOwner` (admin-only).
+- **Request bodies**: identical (cancel takes optional `reason`; resolve/reject take no body).
+- **Response bodies**: identical (cancel returns `{success: true}`; resolve/reject return 204 No Content).
+
+### Frontend dispatch
+
+`SentinelConfirm.tsx` currently calls:
+
+```ts
+const dispatch = async (kind: 'override' | 'cancel') => {
+  const res = await fetch(`${API_URL}/api/sentinel/${kind}/${encodeURIComponent(flagId)}`, ...)
+}
+```
+
+After rename:
+
+```ts
+const dispatch = async (verb: 'resolve' | 'reject') => {
+  const res = await fetch(`${API_URL}/api/sentinel/promise-gate/${encodeURIComponent(flagId)}/${verb}`, ...)
+}
+```
+
+Internal vocabulary (`kind` → `verb`, `'override'|'cancel'` → `'resolve'|'reject'`) is renamed to match the new URL shape. User-facing button copy in the same component (`Override & Send`, `Cancel`) stays unchanged — that's UX wording, not API contract.
+
+## Files In Scope
+
+### Source code (3 files)
+
+1. **`packages/agent/src/routes/sentinel-api.ts`**
+   - Three `app.post(...)` first-arg URL strings (lines 141, 181, 200)
+   - Three `@see` JSDoc anchor links (lines 138, 178, 197)
+   - Inline JSDoc prose ("Mapped to `POST /api/sentinel/...`") above each handler
+   - Inline `// NOTE: distinct from /pending/:id/cancel above` comment at line 169 — delete (becomes obsolete after rename)
+
+2. **`packages/agent/src/sentinel/pending.ts`**
+   - 5 JSDoc references (lines 42, 76, 80, 93, 98) — both prose ("Mapped to `POST /api/sentinel/override/:flagId`") and `@see` anchor links
+
+3. **`packages/agent/src/agent.ts`**
+   - 3 prose references in JSDoc (lines 240, 360, 361) — documentation only, no behavioral coupling
+
+### Frontend (1 file)
+
+4. **`app/src/components/SentinelConfirm.tsx`**
+   - `dispatch` function: `kind: 'override' | 'cancel'` → `verb: 'resolve' | 'reject'`
+   - Fetch URL template: `/api/sentinel/${kind}/${flagId}` → `/api/sentinel/promise-gate/${flagId}/${verb}`
+   - Dispatch call sites at the two `Sentinel*` button handlers — update args to new verb names
+   - Button copy unchanged (UX preserved)
+
+### Tests (3 files)
+
+5. **`packages/agent/tests/sentinel/sentinel-api.test.ts`**
+   - Supertest URL strings at lines 130, 136, 144, 146 — old `/pending/:id/cancel` → new `/circuit-breaker/:id/cancel`
+   - `it(...)` text describing the route — match new URL
+
+6. **`packages/agent/tests/sentinel/pause-resume-routes.test.ts` → `promise-gate-routes.test.ts`**
+   - `git mv` to preserve rename detection
+   - `describe` block: `'SENTINEL pause/resume routes'` → `'SENTINEL promise-gate routes'`
+   - Supertest URL strings inside: `/override/:flagId` → `/promise-gate/:flagId/resolve`, `/cancel/:flagId` → `/promise-gate/:flagId/reject`
+   - `it(...)` text matching each URL
+
+7. **`app/src/components/__tests__/SentinelConfirm.test.tsx`**
+   - URL `expect.stringContaining` assertions at lines 40, 60 — old `/api/sentinel/override/abc` and `/api/sentinel/cancel/abc` → new `/api/sentinel/promise-gate/abc/resolve` and `/api/sentinel/promise-gate/abc/reject`
+
+### Surface docs (2 files)
+
+8. **`docs/sentinel/rest-api.md`**
+   - Delete `WARNING` block (lines 8-14) entirely
+   - Rename three section headings (lines 310, 388, 419) to new URLs
+   - Update curl examples inside each renamed section
+   - Update any cross-section references between the three sections (e.g., "see also `/cancel/:flagId`" prose in the override section)
+   - Confirm the existing `Last verified: 2026-05-04` footer date remains accurate (no bump needed if PR ships today)
+
+9. **`docs/sentinel/audit-log.md`**
+   - Line 72 inline link: `[POST /api/sentinel/pending/:id/cancel](./rest-api.md#post-apisentinelpendingidcancel)` → `[POST /api/sentinel/circuit-breaker/:id/cancel](./rest-api.md#post-apisentinelcircuit-breakeridcancel)`
+
+### Top-level (1 file)
+
+10. **`CLAUDE.md`**
+    - Line 487 endpoint-table row: `/v1/sentinel/pending/:id/cancel` → `/v1/sentinel/circuit-breaker/:id/cancel`
+    - Path segment update only; `/v1/` prefix preserved per scope decision (pre-existing mismatch with code's `/api/` prefix is out of scope)
+
+### Untouched (deliberate)
+
+- `e2e/sentinel-flow.spec.ts` — only contains `test.skip` blocks with user-facing button-label regex (`/override & send/i`, `/^cancel$/i`). No URL references; button copy doesn't change.
+- All historical `docs/superpowers/specs/*` and `docs/superpowers/plans/*` entries — these describe state at the time of writing and should not be retroactively edited.
+
+## Anchor Format
+
+GitHub heading-anchor rule (verified against existing anchors in `pending.ts`): lowercase, strip `/` and `:`, collapse word-boundary spaces to single dashes. Hyphens already present in words (`circuit-breaker`, `promise-gate`) are preserved.
+
+| Heading | Anchor |
+|---|---|
+| `### POST /api/sentinel/circuit-breaker/:id/cancel` | `#post-apisentinelcircuit-breakeridcancel` |
+| `### POST /api/sentinel/promise-gate/:flagId/resolve` | `#post-apisentinelpromise-gateflagidresolve` |
+| `### POST /api/sentinel/promise-gate/:flagId/reject` | `#post-apisentinelpromise-gateflagidreject` |
+
+Verification during implementation: render `rest-api.md` in the GitHub preview after the rename, click each TOC link, confirm the jumps land. If GitHub generates different anchors, update the JSDoc `@see` references to match what the renderer produced.
+
+## Testing Strategy
+
+- **TDD per route rename** (handoff convention): for each of tasks 1-3 below, update the supertest URL string first, watch the test fail with a 404, then update the route handler, watch it pass.
+- **Coverage preserved, not extended**: this PR adds zero behavioral surface area. New URLs hit the same handlers as the old URLs. Test count remains 1300 agent / 46 app.
+- **Per-task `pnpm typecheck`** after every commit.
+- **Final whole-branch review** before push — same pattern as #158. Higher value here because cross-cutting doc surface (audit-log, CLAUDE.md, JSDoc anchors across three source files) is more spread out, so per-task review is more likely to miss inter-task drift.
+
+## Commit Strategy / Task Plan
+
+Eight tasks, eight commits. Order chosen so every commit lands with a green test suite — never a broken intermediate state. Tasks 1-3 each pair a handler change with its test (TDD-friendly). Task 4 (`git mv`) intentionally comes after content updates in 2 and 3 so the rename carries already-updated content.
+
+| # | Task | Files | Commit subject |
+|---|------|-------|----------------|
+| 1 | Rename circuit-breaker cancel route | `sentinel-api.ts` (handler + JSDoc + delete inline NOTE) + `sentinel-api.test.ts` | `refactor(sentinel): rename POST /pending/:id/cancel → /circuit-breaker/:id/cancel (#157)` |
+| 2 | Rename promise-gate override → resolve | `sentinel-api.ts` (handler + JSDoc) + `pause-resume-routes.test.ts` URLs | `refactor(sentinel): rename POST /override/:flagId → /promise-gate/:flagId/resolve (#157)` |
+| 3 | Rename promise-gate cancel → reject | `sentinel-api.ts` (handler + JSDoc) + `pause-resume-routes.test.ts` URLs | `refactor(sentinel): rename POST /cancel/:flagId → /promise-gate/:flagId/reject (#157)` |
+| 4 | `git mv` test file | `pause-resume-routes.test.ts` → `promise-gate-routes.test.ts` + `describe` block | `test(sentinel): rename pause-resume-routes.test.ts → promise-gate-routes.test.ts (#157)` |
+| 5 | Update internal JSDoc | `pending.ts`, `agent.ts` (prose + `@see` anchors) | `docs(sentinel): update internal JSDoc for renamed routes (#157)` |
+| 6 | Frontend caller update | `SentinelConfirm.tsx` + `SentinelConfirm.test.tsx` (verb rename + URL template) | `refactor(app): SentinelConfirm uses promise-gate route shape (#157)` |
+| 7 | Surface docs update | `docs/sentinel/rest-api.md` (delete WARNING, three headings, curl) | `docs(sentinel): rename routes in rest-api.md + remove dual-cancel WARNING (#157)` |
+| 8 | Cross-doc cleanup | `docs/sentinel/audit-log.md` + `CLAUDE.md` line 487 | `docs(sentinel): update audit-log + CLAUDE.md route references (#157)` |
+
+## Verification Checklist
+
+Before requesting merge:
+
+- [ ] All eight commits land green (`pnpm --filter @sipher/agent test -- --run` after each task that touches agent; `pnpm --filter @sipher/app test -- --run` after frontend tasks)
+- [ ] `pnpm typecheck` clean at every commit
+- [ ] Final agent test count: 1300 (unchanged)
+- [ ] Final agent suite count: 104 (unchanged — `pause-resume-routes.test.ts` renamed in place, not added/removed)
+- [ ] Final app test count: 46 (unchanged)
+- [ ] `grep -rn 'pending/:id/cancel\|cancel/:flagId\|override/:flagId\|/api/sentinel/pending\|/api/sentinel/cancel\|/api/sentinel/override' --include='*.ts' --include='*.tsx' --include='*.md' --exclude-dir=docs/superpowers` returns zero hits (historical specs/plans excluded — they describe the world at the time written)
+- [ ] `docs/sentinel/rest-api.md` rendered in GitHub preview: WARNING block gone, three new section headings present, TOC anchors resolve
+- [ ] Whole-branch review (one final agent dispatch) covering: stale prose, drift between source JSDoc and surface docs, missed call sites
+- [ ] PR title and body do not mention AI / Co-Authored-By

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -237,7 +237,7 @@ export interface SSEError {
 
 export interface SSESentinelPause {
   type: 'sentinel_pause'
-  /** Server-issued ID — client posts to /api/sentinel/override/:flagId or /cancel/:flagId */
+  /** Server-issued ID — client posts to /api/sentinel/promise-gate/:flagId/resolve or /reject */
   flagId: string
   /** Humanized action label, e.g. "Send to Abc...123" */
   action: string
@@ -357,8 +357,8 @@ export async function chat(
  * and SENTINEL flagged the action without blocking, a pending flag is created
  * (sentinel/pending.ts) and a `sentinel_pause` SSE event is injected into the
  * stream-bridge's external queue. The executor awaits the pending promise
- * until the user POSTs to `/api/sentinel/override/:flagId` (resume) or
- * `/cancel/:flagId` (cancel). Cancellation is surfaced as a synthetic
+ * until the user POSTs to `/api/sentinel/promise-gate/:flagId/resolve` (resume) or
+ * `/promise-gate/:flagId/reject` (cancel). Cancellation is surfaced as a synthetic
  * `{ status: 'cancelled_by_user' }` tool result; the LLM reports it back.
  *
  * The pause event MUST go through streamPiAgent's external queue (not a

--- a/packages/agent/src/routes/sentinel-api.ts
+++ b/packages/agent/src/routes/sentinel-api.ts
@@ -130,15 +130,15 @@ sentinelAdminRouter.delete('/blacklist/:id', (req: Request, res: Response) => {
 
 /**
  * Circuit-breaker cancel — mark a pending action cancelled in SQLite.
- * Circuit-breaker cancel — distinct from the promise-gate `/cancel/:flagId`.
+ * Operates on the durable circuit-breaker queue (distinct from the in-memory promise-gate routes).
  * @auth verifyJwt + requireOwner
  * @param id pending action id
  * @body { reason? string }
  * @returns 200 { success: true } | 404 ErrorEnvelope
- * @see docs/sentinel/rest-api.md#post-apisentinelpendingidcancel
+ * @see docs/sentinel/rest-api.md#post-apisentinelcircuit-breakeridcancel
  * @see docs/sentinel/rest-api.md#error-envelope
  */
-sentinelAdminRouter.post('/pending/:id/cancel', (req: Request, res: Response) => {
+sentinelAdminRouter.post('/circuit-breaker/:id/cancel', (req: Request, res: Response) => {
   const reason = (req.body?.reason as string) ?? 'manual cancel'
   const w = (req as unknown as Record<string, unknown>).wallet
   const wallet = (typeof w === 'string' ? w : undefined)
@@ -166,7 +166,6 @@ sentinelAdminRouter.get('/decisions', (req: Request, res: Response) => {
 })
 
 // ─── Promise-gate endpoints (pause/resume for advisory mode) ────────────────
-// NOTE: distinct from /pending/:id/cancel above (circuit-breaker, SQLite-backed).
 // These act on in-memory pending promises owned by sentinel/pending.ts.
 
 /**

--- a/packages/agent/src/routes/sentinel-api.ts
+++ b/packages/agent/src/routes/sentinel-api.ts
@@ -170,14 +170,14 @@ sentinelAdminRouter.get('/decisions', (req: Request, res: Response) => {
 
 /**
  * Promise-gate resolve — approve a paused advisory-mode action.
- * Promise-gate resolve — see also `/cancel/:flagId` reject.
+ * Operates on the in-memory pending-promise registry owned by `sentinel/pending.ts`.
  * @auth verifyJwt + requireOwner
  * @param flagId in-memory promise flag id
  * @returns 204 | 404 ErrorEnvelope
- * @see docs/sentinel/rest-api.md#post-apisentineloverrideflagid
+ * @see docs/sentinel/rest-api.md#post-apisentinelpromise-gateflagidresolve
  * @see docs/sentinel/rest-api.md#error-envelope
  */
-sentinelAdminRouter.post('/override/:flagId', (req: Request, res: Response) => {
+sentinelAdminRouter.post('/promise-gate/:flagId/resolve', (req: Request, res: Response) => {
   const flagId = String(req.params.flagId)
   const ok = resolvePending(flagId)
   if (!ok) {

--- a/packages/agent/src/routes/sentinel-api.ts
+++ b/packages/agent/src/routes/sentinel-api.ts
@@ -189,14 +189,14 @@ sentinelAdminRouter.post('/promise-gate/:flagId/resolve', (req: Request, res: Re
 
 /**
  * Promise-gate reject — deny a paused advisory-mode action.
- * Promise-gate reject — distinct from the circuit-breaker `/pending/:id/cancel`.
+ * Operates on the in-memory pending-promise registry owned by `sentinel/pending.ts`.
  * @auth verifyJwt + requireOwner
  * @param flagId in-memory promise flag id
  * @returns 204 | 404 ErrorEnvelope
- * @see docs/sentinel/rest-api.md#post-apisentinelcancelflagid
+ * @see docs/sentinel/rest-api.md#post-apisentinelpromise-gateflagidreject
  * @see docs/sentinel/rest-api.md#error-envelope
  */
-sentinelAdminRouter.post('/cancel/:flagId', (req: Request, res: Response) => {
+sentinelAdminRouter.post('/promise-gate/:flagId/reject', (req: Request, res: Response) => {
   const flagId = String(req.params.flagId)
   const ok = rejectPending(flagId, 'cancelled_by_user')
   if (!ok) {

--- a/packages/agent/src/sentinel/pending.ts
+++ b/packages/agent/src/sentinel/pending.ts
@@ -30,7 +30,7 @@ export function _setTimeoutMsForTests(ms: number): void {
 }
 
 /**
- * Create an in-memory pending flag awaiting admin override or cancellation.
+ * Create an in-memory pending flag awaiting admin approval or denial.
  * Used by the pause/resume flow when SentinelCore returns a `flag` verdict in advisory mode.
  * The returned `promise` resolves on `resolvePending(flagId)` or rejects on `rejectPending(flagId)`
  * or after `TIMEOUT_MS` (120 s by default).
@@ -39,7 +39,7 @@ export function _setTimeoutMsForTests(ms: number): void {
  * @param toolInput - full tool input payload (forwarded to the admin UI for review)
  * @returns `{ flagId, promise }` — emit `flagId` in the SSE `sentinel_pause` event;
  *   await `promise` in the tool executor until the admin resolves or rejects the flag.
- * @see docs/sentinel/rest-api.md#post-apisentineloverrideflagid
+ * @see docs/sentinel/rest-api.md#post-apisentinelpromise-gateflagidresolve
  */
 export function createPending(
   sessionId: string,
@@ -72,12 +72,12 @@ export function createPending(
 }
 
 /**
- * Resolve a pending flag — admin override path.
- * Mapped to `POST /api/sentinel/override/:flagId`.
+ * Resolve a pending flag — admin approval path.
+ * Mapped to `POST /api/sentinel/promise-gate/:flagId/resolve`.
  * Clears the auto-timeout, removes the flag from the Map, and calls the promise resolver.
  * @param flagId - flag identifier returned by `createPending`
  * @returns `true` if the flag existed and was resolved; `false` if not found or already settled.
- * @see docs/sentinel/rest-api.md#post-apisentineloverrideflagid
+ * @see docs/sentinel/rest-api.md#post-apisentinelpromise-gateflagidresolve
  */
 export function resolvePending(flagId: string): boolean {
   const entry = pending.get(flagId)
@@ -89,13 +89,13 @@ export function resolvePending(flagId: string): boolean {
 }
 
 /**
- * Reject a pending flag — admin cancel path.
- * Mapped to `POST /api/sentinel/cancel/:flagId`.
+ * Reject a pending flag — admin denial path.
+ * Mapped to `POST /api/sentinel/promise-gate/:flagId/reject`.
  * Clears the auto-timeout, removes the flag from the Map, and rejects the promise with `reason`.
  * @param flagId - flag identifier returned by `createPending`
  * @param reason - rejection reason string (e.g. `'cancelled_by_user'`), wrapped in an Error
  * @returns `true` if the flag existed and was rejected; `false` if not found or already settled.
- * @see docs/sentinel/rest-api.md#post-apisentinelcancelflagid
+ * @see docs/sentinel/rest-api.md#post-apisentinelpromise-gateflagidreject
  */
 export function rejectPending(flagId: string, reason: string): boolean {
   const entry = pending.get(flagId)

--- a/packages/agent/tests/sentinel/pause-resume-routes.test.ts
+++ b/packages/agent/tests/sentinel/pause-resume-routes.test.ts
@@ -69,13 +69,13 @@ describe('SENTINEL pause/resume routes', () => {
     await expect(promise).resolves.toBeUndefined()
   })
 
-  it('POST /api/sentinel/cancel/:flagId rejects the pending promise (204)', async () => {
+  it('POST /api/sentinel/promise-gate/:flagId/reject rejects the pending promise (204)', async () => {
     const { flagId, promise } = createPending('test-session', 'send', { amount: 1 })
     // attach noop catch before the HTTP call so Node doesn't flag the rejection as unhandled
     // before our .rejects assertion consumes it
     promise.catch(() => {})
     const res = await supertest(createApp())
-      .post(`/api/sentinel/cancel/${flagId}`)
+      .post(`/api/sentinel/promise-gate/${flagId}/reject`)
       .set('Authorization', `Bearer ${signJwt(ADMIN_WALLET)}`)
     expect(res.status).toBe(204)
     await expect(promise).rejects.toThrow(/cancelled/i)

--- a/packages/agent/tests/sentinel/pause-resume-routes.test.ts
+++ b/packages/agent/tests/sentinel/pause-resume-routes.test.ts
@@ -60,10 +60,10 @@ function createApp() {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('SENTINEL pause/resume routes', () => {
-  it('POST /api/sentinel/override/:flagId resolves the pending promise (204)', async () => {
+  it('POST /api/sentinel/promise-gate/:flagId/resolve resolves the pending promise (204)', async () => {
     const { flagId, promise } = createPending('test-session', 'send', { amount: 1 })
     const res = await supertest(createApp())
-      .post(`/api/sentinel/override/${flagId}`)
+      .post(`/api/sentinel/promise-gate/${flagId}/resolve`)
       .set('Authorization', `Bearer ${signJwt(ADMIN_WALLET)}`)
     expect(res.status).toBe(204)
     await expect(promise).resolves.toBeUndefined()
@@ -83,7 +83,7 @@ describe('SENTINEL pause/resume routes', () => {
 
   it('returns 404 for unknown flag id', async () => {
     const res = await supertest(createApp())
-      .post('/api/sentinel/override/does-not-exist')
+      .post('/api/sentinel/promise-gate/does-not-exist/resolve')
       .set('Authorization', `Bearer ${signJwt(ADMIN_WALLET)}`)
     expect(res.status).toBe(404)
     expect(res.body.error.code).toBe('NOT_FOUND')
@@ -94,7 +94,7 @@ describe('SENTINEL pause/resume routes', () => {
     const { flagId, promise } = createPending('test-session', 'send', { amount: 1 })
     promise.catch(() => {})
     const res = await supertest(createApp())
-      .post(`/api/sentinel/override/${flagId}`)
+      .post(`/api/sentinel/promise-gate/${flagId}/resolve`)
       .set('Authorization', `Bearer ${signJwt(NON_ADMIN_WALLET)}`)
     expect(res.status).toBe(403)
   })
@@ -103,7 +103,7 @@ describe('SENTINEL pause/resume routes', () => {
     // attach noop catch — afterEach clearAll rejects this promise, suppress the unhandled noise
     const { flagId, promise } = createPending('test-session', 'send', { amount: 1 })
     promise.catch(() => {})
-    const res = await supertest(createApp()).post(`/api/sentinel/override/${flagId}`)
+    const res = await supertest(createApp()).post(`/api/sentinel/promise-gate/${flagId}/resolve`)
     expect(res.status).toBe(401)
   })
 })

--- a/packages/agent/tests/sentinel/promise-gate-routes.test.ts
+++ b/packages/agent/tests/sentinel/promise-gate-routes.test.ts
@@ -59,7 +59,7 @@ function createApp() {
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('SENTINEL pause/resume routes', () => {
+describe('SENTINEL promise-gate routes', () => {
   it('POST /api/sentinel/promise-gate/:flagId/resolve resolves the pending promise (204)', async () => {
     const { flagId, promise } = createPending('test-session', 'send', { amount: 1 })
     const res = await supertest(createApp())

--- a/packages/agent/tests/sentinel/sentinel-api.test.ts
+++ b/packages/agent/tests/sentinel/sentinel-api.test.ts
@@ -127,13 +127,13 @@ describe('sentinel REST endpoints', () => {
     expect((res.body.actions as unknown[]).length).toBe(1)
   })
 
-  it('POST /pending/:id/cancel cancels an action', async () => {
+  it('POST /circuit-breaker/:id/cancel cancels an action', async () => {
     const app = await buildApp(vi.fn())
     const cb = await import('../../src/sentinel/circuit-breaker.js')
     const id = cb.scheduleCancellableAction({
       actionType: 'refund', payload: {}, reasoning: 'r', wallet: 'w1', delayMs: 60000,
     })
-    const res = await request(app).post(`/api/sentinel/pending/${id}/cancel`).send({ reason: 'user cancelled' })
+    const res = await request(app).post(`/api/sentinel/circuit-breaker/${id}/cancel`).send({ reason: 'user cancelled' })
     expect(res.status).toBe(200)
     expect(res.body.success).toBe(true)
     const { getPendingAction } = await import('../../src/db.js')
@@ -141,9 +141,9 @@ describe('sentinel REST endpoints', () => {
     cb.clearAllTimers()
   })
 
-  it('POST /pending/:id/cancel returns 404 + NOT_FOUND when ID does not exist', async () => {
+  it('POST /circuit-breaker/:id/cancel returns 404 + NOT_FOUND when ID does not exist', async () => {
     const app = await buildApp(vi.fn())
-    const res = await request(app).post('/api/sentinel/pending/does-not-exist/cancel').send({
+    const res = await request(app).post('/api/sentinel/circuit-breaker/does-not-exist/cancel').send({
       reason: 'attempted cancel',
     })
     expect(res.status).toBe(404)


### PR DESCRIPTION
## Summary

- Rename three SENTINEL admin routes so URL names announce which state store they touch (closes #157)
- Delete the dual-cancel `WARNING` block in `docs/sentinel/rest-api.md` — the URL namespaces (`circuit-breaker/*` vs `promise-gate/*`) make the architectural distinction self-documenting
- `git mv` `pause-resume-routes.test.ts` → `promise-gate-routes.test.ts` to match the route namespace it exercises

## Route map

| Old | New |
|---|---|
| `POST /api/sentinel/pending/:id/cancel` | `POST /api/sentinel/circuit-breaker/:id/cancel` |
| `POST /api/sentinel/override/:flagId` | `POST /api/sentinel/promise-gate/:flagId/resolve` |
| `POST /api/sentinel/cancel/:flagId` | `POST /api/sentinel/promise-gate/:flagId/reject` |

Clean cut migration — no compatibility layer (same precedent as #158/PR #167). Behavior, status codes, error envelope, auth requirements all preserved. Frontend caller `SentinelConfirm.tsx` updated in the same PR.

## Test plan

- [x] `pnpm --filter @sipher/agent test -- --run` — 1300/104 passing (unchanged)
- [x] `pnpm --filter @sipher/app test -- --run` — 46/12 passing (unchanged)
- [x] `pnpm typecheck` — clean
- [x] Stale-reference grep returns zero hits across `*.ts`, `*.tsx`, `*.md` (excluding historical specs/plans)
- [x] Final whole-branch review (subagent dispatch) — no remaining drift