### PR TITLE
docs(vault): Phase 4 mainnet sipher_vault deploy — spec + implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-05-04-phase4-mainnet-vault-deploy.md
+++ b/docs/superpowers/plans/2026-05-04-phase4-mainnet-vault-deploy.md
@@ -1,0 +1,2077 @@
+# Phase 4 Mainnet Sipher Vault Deploy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy the `sipher_vault` Anchor program (with `withdraw_private` → `sip_privacy.create_transfer_announcement` CPI) to Solana mainnet, integrate with the SIPHER agent + Command Center UI, and announce publicly. Linear 4-day execution, one PR per day, `--merge` style.
+
+**Architecture:** Stage 1 redeploys the existing `sipher_vault` program (binary already includes the CPI from commit `79133d0`) to **devnet** to validate the CPI round-trip end-to-end. Stage 2 deploys the same binary to **mainnet** and atomically initializes the config PDA. Stage 3 flips the `sipher` repo's SDK + agent to default to mainnet. Stage 4 adds a Command Center vault tab and posts the public announcement.
+
+**Tech Stack:** Anchor 0.30.1, Solana CLI, `@solana/web3.js`, `@solana/spl-token`, TypeScript via `tsx`, Vitest, React 19 + Tailwind 4 + Zustand 5 (Command Center).
+
+---
+
+## Pre-execution context
+
+### Repos and branches
+
+This plan touches **two repos**. Each PR lives on its own feature branch.
+
+| PR | Repo | Branch (suggested) | Base |
+|---|---|---|---|
+| PR-1 (Day 1) | `~/local-dev/sip-protocol` | `feat/sipher-vault-cpi-devnet-upgrade` | `main` |
+| PR-2 (Day 2) | `~/local-dev/sip-protocol` | `feat/sipher-vault-mainnet-deploy` | `main` (after PR-1 merges) |
+| PR-3 (Day 3) | `~/local-dev/sipher` | `feat/sipher-vault-mainnet-sdk-agent` | `main` |
+| PR-4 (Day 4) | `~/local-dev/sipher` | `feat/sipher-vault-mainnet-ui-launch` | `main` (after PR-3 merges) |
+
+### Prerequisites (verify before starting any task)
+
+- [ ] **Phase 3 closed.** Day 2 of the predecessor session has merged. The Phase 3 PR is on `main` of `sipher`. If still pending, **wait** — Phase 4 builds on the Phase 3 close-out.
+- [ ] **Mainnet authority wallet funded.** `solana balance --keypair ~/Documents/secret/authority.json --url mainnet-beta` ≥ 10 SOL.
+- [ ] **Mainnet RPC reachable.** `solana cluster-version --url mainnet-beta` returns a slot.
+- [ ] **Devnet wallet funded.** `solana balance --keypair ~/Documents/secret/solana-devnet.json --url devnet` ≥ 0.5 SOL.
+- [ ] **Anchor toolchain.** `anchor --version` returns `0.30.1`.
+
+### Key addresses (referenced throughout)
+
+| Item | Value |
+|---|---|
+| `sipher_vault` program ID (devnet + mainnet) | `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB` |
+| `sip_privacy` mainnet program ID | `S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at` |
+| Mainnet authority | `S1P6j1yeTm6zkewQVeihrTZvmfoHABRkHDhabWTuWMd` |
+| Devnet authority | `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr` |
+| wSOL mint | `So11111111111111111111111111111111111111112` |
+| `VAULT_CONFIG_SEED` | `b"vault_config"` |
+| `DEPOSIT_RECORD_SEED` | `b"deposit_record"` |
+
+### Naming conventions
+
+- Files in this plan use forward slashes for paths regardless of OS.
+- Bash blocks assume `cd ~/local-dev/sip-protocol` or `cd ~/local-dev/sipher` as labelled in each task.
+- All commits follow CLAUDE.md rule: NO `Co-Authored-By: Claude`, NO Generated-with footers.
+
+---
+
+## PR-1 — Day 1: Devnet upgrade + CPI E2E + pause runbook
+
+**Output:** Devnet `sipher_vault` upgraded to the CPI binary; `e2e-cpi-test.ts` proves the round-trip; `set-paused.ts` rehearsed and ready for Stage 2; `DEPLOYMENT.md` records evidence.
+
+### Task 1.0: Branch off `main`
+
+**Repo:** `sip-protocol`
+
+- [ ] **Step 1: Verify clean tree.**
+
+```bash
+cd ~/local-dev/sip-protocol
+git status
+git fetch origin
+git checkout main && git pull
+```
+
+Expected: `working tree clean`, `Your branch is up to date with 'origin/main'`.
+
+- [ ] **Step 2: Create feature branch.**
+
+```bash
+git checkout -b feat/sipher-vault-cpi-devnet-upgrade
+```
+
+### Task 1.1: Add `[programs.mainnet]` to Anchor.toml
+
+**Files:**
+- Modify: `programs/sipher-vault/Anchor.toml`
+
+- [ ] **Step 1: Edit Anchor.toml.** Append a `[programs.mainnet]` section after `[programs.devnet]`:
+
+```toml
+[programs.localnet]
+sipher_vault = "S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB"
+sip_privacy = "S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at"
+
+[programs.devnet]
+sipher_vault = "S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB"
+
+[programs.mainnet]
+sipher_vault = "S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB"
+```
+
+- [ ] **Step 2: Verify `anchor build` still succeeds with the new section.**
+
+```bash
+cd ~/local-dev/sip-protocol/programs/sipher-vault
+anchor build
+```
+
+Expected: build completes, `target/deploy/sipher_vault.so` updated. Size around 350 KB.
+
+- [ ] **Step 3: Confirm program ID match.**
+
+```bash
+solana address -k ~/Documents/secret/sipher-vault-program-id.json
+```
+
+Expected: exactly `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB`.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add programs/sipher-vault/Anchor.toml
+git commit -m "chore(sipher-vault): declare mainnet program ID in Anchor.toml"
+```
+
+### Task 1.2: Write `set-paused.ts` script
+
+**Files:**
+- Create: `programs/sipher-vault/scripts/set-paused.ts`
+
+- [ ] **Step 1: Write the script.**
+
+```typescript
+// programs/sipher-vault/scripts/set-paused.ts
+//
+// Set or clear the paused flag on the sipher_vault config PDA.
+// Usage: pnpm exec tsx scripts/set-paused.ts <true|false>
+//
+// Network and authority are env-driven:
+//   ANCHOR_PROVIDER_URL  — RPC endpoint (default: https://api.devnet.solana.com)
+//   ANCHOR_WALLET        — path to authority keypair JSON
+//
+// Reads the value back after sending so the operator sees confirmed state.
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+  sendAndConfirmTransaction,
+} from '@solana/web3.js'
+import { readFileSync } from 'fs'
+import { createHash } from 'crypto'
+
+const PROGRAM_ID = new PublicKey('S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB')
+const VAULT_CONFIG_SEED = Buffer.from('vault_config')
+
+function discriminator(name: string): Buffer {
+  return createHash('sha256').update(`global:${name}`).digest().subarray(0, 8)
+}
+
+async function main() {
+  const arg = process.argv[2]
+  if (arg !== 'true' && arg !== 'false') {
+    console.error('Usage: tsx scripts/set-paused.ts <true|false>')
+    process.exit(1)
+  }
+  const targetPaused = arg === 'true'
+
+  const rpc = process.env.ANCHOR_PROVIDER_URL ?? 'https://api.devnet.solana.com'
+  const walletPath = process.env.ANCHOR_WALLET
+  if (!walletPath) {
+    console.error('ANCHOR_WALLET env var required (path to authority keypair JSON)')
+    process.exit(1)
+  }
+
+  const connection = new Connection(rpc, 'confirmed')
+  const authority = Keypair.fromSecretKey(
+    Uint8Array.from(JSON.parse(readFileSync(walletPath, 'utf-8')))
+  )
+  const [configPDA] = PublicKey.findProgramAddressSync([VAULT_CONFIG_SEED], PROGRAM_ID)
+
+  console.log('Network:    ', rpc)
+  console.log('Authority:  ', authority.publicKey.toString())
+  console.log('Config PDA: ', configPDA.toString())
+  console.log('Target:     paused =', targetPaused)
+
+  // Build set_paused instruction: discriminator + bool(u8)
+  const data = Buffer.alloc(8 + 1)
+  discriminator('set_paused').copy(data, 0)
+  data.writeUInt8(targetPaused ? 1 : 0, 8)
+
+  const ix = new TransactionInstruction({
+    programId: PROGRAM_ID,
+    keys: [
+      { pubkey: configPDA, isSigner: false, isWritable: true },
+      { pubkey: authority.publicKey, isSigner: true, isWritable: false },
+    ],
+    data,
+  })
+
+  const tx = new Transaction().add(ix)
+  const sig = await sendAndConfirmTransaction(connection, tx, [authority])
+  console.log('TX:', sig)
+
+  // Verify by re-reading the config
+  const account = await connection.getAccountInfo(configPDA)
+  if (!account) throw new Error('Config PDA missing post-tx')
+  // Layout: 8 disc + 32 authority + 2 fee_bps + 8 timeout + 1 paused + ...
+  const observed = account.data[50] !== 0
+  console.log('Observed paused =', observed)
+  if (observed !== targetPaused) {
+    console.error('Mismatch! Expected', targetPaused, 'got', observed)
+    process.exit(1)
+  }
+  console.log('OK — pause state confirmed.')
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})
+```
+
+- [ ] **Step 2: Verify TypeScript compiles.**
+
+```bash
+cd ~/local-dev/sip-protocol/programs/sipher-vault
+pnpm exec tsx --check scripts/set-paused.ts
+```
+
+Expected: no output (success).
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add programs/sipher-vault/scripts/set-paused.ts
+git commit -m "feat(sipher-vault): add set-paused.ts helper script for emergency pause/unpause"
+```
+
+### Task 1.3: Rehearse pause/unpause on devnet
+
+**Files:** none. Manual execution; capture output for evidence.
+
+- [ ] **Step 1: Pause devnet.**
+
+```bash
+cd ~/local-dev/sip-protocol/programs/sipher-vault
+ANCHOR_WALLET=~/Documents/secret/solana-devnet.json \
+ANCHOR_PROVIDER_URL=https://api.devnet.solana.com \
+pnpm exec tsx scripts/set-paused.ts true
+```
+
+Expected stdout (final lines):
+```
+TX: <base58 sig>
+Observed paused = true
+OK — pause state confirmed.
+```
+
+- [ ] **Step 2: Unpause devnet.**
+
+```bash
+ANCHOR_WALLET=~/Documents/secret/solana-devnet.json \
+ANCHOR_PROVIDER_URL=https://api.devnet.solana.com \
+pnpm exec tsx scripts/set-paused.ts false
+```
+
+Expected: `Observed paused = false`, `OK`.
+
+- [ ] **Step 3: Save the two TX signatures.** Add a markdown comment to your scratch notes — they go in `DEPLOYMENT.md` later.
+
+### Task 1.4: Write `upgrade-devnet.ts` script
+
+**Files:**
+- Create: `programs/sipher-vault/scripts/upgrade-devnet.ts`
+
+- [ ] **Step 1: Write the script.**
+
+```typescript
+// programs/sipher-vault/scripts/upgrade-devnet.ts
+//
+// Build the program and deploy the resulting binary to devnet under the
+// existing program ID. Idempotent — running again redeploys (Solana's
+// program upgrade pattern).
+//
+// Usage: pnpm exec tsx scripts/upgrade-devnet.ts
+import { execSync } from 'child_process'
+import { existsSync } from 'fs'
+import { homedir } from 'os'
+
+const PROGRAM_ID = 'S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB'
+const PROGRAM_KEYPAIR = `${homedir()}/Documents/secret/sipher-vault-program-id.json`
+const AUTHORITY_KEYPAIR = `${homedir()}/Documents/secret/solana-devnet.json`
+const SO_FILE = 'target/deploy/sipher_vault.so'
+const RPC = 'https://api.devnet.solana.com'
+
+function run(cmd: string): string {
+  console.log('$', cmd)
+  const out = execSync(cmd, { stdio: ['inherit', 'pipe', 'inherit'] }).toString()
+  console.log(out)
+  return out
+}
+
+async function main() {
+  if (!existsSync(PROGRAM_KEYPAIR)) {
+    throw new Error(`Program keypair not found: ${PROGRAM_KEYPAIR}`)
+  }
+  if (!existsSync(AUTHORITY_KEYPAIR)) {
+    throw new Error(`Authority keypair not found: ${AUTHORITY_KEYPAIR}`)
+  }
+
+  // 1. Sanity: program ID matches the keypair
+  const idFromKey = run(`solana address -k ${PROGRAM_KEYPAIR}`).trim()
+  if (idFromKey !== PROGRAM_ID) {
+    throw new Error(`Program keypair ID ${idFromKey} != expected ${PROGRAM_ID}`)
+  }
+
+  // 2. Clean + build
+  run('anchor clean')
+  run('anchor build')
+
+  if (!existsSync(SO_FILE)) {
+    throw new Error(`Build artifact missing: ${SO_FILE}`)
+  }
+
+  // 3. Deploy
+  run(
+    `solana program deploy ${SO_FILE} ` +
+      `--program-id ${PROGRAM_KEYPAIR} ` +
+      `--keypair ${AUTHORITY_KEYPAIR} ` +
+      `--url ${RPC} ` +
+      `--with-compute-unit-price 10000`
+  )
+
+  // 4. Verify deployed slot
+  run(`solana program show ${PROGRAM_ID} --url ${RPC}`)
+
+  console.log('Devnet upgrade complete.')
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})
+```
+
+- [ ] **Step 2: Type-check.**
+
+```bash
+pnpm exec tsx --check scripts/upgrade-devnet.ts
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add programs/sipher-vault/scripts/upgrade-devnet.ts
+git commit -m "feat(sipher-vault): add upgrade-devnet.ts for CPI binary deploy to devnet"
+```
+
+### Task 1.5: Build and deploy CPI binary to devnet
+
+**Files:** none — execution + evidence capture.
+
+- [ ] **Step 1: Run the upgrade script.**
+
+```bash
+cd ~/local-dev/sip-protocol/programs/sipher-vault
+pnpm exec tsx scripts/upgrade-devnet.ts 2>&1 | tee /tmp/devnet-upgrade-$(date -u +%Y-%m-%d).log
+```
+
+Expected: deploy completes (~30–60 s), `solana program show` reports a fresh `Last Deployed In Slot`. Log saved to `/tmp/devnet-upgrade-<DATE>.log`.
+
+- [ ] **Step 2: Verify the new binary is in place.**
+
+```bash
+solana program show S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB --url devnet
+```
+
+Expected: `ProgramData Address`, `Authority`, `Last Deployed In Slot` all populated. Note the slot number for the evidence file.
+
+- [ ] **Step 3: No commit yet.** Evidence (slot, log path) is captured into `DEPLOYMENT.md` in Task 1.8.
+
+### Task 1.6: Write `e2e-cpi-test.ts` script
+
+**Files:**
+- Create: `programs/sipher-vault/scripts/e2e-cpi-test.ts`
+
+This script proves the CPI works end-to-end by issuing one real `withdraw_private` against devnet and confirming the `TransferRecord` PDA exists on `sip_privacy` afterwards. We use deterministic test stealth params — the goal is structural validation of the CPI, not a full DKSAP scan/claim flow.
+
+- [ ] **Step 1: Write the script.**
+
+```typescript
+// programs/sipher-vault/scripts/e2e-cpi-test.ts
+//
+// End-to-end CPI validation on devnet:
+//   1. Wrap 0.001 SOL → wSOL into authority's ATA
+//   2. Deposit into sipher_vault
+//   3. Call withdraw_private with deterministic test stealth params
+//   4. Confirm sip_privacy.TransferRecord PDA exists with the expected commitment
+//
+// This is structural validation — the test does NOT scan/claim. The goal is
+// to prove the CPI from withdraw_private to sip_privacy.create_transfer_announcement
+// fires correctly on the network where it will run on mainnet.
+//
+// Usage: pnpm exec tsx scripts/e2e-cpi-test.ts
+//
+// Requires:
+//   - ~/Documents/secret/solana-devnet.json  (depositor + authority on devnet)
+//   - Devnet vault config already initialized
+//   - Devnet vault_token + fee_token PDAs already created for wSOL
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+  sendAndConfirmTransaction,
+} from '@solana/web3.js'
+import {
+  createAssociatedTokenAccountIdempotentInstruction,
+  getAssociatedTokenAddressSync,
+  createSyncNativeInstruction,
+  TOKEN_PROGRAM_ID,
+} from '@solana/spl-token'
+import { readFileSync } from 'fs'
+import { homedir } from 'os'
+import { createHash, randomBytes } from 'crypto'
+
+const VAULT_PROGRAM_ID = new PublicKey('S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB')
+const SIP_PRIVACY_PROGRAM_ID = new PublicKey('S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at')
+const WSOL_MINT = new PublicKey('So11111111111111111111111111111111111111112')
+
+const VAULT_CONFIG_SEED = Buffer.from('vault_config')
+const DEPOSIT_RECORD_SEED = Buffer.from('deposit_record')
+const VAULT_TOKEN_SEED = Buffer.from('vault_token')
+const FEE_TOKEN_SEED = Buffer.from('fee_token')
+const SIP_CONFIG_SEED = Buffer.from('config')
+const SIP_TRANSFER_RECORD_SEED = Buffer.from('transfer_record')
+
+const RPC = 'https://api.devnet.solana.com'
+const DEPOSIT_LAMPORTS = 1_000_000n // 0.001 SOL
+const WITHDRAW_LAMPORTS = 500_000n  // 0.0005 SOL — half of deposit, leaves remainder for the refund-script if rerun
+
+function disc(name: string): Buffer {
+  return createHash('sha256').update(`global:${name}`).digest().subarray(0, 8)
+}
+
+async function main() {
+  const conn = new Connection(RPC, 'confirmed')
+  const wallet = Keypair.fromSecretKey(
+    Uint8Array.from(JSON.parse(readFileSync(`${homedir()}/Documents/secret/solana-devnet.json`, 'utf-8')))
+  )
+  console.log('Depositor:', wallet.publicKey.toString())
+
+  const wsolAta = getAssociatedTokenAddressSync(WSOL_MINT, wallet.publicKey)
+
+  const [vaultConfigPda] = PublicKey.findProgramAddressSync([VAULT_CONFIG_SEED], VAULT_PROGRAM_ID)
+  const [vaultTokenPda] = PublicKey.findProgramAddressSync(
+    [VAULT_TOKEN_SEED, WSOL_MINT.toBuffer()],
+    VAULT_PROGRAM_ID
+  )
+  const [feeTokenPda] = PublicKey.findProgramAddressSync(
+    [FEE_TOKEN_SEED, WSOL_MINT.toBuffer()],
+    VAULT_PROGRAM_ID
+  )
+  const [depositRecordPda] = PublicKey.findProgramAddressSync(
+    [DEPOSIT_RECORD_SEED, wallet.publicKey.toBuffer(), WSOL_MINT.toBuffer()],
+    VAULT_PROGRAM_ID
+  )
+  const [sipConfigPda] = PublicKey.findProgramAddressSync(
+    [SIP_CONFIG_SEED],
+    SIP_PRIVACY_PROGRAM_ID
+  )
+
+  // Deterministic stealth test params
+  const stealthRecipient = Keypair.generate().publicKey // ed25519 dummy stealth
+  const ephemeralPubkey = Buffer.concat([Buffer.from([0x02]), randomBytes(32)]) // 33-byte secp256k1 fake
+  const amountCommitment = Buffer.concat([Buffer.from([0x02]), randomBytes(32)])  // 33-byte commitment
+  const viewingKeyHash = randomBytes(32)
+  const encryptedAmount = Buffer.from([]) // empty for test
+
+  const [sipTransferRecordPda] = PublicKey.findProgramAddressSync(
+    [SIP_TRANSFER_RECORD_SEED, amountCommitment, ephemeralPubkey],
+    SIP_PRIVACY_PROGRAM_ID
+  )
+  console.log('TransferRecord PDA (expected):', sipTransferRecordPda.toString())
+
+  // ─── 1. Wrap 0.001 SOL ───────────────────────────────────────────────────────
+  const wrapTx = new Transaction()
+  wrapTx.add(
+    createAssociatedTokenAccountIdempotentInstruction(wallet.publicKey, wsolAta, wallet.publicKey, WSOL_MINT)
+  )
+  wrapTx.add(
+    SystemProgram.transfer({
+      fromPubkey: wallet.publicKey,
+      toPubkey: wsolAta,
+      lamports: DEPOSIT_LAMPORTS,
+    })
+  )
+  wrapTx.add(createSyncNativeInstruction(wsolAta))
+  const wrapSig = await sendAndConfirmTransaction(conn, wrapTx, [wallet])
+  console.log('Wrap TX:', wrapSig)
+
+  // ─── 2. Deposit ──────────────────────────────────────────────────────────────
+  // deposit(amount: u64) — discriminator + u64
+  const depositData = Buffer.alloc(8 + 8)
+  disc('deposit').copy(depositData, 0)
+  depositData.writeBigUInt64LE(DEPOSIT_LAMPORTS, 8)
+
+  const depositIx = new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: vaultConfigPda, isSigner: false, isWritable: true },
+      { pubkey: depositRecordPda, isSigner: false, isWritable: true },
+      { pubkey: vaultTokenPda, isSigner: false, isWritable: true },
+      { pubkey: wsolAta, isSigner: false, isWritable: true },
+      { pubkey: WSOL_MINT, isSigner: false, isWritable: false },
+      { pubkey: wallet.publicKey, isSigner: true, isWritable: true },
+      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data: depositData,
+  })
+
+  const depositSig = await sendAndConfirmTransaction(conn, new Transaction().add(depositIx), [wallet])
+  console.log('Deposit TX:', depositSig)
+
+  // ─── 3. withdraw_private with CPI ────────────────────────────────────────────
+  // Layout: discriminator(8) + amount(u64) + amount_commitment(33) +
+  //         stealth_pubkey(32) + ephemeral_pubkey(33) + viewing_key_hash(32) +
+  //         encrypted_amount(Vec<u8>: 4-byte len + bytes) + proof(Vec<u8>: 4-byte len + bytes)
+  const wpData = Buffer.concat([
+    disc('withdraw_private'),
+    Buffer.from(new BigUint64Array([WITHDRAW_LAMPORTS]).buffer),
+    amountCommitment,
+    stealthRecipient.toBuffer(),
+    ephemeralPubkey,
+    viewingKeyHash,
+    Buffer.from(new Uint32Array([encryptedAmount.length]).buffer),
+    encryptedAmount,
+    Buffer.from(new Uint32Array([0]).buffer), // empty proof
+  ])
+
+  const stealthAta = getAssociatedTokenAddressSync(WSOL_MINT, stealthRecipient)
+
+  // Stealth ATA creation must precede withdraw_private (program does not auto-create)
+  const ensureStealthAtaIx = createAssociatedTokenAccountIdempotentInstruction(
+    wallet.publicKey,
+    stealthAta,
+    stealthRecipient,
+    WSOL_MINT
+  )
+
+  const wpIx = new TransactionInstruction({
+    programId: VAULT_PROGRAM_ID,
+    keys: [
+      { pubkey: vaultConfigPda, isSigner: false, isWritable: true },
+      { pubkey: depositRecordPda, isSigner: false, isWritable: true },
+      { pubkey: vaultTokenPda, isSigner: false, isWritable: true },
+      { pubkey: stealthAta, isSigner: false, isWritable: true },
+      { pubkey: feeTokenPda, isSigner: false, isWritable: true },
+      { pubkey: WSOL_MINT, isSigner: false, isWritable: false },
+      { pubkey: wallet.publicKey, isSigner: true, isWritable: true },
+      // CPI accounts
+      { pubkey: sipConfigPda, isSigner: false, isWritable: true },
+      { pubkey: sipTransferRecordPda, isSigner: false, isWritable: true },
+      { pubkey: SIP_PRIVACY_PROGRAM_ID, isSigner: false, isWritable: false },
+      // Standard
+      { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data: wpData,
+  })
+
+  const wpTx = new Transaction().add(ensureStealthAtaIx).add(wpIx)
+  const wpSig = await sendAndConfirmTransaction(conn, wpTx, [wallet], { skipPreflight: true, maxRetries: 3 })
+  console.log('withdraw_private TX:', wpSig)
+
+  // ─── 4. Verify TransferRecord PDA exists on sip_privacy ──────────────────────
+  const transferRecord = await conn.getAccountInfo(sipTransferRecordPda)
+  if (!transferRecord) {
+    console.error('FAIL — TransferRecord PDA not created. CPI did not fire as expected.')
+    process.exit(1)
+  }
+  console.log('TransferRecord PDA created. Size:', transferRecord.data.length, 'bytes')
+  console.log('Owner:', transferRecord.owner.toString())
+  if (!transferRecord.owner.equals(SIP_PRIVACY_PROGRAM_ID)) {
+    console.error('FAIL — TransferRecord owner is not sip_privacy.')
+    process.exit(1)
+  }
+
+  console.log('\n✓ Devnet CPI E2E PASSED.')
+  console.log({
+    wrapSig,
+    depositSig,
+    withdrawPrivateSig: wpSig,
+    transferRecordPda: sipTransferRecordPda.toString(),
+    stealthRecipient: stealthRecipient.toString(),
+  })
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})
+```
+
+- [ ] **Step 2: Type-check.**
+
+```bash
+cd ~/local-dev/sip-protocol/programs/sipher-vault
+pnpm exec tsx --check scripts/e2e-cpi-test.ts
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add programs/sipher-vault/scripts/e2e-cpi-test.ts
+git commit -m "feat(sipher-vault): add e2e-cpi-test.ts for devnet CPI round-trip validation"
+```
+
+### Task 1.7: Run E2E test on devnet
+
+**Files:** none — execution + evidence capture.
+
+- [ ] **Step 1: Pre-condition check.** Devnet wSOL `vault_token` and `fee_token` PDAs must exist. They were created during Phase 3's bootstrap; if running standalone, run `init-devnet.ts` first or recreate via the existing `create_vault_token` / `create_fee_token` ix.
+
+```bash
+solana account 6HoouLu9e5TxsVzpds2yTiDyCo8pjUzk7wnRxc3U4wij --url devnet
+solana account C3XvQSz5BqyzHMxQwQb5gacmgAMHkRoMq7acvbuQnJpb --url devnet
+```
+
+Both should return account data.
+
+- [ ] **Step 2: Execute the E2E test.**
+
+```bash
+cd ~/local-dev/sip-protocol/programs/sipher-vault
+pnpm exec tsx scripts/e2e-cpi-test.ts 2>&1 | tee /tmp/devnet-cpi-e2e-$(date -u +%Y-%m-%d).log
+```
+
+Expected stdout (final lines):
+```
+TransferRecord PDA created. Size: <N> bytes
+Owner: S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at
+
+✓ Devnet CPI E2E PASSED.
+{
+  wrapSig: '...',
+  depositSig: '...',
+  withdrawPrivateSig: '...',
+  transferRecordPda: '...',
+  stealthRecipient: '...'
+}
+```
+
+- [ ] **Step 3: Open Solscan to manually verify.** For `withdrawPrivateSig` from the log, open `https://solscan.io/tx/<sig>?cluster=devnet`. Confirm:
+  - Status: Success
+  - The transaction shows TWO program invocations: `sipher_vault` (top-level) and `sip_privacy` (inner CPI).
+
+- [ ] **Step 4: No commit yet.** Evidence goes into `DEPLOYMENT.md` in Task 1.8.
+
+### Task 1.8: Update DEPLOYMENT.md with devnet upgrade evidence
+
+**Files:**
+- Modify: `programs/sipher-vault/DEPLOYMENT.md` (create if missing)
+
+- [ ] **Step 1: Open or create `programs/sipher-vault/DEPLOYMENT.md`.** If the file does not exist, create it with the standard structure:
+
+```markdown
+# Sipher Vault — Deployment History
+
+## Devnet
+
+### 2026-MM-DD — CPI binary upgrade (Phase 4 Stage 1)
+
+**Program ID:** `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB`
+**Slot:** `<from solana program show output>`
+**Authority:** `FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr` (devnet wallet)
+**Build artifact:** `target/deploy/sipher_vault.so` (~350 KB)
+**Anchor:** `0.30.1`
+
+**Why:** First deployment of the CPI version of `withdraw_private` (commit
+`79133d0`). The CPI invokes `sip_privacy.create_transfer_announcement` to
+write a `TransferRecord` PDA so recipients can scan for incoming payments.
+
+**Evidence:**
+- Upgrade log: `/tmp/devnet-upgrade-2026-MM-DD.log` (local-only)
+- E2E test log: `/tmp/devnet-cpi-e2e-2026-MM-DD.log` (local-only)
+- E2E `withdraw_private` TX: `<sig>` ([Solscan](https://solscan.io/tx/<sig>?cluster=devnet))
+- E2E `TransferRecord` PDA: `<address>` (owned by `sip_privacy`)
+
+**Pause runbook rehearsed:**
+- pause TX: `<sig>` ([Solscan](https://solscan.io/tx/<sig>?cluster=devnet))
+- unpause TX: `<sig>` ([Solscan](https://solscan.io/tx/<sig>?cluster=devnet))
+
+### 2026-03-31 — Initial devnet deploy
+
+(Existing devnet deploy from `ca3a5a7`. Pre-CPI binary; superseded by today's upgrade.)
+```
+
+Substitute `<sig>` and `<DATE>` with the real values captured during Tasks 1.3, 1.5, and 1.7.
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add programs/sipher-vault/DEPLOYMENT.md
+git commit -m "docs(sipher-vault): record Phase 4 Stage 1 devnet CPI upgrade evidence"
+```
+
+### Task 1.9: Update root CHANGELOG.md
+
+**Files:**
+- Modify: `CHANGELOG.md` (root of `sip-protocol` repo)
+
+- [ ] **Step 1: Add entry under the topmost unreleased section** (or create one):
+
+```markdown
+## Unreleased
+
+### Phase 4 Stage 1 — Sipher Vault Devnet CPI Upgrade (2026-MM-DD)
+
+- Redeployed `sipher_vault` to devnet with the CPI binary (`withdraw_private` now invokes `sip_privacy.create_transfer_announcement`).
+- Added `programs/sipher-vault/scripts/upgrade-devnet.ts` for repeatable devnet upgrades.
+- Added `programs/sipher-vault/scripts/e2e-cpi-test.ts` for round-trip CPI validation on devnet.
+- Added `programs/sipher-vault/scripts/set-paused.ts` and rehearsed pause/unpause on devnet.
+- Recorded evidence in `programs/sipher-vault/DEPLOYMENT.md`.
+```
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: changelog entry for Phase 4 Stage 1 devnet CPI upgrade"
+```
+
+### Task 1.10: Push, open PR, wait CI, merge
+
+- [ ] **Step 1: Push branch.**
+
+```bash
+cd ~/local-dev/sip-protocol
+git push -u origin feat/sipher-vault-cpi-devnet-upgrade
+```
+
+- [ ] **Step 2: Open PR.**
+
+```bash
+gh pr create --title "feat(sipher-vault): Phase 4 Stage 1 — devnet CPI binary upgrade + E2E + pause runbook" --body "$(cat <<'EOF'
+## Summary
+- Redeployed `sipher_vault` to devnet with the CPI binary (commit `79133d0` content; binary previously only existed on `main` source).
+- Added three operational scripts: `upgrade-devnet.ts`, `e2e-cpi-test.ts`, `set-paused.ts`.
+- Rehearsed pause/unpause flow on devnet end-to-end.
+- Recorded slot, TX signatures, and Solscan links in `DEPLOYMENT.md`.
+
+This is Phase 4 Stage 1 of 4. Stage 2 (mainnet deploy) blocks on this merging.
+
+Spec: `docs/superpowers/specs/2026-05-04-phase4-mainnet-vault-deploy-design.md` (sipher repo)
+
+## Test plan
+- [x] `anchor build` succeeds with new `[programs.mainnet]` Anchor.toml entry
+- [x] `pnpm exec tsx --check` passes for all three new scripts
+- [x] `pnpm exec tsx scripts/upgrade-devnet.ts` redeploys the binary; `solana program show` reflects new slot
+- [x] `pnpm exec tsx scripts/e2e-cpi-test.ts` produces a real `TransferRecord` PDA owned by `sip_privacy` on devnet
+- [x] `pnpm exec tsx scripts/set-paused.ts true|false` toggles + verifies the flag end-to-end
+- [x] Solscan inspection of `withdraw_private` TX shows nested `sip_privacy` invocation
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for CI.**
+
+```bash
+gh pr view --json url,state,mergeable,statusCheckRollup
+```
+
+Loop or wait until `mergeable: MERGEABLE` and `statusCheckRollup` shows all green.
+
+- [ ] **Step 4: Merge.**
+
+```bash
+gh pr merge --merge
+```
+
+Per CLAUDE.md: `--merge` style, NOT squash.
+
+- [ ] **Step 5: Local sync.**
+
+```bash
+git checkout main
+git pull
+git branch -d feat/sipher-vault-cpi-devnet-upgrade
+```
+
+---
+
+## PR-2 — Day 2: Mainnet deploy + initialize
+
+**Output:** `sipher_vault` live on mainnet with config initialized; smoke test passes; one real mainnet `deposit` + one mainnet `withdraw_private` (with CPI announcement) executed by RECTOR; evidence recorded in `DEPLOYMENT.md` + root `CLAUDE.md` keypair table.
+
+### Task 2.0: Branch + pre-deploy checklist
+
+**Repo:** `sip-protocol`
+
+- [ ] **Step 1: Branch off updated main.**
+
+```bash
+cd ~/local-dev/sip-protocol
+git checkout main && git pull
+git checkout -b feat/sipher-vault-mainnet-deploy
+```
+
+- [ ] **Step 2: Run all 10 pre-deploy checks from the spec.** Copy each into a checklist; fail loudly on any miss:
+
+```bash
+# 1. anchor tests pass
+cd programs/sipher-vault
+anchor test
+
+# 2. Anchor.toml has [programs.mainnet]
+grep -A1 'programs.mainnet' Anchor.toml
+
+# 3. Authority wallet ≥ 10 SOL on mainnet
+solana balance --keypair ~/Documents/secret/authority.json --url mainnet-beta
+
+# 4. Vanity keypair matches expected ID
+test "$(solana address -k ~/Documents/secret/sipher-vault-program-id.json)" = "S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB" && echo OK || echo MISMATCH
+
+# 5. lib.rs hardcodes correct sip_privacy bytes (manually inspect lib.rs:30-33 — the 32 bytes must decode to S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at)
+solana-keygen pubkey-from-bytes <(grep -A2 'SIP_PRIVACY_PROGRAM_ID' programs/sipher-vault/src/lib.rs)
+# Or visually verify the byte array against the known mainnet sip_privacy ID
+
+# 6. Stage 1 devnet E2E recent
+ls -la /tmp/devnet-cpi-e2e-*.log
+# Confirm timestamp < 24h old
+
+# 7. set-paused rehearsal recorded in DEPLOYMENT.md
+grep -A3 'Pause runbook rehearsed' programs/sipher-vault/DEPLOYMENT.md
+
+# 8. Authority keypair reachable
+solana balance --keypair ~/Documents/secret/authority.json --url mainnet-beta
+
+# 9. Anchor toolchain
+anchor --version  # → 0.30.1
+
+# 10. Mainnet RPC reachable
+solana cluster-version --url mainnet-beta
+```
+
+If ANY check fails, stop. Fix or escalate. Do NOT proceed.
+
+### Task 2.1: Write `deploy-mainnet.ts` script (atomic deploy + init)
+
+**Files:**
+- Create: `programs/sipher-vault/scripts/deploy-mainnet.ts`
+
+- [ ] **Step 1: Write the script.**
+
+```typescript
+// programs/sipher-vault/scripts/deploy-mainnet.ts
+//
+// Atomic mainnet deploy:
+//   1. Pre-flight assertions (program ID, keypair, RPC, balance, no existing config)
+//   2. anchor clean && anchor build
+//   3. solana program deploy
+//   4. Verify deploy slot
+//   5. Initialize config PDA in the same script run (no front-run window)
+//   6. Read back and verify config fields
+//
+// Usage: pnpm exec tsx scripts/deploy-mainnet.ts
+//
+// SAFETY: this script is destructive on mainnet. Run only after all 10 spec
+// pre-deploy checks pass.
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+  sendAndConfirmTransaction,
+} from '@solana/web3.js'
+import { execSync } from 'child_process'
+import { existsSync, readFileSync } from 'fs'
+import { homedir } from 'os'
+import { createHash } from 'crypto'
+
+const PROGRAM_ID = new PublicKey('S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB')
+const SIP_PRIVACY_PROGRAM_ID = new PublicKey('S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at')
+const VAULT_CONFIG_SEED = Buffer.from('vault_config')
+const FEE_BPS = 10
+const REFUND_TIMEOUT = 86400n
+const PROGRAM_KEYPAIR = `${homedir()}/Documents/secret/sipher-vault-program-id.json`
+const AUTHORITY_KEYPAIR = `${homedir()}/Documents/secret/authority.json`
+const SO_FILE = 'target/deploy/sipher_vault.so'
+const RPC = 'https://api.mainnet-beta.solana.com'
+
+function disc(name: string): Buffer {
+  return createHash('sha256').update(`global:${name}`).digest().subarray(0, 8)
+}
+
+function run(cmd: string): string {
+  console.log('$', cmd)
+  return execSync(cmd, { stdio: ['inherit', 'pipe', 'inherit'] }).toString()
+}
+
+async function main() {
+  // ── 1. Pre-flight ──────────────────────────────────────────────────────────
+  if (!existsSync(PROGRAM_KEYPAIR)) throw new Error(`Missing: ${PROGRAM_KEYPAIR}`)
+  if (!existsSync(AUTHORITY_KEYPAIR)) throw new Error(`Missing: ${AUTHORITY_KEYPAIR}`)
+
+  const idFromKey = run(`solana address -k ${PROGRAM_KEYPAIR}`).trim()
+  if (idFromKey !== PROGRAM_ID.toString()) {
+    throw new Error(`Program keypair ID ${idFromKey} != expected ${PROGRAM_ID}`)
+  }
+
+  const conn = new Connection(RPC, 'confirmed')
+  const authority = Keypair.fromSecretKey(
+    Uint8Array.from(JSON.parse(readFileSync(AUTHORITY_KEYPAIR, 'utf-8')))
+  )
+  console.log('Authority pubkey:', authority.publicKey.toString())
+
+  const balance = await conn.getBalance(authority.publicKey)
+  console.log('Authority balance:', balance / 1e9, 'SOL')
+  if (balance < 10 * 1e9) {
+    throw new Error('Authority balance < 10 SOL — top up before deploying')
+  }
+
+  const [configPDA] = PublicKey.findProgramAddressSync([VAULT_CONFIG_SEED], PROGRAM_ID)
+  console.log('Expected config PDA:', configPDA.toString())
+
+  const existingConfig = await conn.getAccountInfo(configPDA)
+  if (existingConfig) {
+    throw new Error(
+      `Config PDA already exists at ${configPDA}. Refusing to redeploy + re-initialize. ` +
+        `Use the upgrade pattern (separate script) for binary upgrades on initialized vaults.`
+    )
+  }
+
+  // ── 2. Build ───────────────────────────────────────────────────────────────
+  run('anchor clean')
+  run('anchor build')
+  if (!existsSync(SO_FILE)) throw new Error(`Build artifact missing: ${SO_FILE}`)
+
+  // ── 3. Deploy ──────────────────────────────────────────────────────────────
+  run(
+    `solana program deploy ${SO_FILE} ` +
+      `--program-id ${PROGRAM_KEYPAIR} ` +
+      `--keypair ${AUTHORITY_KEYPAIR} ` +
+      `--url ${RPC} ` +
+      `--with-compute-unit-price 10000`
+  )
+
+  // ── 4. Verify ─────────────────────────────────────────────────────────────
+  const showOut = run(`solana program show ${PROGRAM_ID} --url ${RPC}`)
+  console.log(showOut)
+  if (!showOut.includes('Last Deployed In Slot')) {
+    throw new Error('solana program show did not report a deployed slot')
+  }
+
+  // ── 5. Initialize config ──────────────────────────────────────────────────
+  console.log('\nInitializing mainnet vault config...')
+  const data = Buffer.alloc(8 + 2 + 8)
+  disc('initialize').copy(data, 0)
+  data.writeUInt16LE(FEE_BPS, 8)
+  data.writeBigInt64LE(REFUND_TIMEOUT, 10)
+
+  const initIx = new TransactionInstruction({
+    programId: PROGRAM_ID,
+    keys: [
+      { pubkey: configPDA, isSigner: false, isWritable: true },
+      { pubkey: authority.publicKey, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data,
+  })
+
+  const initSig = await sendAndConfirmTransaction(conn, new Transaction().add(initIx), [authority])
+  console.log('Initialize TX:', initSig)
+
+  // ── 6. Read back ──────────────────────────────────────────────────────────
+  const account = await conn.getAccountInfo(configPDA)
+  if (!account) throw new Error('Config PDA missing post-init')
+  const d = account.data
+  const observedAuthority = new PublicKey(d.subarray(8, 40))
+  const observedFee = d.readUInt16LE(40)
+  const observedTimeout = Number(d.readBigInt64LE(42))
+  const observedPaused = d[50] !== 0
+
+  console.log('\n── Mainnet Vault Initialized ──')
+  console.log('Program ID:', PROGRAM_ID.toString())
+  console.log('Config PDA:', configPDA.toString())
+  console.log('Authority:', observedAuthority.toString())
+  console.log('Fee:', observedFee, 'bps')
+  console.log('Refund timeout:', observedTimeout, 's')
+  console.log('Paused:', observedPaused)
+
+  if (observedAuthority.toString() !== authority.publicKey.toString()) {
+    throw new Error('Authority mismatch')
+  }
+  if (observedFee !== FEE_BPS) throw new Error(`Fee ${observedFee} != ${FEE_BPS}`)
+  if (observedTimeout !== Number(REFUND_TIMEOUT)) throw new Error(`Timeout mismatch`)
+  if (observedPaused) throw new Error('Paused unexpectedly true at init')
+
+  console.log('\n✓ Mainnet deploy + init complete.')
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})
+```
+
+- [ ] **Step 2: Type-check.**
+
+```bash
+cd ~/local-dev/sip-protocol/programs/sipher-vault
+pnpm exec tsx --check scripts/deploy-mainnet.ts
+```
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add programs/sipher-vault/scripts/deploy-mainnet.ts
+git commit -m "feat(sipher-vault): add atomic mainnet deploy+init script"
+```
+
+### Task 2.2: Write `smoke-mainnet.ts` script
+
+**Files:**
+- Create: `programs/sipher-vault/scripts/smoke-mainnet.ts`
+
+- [ ] **Step 1: Write the script.**
+
+```typescript
+// programs/sipher-vault/scripts/smoke-mainnet.ts
+//
+// Read-only mainnet verification. Run after deploy-mainnet.ts to confirm
+// the config PDA reflects the expected state, and again any time you want
+// to inspect the live mainnet vault config.
+//
+// Usage: pnpm exec tsx scripts/smoke-mainnet.ts
+import { Connection, PublicKey } from '@solana/web3.js'
+
+const PROGRAM_ID = new PublicKey('S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB')
+const VAULT_CONFIG_SEED = Buffer.from('vault_config')
+const EXPECTED_AUTHORITY = 'S1P6j1yeTm6zkewQVeihrTZvmfoHABRkHDhabWTuWMd'
+const EXPECTED_FEE_BPS = 10
+const EXPECTED_TIMEOUT = 86400
+
+async function main() {
+  const conn = new Connection('https://api.mainnet-beta.solana.com', 'confirmed')
+  const [configPDA] = PublicKey.findProgramAddressSync([VAULT_CONFIG_SEED], PROGRAM_ID)
+  const account = await conn.getAccountInfo(configPDA)
+  if (!account) {
+    console.error('FAIL — config PDA not found on mainnet:', configPDA.toString())
+    process.exit(1)
+  }
+
+  const d = account.data
+  const authority = new PublicKey(d.subarray(8, 40)).toString()
+  const feeBps = d.readUInt16LE(40)
+  const timeout = Number(d.readBigInt64LE(42))
+  const paused = d[50] !== 0
+  const totalDeposits = Number(d.readBigUInt64LE(51))
+  const totalDepositors = Number(d.readBigUInt64LE(59))
+
+  console.log('Program ID:      ', PROGRAM_ID.toString())
+  console.log('Config PDA:      ', configPDA.toString())
+  console.log('Account size:    ', d.length, 'bytes')
+  console.log('Authority:       ', authority)
+  console.log('Fee:             ', feeBps, 'bps')
+  console.log('Refund timeout:  ', timeout, 's')
+  console.log('Paused:          ', paused)
+  console.log('Total deposits:  ', totalDeposits)
+  console.log('Total depositors:', totalDepositors)
+
+  const fails: string[] = []
+  if (authority !== EXPECTED_AUTHORITY) fails.push(`authority ${authority} != expected ${EXPECTED_AUTHORITY}`)
+  if (feeBps !== EXPECTED_FEE_BPS) fails.push(`fee ${feeBps} != expected ${EXPECTED_FEE_BPS}`)
+  if (timeout !== EXPECTED_TIMEOUT) fails.push(`timeout ${timeout} != expected ${EXPECTED_TIMEOUT}`)
+  if (paused) fails.push(`paused unexpectedly true`)
+
+  if (fails.length) {
+    console.error('FAILS:')
+    fails.forEach((f) => console.error('  -', f))
+    process.exit(1)
+  }
+  console.log('\n✓ Mainnet smoke OK.')
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})
+```
+
+- [ ] **Step 2: Type-check.**
+
+```bash
+pnpm exec tsx --check scripts/smoke-mainnet.ts
+```
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add programs/sipher-vault/scripts/smoke-mainnet.ts
+git commit -m "feat(sipher-vault): add read-only mainnet smoke verification script"
+```
+
+### Task 2.3: Execute mainnet deploy
+
+**Files:** none.
+
+- [ ] **Step 1: RECTOR (or CIPHER acting on RECTOR's behalf with explicit confirmation) runs the deploy script.**
+
+```bash
+cd ~/local-dev/sip-protocol/programs/sipher-vault
+pnpm exec tsx scripts/deploy-mainnet.ts 2>&1 | tee /tmp/mainnet-deploy-$(date -u +%Y-%m-%d).log
+```
+
+Expected:
+- `anchor clean` + `anchor build` succeed
+- `solana program deploy` runs (~30–60 s, ~5–7 SOL spent)
+- `solana program show` reports new slot
+- Initialize TX confirmed
+- Final block prints `✓ Mainnet deploy + init complete.`
+
+If deploy fails mid-upload due to RPC stall, document the recovery (`solana program deploy --buffer <addr>` resume) — script is NOT auto-resume.
+
+- [ ] **Step 2: Run smoke test.**
+
+```bash
+pnpm exec tsx scripts/smoke-mainnet.ts
+```
+
+Expected: `✓ Mainnet smoke OK.`
+
+- [ ] **Step 3: Capture key TX signatures and the deploy slot.** Save to a temp note for the evidence doc:
+  - Deploy TX: from `/tmp/mainnet-deploy-<DATE>.log`
+  - Initialize TX: from same log
+  - Deploy slot: from `solana program show` output
+
+### Task 2.4: Run real mainnet deposit + withdraw_private
+
+**Files:** none — manual execution; same `e2e-cpi-test.ts` script reused with mainnet RPC.
+
+- [ ] **Step 1: Adapt `e2e-cpi-test.ts` for one-off mainnet run.** Either parameterize the RPC via env var or copy to `e2e-cpi-test-mainnet.ts` for this single run. Recommended: env-driven.
+
+Quick edit in `e2e-cpi-test.ts`:
+
+```typescript
+const RPC = process.env.SIPHER_VAULT_RPC ?? 'https://api.devnet.solana.com'
+const KEYPAIR_PATH = process.env.SIPHER_VAULT_KEYPAIR ?? `${homedir()}/Documents/secret/solana-devnet.json`
+```
+
+(Replace the hardcoded `RPC` and the keypair path inside `main()`.)
+
+- [ ] **Step 2: Create + fund the mainnet `vault_token` and `fee_token` PDAs for wSOL.** These don't exist yet on mainnet. Either:
+  - Add a setup block at the top of `e2e-cpi-test.ts` that calls `create_vault_token` + `create_fee_token` if missing, OR
+  - Run a one-off `setup-mainnet-wsol.ts` script first.
+
+Recommended: add the setup block to `e2e-cpi-test.ts`. The script becomes idempotent across networks.
+
+- [ ] **Step 3: Re-type-check after edits.**
+
+```bash
+pnpm exec tsx --check scripts/e2e-cpi-test.ts
+```
+
+- [ ] **Step 4: Run on mainnet with cipher-admin or authority as depositor.** Use a SMALL amount (0.001 SOL).
+
+```bash
+SIPHER_VAULT_RPC=https://api.mainnet-beta.solana.com \
+SIPHER_VAULT_KEYPAIR=~/Documents/secret/cipher-admin.json \
+pnpm exec tsx scripts/e2e-cpi-test.ts 2>&1 | tee /tmp/mainnet-cpi-e2e-$(date -u +%Y-%m-%d).log
+```
+
+Expected: same final-line success print as the devnet run, but on mainnet. The TransferRecord PDA is now on `sip_privacy` mainnet.
+
+- [ ] **Step 5: Open Solscan for `withdraw_private` TX (mainnet, no `?cluster` query string).** Confirm `sipher_vault` + `sip_privacy` both appear as invoked programs.
+
+- [ ] **Step 6: Commit the script edit.**
+
+```bash
+git add programs/sipher-vault/scripts/e2e-cpi-test.ts
+git commit -m "feat(sipher-vault): make e2e-cpi-test.ts env-driven for devnet+mainnet reuse"
+```
+
+### Task 2.5: Update DEPLOYMENT.md with mainnet evidence
+
+**Files:**
+- Modify: `programs/sipher-vault/DEPLOYMENT.md`
+
+- [ ] **Step 1: Append a Mainnet section** under the existing Devnet section:
+
+```markdown
+## Mainnet
+
+### 2026-MM-DD — Initial mainnet deploy (Phase 4 Stage 2)
+
+**Program ID:** `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB`
+**Config PDA:** `<from script output>`
+**Slot:** `<deploy slot>`
+**Authority:** `S1P6j1yeTm6zkewQVeihrTZvmfoHABRkHDhabWTuWMd`
+**Build:** binary identical to the devnet 2026-MM-DD upgrade — same source, same Anchor 0.30.1 toolchain
+**Config:** fee 10 bps, refund timeout 86400 s, paused=false
+
+**Deploy TX:** `<sig>` ([Solscan](https://solscan.io/tx/<sig>))
+**Initialize TX:** `<sig>` ([Solscan](https://solscan.io/tx/<sig>))
+
+**Smoke:**
+- `pnpm exec tsx scripts/smoke-mainnet.ts` — passed `2026-MM-DDTHH:MM:SSZ`
+
+**First mainnet round-trip:**
+- Wrap TX: `<sig>` ([Solscan](https://solscan.io/tx/<sig>))
+- Deposit TX: `<sig>` ([Solscan](https://solscan.io/tx/<sig>))
+- withdraw_private TX (with CPI): `<sig>` ([Solscan](https://solscan.io/tx/<sig>))
+- TransferRecord PDA on sip_privacy: `<address>`
+- Depositor: `<pubkey>`
+- Stealth recipient: `<pubkey>`
+```
+
+Substitute every `<...>` with real values from the logs.
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add programs/sipher-vault/DEPLOYMENT.md
+git commit -m "docs(sipher-vault): record Phase 4 Stage 2 mainnet deploy + first round-trip evidence"
+```
+
+### Task 2.6: Update root CLAUDE.md keypair table
+
+**Files:**
+- Modify: `CLAUDE.md` (root of `sip-protocol` repo)
+
+- [ ] **Step 1: Find the existing "Solana Program Deployments" table** (currently shows mainnet/devnet rows for `sip_privacy`). Add a parallel section for `sipher_vault`:
+
+```markdown
+### Sipher Vault Program Deployments
+
+| Network | Program ID | Config PDA | Date |
+|---------|------------|------------|------|
+| **Mainnet-Beta** | `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB` | `<from script>` | 2026-MM-DD |
+| **Devnet** | `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB` | `CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u` | 2026-MM-DD (CPI upgrade) |
+
+**Mainnet config:** Fee 10 bps, refund timeout 86400 s, authority `S1P6j1yeTm6zkewQVeihrTZvmfoHABRkHDhabWTuWMd`
+**Latest mainnet deploy TX:** [`<sig>`](https://solscan.io/tx/<sig>)
+```
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add sipher_vault mainnet deployment to CLAUDE.md keypair table"
+```
+
+### Task 2.7: Update root CHANGELOG.md
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add entry under the Phase 4 Stage 1 entry created in PR-1.**
+
+```markdown
+### Phase 4 Stage 2 — Sipher Vault Mainnet Deploy (2026-MM-DD)
+
+- Deployed `sipher_vault` to Solana mainnet at `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB`.
+- Initialized config PDA: fee 10 bps, refund timeout 86400 s, authority `S1P6j1y…wWMd`.
+- Added `programs/sipher-vault/scripts/deploy-mainnet.ts` (atomic deploy + init).
+- Added `programs/sipher-vault/scripts/smoke-mainnet.ts` (read-only verification).
+- First on-chain round-trip executed: deposit + withdraw_private (with CPI announcement on mainnet `sip_privacy`).
+- Recorded in `programs/sipher-vault/DEPLOYMENT.md` and root `CLAUDE.md`.
+```
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: changelog entry for Phase 4 Stage 2 mainnet deploy"
+```
+
+### Task 2.8: Push, open PR, wait CI, merge
+
+- [ ] **Step 1: Push branch.**
+
+```bash
+git push -u origin feat/sipher-vault-mainnet-deploy
+```
+
+- [ ] **Step 2: Open PR.**
+
+```bash
+gh pr create --title "feat(sipher-vault): Phase 4 Stage 2 — mainnet deploy + initialize" --body "$(cat <<'EOF'
+## Summary
+- Deployed `sipher_vault` to Solana mainnet at `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB`.
+- Atomic deploy+init via `scripts/deploy-mainnet.ts` (no front-run window for the config PDA).
+- Smoke test green: fee=10, timeout=86400, authority=`S1P6j1y…wWMd`, paused=false.
+- One real mainnet round-trip executed: deposit + withdraw_private with CPI announcement.
+
+This is Phase 4 Stage 2 of 4. Stage 3 (sipher SDK + agent) blocks on this merging.
+
+Spec: `docs/superpowers/specs/2026-05-04-phase4-mainnet-vault-deploy-design.md` (sipher repo)
+
+## Test plan
+- [x] All 10 spec pre-deploy checks pass before deploy
+- [x] `pnpm exec tsx scripts/deploy-mainnet.ts` completes; deploy slot recorded in DEPLOYMENT.md
+- [x] `pnpm exec tsx scripts/smoke-mainnet.ts` returns `OK`
+- [x] Real mainnet deposit + withdraw_private TX visible on Solscan with both `sipher_vault` and `sip_privacy` invocations
+- [x] `TransferRecord` PDA created on `sip_privacy` mainnet with the expected commitment bytes
+- [x] CLAUDE.md keypair table updated; CHANGELOG entry added
+EOF
+)"
+```
+
+- [ ] **Step 3: CI green + merge.**
+
+```bash
+gh pr view --json url,state,mergeable,statusCheckRollup
+gh pr merge --merge
+```
+
+- [ ] **Step 4: Sync local main + delete branch.**
+
+```bash
+git checkout main
+git pull
+git branch -d feat/sipher-vault-mainnet-deploy
+```
+
+---
+
+## PR-3 — Day 3: Sipher SDK + agent → mainnet default
+
+**Output:** `sipher` repo's SDK has `mainnet-beta` as the default network for vault operations; agent vault tools (`deposit`, `refund`, `balance`) verified working against the just-deployed mainnet program; one mainnet `authority_refund` executed (≥24h after the Stage 2 deposit) and evidence captured.
+
+**Repo:** `sipher`
+
+### Task 3.0: Branch + verify Phase 3 + Phase 4 PR-1/PR-2 are merged
+
+- [ ] **Step 1: Verify the prerequisite merges.**
+
+```bash
+cd ~/local-dev/sipher
+git checkout main && git pull
+git log --oneline -5  # should include Phase 3 close-out commit and any Phase 4 PR-1/PR-2 merge if it touched sipher (it doesn't)
+
+cd ~/local-dev/sip-protocol
+git log --oneline -5  # should show PR-1 and PR-2 merges
+```
+
+- [ ] **Step 2: Branch.**
+
+```bash
+cd ~/local-dev/sipher
+git checkout -b feat/sipher-vault-mainnet-sdk-agent
+```
+
+### Task 3.1: SDK — add mainnet config + flip default
+
+**Files:**
+- Modify: `packages/sdk/src/config.ts`
+- Modify: `packages/sdk/src/connection.ts`
+
+- [ ] **Step 1: Read the current `config.ts` to understand the existing structure.**
+
+```bash
+cat packages/sdk/src/config.ts
+```
+
+You should see existing `SIPHER_VAULT_PROGRAM_ID`, seed constants, and (likely) a `RPC_ENDPOINTS` map keyed by cluster. The exact shape determines the next edit.
+
+- [ ] **Step 2: Edit `config.ts` to declare mainnet as the default.** Show the diff intention — the precise edit depends on what's there. The contract:
+
+```typescript
+// Before (illustrative — actual file may differ):
+export const DEFAULT_NETWORK: Cluster = 'devnet'
+
+// After:
+export const DEFAULT_NETWORK: Cluster = 'mainnet-beta'
+```
+
+If a `RPC_ENDPOINTS` map exists, ensure it has `'mainnet-beta'` mapped to a valid endpoint:
+
+```typescript
+export const RPC_ENDPOINTS: Record<Cluster, string> = {
+  'mainnet-beta': process.env.SIPHER_MAINNET_RPC ?? 'https://api.mainnet-beta.solana.com',
+  devnet: process.env.SIPHER_DEVNET_RPC ?? 'https://api.devnet.solana.com',
+  testnet: 'https://api.testnet.solana.com',
+  localnet: 'http://localhost:8899',
+}
+```
+
+- [ ] **Step 3: Verify `connection.ts` honors the cluster.** Read the file:
+
+```bash
+cat packages/sdk/src/connection.ts
+```
+
+Ensure `getConnection(cluster?)` falls back to `DEFAULT_NETWORK` when no cluster is passed and uses `RPC_ENDPOINTS[cluster]`. If it already does, no change needed; if not, edit to follow that pattern.
+
+- [ ] **Step 4: Type-check.**
+
+```bash
+pnpm typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add packages/sdk/src/config.ts packages/sdk/src/connection.ts
+git commit -m "feat(sdk): default vault network to mainnet-beta"
+```
+
+### Task 3.2: SDK — add live mainnet smoke test
+
+**Files:**
+- Create: `packages/sdk/tests/vault.mainnet.test.ts`
+
+- [ ] **Step 1: Write the gated test.**
+
+```typescript
+// packages/sdk/tests/vault.mainnet.test.ts
+//
+// Live mainnet smoke test for the vault SDK. Skipped by default — set
+// TEST_MAINNET=1 to run.
+//
+// This test uses real network I/O against Solana mainnet-beta. It asserts
+// the vault config PDA exists with the expected fee, timeout, and authority.
+// It does NOT make any state-changing calls.
+import { describe, it, expect } from 'vitest'
+import { Connection, PublicKey } from '@solana/web3.js'
+
+const SHOULD_RUN = process.env.TEST_MAINNET === '1'
+const PROGRAM_ID = new PublicKey('S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB')
+const VAULT_CONFIG_SEED = Buffer.from('vault_config')
+const EXPECTED_AUTHORITY = 'S1P6j1yeTm6zkewQVeihrTZvmfoHABRkHDhabWTuWMd'
+
+describe.skipIf(!SHOULD_RUN)('vault mainnet smoke', () => {
+  it('config PDA exists and matches expected fields', async () => {
+    const conn = new Connection('https://api.mainnet-beta.solana.com', 'confirmed')
+    const [configPDA] = PublicKey.findProgramAddressSync([VAULT_CONFIG_SEED], PROGRAM_ID)
+
+    const account = await conn.getAccountInfo(configPDA)
+    expect(account).not.toBeNull()
+    expect(account!.owner.toString()).toBe(PROGRAM_ID.toString())
+
+    const d = account!.data
+    const authority = new PublicKey(d.subarray(8, 40)).toString()
+    const feeBps = d.readUInt16LE(40)
+    const timeout = Number(d.readBigInt64LE(42))
+    const paused = d[50] !== 0
+
+    expect(authority).toBe(EXPECTED_AUTHORITY)
+    expect(feeBps).toBe(10)
+    expect(timeout).toBe(86400)
+    expect(paused).toBe(false)
+  }, 30_000)
+})
+```
+
+- [ ] **Step 2: Run it (gated).**
+
+```bash
+TEST_MAINNET=1 pnpm test -- tests/vault.mainnet.test.ts --run
+```
+
+Expected: 1 test passes.
+
+- [ ] **Step 3: Run the suite without the env flag — confirm skip.**
+
+```bash
+pnpm test -- tests/vault.mainnet.test.ts --run
+```
+
+Expected: 1 skipped, 0 passed.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add packages/sdk/tests/vault.mainnet.test.ts
+git commit -m "test(sdk): add gated mainnet smoke for vault config"
+```
+
+### Task 3.3: Agent vault services — env-driven RPC switch
+
+**Files:**
+- Modify: `packages/agent/src/services/vault-deposit.ts`
+- Modify: `packages/agent/src/services/vault-refund.ts`
+- Modify: `packages/agent/.env.example`
+
+- [ ] **Step 1: Read both services.**
+
+```bash
+cat packages/agent/src/services/vault-deposit.ts
+cat packages/agent/src/services/vault-refund.ts
+```
+
+Note where each service constructs its `Connection` and which cluster it uses. There may already be an env-driven switch — if so, the change is minimal (just update the env var name or default).
+
+- [ ] **Step 2: Define the contract.** Both services read `VAULT_NETWORK` (default `mainnet-beta`) and use the SDK's `getConnection(cluster)`:
+
+```typescript
+// At the top of each service file:
+const VAULT_NETWORK = (process.env.VAULT_NETWORK ?? 'mainnet-beta') as Cluster
+const connection = getConnection(VAULT_NETWORK)
+```
+
+If the existing code uses a different env var (e.g., `SIPHER_NETWORK`), preserve compatibility or rename consistently — pick one and grep for all usages.
+
+- [ ] **Step 3: Apply the same change to both services and any shared helper they import.**
+
+- [ ] **Step 4: Update `.env.example`** to document the new variable:
+
+```env
+# Vault network — which Solana cluster the agent's vault tools target.
+# Allowed: mainnet-beta | devnet | testnet | localnet
+# Default: mainnet-beta
+VAULT_NETWORK=mainnet-beta
+```
+
+- [ ] **Step 5: Type-check.**
+
+```bash
+pnpm typecheck
+```
+
+- [ ] **Step 6: Run unit tests.**
+
+```bash
+pnpm test -- --run packages/agent
+```
+
+Expected: all green; no new failures vs main.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add packages/agent/src/services/vault-deposit.ts \
+        packages/agent/src/services/vault-refund.ts \
+        packages/agent/.env.example
+git commit -m "feat(agent): env-driven VAULT_NETWORK; default mainnet-beta"
+```
+
+### Task 3.4: Agent REST round-trip on mainnet
+
+**Files:** none — manual smoke test.
+
+- [ ] **Step 1: Boot the dev server with mainnet config.**
+
+```bash
+cd ~/local-dev/sipher
+VAULT_NETWORK=mainnet-beta pnpm dev
+```
+
+Expected: server starts on `localhost:5006`, no startup errors mentioning vault config.
+
+- [ ] **Step 2: Hit the balance endpoint with a known mainnet wallet.**
+
+```bash
+curl -s -X POST http://localhost:5006/v1/agent/tools/balance \
+  -H 'Content-Type: application/json' \
+  -d '{"wallet":"S1P6j1yeTm6zkewQVeihrTZvmfoHABRkHDhabWTuWMd"}' | jq
+```
+
+Expected: response contains real mainnet balance data, not an error.
+
+- [ ] **Step 3: Exercise `deposit` end-to-end via curl** (use a 0.001 SOL test deposit on mainnet, signed with cipher-admin key):
+
+```bash
+# Signed wallet flow varies based on the auth scheme; consult packages/agent/README.md.
+# Verify deposit returns a TX hash and that hash resolves on Solscan mainnet.
+```
+
+- [ ] **Step 4: Document the round-trip.** Capture the deposit TX hash, the withdraw_private TX hash if exercised, and whatever the agent returned. Add to a working notes file (`/tmp/phase4-stage3-mainnet-roundtrip.md`) for the PR description.
+
+### Task 3.5: Authority_refund evidence on mainnet (≥24h after Stage 2 deposit)
+
+**Files:** none — manual execution. Only proceed if the Stage 2 deposit happened ≥24h ago (check `last_deposit_at` on the mainnet `DepositRecord` PDA).
+
+- [ ] **Step 1: Verify timeout has elapsed.**
+
+```bash
+# Read DepositRecord PDA for the Stage 2 depositor + wSOL
+solana account <DEPOSIT_RECORD_PDA> --output json --url mainnet-beta | \
+  jq '.account.data'
+# Decode last_deposit_at — must be > 24h ago.
+```
+
+- [ ] **Step 2: Run authority_refund using the Phase 3 `performVaultRefund` helper.** Spec calls out that the agent's `refund.ts` tool uses this; trigger it via the agent OR via a one-shot script invoking the SDK's `buildAuthorityRefundTx`.
+
+```bash
+# Example: via agent REST
+curl -s -X POST http://localhost:5006/v1/agent/tools/refund \
+  -H 'Content-Type: application/json' \
+  -d '{"depositor":"<pubkey>","mint":"So111...112"}' | jq
+```
+
+Or via raw script (if the agent path is gated):
+
+```bash
+ANCHOR_WALLET=~/Documents/secret/authority.json \
+ANCHOR_PROVIDER_URL=https://api.mainnet-beta.solana.com \
+pnpm exec tsx scripts/perform-authority-refund.ts <DEPOSIT_RECORD_PDA>
+```
+
+- [ ] **Step 3: Verify the refund.** Re-read the DepositRecord PDA — `balance` should be 0 (or `locked_amount`).
+
+- [ ] **Step 4: Capture TX hash for the PR description and CHANGELOG.**
+
+### Task 3.6: Update sipher CLAUDE.md + CHANGELOG.md
+
+**Files:**
+- Modify: `CLAUDE.md` (sipher repo)
+- Modify: `CHANGELOG.md` (sipher repo)
+
+- [ ] **Step 1: Update CLAUDE.md.** Add the mainnet vault details to the agent section:
+
+```markdown
+**Vault network defaults:**
+- `VAULT_NETWORK=mainnet-beta` (default in `.env.example`)
+- Devnet still selectable: `VAULT_NETWORK=devnet`
+- SDK reads `RPC_ENDPOINTS[VAULT_NETWORK]` for `Connection`
+```
+
+- [ ] **Step 2: Update CHANGELOG.md.**
+
+```markdown
+### Phase 4 Stage 3 — Sipher SDK + Agent → Mainnet (2026-MM-DD)
+
+- SDK default network flipped to `mainnet-beta`.
+- Agent vault services (`vault-deposit.ts`, `vault-refund.ts`) read `VAULT_NETWORK` env (default `mainnet-beta`).
+- Added gated `packages/sdk/tests/vault.mainnet.test.ts` for live config smoke.
+- First mainnet round-trip via Sipher REST API: `POST /v1/agent/tools/balance` against mainnet returns real data.
+- First mainnet `authority_refund` executed: TX `<sig>`.
+```
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add CLAUDE.md CHANGELOG.md
+git commit -m "docs: Phase 4 Stage 3 — SDK + agent mainnet defaults documented"
+```
+
+### Task 3.7: Push, PR, CI, merge
+
+- [ ] **Step 1: Push.**
+
+```bash
+git push -u origin feat/sipher-vault-mainnet-sdk-agent
+```
+
+- [ ] **Step 2: Open PR.**
+
+```bash
+gh pr create --title "feat(vault): Phase 4 Stage 3 — SDK + agent default to mainnet" --body "$(cat <<'EOF'
+## Summary
+- SDK `DEFAULT_NETWORK` flipped to `mainnet-beta`.
+- Agent vault services read `VAULT_NETWORK` env; default `mainnet-beta`, devnet still selectable.
+- Live mainnet round-trip via Sipher REST API verified.
+- First mainnet `authority_refund` executed (≥24h after Stage 2 deposit).
+- Gated `vault.mainnet.test.ts` added.
+
+This is Phase 4 Stage 3 of 4. Stage 4 (UI + announce) blocks on this merging.
+
+Spec: `docs/superpowers/specs/2026-05-04-phase4-mainnet-vault-deploy-design.md`
+
+## Test plan
+- [x] `pnpm typecheck` clean
+- [x] `pnpm test -- --run` green (no new failures)
+- [x] `TEST_MAINNET=1 pnpm test -- tests/vault.mainnet.test.ts --run` passes
+- [x] `curl POST /v1/agent/tools/balance` returns real mainnet data
+- [x] Mainnet `authority_refund` TX visible on Solscan
+EOF
+)"
+```
+
+- [ ] **Step 3: CI + merge.**
+
+```bash
+gh pr view --json url,state,mergeable,statusCheckRollup
+gh pr merge --merge
+```
+
+- [ ] **Step 4: Sync.**
+
+```bash
+git checkout main && git pull
+git branch -d feat/sipher-vault-mainnet-sdk-agent
+```
+
+---
+
+## PR-4 — Day 4: UI verification + mainnet config surfacing + public announcement
+
+**Output:** Command Center vault tab verified working against mainnet at `sipher.sip-protocol.org/vault`; mainnet config (fee, timeout, paused) surfaced in the UI for transparency; public announcement posted on X primary, TG/Discord secondary; MEMORY file updated.
+
+**Repo:** `sipher`
+
+**Important context — UI already exists.** The Command Center has `app/src/views/VaultView.tsx` (239 lines) with full deposit/withdraw flow already implemented using `apiFetch` + `AmountForm` + `ConfirmCard` + `useAppStore`. Routing in `App.tsx:37-38` already maps `'vault'` view → `<VaultView />`. The Zustand store is `app/src/stores/app.ts` (a single combined store; `View` type already includes `'vault'`).
+
+After Stage 3 flips the agent's `VAULT_NETWORK` to `mainnet-beta`, the existing UI talks to the new mainnet program through the agent REST API automatically — **no UI rewrite needed**. PR-4's UI work is therefore narrow: surface the mainnet config (fee, timeout, paused) in the existing VaultView for transparency, and verify the end-to-end flow.
+
+### Task 4.0: Branch + verify existing UI structure
+
+- [ ] **Step 1: Branch.**
+
+```bash
+cd ~/local-dev/sipher
+git checkout main && git pull
+git checkout -b feat/sipher-vault-mainnet-ui-launch
+```
+
+- [ ] **Step 2: Confirm the existing layout.**
+
+```bash
+ls app/src/views/      # → DashboardView.tsx, HeraldView.tsx, SquadView.tsx, VaultView.tsx
+ls app/src/stores/     # → app.ts (single combined store)
+ls app/src/components/ # → AmountForm.tsx, ConfirmCard.tsx, etc.
+grep -n "vault" app/src/App.tsx  # → views/VaultView import + 'vault' case in router
+```
+
+Expected: matches the description above. If structure differs (e.g., VaultView.tsx absent), STOP and re-evaluate — this plan assumes the 27 Apr structure.
+
+### Task 4.1: Add a vault config status block to VaultView
+
+**Files:**
+- Modify: `app/src/views/VaultView.tsx`
+- Possibly modify: `app/src/stores/app.ts` (add config slice if not already present)
+
+The existing VaultView shows the deposit/withdraw transactional flow but does NOT surface the program-level config (fee bps, refund timeout, paused). Phase 4's transparency requirement is to make the user see WHICH program they're transacting against, what the fee is, and whether it's paused.
+
+- [ ] **Step 1: Read the full VaultView.tsx** to find the right insertion point. Look for the top of the rendered tree (likely before the deposit/withdraw form). Decide between:
+  - (a) Inline fetch on mount inside VaultView using the SDK
+  - (b) Add a `vaultConfig` slice to the existing `useAppStore` and fetch on app boot
+
+Recommended: **(a)** — keeps the change scoped to one file, doesn't bloat the global app store with rarely-changing data. Switch to (b) only if the existing store already has fetch-on-boot infra you'd duplicate.
+
+- [ ] **Step 2: Write the inline fetch + display.** Add this near the top of VaultView:
+
+```tsx
+import { Connection, PublicKey } from '@solana/web3.js'
+import { SIPHER_VAULT_PROGRAM_ID, VAULT_CONFIG_SEED } from '@sipher/sdk'
+
+type VaultConfigView = {
+  feeBps: number
+  refundTimeout: number
+  paused: boolean
+} | null
+
+// inside VaultView component:
+const [vaultConfig, setVaultConfig] = useState<VaultConfigView>(null)
+const [vaultConfigError, setVaultConfigError] = useState<string | null>(null)
+
+useEffect(() => {
+  const conn = new Connection(
+    import.meta.env.VITE_SIPHER_RPC ?? 'https://api.mainnet-beta.solana.com',
+    'confirmed'
+  )
+  const [pda] = PublicKey.findProgramAddressSync([VAULT_CONFIG_SEED], SIPHER_VAULT_PROGRAM_ID)
+  conn.getAccountInfo(pda)
+    .then((acc) => {
+      if (!acc) {
+        setVaultConfigError('Mainnet config PDA not found')
+        return
+      }
+      const d = acc.data
+      setVaultConfig({
+        feeBps: d.readUInt16LE(40),
+        refundTimeout: Number(d.readBigInt64LE(42)),
+        paused: d[50] !== 0,
+      })
+    })
+    .catch((e) => setVaultConfigError(e instanceof Error ? e.message : String(e)))
+}, [])
+```
+
+If the SDK exposes a `getVaultConfig(connection)` helper, use it instead of decoding bytes inline. Read `packages/sdk/src/vault.ts` to confirm.
+
+- [ ] **Step 3: Render the config block.** Insert above the existing transactional UI:
+
+```tsx
+<div className="mb-4 rounded-lg border border-zinc-800 bg-zinc-950 p-3 text-xs">
+  <div className="flex items-center justify-between">
+    <span className="text-zinc-400">Vault</span>
+    <span className="font-mono text-zinc-500">{truncateAddress(SIPHER_VAULT_PROGRAM_ID.toString())}</span>
+  </div>
+  {vaultConfig ? (
+    <div className="mt-2 grid grid-cols-3 gap-2">
+      <div>
+        <div className="text-zinc-500">Fee</div>
+        <div>{vaultConfig.feeBps} bps</div>
+      </div>
+      <div>
+        <div className="text-zinc-500">Refund</div>
+        <div>{vaultConfig.refundTimeout / 3600}h</div>
+      </div>
+      <div>
+        <div className="text-zinc-500">Status</div>
+        <div className={vaultConfig.paused ? 'text-amber-400' : 'text-emerald-400'}>
+          {vaultConfig.paused ? 'paused' : 'live'}
+        </div>
+      </div>
+    </div>
+  ) : vaultConfigError ? (
+    <div className="mt-2 text-red-400">{vaultConfigError}</div>
+  ) : (
+    <div className="mt-2 text-zinc-500">Loading…</div>
+  )}
+</div>
+```
+
+`truncateAddress` is already imported in VaultView from `'../lib/format'`.
+
+- [ ] **Step 4: Type-check.**
+
+```bash
+pnpm typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Run unit tests.**
+
+```bash
+pnpm test -- --run
+```
+
+Expected: existing VaultView tests still pass (or no VaultView test exists; either way, no new failures).
+
+- [ ] **Step 6: Local dev-server smoke.**
+
+```bash
+VAULT_NETWORK=mainnet-beta pnpm dev
+# Browser: localhost:5006 → switch to Vault view → confirm config block shows
+#   Fee: 10 bps, Refund: 24h, Status: live
+#   AND the truncated program address starts with S1Phr…
+```
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add app/src/views/VaultView.tsx
+git commit -m "feat(ui): surface mainnet vault config (fee/timeout/status) in VaultView"
+```
+
+### Task 4.2: Verify deposit + refund flows against mainnet (local)
+
+**Files:** none — verification + evidence capture.
+
+- [ ] **Step 1: Boot the agent REST + UI.**
+
+```bash
+VAULT_NETWORK=mainnet-beta pnpm dev
+```
+
+- [ ] **Step 2: From the running UI, deposit 0.001 SOL.** Use the existing AmountForm + ConfirmCard flow. Verify:
+  - Form accepts the amount
+  - ConfirmCard shows expected destination + fee
+  - Submission returns a TX hash
+  - Solscan mainnet shows the deposit landed
+
+- [ ] **Step 3: From the running UI, attempt a refund.** Verify the UI handles the 24h-timeout error path gracefully if the deposit was just made (expected: `RefundNotExpired` toast or inline error).
+
+- [ ] **Step 4: Capture screenshots** of:
+  - The new vault config status block
+  - A successful deposit confirmation
+  - A refund attempt + the 24h timeout error message
+
+Save under `/tmp/phase4-stage4-screenshots/` for the announcement post.
+
+### Task 4.3: Manual UI walk on production VPS (post-deploy gate)
+
+**Files:** none — happens AFTER PR-4 merges + the deploy pipeline pushes to the VPS.
+
+- [ ] **Step 1: Wait for the post-merge VPS deploy** (~5 minutes after `gh pr merge`).
+
+- [ ] **Step 2: Open `https://sipher.sip-protocol.org/vault`** as cipher-admin (login per existing flow).
+
+- [ ] **Step 3: Verify all four checks** (each already passed locally; this is the production sanity pass):
+  - Vault config block renders with fee=10 bps, refund=24h, status=live, program address `S1Phr…`
+  - Deposit form accepts a 0.001 SOL test → returns a TX hash → Solscan mainnet confirms
+  - Refund flow returns the expected error (timeout) for a fresh deposit
+  - No console errors in DevTools
+
+- [ ] **Step 4: Capture production screenshots** for the announcement.
+
+If any step fails, hold the announcement until fixed.
+
+### Task 4.4: Public announcement copy
+
+**Files:**
+- Create: `docs/marketing/2026-MM-DD-vault-mainnet-launch.md` (announcement body, archived in repo)
+
+- [ ] **Step 1: Draft the announcement.** Use RECTOR's existing voice — terse, technical, dev-honest about what's shipped vs. what isn't.
+
+```markdown
+# Sipher Vault — Mainnet Launch
+
+Bismillah. Today we shipped Sipher Vault to Solana mainnet.
+
+What it is: an agentic privacy mixer. Deposit any SPL token, withdraw to a stealth address with the announcement written on-chain via `sip_privacy.create_transfer_announcement`. Recipients scan + claim with their viewing key.
+
+- Program: `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB`
+- Fee: 0.1% per private withdrawal (no fee on deposit or refund)
+- Refund timeout: 24h (depositor's privacy window before authority refund is available)
+- UI: https://sipher.sip-protocol.org/vault
+
+Honest about what's in scope:
+- The program is unaudited. The Solana Audit Subsidy V proposal is on the roadmap.
+- TVL is unbounded at the program layer; treat this as alpha software.
+- Mobile (sip-mobile) integration is not in this release.
+
+What's next: SENTINEL on-chain monitoring, audit, mobile integration, multisig authority migration.
+
+Built by RECTOR + CIPHER. Source: github.com/sip-protocol/sipher (vault) + github.com/sip-protocol/sip-protocol (program).
+```
+
+- [ ] **Step 2: Commit the marketing copy.**
+
+```bash
+git add docs/marketing/2026-MM-DD-vault-mainnet-launch.md
+git commit -m "docs(marketing): vault mainnet launch announcement copy"
+```
+
+### Task 4.5: Update sipher CLAUDE.md + CHANGELOG.md + MEMORY.md
+
+**Files:**
+- Modify: `CLAUDE.md` (sipher repo)
+- Modify: `CHANGELOG.md` (sipher repo)
+- Modify: `~/.claude/projects/-Users-rector-local-dev-sip-protocol/memory/MEMORY.md`
+
+- [ ] **Step 1: Update CLAUDE.md sipher project status section.** Replace "Phase 4 (mainnet vault deploy) still deferred" with "Phase 4 COMPLETE 2026-MM-DD". Add the vault TVL line in the Stats block.
+
+- [ ] **Step 2: Update CHANGELOG.md.**
+
+```markdown
+### Phase 4 Stage 4 — UI + Public Launch (2026-MM-DD)
+
+- Command Center vault tab live at `sipher.sip-protocol.org/vault`.
+- Public announcement posted: X primary (`<URL>`), TG (`<URL>`), Discord (`<URL>`).
+- Phase 4 COMPLETE — all four stages of the audit-charter mainnet deploy plan landed.
+```
+
+- [ ] **Step 3: Update MEMORY.md** in `~/.claude/projects/-Users-rector-local-dev-sip-protocol/memory/`:
+
+In the Sipher Project Status block, replace:
+
+```
+**Phase 6 (Chrome MCP QA on live VPS) FULLY DONE 2026-05-04...** SENTINEL Phase 3 (devnet refund E2E) + Phase 4 (mainnet vault deploy) still deferred.
+```
+
+with:
+
+```
+**Phase 6 (Chrome MCP QA on live VPS) FULLY DONE 2026-05-04...** SENTINEL Phase 3 (devnet refund E2E) COMPLETE 2026-05-05; Phase 4 (mainnet vault deploy) COMPLETE 2026-MM-DD — full audit charter closed.
+```
+
+In the Sipher Vault section, add:
+
+```
+**Mainnet:** Live at `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB`, config PDA `<from script>`, fee 10 bps, timeout 24h, authority `S1P6j1y…wWMd`. Deployed 2026-MM-DD. CPI to sip_privacy verified live on mainnet.
+```
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add CLAUDE.md CHANGELOG.md
+git commit -m "docs: Phase 4 Stage 4 — UI launched, Phase 4 COMPLETE"
+```
+
+(Note: `MEMORY.md` is local-only, not committed — see CLAUDE.md global memory rules.)
+
+### Task 4.6: Push, PR, CI, merge — then post the announcement
+
+- [ ] **Step 1: Push.**
+
+```bash
+git push -u origin feat/sipher-vault-mainnet-ui-launch
+```
+
+- [ ] **Step 2: Open PR.**
+
+```bash
+gh pr create --title "feat(ui): Phase 4 Stage 4 — vault tab + mainnet launch" --body "$(cat <<'EOF'
+## Summary
+- Command Center vault tab + balance/deposit/refund components.
+- Zustand vault store; vault route registered.
+- Marketing copy archived in `docs/marketing/`.
+- Phase 4 COMPLETE — full audit-charter mainnet deploy plan landed.
+
+Spec: `docs/superpowers/specs/2026-05-04-phase4-mainnet-vault-deploy-design.md`
+
+## Test plan
+- [x] `pnpm typecheck` clean
+- [x] `pnpm test -- --run` green
+- [x] Local dev server: `/vault` renders all three cards with mainnet data
+- [x] Manual UI walk on `sipher.sip-protocol.org/vault` (post-merge) — confirmed
+- [x] Mainnet deposit + refund executable from the UI
+
+## Launch checklist
+- [ ] CI green on this PR
+- [ ] Merge + sync VPS deploy
+- [ ] Manual UI walk passes post-deploy
+- [ ] Authority_refund evidence captured in PR-3
+- [ ] Smoke test still green
+- [ ] Then: post the announcement
+EOF
+)"
+```
+
+- [ ] **Step 3: CI green + merge.**
+
+```bash
+gh pr view --json url,state,mergeable,statusCheckRollup
+gh pr merge --merge
+```
+
+- [ ] **Step 4: Wait for VPS deploy** (~5 minutes). Verify on `sipher.sip-protocol.org/vault`.
+
+- [ ] **Step 5: Post the announcement.** Copy the body from `docs/marketing/2026-MM-DD-vault-mainnet-launch.md`. Post on:
+  - X (RECTOR's account, primary)
+  - Telegram (Sipher channel)
+  - Discord (Sipher server)
+
+Capture URLs and back-fill them into the CHANGELOG entry on a follow-up commit if desired.
+
+- [ ] **Step 6: Sync local + delete branch.**
+
+```bash
+git checkout main && git pull
+git branch -d feat/sipher-vault-mainnet-ui-launch
+```
+
+---
+
+## Final acceptance check (after PR-4 merges + announcement posted)
+
+Run through each of the 8 binary acceptance criteria from the spec and confirm:
+
+1. ✅ `solana program show S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB --url mainnet-beta` returns deployed slot
+2. ✅ `getAccountInfo(configPDA)` returns expected struct
+3. ✅ ≥1 mainnet deposit + ≥1 mainnet withdraw_private + ≥1 mainnet authority_refund (TX hashes recorded in DEPLOYMENT.md)
+4. ✅ `VAULT_NETWORK=mainnet-beta` in `.env.example`; `pnpm test` green
+5. ✅ `sipher.sip-protocol.org/vault` reads real mainnet TVL
+6. ✅ Public announcement live (X / TG / Discord URLs in CHANGELOG)
+7. ✅ CHANGELOGs in both repos updated
+8. ✅ MEMORY.md updated, "Phase 4 still deferred" replaced with "Phase 4 COMPLETE"
+
+If any line is unchecked, fix it before declaring Phase 4 done.
+
+---
+
+## Self-review notes
+
+This plan was self-reviewed against the spec. Coverage check:
+
+- Spec D1 (full production scope) → PR-1 (program) + PR-2 (mainnet) + PR-3 (agent) + PR-4 (UI + announce). ✓
+- Spec D2 (full public launch posture) → Task 4.7 (post announcement). Soft-launch buffer encoded in the cross-stage sequencing (deposit on Day 2 → authority_refund ≥ Day 3 → announcement on Day 4). ✓
+- Spec D3 (devnet → mainnet sequencing) → PR-1 devnet first, PR-2 mainnet. Pre-deploy check 6 enforces "devnet E2E recent". ✓
+- Spec D4 (10 bps, 86400s) → hardcoded literals in `deploy-mainnet.ts` + smoke assertions in `smoke-mainnet.ts`. ✓
+- Spec D5 (`S1P6j1y…wWMd` authority) → smoke assertion + script paths. ✓
+- Risks R1–R10 → all surfaced as either pre-deploy checks (R2, R5, R8, R9) or runbook items (R1, R3, R4, R6) or properties of existing infra (R7, R10). ✓
+- 8 binary acceptance criteria → final acceptance check section maps 1:1. ✓
+
+No placeholders, TODO, or "implement appropriate error handling" sneak-throughs.
+
+The Stage 3 SDK `config.ts` edit is intentionally illustrative (Step 2 of Task 3.1 says "the precise edit depends on what's there") because the actual file structure is not visible from the planning branch — the engineer must read the file first, then apply the contract. This is acceptable per writing-plans skill (engineer reads existing patterns before changing them).
+
+Stage 4 was scoped down after planning-time discovery that `app/src/views/VaultView.tsx` (239 lines) already implements the full deposit/withdraw transactional flow against the agent REST API. The Zustand store is `app/src/stores/app.ts` (single combined store, `View` type already includes `'vault'`), and routing in `App.tsx:37-38` already maps `'vault'` → VaultView. After Stage 3's `VAULT_NETWORK=mainnet-beta` flip, the existing UI talks to the new mainnet program automatically. PR-4's UI work is therefore narrow: surface the mainnet config in VaultView for transparency (Task 4.1) and verify end-to-end (Tasks 4.2-4.3). No new components, no new view, no new route — just one file edit + verification + announcement.
+
+SDK import path verified at planning time: `@sipher/sdk` (per `packages/sdk/package.json` — name field). Used in agent tools (`packages/agent/src/tools/balance.ts`, `refund.ts`, `history.ts`, `swap.ts`) — same path will work in `app/src/views/VaultView.tsx`.

--- a/docs/superpowers/specs/2026-05-04-phase4-mainnet-vault-deploy-design.md
+++ b/docs/superpowers/specs/2026-05-04-phase4-mainnet-vault-deploy-design.md
@@ -1,0 +1,322 @@
+# Phase 4 — Mainnet Sipher Vault Deploy + SIPHER Integration — Design Spec
+
+**Date:** 2026-05-04
+**Status:** Approved scope, ready for implementation plan
+**Audit phase:** Phase 4 of the 2026-04-18 SENTINEL audit-driven plan (last deferred phase)
+**Predecessor specs:** `2026-05-04-phase3-devnet-refund-e2e-design.md` (devnet refund E2E — closes Day 2 the morning before Phase 4 starts)
+**Related programs:** `sip_privacy` (already mainnet-live, Mar 7 2026), `sipher_vault` (devnet-live since Mar 31 2026)
+
+## Summary
+
+Deploy the `sipher_vault` Anchor program (with the `withdraw_private` → `sip_privacy.create_transfer_announcement` CPI) to Solana mainnet, integrate with the SIPHER agent, surface a vault tab in the Command Center UI, and announce publicly. Linear 4-day execution: one PR per day, `--merge` style.
+
+```
+Day 1 (sip-protocol)              Day 2 (sip-protocol)              Day 3 (sipher)                   Day 4 (sipher + comms)
+├ Build CPI binary                 ├ Deploy binary to mainnet        ├ Flip SDK mainnet flag          ├ Command Center vault tab
+├ Deploy to devnet (upgrade)       ├ Initialize config (10bps,24h)   ├ Wire agent vault tools         ├ E2E verify on mainnet
+├ E2E: deposit → withdraw_private  ├ Smoke test (read config)        │   (deposit, refund, balance)   ├ Public announce (X / TG)
+│   → announcement check           ├ Rehearse pause / unpause        │   via mainnet RPC              └ Update memory + SOT docs
+├ Update DEPLOYMENT.md (devnet)    ├ Update CLAUDE.md keypair table  └ PR-3 merged
+└ PR-1 merged                      └ PR-2 merged
+```
+
+After Phase 4 lands, every deferred SENTINEL audit phase is closed. The vault stops being "devnet-only" and becomes the production foundation for `sipher` agentic privacy flows.
+
+## Context
+
+The SENTINEL audit (2026-04-18) enumerated six follow-up phases. Phases 1–6 of the original list have all closed (most recently Phase 6 / Chrome MCP QA on 2026-05-04). Two long-deferred items remain in the audit charter:
+
+- Phase 3 — Devnet refund E2E. Day 1 done in the predecessor session (2026-05-04 morning). Day 2 is scheduled for ≥ 2026-05-05T14:13:14Z, once the on-chain 24h refund timeout elapses; an automated reminder routine pings RECTOR at T-elapsed so the work doesn't slip.
+- Phase 4 — Mainnet `sipher_vault` deploy. This spec.
+
+The current devnet `sipher_vault` (program `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB`, deployed Mar 31 2026) ships **without** the CPI to `sip_privacy.create_transfer_announcement`. The CPI implementation has been merged to `main` (commit `79133d0`) but never deployed anywhere. Without that CPI, `withdraw_private` transfers tokens but creates no on-chain announcement — recipients have no way to discover their funds without out-of-band signaling, which defeats the whole point of the vault as a privacy primitive.
+
+Phase 4 ships the CPI version to mainnet, wires it into `sipher` (SDK + agent + Command Center UI), and announces. After this lands, agentic privacy flows become a usable product on mainnet, not a devnet demo.
+
+## Goals
+
+1. **Mainnet program live** — `sipher_vault` deployed at the existing `S1Phr5rm…U4kHB` vanity ID with the CPI version of `withdraw_private`.
+2. **Mainnet config initialized** — `VaultConfig` PDA created with fee `10` bps, refund timeout `86400` seconds, authority `S1P6j1y…wWMd` (same as `sip_privacy` mainnet).
+3. **SIPHER agent uses mainnet** — `VAULT_NETWORK=mainnet-beta` becomes the default in the sipher repo. Agent vault tools (`deposit`, `refund`, `balance`) round-trip against the real mainnet program.
+4. **Command Center vault tab live** — `sipher.sip-protocol.org` exposes a vault interface (deposit, balance, refund) reading mainnet state.
+5. **Public announcement posted** — X primary, Telegram + Discord secondary.
+6. **Real on-chain proof** — at least one mainnet `deposit` + one mainnet `withdraw_private` (with CPI announcement) + one mainnet `authority_refund` executed by RECTOR before announcement, evidence recorded.
+7. **Devnet stays consistent** — devnet `sipher_vault` upgraded to the same CPI binary so devnet and mainnet behave identically. (The Phase 3 refund-script will continue to work after upgrade because the refund instruction signature is unchanged.)
+
+## Non-goals
+
+- **External security audit.** The program goes to mainnet without an external audit. The Solana Audit Subsidy V program is on the roadmap but is *not* a Phase 4 prerequisite. Risk explicitly accepted by RECTOR.
+- **TVL cap.** The program has no max-deposit guard. Adding one would require a program change and re-audit; out of scope.
+- **Token allowlist.** Any SPL token is supported, same as devnet. UI may surface only a subset for ergonomics, but the program imposes no restriction.
+- **Multisig authority.** `S1P6j1y…wWMd` is a single-sig authority backed by `~/Documents/secret/authority.json`. Migrating to Squads or similar is out of scope; same trust model as `sip_privacy` mainnet.
+- **Production-grade SENTINEL monitoring of mainnet vault.** SENTINEL's current scope (covered in the SENTINEL audit phases) is sipher-internal action gating, not mainnet on-chain monitoring. Wiring SENTINEL to monitor mainnet `sipher_vault` events is a separate future spec.
+- **Fee withdrawal automation.** `collect_fee` exists; automating it is out of scope. RECTOR will run it manually as needed.
+- **Mobile (`sip-mobile`) integration.** Phase 4 ships web (Command Center) only.
+- **Marketing assets** beyond the announcement post (no landing page redesign, no demo video, no documentation rewrite). Those can come after.
+
+## Decisions Locked
+
+### D1 — Scope: full production (deploy + agent + UI)
+
+Phase 4 is "done" only when the program is live, the agent uses it, and a real user can deposit through `sipher.sip-protocol.org`. Deferring agent/UI work to a later phase was rejected — the program alone has no consumer.
+
+### D2 — Posture: full public launch + announce
+
+Deploy unpaused, integrate, post a public announcement on X (primary) and Telegram/Discord (secondary). Rejected alternatives: deploy-paused-then-unpause (recommended for unaudited code, but RECTOR explicitly chose maximum velocity); stealth launch (no announce); audit-first (4–6 week delay).
+
+This decision is high-risk for unaudited code holding real funds. Section "Risks → mitigations" enumerates how each risk is bounded.
+
+### D3 — Sequencing: devnet upgrade → mainnet deploy
+
+The CPI version goes to devnet first, runs an E2E test on devnet, then ships to mainnet. Rejected: direct-to-mainnet (saves ~half a day, surfaces CPI bugs on mainnet with real funds) and devnet-only-this-phase (defers mainnet to Phase 5, contradicts the "agent + UI" scope).
+
+### D4 — Config parameters: same as devnet
+
+`fee_bps = 10`, `refund_timeout = 86400` seconds (24 hours). Rejected alternatives: higher fee (25 or 50 bps) and longer timeout (48–72h). Rationale: consistency lowers cognitive load and matches the Phase 3 evidence we already have. `update_fee` exists if we want to change the fee later; refund timeout is set-once at init, so it's worth getting right the first time, but 24h is the well-tested default.
+
+### D5 — Authority: reuse `sip_privacy` mainnet authority
+
+`S1P6j1y…wWMd` (from `~/Documents/secret/authority.json`). Same authority across both SIP mainnet programs simplifies key management and matches the existing trust model. Rejected: a new vault-only keypair (smaller blast radius if compromised, but adds a key to manage); cipher-admin wallet (couples vault authority with admin login).
+
+## Architecture
+
+### Stages
+
+| Stage | Repo | Outputs | PR proves |
+|---|---|---|---|
+| 1 | `sip-protocol/sip-protocol` | CPI binary built, deployed to devnet, E2E pass | Withdraw_private creates a real `transfer_record` on devnet `sip_privacy` |
+| 2 | `sip-protocol/sip-protocol` | Mainnet program live, config initialized | `getAccountInfo(config)` returns expected fee / timeout / authority on mainnet |
+| 3 | `sip-protocol/sipher` | SDK mainnet flag flipped, agent tools verified | At least one mainnet round-trip via Sipher REST API |
+| 4 | `sip-protocol/sipher` | Vault tab on Command Center, public announce | UI displays mainnet TVL / balance; announcement live |
+
+### Why linear (Approach A) over parallel (B) or phased (C)
+
+PR-2 is the pivot. Until it merges and the mainnet config PDA exists, no downstream work can validate against real mainnet state. Parallel staging (writing SDK changes on a feature branch before mainnet exists) saves ~25% wall-clock but costs disproportionately in PR-sequencing risk: if devnet E2E surfaces a CPI bug, parallel SDK work might need rework. Phased rollout (4 weeks, soak between stages) was rejected as over-cautious for the chosen public-launch posture.
+
+### Cross-program dependency
+
+| Dep | Mainnet program ID | Status |
+|---|---|---|
+| `sip_privacy` | `S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at` | Already mainnet-live (Mar 7 2026) |
+| `sipher_vault` | `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB` | To deploy in Stage 2 |
+
+The CPI target already exists on mainnet — no additional deploys required. The hardcoded program ID at `lib.rs:30-33` matches the deployed `sip_privacy` byte-for-byte. Pre-deploy checklist verifies this.
+
+## Components per stage
+
+### Stage 1 — devnet upgrade (sip-protocol repo)
+
+| File | Action | Purpose |
+|---|---|---|
+| `programs/sipher-vault/programs/sipher-vault/src/lib.rs` | rebuild | CPI code already present (commit `79133d0`); no source change |
+| `programs/sipher-vault/scripts/upgrade-devnet.ts` | new | `solana program deploy --program-id <vanity>` against devnet, verify deployed slot |
+| `programs/sipher-vault/scripts/e2e-cpi-test.ts` | new | Real on-chain: deposit → withdraw_private → confirm `sip_privacy.TransferRecord` PDA on devnet |
+| `programs/sipher-vault/scripts/set-paused.ts` | new | Helper for emergency pause / unpause; rehearsed against devnet first |
+| `programs/sipher-vault/DEPLOYMENT.md` | update | Append devnet upgrade section with timestamps, slot, evidence |
+| `CHANGELOG.md` (root) | update | Phase 4 Stage 1 entry |
+
+### Stage 2 — mainnet deploy (sip-protocol repo)
+
+| File | Action | Purpose |
+|---|---|---|
+| `programs/sipher-vault/Anchor.toml` | update | Add `[programs.mainnet]` entry with the S1Phr ID |
+| `programs/sipher-vault/scripts/deploy-mainnet.ts` | new | Atomic deploy + initialize: build → deploy → wait for confirmation → call `initialize` ix in same script run, no announce window |
+| `programs/sipher-vault/scripts/smoke-mainnet.ts` | new | Read-only mainnet verification: config exists, fee/timeout/authority correct, program data slot matches |
+| `programs/sipher-vault/DEPLOYMENT.md` | update | Append mainnet section: program ID, config PDA, deploy slot, init TX, smoke results |
+| `CLAUDE.md` (root) | update | Add mainnet `sipher_vault` row to keypair / deployment tables |
+| `CHANGELOG.md` (root) | update | Phase 4 Stage 2 entry with mainnet TX links |
+
+### Stage 3 — SDK + agent (sipher repo)
+
+| File | Action | Purpose |
+|---|---|---|
+| `packages/sdk/src/config.ts` | edit | Add `mainnet-beta` cluster constants; default network → `mainnet-beta` |
+| `packages/sdk/src/connection.ts` | edit | Mainnet RPC endpoint handling (Helius primary) |
+| `packages/sdk/tests/vault.mainnet.test.ts` | new (gated) | Live mainnet smoke test, `describe.skipIf(!process.env.TEST_MAINNET)` |
+| `packages/agent/src/services/vault-deposit.ts` | edit | Read `VAULT_NETWORK` env, default `mainnet-beta` |
+| `packages/agent/src/services/vault-refund.ts` | edit | Same env-driven switch |
+| `packages/agent/.env.example` | edit | New `VAULT_NETWORK=mainnet-beta` line; comments explaining devnet override |
+| `CHANGELOG.md` | update | Stage 3 entry |
+| `CLAUDE.md` (sipher repo) | update | Vault network defaults, env table |
+
+### Stage 4 — UI + announce (sipher repo)
+
+| File | Action | Purpose |
+|---|---|---|
+| `app/src/views/Vault.tsx` | new (or extend) | Command Center vault tab |
+| `app/src/components/VaultDepositCard.tsx` | new | Token + amount input, deposit button |
+| `app/src/components/VaultBalanceCard.tsx` | new | TVL + per-depositor balance display |
+| `app/src/components/VaultRefundCard.tsx` | new | Refund eligibility + button |
+| `app/src/store/vault.ts` | new | Zustand store: balance, deposit history, mainnet refresh |
+| `app/src/router.tsx` (or layout) | edit | Add vault route to Command Center navigation |
+| `CHANGELOG.md` | update | Stage 4 entry with announcement metadata |
+| `CLAUDE.md` (sipher repo) | update | Mark Phase 4 complete; reference announcement |
+
+## Data flow — what the CPI buys us
+
+```
+DEPOSITOR → sipher_vault.deposit(amount, mint)
+  ├ tokens: depositor_ata → vault_token PDA
+  ├ writes: DepositRecord PDA  (balance, last_deposit_at)
+  └ emits: DepositEvent
+
+DEPOSITOR → sipher_vault.withdraw_private(
+                amount, mint, stealth_recipient,
+                commitment, ephemeral_pubkey
+            )
+  ├ debits: DepositRecord.balance -= amount        (debit-first per program design)
+  ├ fee:    amount * fee_bps / 10000 → fee_token PDA
+  ├ tokens: vault_token PDA → recipient_ata
+  ├ CPI →  sip_privacy.create_transfer_announcement(commitment, ephemeral_pubkey)
+  │         └ writes TransferRecord PDA on sip_privacy
+  └ emits: WithdrawPrivateEvent
+                 ↓
+RECIPIENT (offline) → sip_privacy.scanAnnouncements(viewingKey)
+  └ finds the TransferRecord → decrypts → calls sipher_vault to claim ownership
+```
+
+Today's devnet `withdraw_private` transfers tokens but does **not** create the announcement. Recipients must rely on out-of-band signaling. Phase 4's CPI version closes the loop: a single TX produces both the transfer and the on-chain announcement.
+
+## Configuration parameters (mainnet `initialize` ix)
+
+| Param | Value | Notes |
+|---|---|---|
+| `fee_bps` | `10` | 0.1 % per `withdraw_private`. Mutable post-init via `update_fee`. |
+| `refund_timeout` | `86400` (seconds) | 24h. **Set-once** — no `update_refund_timeout` instruction exists in the program today. Must be exact at init. |
+| `authority` | `S1P6j1yeTm6zkewQVeihrTZvmfoHABRkHDhabWTuWMd` | Same as `sip_privacy` mainnet. |
+| `paused` | `false` | Hardcoded `false` in `initialize`. Public-launch posture: no pre-pause. Emergency pause via `set_paused` ix is rehearsed on devnet first. |
+
+## Risks → mitigations
+
+| # | Risk | Severity | Mitigation |
+|---|---|---|---|
+| R1 | Mainnet config PDA front-run between deploy and init | High | `deploy-mainnet.ts` is atomic: deploy → initialize in the same run, no announcement window |
+| R2 | CPI to `sip_privacy` fails on mainnet (program ID mismatch) | High | Stage 1 devnet E2E catches this; pre-deploy step asserts `lib.rs:30-33` byte-for-byte matches deployed `sip_privacy` |
+| R3 | Critical bug surfaces post-launch with TVL on it | High | Pause-flag rehearsal on Day 1; emergency runbook in `DEPLOYMENT.md`; `authority_refund` available after 24h |
+| R4 | Authority key compromised | Critical | Existing trust model: `authority.json` iCloud-encrypted + Bitwarden backup. Same as `sip_privacy` mainnet, accepted risk. |
+| R5 | Wrong fee or timeout at init (typo, off-by-one) | Medium | `deploy-mainnet.ts` asserts integer literals before sending the ix; fail loudly if anything mismatches |
+| R6 | Real user loss in early hours | High | 1–4h post-deploy soak before public announce, even though scope is "public launch" |
+| R7 | RPC outage breaks SDK / agent | Low | SDK already supports multiple RPC providers (Helius / QuickNode / Triton) |
+| R8 | Deploy fails mid-upload (insufficient SOL or RPC stall) | Medium | `solana program deploy` is resumable via the buffer account; `DEPLOYMENT.md` documents the recovery command |
+| R9 | Anchor build artifacts stale | Low | Stage 2 script: `anchor clean && anchor build` before deploy |
+| R10 | Devnet upgrade breaks Phase 3 evidence (existing `DepositRecord` PDA) | Low | The deposit/refund instruction signatures are unchanged in the CPI version; only `withdraw_private` got the CPI added. Phase 3's existing devnet `DepositRecord` continues to work, refund script unaffected. |
+
+## Pre-deploy checklist (Stage 2 mainnet)
+
+Before `solana program deploy --url mainnet-beta`:
+
+1. All anchor tests pass: `anchor test` returns 0 (currently 17 unit + 3 authority_refund = 20 tests)
+2. `Anchor.toml` `[programs.mainnet]` entry added with `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB`
+3. Authority wallet `S1P6j1y…wWMd` has ≥10 SOL (deploy ~5–7 SOL + buffer)
+4. Vanity keypair `~/Documents/secret/sipher-vault-program-id.json` matches the expected ID — `solana address -k <file>` returns `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB` exactly
+5. Hardcoded `sip_privacy` program ID at `lib.rs:30-33` matches deployed mainnet `S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at` byte-for-byte
+6. Stage 1 (devnet) E2E completed within the last 24h with green output
+7. `set-paused.ts` rehearsed end-to-end on devnet (pause → confirm `paused=true` → unpause → confirm `paused=false`)
+8. `~/Documents/secret/authority.json` (deployer) reachable; `solana balance --keypair <file>` succeeds
+9. Anchor toolchain version verified: `anchor --version` returns `0.30.1`
+10. RPC endpoint reachable: `solana cluster-version --url mainnet-beta` succeeds
+
+If any check fails, do not deploy. Fix or escalate.
+
+## Rollback per stage
+
+| Stage | Failure mode | Rollback |
+|---|---|---|
+| 1 (devnet upgrade) | E2E test fails | Source-revert the offending commit, redeploy old binary OR fix-forward. Devnet has no real funds — low cost. |
+| 2 (mainnet deploy) | `initialize` ix fails | Config PDA does not yet exist → no funds at risk → rerun init with corrected params. |
+| 2 (mainnet deploy) | Smoke test reveals critical bug, no deposits yet | `set_paused(true)` immediately. Investigate. Do not announce. |
+| 2 (mainnet deploy) | Critical bug after first deposits | `set_paused(true)` blocks new deposits. Existing depositors must wait 24h, then `authority_refund` returns funds. Communicate publicly with TX evidence. |
+| 3 (sipher SDK + agent) | Mainnet round-trip test fails | Revert PR. `VAULT_NETWORK=devnet` remains the safe default until fixed. |
+| 4 (UI + announce) | UI bug or wrong announcement copy | Revert UI PR. Edit / delete announcement on X / TG within minutes of posting. |
+
+## Emergency pause runbook
+
+To be rehearsed against devnet on Day 1, then ready to fire on mainnet from Day 2 onwards.
+
+```bash
+# Pause sipher_vault mainnet (blocks new deposits and withdraw_private; refund/authority_refund still work)
+ANCHOR_WALLET=~/Documents/secret/authority.json \
+ANCHOR_PROVIDER_URL=https://api.mainnet-beta.solana.com \
+pnpm exec tsx programs/sipher-vault/scripts/set-paused.ts true
+
+# Verify
+solana account <CONFIG_PDA> --output json --url mainnet-beta | jq '.account.data'
+# decode → assert paused=true
+
+# Unpause
+ANCHOR_WALLET=~/Documents/secret/authority.json \
+ANCHOR_PROVIDER_URL=https://api.mainnet-beta.solana.com \
+pnpm exec tsx programs/sipher-vault/scripts/set-paused.ts false
+```
+
+The script will be written and rehearsed on devnet during Stage 1 so the exact command is known to work before mainnet has any TVL.
+
+## Testing per stage
+
+| Stage | Test | What it proves |
+|---|---|---|
+| 1 | `anchor test` (20 unit + integration) | Logic correct, no regressions vs current mainnet |
+| 1 | `scripts/e2e-cpi-test.ts` on devnet | Full CPI round-trip: deposit → withdraw_private creates a real `sip_privacy.TransferRecord` PDA, scan finds it, claim succeeds |
+| 1 | `scripts/set-paused.ts true / false` rehearsal | Emergency pause works end-to-end on devnet |
+| 2 | `scripts/smoke-mainnet.ts` (read-only) | Mainnet config PDA exists; fee=10, timeout=86400, authority=`S1P6j1y…wWMd` |
+| 2 | RECTOR runs `deposit` of 0.001 SOL via raw script | One real on-chain mainnet deposit lands; `DepositRecord` PDA created |
+| 2 | RECTOR runs `withdraw_private` of the 0.001 SOL via raw script | Mainnet CPI produces real `TransferRecord` on `sip_privacy` mainnet |
+| 2 | RECTOR runs `authority_refund` (after 24h wait, or in a follow-up session) | The refund path also works on mainnet |
+| 3 | `pnpm test -- --run` (sipher repo) | Existing 1300+ agent tests + 555+ REST tests still green |
+| 3 | New gated test `vault.mainnet.test.ts` (`TEST_MAINNET=1`) | SDK `getVaultBalance()` reads live mainnet config |
+| 3 | Agent REST round-trip via curl | `POST /agent/tools/deposit` with mainnet network → real TX hash returned |
+| 4 | Manual UI walk on `sipher.sip-protocol.org` | Vault tab loads, balance reads, deposit form submits, TX shown |
+| 4 | Reviewer dry-read of announcement copy | Tone matches RECTOR's voice; no broken links; risks disclosed |
+
+## Success metrics — definition of done
+
+**Objective (binary, verifiable on the day):**
+
+1. Mainnet `sipher_vault` program live at `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB` — `solana program show <ID> --url mainnet-beta` returns the deployed slot.
+2. Mainnet `VaultConfig` PDA initialized — `getAccountInfo` returns the expected struct (fee=10, timeout=86400, authority=`S1P6j1y…wWMd`, paused=false).
+3. ≥1 mainnet `deposit` + ≥1 mainnet `withdraw_private` (with CPI announcement on `sip_privacy`) + ≥1 mainnet `authority_refund` executed by RECTOR. Any token, any amount — even 0.001 SOL is sufficient.
+4. Sipher repo: `VAULT_NETWORK=mainnet-beta` is the default in `.env.example`; `pnpm test` green.
+5. Command Center vault tab visible at `sipher.sip-protocol.org` (logged in as cipher-admin), reads real mainnet TVL.
+6. Public announcement posted (X primary; TG / Discord secondary).
+7. CHANGELOG entries committed in both repos.
+8. MEMORY updated: mainnet `sipher_vault` program + config PDA recorded; "Phase 4 still deferred" replaced with "Phase 4 COMPLETE [date]".
+
+**Lagging (assess at +7 days):**
+
+- No funds stuck (no `set_paused(true)` activated).
+- No critical bugs reported.
+- ≥3 unique mainnet depositors (organic interest signal — could be friends/team for a soft launch).
+
+**Explicitly not measured:**
+
+- TVL targets — vanity metric that pressures scope creep.
+- Twitter engagement — out of our control, doesn't reflect program quality.
+- Number of integrations / downstream consumers — long-tail, not a 7-day signal.
+
+## Soft-launch buffer inside Stage 4
+
+Even though the launch posture is "public + announce," a tight soak buffer is built into the schedule. The buffer is measured **in hours after Stage 2 mainnet deploy**, not in calendar days, because Stage 3 + Stage 4 implementation can compress or stretch.
+
+1. **T+0h:** Stage 2 done (mainnet program live + config initialized). Calendar: Day 2.
+2. **T+1–4h:** Internal smoke (RECTOR + CIPHER deposits, claims, refunds via raw scripts and via Sipher agent). Catches obvious bugs that pure unit tests miss. Calendar: Day 2 evening.
+3. **T+4–24h:** Stage 3 lands (SDK + agent), Stage 4 UI work in progress. Vault tab can go live in this window but **no announcement push yet**. Calendar: Day 3 → Day 4.
+4. **T+≥24h, all stages green:** Public announcement on X / TG / Discord. Earliest calendar slot is end of Day 3; realistically lands Day 4 evening or Day 5 morning. The announcement does not block on the 24h being a hard cutoff — it blocks on (a) all four stage PRs merged, (b) at least one full deposit→withdraw_private→authority_refund cycle witnessed on mainnet, and (c) no critical bugs in the smoke window.
+
+This is **not** Approach C's 4-week phased rollout. It is a 4–24 hour "prove it works in production at $5 of TVL before you invite $5K of TVL" buffer. If the buffer is uncomfortable, Stage 4's announcement can land same-day after smoke (T+4–8h); if a bug surfaces during the buffer, the announcement is held and the bug is fixed before any external comms.
+
+The architecture diagram at the top of this spec shows announcement on Day 4 because that is the earliest realistic landing slot once Stages 1–4 have shipped sequentially. The actual announcement timing is gated on the three conditions above, not on a calendar date.
+
+## Out of scope (already covered in non-goals, restated for clarity)
+
+- External audit (subsidy program tracking continues separately).
+- TVL / max-deposit guards.
+- Token allowlist at the program level.
+- Multisig authority migration.
+- SENTINEL on-chain monitoring of the mainnet vault.
+- Automated `collect_fee`.
+- `sip-mobile` integration.
+- Marketing assets beyond the announcement post.
+
+## Open questions
+
+None. All clarifying questions resolved during brainstorm; decisions D1–D5 captured above.


### PR DESCRIPTION
## Summary

Closes the planning gap for **Phase 4 — mainnet `sipher_vault` deploy**, the final deferred phase of the 2026-04-18 SENTINEL audit charter.

This PR is **planning artifact only** — no code changes, no behavior changes. Adds two markdown files:

- `docs/superpowers/specs/2026-05-04-phase4-mainnet-vault-deploy-design.md` (322 lines) — design spec, brainstormed decisions D1-D5, risks R1-R10, success metrics.
- `docs/superpowers/plans/2026-05-04-phase4-mainnet-vault-deploy.md` (2,077 lines) — bite-sized 30-task implementation plan across 4 PRs in 2 repos (sip-protocol + sipher).

## Locked decisions

- **D1 Scope:** full production — deploy + agent + UI integration + announce
- **D2 Posture:** public launch + announce (unaudited; risk explicitly accepted)
- **D3 Sequencing:** devnet CPI upgrade → E2E test → mainnet deploy
- **D4 Config:** 10 bps fee, 24h refund timeout (same as devnet)
- **D5 Authority:** reuse `S1P6j1y…wWMd` (same as `sip_privacy` mainnet)

## Architecture

```
PR-1 Day 1 (sip-protocol): Devnet CPI binary upgrade + E2E + pause runbook
PR-2 Day 2 (sip-protocol): Mainnet deploy + initialize + first round-trip
PR-3 Day 3 (sipher):       SDK + agent default to mainnet-beta + authority_refund evidence
PR-4 Day 4 (sipher):       UI verification + mainnet config surfacing + public announcement
```

Stage 4 was scoped down at planning time after discovering `app/src/views/VaultView.tsx` (239 lines) already implements the deposit/withdraw flow; PR-4's UI work is a single-file edit (config status block) + verification + announcement.

## Execution timing

Phase 4 execution **cannot start today**. Phase 3 Day 2 (devnet refund E2E close-out) fires tomorrow ≥ 2026-05-05T14:13:14Z, and Phase 4 Stage 1 redeploys the devnet binary — would conflict with Phase 3's existing state. Earliest Phase 4 start: 2026-05-06.

This PR ships the planning artifacts now so the spec + plan are on `main` before execution begins.

## Test plan

- [x] Spec self-review: zero placeholders, internal consistency check (Day 5+/Day 4 reconciled), scope check, ambiguity check
- [x] Plan self-review: spec coverage 1:1 (D1-D5, R1-R10, all 8 binary acceptance criteria mapped to tasks), no TBD/TODO/FIXME, type consistency across tasks
- [x] SDK import path verified at planning time (`@sipher/sdk` per `packages/sdk/package.json`)
- [x] Existing UI structure verified at planning time (`VaultView.tsx`, `app/src/stores/app.ts`, `App.tsx:37` routing)