### PR TITLE
Phase 4a: env-var network config + BetaBanner + gate-check + gitleaks CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,7 @@ RPC_PROVIDER=generic
 RPC_PROVIDER_API_KEY=
 
 # Helius (dedicated key — used when RPC_PROVIDER=helius and RPC_PROVIDER_API_KEY is empty)
-SIPHER_HELIUS_API_KEY=
+SIPHER_HELIUS_API_KEY=__set_in_vps_only__
 
 # Redis (optional — falls back to in-memory LRU)
 REDIS_URL=
@@ -73,3 +73,17 @@ SENTINEL_MODE=advisory
 # Path to vault authority keypair JSON. Required for auto-refunds.
 # Empty = refund attempts throw at runtime (caught by circuit breaker).
 SENTINEL_AUTHORITY_KEYPAIR=
+
+# ───────────────────────────────────────────
+# Phase 4 — Network configuration
+# ───────────────────────────────────────────
+
+# REQUIRED. Controls UI BetaBanner + /api/config response + Solscan cluster suffix.
+# Must match SOLANA_NETWORK above (until SOLANA_NETWORK is migrated to use this in a future PR).
+# devnet | mainnet
+SIPHER_NETWORK=devnet
+
+# NOTE: SOLANA_NETWORK and SIPHER_NETWORK MUST stay in sync until SOLANA_NETWORK is removed.
+# SOLANA_NETWORK is read by 11 agent tool files (deposit, send, refund, balance, scan, etc.) for
+# actual RPC calls; SIPHER_NETWORK drives UI chrome + /api/config. A mismatch produces a footgun
+# where UI shows 'devnet' banner while tools transact on mainnet (or vice versa).

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,21 @@
+name: gitleaks
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 5 * * *'  # nightly 05:00 UTC
+  workflow_dispatch:
+
+jobs:
+  gitleaks:
+    name: Scan for secrets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -15,7 +15,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_CONFIG: .gitleaks.toml
+
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.27.2/gitleaks_8.27.2_linux_x64.tar.gz \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Scan for secrets
+        run: gitleaks detect --config .gitleaks.toml --source . --no-banner

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,47 @@
+# .gitleaks.toml — custom config for sipher repo
+title = "Sipher gitleaks config"
+
+[allowlist]
+  description = "Test fixtures, SDK stubs, docs, and known safe placeholders"
+  paths = [
+    # Root integration test suites (contain dummy keys/addresses for API shape testing)
+    '''tests/.*''',
+    # Agent package test suites (Pi agent, sentinel, HERALD tool tests)
+    '''packages/agent/tests/.*''',
+    # Colocated __tests__ directories in the app frontend
+    '''app/src/.*__tests__/.*''',
+    # Auto-generated Python SDK stubs (openapi-generator output, not secrets)
+    '''sdks/python/test/.*''',
+    # Go SDK OpenAPI spec (example values, not secrets)
+    '''sdks/go/api/openapi.yaml''',
+    # Internal docs: plans, specs, evidence files
+    '''docs/superpowers/plans/.*''',
+    '''docs/superpowers/specs/.*''',
+    '''docs/sentinel/evidence/.*''',
+    # Integration READMEs with usage examples
+    '''integrations/.*''',
+  ]
+  regexes = [
+    # Placeholder used in .env.example for Helius key slot
+    '''SIPHER_HELIUS_API_KEY=__set_in_vps_only__''',
+    # Stripe webhook secret dev default in src/config.ts (not a real whsec_ token)
+    '''whsec_sipher_dev_secret''',
+    # Common test-fixture API key literals used across test suites
+    '''test-key''',
+    '''test-key-DO-NOT-LEAK-THIS''',
+    '''test-key-1''',
+    '''test-key-2''',
+    '''test-key-3''',
+    '''dev-key-1''',
+    '''dev-key-2''',
+    '''key-a''',
+    '''key-b''',
+    # JWT secret literals in test files
+    '''test-secret-for-sentinel-pause-tests''',
+    '''test-secret-for-queue-patch-tests''',
+    '''e2e-test-secret-at-least-16-chars''',
+    # Test JWT token literal in frontend component tests
+    '''test-jwt''',
+    # Helius fixture key used in rpc-provider tests
+    '''test-helius-key-12345''',
+  ]

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react'
 import { WalletModalProvider } from '@solana/wallet-adapter-react-ui'
 import {
@@ -11,6 +11,7 @@ import './styles/theme.css'
 import Header from './components/Header'
 import BottomNav from './components/BottomNav'
 import ChatSidebar from './components/ChatSidebar'
+import { BetaBanner } from './components/BetaBanner'
 import DashboardView from './views/DashboardView'
 import VaultView from './views/VaultView'
 import HeraldView from './views/HeraldView'
@@ -18,17 +19,13 @@ import SquadView from './views/SquadView'
 import { useAppStore } from './stores/app'
 import { useAuth } from './hooks/useAuth'
 import { useSSE } from './hooks/useSSE'
-
-const NETWORK = (import.meta.env.VITE_SOLANA_NETWORK ?? 'mainnet-beta') as 'devnet' | 'mainnet-beta'
-const ENDPOINTS: Record<string, string> = {
-  devnet: 'https://api.devnet.solana.com',
-  'mainnet-beta': 'https://api.mainnet-beta.solana.com',
-}
+import { useNetworkConfigStore, fetchNetworkConfig } from './lib/networkConfig'
 
 function AppShell() {
   const activeView = useAppStore((s) => s.activeView)
   const { token, isAdmin } = useAuth()
   const { events } = useSSE(token)
+  const beta = useNetworkConfigStore((s) => s.config?.beta ?? false)
 
   const renderView = () => {
     switch (activeView) {
@@ -53,6 +50,7 @@ function AppShell() {
 
   return (
     <div className="flex flex-col h-dvh bg-bg">
+      <BetaBanner beta={beta} />
       <Header />
 
       <div className="flex-1 flex overflow-hidden">
@@ -72,14 +70,39 @@ function AppShell() {
 }
 
 export default function App() {
-  const endpoint = import.meta.env.VITE_SOLANA_RPC_URL ?? ENDPOINTS[NETWORK]
+  const config = useNetworkConfigStore((s) => s.config)
+  const error = useNetworkConfigStore((s) => s.error)
+
+  useEffect(() => {
+    fetchNetworkConfig()
+  }, [])
+
   const wallets = useMemo(
     () => [new PhantomWalletAdapter(), new SolflareWalletAdapter()],
-    []
+    [],
   )
 
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-bg text-text">
+        <div className="max-w-md p-6 text-center">
+          <h1 className="text-xl font-semibold mb-2">Sipher temporarily unavailable</h1>
+          <p className="text-sm text-text-muted">{error}</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!config) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-bg text-text-muted">
+        <p className="text-sm">Loading…</p>
+      </div>
+    )
+  }
+
   return (
-    <ConnectionProvider endpoint={endpoint}>
+    <ConnectionProvider endpoint={config.publicRpcUrl}>
       <WalletProvider wallets={wallets} autoConnect>
         <WalletModalProvider>
           <AppShell />

--- a/app/src/components/BetaBanner.tsx
+++ b/app/src/components/BetaBanner.tsx
@@ -31,7 +31,7 @@ export function BetaBanner({ beta }: { beta: boolean }) {
             rel="noreferrer"
             className="underline font-medium"
           >
-            Get SOL from devnet faucet →
+            Get devnet SOL →
           </a>
         </p>
         <button

--- a/app/src/components/BetaBanner.tsx
+++ b/app/src/components/BetaBanner.tsx
@@ -1,13 +1,11 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 
 const STORAGE_KEY = 'sipher.beta-banner.dismissed'
 
 export function BetaBanner({ beta }: { beta: boolean }) {
-  const [dismissed, setDismissed] = useState<boolean>(false)
-
-  useEffect(() => {
-    setDismissed(sessionStorage.getItem(STORAGE_KEY) === 'true')
-  }, [])
+  const [dismissed, setDismissed] = useState<boolean>(
+    () => sessionStorage.getItem(STORAGE_KEY) === 'true',
+  )
 
   if (!beta) return null
   if (dismissed) return null
@@ -19,7 +17,7 @@ export function BetaBanner({ beta }: { beta: boolean }) {
 
   return (
     <div
-      role="alert"
+      role="status"
       className="sticky top-0 z-50 w-full bg-amber-100 text-amber-900 border-b border-amber-300"
     >
       <div className="max-w-7xl mx-auto px-4 py-2 flex items-center justify-between gap-4">

--- a/app/src/components/BetaBanner.tsx
+++ b/app/src/components/BetaBanner.tsx
@@ -1,0 +1,48 @@
+import { useState, useEffect } from 'react'
+
+const STORAGE_KEY = 'sipher.beta-banner.dismissed'
+
+export function BetaBanner({ beta }: { beta: boolean }) {
+  const [dismissed, setDismissed] = useState<boolean>(false)
+
+  useEffect(() => {
+    setDismissed(sessionStorage.getItem(STORAGE_KEY) === 'true')
+  }, [])
+
+  if (!beta) return null
+  if (dismissed) return null
+
+  function handleDismiss() {
+    sessionStorage.setItem(STORAGE_KEY, 'true')
+    setDismissed(true)
+  }
+
+  return (
+    <div
+      role="alert"
+      className="sticky top-0 z-50 w-full bg-amber-100 text-amber-900 border-b border-amber-300"
+    >
+      <div className="max-w-7xl mx-auto px-4 py-2 flex items-center justify-between gap-4">
+        <p className="text-sm">
+          🧪 You're on <strong>DEVNET BETA</strong>. This is testnet — funds are not real.{' '}
+          <a
+            href="https://faucet.solana.com"
+            target="_blank"
+            rel="noreferrer"
+            className="underline font-medium"
+          >
+            Get SOL from devnet faucet →
+          </a>
+        </p>
+        <button
+          type="button"
+          aria-label="Dismiss"
+          onClick={handleDismiss}
+          className="text-amber-900 hover:text-amber-700 text-lg leading-none"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -11,8 +11,7 @@ import { useAppStore, type View } from '../stores/app'
 import { useAuth } from '../hooks/useAuth'
 import AgentDot from './AgentDot'
 import { truncateAddress } from '../lib/format'
-
-const NETWORK = (import.meta.env.VITE_SOLANA_NETWORK ?? 'mainnet-beta') as string
+import { useNetworkConfigStore } from '../lib/networkConfig'
 
 interface Tab {
   id: View
@@ -36,6 +35,7 @@ export default function Header() {
   const { isAuthenticated, authenticate, isAdmin } = useAuth()
   const activeView = useAppStore((s) => s.activeView)
   const setActiveView = useAppStore((s) => s.setActiveView)
+  const network = useNetworkConfigStore((s) => s.config?.network ?? 'mainnet')
 
   const visibleTabs = TABS.filter((t) => {
     if (t.adminOnly && !isAdmin) return false
@@ -78,7 +78,7 @@ export default function Header() {
         </div>
 
         <span className="text-[10px] font-mono text-text-muted bg-elevated px-1.5 py-0.5 rounded">
-          {NETWORK === 'mainnet-beta' ? 'mainnet' : 'devnet'}
+          {network}
         </span>
 
         {connected && publicKey ? (

--- a/app/src/components/__tests__/BetaBanner.test.tsx
+++ b/app/src/components/__tests__/BetaBanner.test.tsx
@@ -10,7 +10,7 @@ describe('BetaBanner', () => {
   it('renders when beta=true', () => {
     render(<BetaBanner beta={true} />)
     expect(screen.getByText(/DEVNET BETA/i)).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /faucet/i })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /devnet sol/i })).toHaveAttribute(
       'href',
       'https://faucet.solana.com',
     )

--- a/app/src/components/__tests__/BetaBanner.test.tsx
+++ b/app/src/components/__tests__/BetaBanner.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { BetaBanner } from '../BetaBanner'
+
+describe('BetaBanner', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('renders when beta=true', () => {
+    render(<BetaBanner beta={true} />)
+    expect(screen.getByText(/DEVNET BETA/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /faucet/i })).toHaveAttribute(
+      'href',
+      'https://faucet.solana.com',
+    )
+  })
+
+  it('renders nothing when beta=false', () => {
+    const { container } = render(<BetaBanner beta={false} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('is dismissible via button, hides for the rest of the session', () => {
+    render(<BetaBanner beta={true} />)
+    expect(screen.getByText(/DEVNET BETA/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+    expect(screen.queryByText(/DEVNET BETA/i)).not.toBeInTheDocument()
+  })
+
+  it('respects sessionStorage dismissal across re-renders', () => {
+    sessionStorage.setItem('sipher.beta-banner.dismissed', 'true')
+    render(<BetaBanner beta={true} />)
+    expect(screen.queryByText(/DEVNET BETA/i)).not.toBeInTheDocument()
+  })
+})

--- a/app/src/lib/__tests__/networkConfig.test.ts
+++ b/app/src/lib/__tests__/networkConfig.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { useNetworkConfigStore, fetchNetworkConfig } from '../networkConfig'
+
+describe('networkConfig store', () => {
+  beforeEach(() => {
+    useNetworkConfigStore.setState({ config: null, error: null, loading: false })
+    vi.restoreAllMocks()
+  })
+
+  it('fetchNetworkConfig populates store from /api/config', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        network: 'devnet',
+        clusterName: 'devnet',
+        publicRpcUrl: 'https://api.devnet.solana.com',
+        programIds: { sipherVault: 'S1Phr...', sipPrivacy: 'S1PMF...' },
+        vaultConfig: 'CpL4q...',
+        beta: true,
+        solscanSuffix: '?cluster=devnet',
+      }),
+    }))
+
+    await fetchNetworkConfig()
+    const state = useNetworkConfigStore.getState()
+    expect(state.config?.network).toBe('devnet')
+    expect(state.config?.beta).toBe(true)
+    expect(state.error).toBeNull()
+    expect(state.loading).toBe(false)
+  })
+
+  it('fetchNetworkConfig sets error on 5xx', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: 'service unavailable' }),
+    }))
+
+    await fetchNetworkConfig()
+    const state = useNetworkConfigStore.getState()
+    expect(state.config).toBeNull()
+    expect(state.error).toBeTruthy()
+    expect(state.loading).toBe(false)
+  })
+
+  it('fetchNetworkConfig sets error when fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network unreachable')))
+    await fetchNetworkConfig()
+    const state = useNetworkConfigStore.getState()
+    expect(state.config).toBeNull()
+    expect(state.error).toContain('network unreachable')
+    expect(state.loading).toBe(false)
+  })
+
+  it('solscanUrl helper appends suffix correctly', async () => {
+    const { solscanUrl } = await import('../networkConfig')
+    expect(solscanUrl('abc123', '?cluster=devnet')).toBe('https://solscan.io/tx/abc123?cluster=devnet')
+    expect(solscanUrl('abc123', '')).toBe('https://solscan.io/tx/abc123')
+  })
+})

--- a/app/src/lib/__tests__/networkConfig.test.ts
+++ b/app/src/lib/__tests__/networkConfig.test.ts
@@ -3,7 +3,7 @@ import { useNetworkConfigStore, fetchNetworkConfig } from '../networkConfig'
 
 describe('networkConfig store', () => {
   beforeEach(() => {
-    useNetworkConfigStore.setState({ config: null, error: null, loading: false })
+    useNetworkConfigStore.setState({ config: null, error: null })
     vi.restoreAllMocks()
   })
 
@@ -26,7 +26,6 @@ describe('networkConfig store', () => {
     expect(state.config?.network).toBe('devnet')
     expect(state.config?.beta).toBe(true)
     expect(state.error).toBeNull()
-    expect(state.loading).toBe(false)
   })
 
   it('fetchNetworkConfig sets error on 5xx', async () => {
@@ -40,7 +39,6 @@ describe('networkConfig store', () => {
     const state = useNetworkConfigStore.getState()
     expect(state.config).toBeNull()
     expect(state.error).toBeTruthy()
-    expect(state.loading).toBe(false)
   })
 
   it('fetchNetworkConfig sets error when fetch throws', async () => {
@@ -49,7 +47,6 @@ describe('networkConfig store', () => {
     const state = useNetworkConfigStore.getState()
     expect(state.config).toBeNull()
     expect(state.error).toContain('network unreachable')
-    expect(state.loading).toBe(false)
   })
 
   it('solscanUrl helper appends suffix correctly', async () => {

--- a/app/src/lib/networkConfig.ts
+++ b/app/src/lib/networkConfig.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { apiFetch } from '../api/client'
 
 export type NetworkConfigPublic = {
   network: 'devnet' | 'mainnet'
@@ -16,30 +17,23 @@ export type NetworkConfigPublic = {
 type Store = {
   config: NetworkConfigPublic | null
   error: string | null
-  loading: boolean
 }
 
 export const useNetworkConfigStore = create<Store>(() => ({
   config: null,
   error: null,
-  loading: false,
 }))
 
 export async function fetchNetworkConfig(): Promise<void> {
-  useNetworkConfigStore.setState({ loading: true, error: null })
   try {
-    const res = await fetch('/api/config')
-    if (!res.ok) {
-      throw new Error(`Config endpoint returned ${res.status}`)
-    }
-    const config = (await res.json()) as NetworkConfigPublic
-    useNetworkConfigStore.setState({ config, loading: false, error: null })
+    const config = await apiFetch<NetworkConfigPublic>('/api/config')
+    useNetworkConfigStore.setState({ config, error: null })
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error fetching config'
-    useNetworkConfigStore.setState({ config: null, loading: false, error: message })
+    useNetworkConfigStore.setState({ config: null, error: message })
   }
 }
 
-export function solscanUrl(txOrAccount: string, suffix: string): string {
-  return `https://solscan.io/tx/${txOrAccount}${suffix}`
+export function solscanUrl(tx: string, suffix: string): string {
+  return `https://solscan.io/tx/${tx}${suffix}`
 }

--- a/app/src/lib/networkConfig.ts
+++ b/app/src/lib/networkConfig.ts
@@ -1,0 +1,45 @@
+import { create } from 'zustand'
+
+export type NetworkConfigPublic = {
+  network: 'devnet' | 'mainnet'
+  clusterName: 'devnet' | 'mainnet-beta'
+  publicRpcUrl: string
+  programIds: {
+    sipherVault: string
+    sipPrivacy: string
+  }
+  vaultConfig: string
+  beta: boolean
+  solscanSuffix: string
+}
+
+type Store = {
+  config: NetworkConfigPublic | null
+  error: string | null
+  loading: boolean
+}
+
+export const useNetworkConfigStore = create<Store>(() => ({
+  config: null,
+  error: null,
+  loading: false,
+}))
+
+export async function fetchNetworkConfig(): Promise<void> {
+  useNetworkConfigStore.setState({ loading: true, error: null })
+  try {
+    const res = await fetch('/api/config')
+    if (!res.ok) {
+      throw new Error(`Config endpoint returned ${res.status}`)
+    }
+    const config = (await res.json()) as NetworkConfigPublic
+    useNetworkConfigStore.setState({ config, loading: false, error: null })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error fetching config'
+    useNetworkConfigStore.setState({ config: null, loading: false, error: message })
+  }
+}
+
+export function solscanUrl(txOrAccount: string, suffix: string): string {
+  return `https://solscan.io/tx/${txOrAccount}${suffix}`
+}

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -2,8 +2,6 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_URL?: string
-  readonly VITE_SOLANA_NETWORK?: 'devnet' | 'mainnet-beta'
-  readonly VITE_SOLANA_RPC_URL?: string
 }
 
 interface ImportMeta {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@sip-protocol/types": "^0.2.2",
     "@solana/spl-token": "^0.4.0",
     "@solana/web3.js": "^1.95.0",
+    "bs58": "^6.0.0",
     "compression": "^1.8.1",
     "cors": "^2.8.5",
     "envalid": "^8.1.1",

--- a/packages/agent/src/config/network.ts
+++ b/packages/agent/src/config/network.ts
@@ -1,0 +1,67 @@
+export type Network = 'devnet' | 'mainnet'
+
+export type NetworkConfig = {
+  network: Network
+  clusterName: 'devnet' | 'mainnet-beta'
+  rpcUrl: string          // SERVER-SIDE ONLY — keyed Helius URL, never exposed to clients
+  publicRpcUrl: string    // un-keyed fallback for UI direct reads
+  programIds: {
+    sipherVault: string
+    sipPrivacy: string
+  }
+  vaultConfig: string     // VaultConfig PDA address
+  beta: boolean
+  solscanSuffix: string
+}
+
+const SIPHER_VAULT_PROGRAM_ID = 'S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB'
+const SIP_PRIVACY_PROGRAM_ID = 'S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at'
+const DEVNET_VAULT_CONFIG = 'CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u'
+// Mainnet vault config is the same PDA as devnet because program ID + seed are identical.
+// PR-B1 will verify this assumption against the live mainnet deployment.
+const MAINNET_VAULT_CONFIG = DEVNET_VAULT_CONFIG
+
+export function loadNetworkConfig(): NetworkConfig {
+  const network = process.env.SIPHER_NETWORK as Network | undefined
+  if (network !== 'devnet' && network !== 'mainnet') {
+    throw new Error(
+      `FATAL: SIPHER_NETWORK env var required (must be 'devnet' or 'mainnet'), got: ${network ?? '(unset)'}`,
+    )
+  }
+
+  const apiKey = process.env.SIPHER_HELIUS_API_KEY
+  if (!apiKey) {
+    throw new Error('FATAL: SIPHER_HELIUS_API_KEY env var required')
+  }
+
+  if (network === 'devnet') {
+    return {
+      network: 'devnet',
+      clusterName: 'devnet',
+      rpcUrl: `https://devnet.helius-rpc.com/?api-key=${apiKey}`,
+      publicRpcUrl: 'https://api.devnet.solana.com',
+      programIds: {
+        sipherVault: SIPHER_VAULT_PROGRAM_ID,
+        sipPrivacy: SIP_PRIVACY_PROGRAM_ID,
+      },
+      vaultConfig: DEVNET_VAULT_CONFIG,
+      beta: true,
+      solscanSuffix: '?cluster=devnet',
+    }
+  }
+
+  // mainnet
+  return {
+    network: 'mainnet',
+    clusterName: 'mainnet-beta',
+    rpcUrl: `https://mainnet.helius-rpc.com/?api-key=${apiKey}`,
+    publicRpcUrl: 'https://api.mainnet-beta.solana.com',
+    programIds: {
+      sipherVault: SIPHER_VAULT_PROGRAM_ID,
+      sipPrivacy: SIP_PRIVACY_PROGRAM_ID,
+    },
+    vaultConfig: MAINNET_VAULT_CONFIG,
+    beta: false,
+    solscanSuffix: '',
+  }
+}

--- a/packages/agent/src/config/network.ts
+++ b/packages/agent/src/config/network.ts
@@ -22,16 +22,19 @@ const DEVNET_VAULT_CONFIG = 'CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u'
 const MAINNET_VAULT_CONFIG = DEVNET_VAULT_CONFIG
 
 export function loadNetworkConfig(): NetworkConfig {
-  const network = process.env.SIPHER_NETWORK as Network | undefined
-  if (network !== 'devnet' && network !== 'mainnet') {
+  const raw = process.env.SIPHER_NETWORK
+  if (raw !== 'devnet' && raw !== 'mainnet') {
     throw new Error(
-      `FATAL: SIPHER_NETWORK env var required (must be 'devnet' or 'mainnet'), got: ${network ?? '(unset)'}`,
+      `FATAL: SIPHER_NETWORK env var required (must be 'devnet' or 'mainnet'), got: ${raw ?? '(unset)'}`,
     )
   }
+  const network: Network = raw
 
   const apiKey = process.env.SIPHER_HELIUS_API_KEY
   if (!apiKey) {
-    throw new Error('FATAL: SIPHER_HELIUS_API_KEY env var required')
+    throw new Error(
+      `FATAL: SIPHER_HELIUS_API_KEY env var required, got: ${apiKey === undefined ? '(unset)' : '(empty string)'}`,
+    )
   }
 
   if (network === 'devnet') {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -25,10 +25,22 @@ import { setSentinelAssessor } from './sentinel/preflight-gate.js'
 import { performVaultRefund, assertVaultRefundWired } from './sentinel/vault-refund.js'
 import { sentinelPublicRouter, sentinelAdminRouter } from './routes/sentinel-api.js'
 import { getSentinelConfig } from './sentinel/config.js'
+import { configRouter } from './routes/config.js'
+import { loadNetworkConfig } from './config/network.js'
 import {
   getAllPendingActionsWithStatus,
   cancelPendingAction as dbCancelPendingAction,
 } from './db.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Network config validation — fail fast before any side-effecting init
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Validate network config first — throws and process exits if SIPHER_NETWORK
+// or SIPHER_HELIUS_API_KEY are missing. Must run BEFORE getDb() so the agent
+// never touches the database when its config is broken.
+const networkConfig = loadNetworkConfig()
+console.log(`  Network: SIPHER_NETWORK=${networkConfig.network} (beta=${networkConfig.beta})`)
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Database & session initialization
@@ -147,6 +159,9 @@ app.use('/admin', adminRouter)
 
 // Auth (nonce + JWT verify) — no auth required on these two
 app.use('/api/auth', authRouter)
+
+// Public network metadata (read by UI before auth) — never returns RPC URL or API key
+app.use('/api/config', configRouter)
 
 // Activity SSE stream — JWT required (EventSource passes ?token=)
 app.get('/api/stream', verifyJwt, streamHandler)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -40,7 +40,9 @@ import {
 // or SIPHER_HELIUS_API_KEY are missing. Must run BEFORE getDb() so the agent
 // never touches the database when its config is broken.
 const networkConfig = loadNetworkConfig()
-console.log(`  Network: SIPHER_NETWORK=${networkConfig.network} (beta=${networkConfig.beta})`)
+console.log(
+  `  Network: ${networkConfig.network} (cluster=${networkConfig.clusterName}, publicRpc=${networkConfig.publicRpcUrl}, beta=${networkConfig.beta})`,
+)
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Database & session initialization

--- a/packages/agent/src/routes/config.ts
+++ b/packages/agent/src/routes/config.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express'
+import { loadNetworkConfig } from '../config/network.js'
+
+export const configRouter = Router()
+
+configRouter.get('/', (_req, res) => {
+  const cfg = loadNetworkConfig()
+  // CRITICAL: explicit whitelist of fields exposed to the UI. NEVER include
+  // rpcUrl or anything derived from SIPHER_HELIUS_API_KEY — that key stays
+  // server-side only. Adding a field here is a deliberate choice, reviewed.
+  res.json({
+    network: cfg.network,
+    clusterName: cfg.clusterName,
+    publicRpcUrl: cfg.publicRpcUrl,
+    programIds: cfg.programIds,
+    vaultConfig: cfg.vaultConfig,
+    beta: cfg.beta,
+    solscanSuffix: cfg.solscanSuffix,
+  })
+})

--- a/packages/agent/src/routes/config.ts
+++ b/packages/agent/src/routes/config.ts
@@ -4,17 +4,24 @@ import { loadNetworkConfig } from '../config/network.js'
 export const configRouter = Router()
 
 configRouter.get('/', (_req, res) => {
-  const cfg = loadNetworkConfig()
   // CRITICAL: explicit whitelist of fields exposed to the UI. NEVER include
   // rpcUrl or anything derived from SIPHER_HELIUS_API_KEY — that key stays
   // server-side only. Adding a field here is a deliberate choice, reviewed.
-  res.json({
-    network: cfg.network,
-    clusterName: cfg.clusterName,
-    publicRpcUrl: cfg.publicRpcUrl,
-    programIds: cfg.programIds,
-    vaultConfig: cfg.vaultConfig,
-    beta: cfg.beta,
-    solscanSuffix: cfg.solscanSuffix,
-  })
+  try {
+    const cfg = loadNetworkConfig()
+    res.json({
+      network: cfg.network,
+      clusterName: cfg.clusterName,
+      publicRpcUrl: cfg.publicRpcUrl,
+      programIds: cfg.programIds,
+      vaultConfig: cfg.vaultConfig,
+      beta: cfg.beta,
+      solscanSuffix: cfg.solscanSuffix,
+    })
+  } catch {
+    // Boot validation already runs loadNetworkConfig() at agent startup,
+    // so this branch is reached only if env vars are mutated post-boot —
+    // exotic but defensible. Never leak FATAL message contents to clients.
+    res.status(500).json({ error: 'server configuration error' })
+  }
 })

--- a/packages/agent/tests/config/network.test.ts
+++ b/packages/agent/tests/config/network.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import { loadNetworkConfig } from '../../src/config/network'
+
+describe('loadNetworkConfig', () => {
+  let originalEnv: NodeJS.ProcessEnv
+
+  beforeEach(() => {
+    originalEnv = { ...process.env }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('resolves devnet config when SIPHER_NETWORK=devnet', () => {
+    process.env.SIPHER_NETWORK = 'devnet'
+    process.env.SIPHER_HELIUS_API_KEY = 'test-key'
+    const cfg = loadNetworkConfig()
+    expect(cfg.network).toBe('devnet')
+    expect(cfg.clusterName).toBe('devnet')
+    expect(cfg.programIds.sipherVault).toBe('S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB')
+    expect(cfg.programIds.sipPrivacy).toBe('S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at')
+    expect(cfg.beta).toBe(true)
+    expect(cfg.solscanSuffix).toBe('?cluster=devnet')
+    expect(cfg.publicRpcUrl).toBe('https://api.devnet.solana.com')
+    expect(cfg.rpcUrl).toContain('devnet')
+    expect(cfg.rpcUrl).toContain('test-key')
+  })
+
+  it('resolves mainnet config when SIPHER_NETWORK=mainnet', () => {
+    process.env.SIPHER_NETWORK = 'mainnet'
+    process.env.SIPHER_HELIUS_API_KEY = 'test-key'
+    const cfg = loadNetworkConfig()
+    expect(cfg.network).toBe('mainnet')
+    expect(cfg.clusterName).toBe('mainnet-beta')
+    expect(cfg.beta).toBe(false)
+    expect(cfg.solscanSuffix).toBe('')
+    expect(cfg.publicRpcUrl).toBe('https://api.mainnet-beta.solana.com')
+  })
+
+  it('throws when SIPHER_NETWORK unset', () => {
+    delete process.env.SIPHER_NETWORK
+    process.env.SIPHER_HELIUS_API_KEY = 'test-key'
+    expect(() => loadNetworkConfig()).toThrow(/SIPHER_NETWORK env var required/)
+  })
+
+  it('throws when SIPHER_NETWORK has invalid value', () => {
+    process.env.SIPHER_NETWORK = 'testnet'
+    process.env.SIPHER_HELIUS_API_KEY = 'test-key'
+    expect(() => loadNetworkConfig()).toThrow(/SIPHER_NETWORK env var required/)
+  })
+
+  it('throws when SIPHER_HELIUS_API_KEY unset', () => {
+    process.env.SIPHER_NETWORK = 'devnet'
+    delete process.env.SIPHER_HELIUS_API_KEY
+    expect(() => loadNetworkConfig()).toThrow(/SIPHER_HELIUS_API_KEY env var required/)
+  })
+})

--- a/packages/agent/tests/config/network.test.ts
+++ b/packages/agent/tests/config/network.test.ts
@@ -25,6 +25,7 @@ describe('loadNetworkConfig', () => {
     expect(cfg.publicRpcUrl).toBe('https://api.devnet.solana.com')
     expect(cfg.rpcUrl).toContain('devnet')
     expect(cfg.rpcUrl).toContain('test-key')
+    expect(cfg.vaultConfig).toBe('CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u')
   })
 
   it('resolves mainnet config when SIPHER_NETWORK=mainnet', () => {
@@ -36,6 +37,9 @@ describe('loadNetworkConfig', () => {
     expect(cfg.beta).toBe(false)
     expect(cfg.solscanSuffix).toBe('')
     expect(cfg.publicRpcUrl).toBe('https://api.mainnet-beta.solana.com')
+    expect(cfg.rpcUrl).toContain('mainnet')
+    expect(cfg.rpcUrl).toContain('test-key')
+    expect(cfg.vaultConfig).toBe('CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u')
   })
 
   it('throws when SIPHER_NETWORK unset', () => {

--- a/packages/agent/tests/routes/config.test.ts
+++ b/packages/agent/tests/routes/config.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest'
+import express from 'express'
+import supertest from 'supertest'
+import { configRouter } from '../../src/routes/config.js'
+
+describe('GET /api/config', () => {
+  let app: express.Express
+  let originalEnv: NodeJS.ProcessEnv
+
+  beforeAll(() => {
+    originalEnv = { ...process.env }
+    process.env.SIPHER_NETWORK = 'devnet'
+    process.env.SIPHER_HELIUS_API_KEY = 'test-key-DO-NOT-LEAK-THIS'
+    app = express()
+    app.use('/api/config', configRouter)
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it('returns network metadata without RPC URL or API key', async () => {
+    const res = await supertest(app).get('/api/config')
+    expect(res.status).toBe(200)
+    expect(res.body.network).toBe('devnet')
+    expect(res.body.clusterName).toBe('devnet')
+    expect(res.body.beta).toBe(true)
+    expect(res.body.solscanSuffix).toBe('?cluster=devnet')
+    expect(res.body.publicRpcUrl).toBe('https://api.devnet.solana.com')
+    expect(res.body.programIds).toEqual({
+      sipherVault: 'S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB',
+      sipPrivacy: 'S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at',
+    })
+    expect(res.body.vaultConfig).toBe('CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u')
+  })
+
+  it('CRITICAL: response NEVER contains the keyed RPC URL or API key', async () => {
+    const res = await supertest(app).get('/api/config')
+    const bodyStr = JSON.stringify(res.body)
+    expect(bodyStr).not.toContain('test-key-DO-NOT-LEAK-THIS')
+    expect(bodyStr).not.toContain('helius-rpc.com')
+    expect(bodyStr).not.toMatch(/api-key/i)
+    expect(res.body).not.toHaveProperty('rpcUrl')
+  })
+})

--- a/packages/agent/tests/routes/config.test.ts
+++ b/packages/agent/tests/routes/config.test.ts
@@ -1,26 +1,29 @@
-import { describe, expect, it, beforeAll, afterAll } from 'vitest'
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
 import express from 'express'
 import supertest from 'supertest'
 import { configRouter } from '../../src/routes/config.js'
 
+function createApp() {
+  const app = express()
+  app.use('/api/config', configRouter)
+  return app
+}
+
 describe('GET /api/config', () => {
-  let app: express.Express
   let originalEnv: NodeJS.ProcessEnv
 
-  beforeAll(() => {
+  beforeEach(() => {
     originalEnv = { ...process.env }
     process.env.SIPHER_NETWORK = 'devnet'
     process.env.SIPHER_HELIUS_API_KEY = 'test-key-DO-NOT-LEAK-THIS'
-    app = express()
-    app.use('/api/config', configRouter)
   })
 
-  afterAll(() => {
+  afterEach(() => {
     process.env = originalEnv
   })
 
   it('returns network metadata without RPC URL or API key', async () => {
-    const res = await supertest(app).get('/api/config')
+    const res = await supertest(createApp()).get('/api/config')
     expect(res.status).toBe(200)
     expect(res.body.network).toBe('devnet')
     expect(res.body.clusterName).toBe('devnet')
@@ -35,11 +38,22 @@ describe('GET /api/config', () => {
   })
 
   it('CRITICAL: response NEVER contains the keyed RPC URL or API key', async () => {
-    const res = await supertest(app).get('/api/config')
+    const res = await supertest(createApp()).get('/api/config')
     const bodyStr = JSON.stringify(res.body)
     expect(bodyStr).not.toContain('test-key-DO-NOT-LEAK-THIS')
     expect(bodyStr).not.toContain('helius-rpc.com')
     expect(bodyStr).not.toMatch(/api-key/i)
     expect(res.body).not.toHaveProperty('rpcUrl')
+  })
+
+  it('returns 500 with clean JSON if env vars are missing at runtime', async () => {
+    delete process.env.SIPHER_NETWORK
+    const res = await supertest(createApp()).get('/api/config')
+    expect(res.status).toBe(500)
+    expect(res.body).toEqual({ error: 'server configuration error' })
+    // CRITICAL: even on error, no FATAL: text or env var names leak
+    const bodyStr = JSON.stringify(res.body)
+    expect(bodyStr).not.toContain('FATAL')
+    expect(bodyStr).not.toContain('SIPHER_NETWORK')
   })
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,6 +41,10 @@ export default defineConfig({
         JWT_SECRET: process.env.JWT_SECRET ?? 'e2e-test-secret-at-least-16-chars',
         SENTINEL_MODE: 'off',
         CORS_ORIGINS: `http://localhost:${PORT_FRONTEND}`,
+        // Phase 4a: network config required at boot — e2e always uses devnet with a dummy key.
+        // Real Helius calls are not made in e2e tests (no deposit/withdraw flows).
+        SIPHER_NETWORK: process.env.SIPHER_NETWORK ?? 'devnet',
+        SIPHER_HELIUS_API_KEY: process.env.SIPHER_HELIUS_API_KEY ?? 'e2e-placeholder-key',
       },
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
       '@solana/web3.js':
         specifier: ^1.95.0
         version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      bs58:
+        specifier: ^6.0.0
+        version: 6.0.0
       compression:
         specifier: ^1.8.1
         version: 1.8.1
@@ -124,13 +127,13 @@ importers:
         version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@solana/wallet-adapter-react':
         specifier: ^0.15.0
-        version: 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(typescript@5.9.3)
+        version: 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(typescript@5.9.3)
       '@solana/wallet-adapter-react-ui':
         specifier: ^0.9.0
-        version: 0.9.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.4(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(typescript@5.9.3)
+        version: 0.9.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.4(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(typescript@5.9.3)
       '@solana/wallet-adapter-wallets':
         specifier: ^0.19.0
-        version: 0.19.37(@babel/runtime@7.28.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.9.2)(react-dom@19.2.4(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+        version: 0.19.37(@babel/runtime@7.28.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.9.2)(react-dom@19.2.4(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@solana/web3.js':
         specifier: ^1.98.0
         version: 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -8590,10 +8593,11 @@ snapshots:
       crypto-js: 4.2.0
       uuidv4: 6.2.13
 
-  '@particle-network/solana-wallet@1.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
+  '@particle-network/solana-wallet@1.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)':
     dependencies:
       '@particle-network/auth': 1.3.1
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      bs58: 6.0.0
 
   '@phala/dcap-qvl-web@0.2.7': {}
 
@@ -10504,9 +10508,9 @@ snapshots:
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
-  '@solana/wallet-adapter-base-ui@0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(typescript@5.9.3)':
+  '@solana/wallet-adapter-base-ui@0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
-      '@solana/wallet-adapter-react': 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(typescript@5.9.3)
+      '@solana/wallet-adapter-react': 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(typescript@5.9.3)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       react: 19.2.4
     transitivePeerDependencies:
@@ -10627,9 +10631,9 @@ snapshots:
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
-  '@solana/wallet-adapter-particle@0.1.16(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
+  '@solana/wallet-adapter-particle@0.1.16(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)':
     dependencies:
-      '@particle-network/solana-wallet': 1.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@particle-network/solana-wallet': 1.3.2(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -10640,11 +10644,11 @@ snapshots:
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
-  '@solana/wallet-adapter-react-ui@0.9.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.4(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(typescript@5.9.3)':
+  '@solana/wallet-adapter-react-ui@0.9.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.4(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
-      '@solana/wallet-adapter-base-ui': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(typescript@5.9.3)
-      '@solana/wallet-adapter-react': 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(typescript@5.9.3)
+      '@solana/wallet-adapter-base-ui': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(typescript@5.9.3)
+      '@solana/wallet-adapter-react': 0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(typescript@5.9.3)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -10654,11 +10658,11 @@ snapshots:
       - react-native
       - typescript
 
-  '@solana/wallet-adapter-react@0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(typescript@5.9.3)':
+  '@solana/wallet-adapter-react@0.15.39(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(typescript@5.9.3)':
     dependencies:
       '@solana-mobile/wallet-adapter-mobile': 2.2.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(typescript@5.9.3)
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
-      '@solana/wallet-standard-wallet-adapter-react': 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(react@19.2.4)
+      '@solana/wallet-standard-wallet-adapter-react': 1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@19.2.4)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       react: 19.2.4
     transitivePeerDependencies:
@@ -10802,7 +10806,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@solana/wallet-adapter-wallets@0.19.37(@babel/runtime@7.28.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.9.2)(react-dom@19.2.4(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)':
+  '@solana/wallet-adapter-wallets@0.19.37(@babel/runtime@7.28.6)(@react-native-async-storage/async-storage@1.24.0(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)))(@solana/sysvars@5.5.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bs58@6.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(ioredis@5.9.2)(react-dom@19.2.4(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10))(react@19.2.4)(tslib@2.8.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
       '@solana/wallet-adapter-alpha': 0.1.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-avana': 0.1.17(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
@@ -10823,7 +10827,7 @@ snapshots:
       '@solana/wallet-adapter-nightly': 0.1.20(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-nufi': 0.1.21(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-onto': 0.1.11(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
-      '@solana/wallet-adapter-particle': 0.1.16(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@solana/wallet-adapter-particle': 0.1.16(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)
       '@solana/wallet-adapter-phantom': 0.9.28(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-safepal': 0.5.22(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-adapter-saifu': 0.1.19(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
@@ -10902,7 +10906,7 @@ snapshots:
       '@solana/wallet-standard-chains': 1.1.1
       '@solana/wallet-standard-features': 1.3.0
 
-  '@solana/wallet-standard-wallet-adapter-base@1.1.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
+  '@solana/wallet-standard-wallet-adapter-base@1.1.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)':
     dependencies:
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/wallet-standard-chains': 1.1.1
@@ -10913,11 +10917,12 @@ snapshots:
       '@wallet-standard/base': 1.1.0
       '@wallet-standard/features': 1.1.0
       '@wallet-standard/wallet': 1.1.0
+      bs58: 6.0.0
 
-  '@solana/wallet-standard-wallet-adapter-react@1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(react@19.2.4)':
+  '@solana/wallet-standard-wallet-adapter-react@1.1.4(@solana/wallet-adapter-base@0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)))(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)(react@19.2.4)':
     dependencies:
       '@solana/wallet-adapter-base': 0.9.27(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
-      '@solana/wallet-standard-wallet-adapter-base': 1.1.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@solana/wallet-standard-wallet-adapter-base': 1.1.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bs58@6.0.0)
       '@wallet-standard/app': 1.1.0
       '@wallet-standard/base': 1.1.0
       react: 19.2.4

--- a/scripts/WALLETS_TO_EXCLUDE.json
+++ b/scripts/WALLETS_TO_EXCLUDE.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Wallets owned by RECTOR / dev infra. Excluded from gate-check distinct-wallet count.",
+  "wallets": [
+    "FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr",
+    "S1P6j1yeTm6zkewQVeihrTZvmfoHABRkHDhabWTuWMd",
+    "S1P9WhBSbAGGatvrVE4TRBZfWpbG96U26zksy2TQj8q",
+    "C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N"
+  ]
+}

--- a/scripts/devnet-beta-gate-check.ts
+++ b/scripts/devnet-beta-gate-check.ts
@@ -12,6 +12,7 @@
 import { Connection, PublicKey } from '@solana/web3.js'
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
+import bs58 from 'bs58'
 
 const VAULT_PROGRAM_ID = new PublicKey('S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB')
 const RPC_URL = process.env.SIPHER_DEVNET_RPC ?? 'https://api.devnet.solana.com'
@@ -49,7 +50,7 @@ type GateResult = {
     C1_days_since_launch: { value: number, pass: boolean }
     C2_deposits: { count: number, distinct_wallets: number, pass: boolean }
     C3_withdraws: { count: number, distinct_wallets: number, pass: boolean }
-    C4_refunds: { count: number, pass: boolean }
+    C4_refunds: { authority_refunds: number, user_refunds: number, pass: boolean }
     C5_reverts: { total: number, user_error: number, unexplained: number, pass: boolean }
     C6_authority_interventions: { count: number, pass: boolean }
   }
@@ -58,8 +59,29 @@ type GateResult = {
   reverts: Revert[]
 }
 
-function classifyError(err: unknown): string {
-  return JSON.stringify(err).slice(0, 200)
+// Custom error codes from the sipher_vault IDL.
+// User errors are clearly caller-side mistakes; anything else is unexplained and fails C5.
+const USER_ERROR_CODES = new Set([
+  6000, // ProgramPaused
+  6001, // Unauthorized
+  6002, // InsufficientBalance
+  6004, // ZeroDeposit
+  6005, // RefundNotExpired
+  6006, // NothingToRefund
+  6010, // BalanceLocked
+])
+
+function classifyError(err: unknown): { error: string; classification: 'user_error' | 'unexplained' } {
+  const errStr = JSON.stringify(err).slice(0, 200)
+  // Anchor Custom error variant: { InstructionError: [ixIndex, { Custom: <code> }] }
+  const customMatch = JSON.stringify(err).match(/"Custom"\s*:\s*(\d+)/)
+  if (customMatch) {
+    const code = Number(customMatch[1])
+    if (USER_ERROR_CODES.has(code)) {
+      return { error: errStr, classification: 'user_error' }
+    }
+  }
+  return { error: errStr, classification: 'unexplained' }
 }
 
 async function main(): Promise<void> {
@@ -74,18 +96,19 @@ async function main(): Promise<void> {
   const excludeSet = new Set(excludeRaw.wallets)
 
   console.log(`Querying TX history for program ${VAULT_PROGRAM_ID.toBase58()} ...`)
-  const sigs = await conn.getSignaturesForAddress(VAULT_PROGRAM_ID, { limit: 1000 })
+  const sigs = await conn.getSignaturesForAddress(VAULT_PROGRAM_ID, { limit: 200 })
   console.log(`Found ${sigs.length} signatures`)
 
   const txDetails = await Promise.all(
-    sigs.slice(0, 200).map((s) =>
+    sigs.map((s) =>
       conn.getParsedTransaction(s.signature, { maxSupportedTransactionVersion: 0 }).catch(() => null),
     ),
   )
 
   let deposits = 0
   let withdraws = 0
-  let refunds = 0
+  let userRefunds = 0
+  let authorityRefunds = 0
   let authorityInterventions = 0
   const depositors = new Set<string>()
   const withdrawSigners = new Set<string>()
@@ -110,44 +133,39 @@ async function main(): Promise<void> {
     for (const ix of ixs) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const data = (ix as any).data ?? ''
-      const disc = Buffer.from(data, 'base64').slice(0, 8).toString('hex')
+      // getParsedTransaction returns bs58-encoded data for unknown (Anchor) programs —
+      // NOT base64. Using base64 silently produces wrong bytes and breaks all discriminator matches.
+      const disc = Buffer.from(bs58.decode(data)).slice(0, 8).toString('hex')
 
       if (disc === IX_DISCRIMINATORS.deposit) {
         if (failed) {
-          reverts.push({
-            tx: sig,
-            error: classifyError(tx.meta!.err),
-            classification: 'user_error',
-            reason: 'deposit failed',
-          })
+          const { error, classification } = classifyError(tx.meta!.err)
+          reverts.push({ tx: sig, error, classification, reason: 'deposit failed' })
         } else if (!excludeSet.has(signer)) {
           deposits++
           depositors.add(signer)
         }
       } else if (disc === IX_DISCRIMINATORS.withdraw_private) {
         if (failed) {
-          reverts.push({
-            tx: sig,
-            error: classifyError(tx.meta!.err),
-            classification: 'user_error',
-            reason: 'withdraw_private failed',
-          })
+          const { error, classification } = classifyError(tx.meta!.err)
+          reverts.push({ tx: sig, error, classification, reason: 'withdraw_private failed' })
         } else if (!excludeSet.has(signer)) {
           withdraws++
           withdrawSigners.add(signer)
         }
-      } else if (
-        disc === IX_DISCRIMINATORS.refund ||
-        disc === IX_DISCRIMINATORS.authority_refund
-      ) {
-        if (!failed) refunds++
+      } else if (disc === IX_DISCRIMINATORS.authority_refund) {
         if (failed) {
-          reverts.push({
-            tx: sig,
-            error: classifyError(tx.meta!.err),
-            classification: 'user_error',
-            reason: 'refund failed',
-          })
+          const { error, classification } = classifyError(tx.meta!.err)
+          reverts.push({ tx: sig, error, classification, reason: 'authority_refund failed' })
+        } else {
+          authorityRefunds++
+        }
+      } else if (disc === IX_DISCRIMINATORS.refund) {
+        if (failed) {
+          const { error, classification } = classifyError(tx.meta!.err)
+          reverts.push({ tx: sig, error, classification, reason: 'refund failed' })
+        } else {
+          userRefunds++
         }
       } else if (
         disc === IX_DISCRIMINATORS.set_paused ||
@@ -180,7 +198,7 @@ async function main(): Promise<void> {
       distinct_wallets: withdrawSigners.size,
       pass: withdraws >= 3 && withdrawSigners.size >= 2,
     },
-    C4_refunds: { count: refunds, pass: refunds >= 1 },
+    C4_refunds: { authority_refunds: authorityRefunds, user_refunds: userRefunds, pass: authorityRefunds >= 1 },
     C5_reverts: {
       total: reverts.length,
       user_error: userErrorReverts,

--- a/scripts/devnet-beta-gate-check.ts
+++ b/scripts/devnet-beta-gate-check.ts
@@ -1,0 +1,218 @@
+// scripts/devnet-beta-gate-check.ts
+// Phase 4a — Devnet Beta gate criteria check.
+//
+// Reads on-chain TX history for the devnet sipher_vault program, classifies
+// each TX as deposit/withdraw/refund/admin/other, counts distinct non-RECTOR
+// wallets per category, classifies failed TXs as user-error vs unexplained,
+// and emits a structured evidence JSON to docs/sentinel/evidence/.
+//
+// Run: pnpm tsx scripts/devnet-beta-gate-check.ts
+// Output: docs/sentinel/evidence/devnet-beta-gate-{YYYY-MM-DD}.json
+
+import { Connection, PublicKey } from '@solana/web3.js'
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const VAULT_PROGRAM_ID = new PublicKey('S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB')
+const RPC_URL = process.env.SIPHER_DEVNET_RPC ?? 'https://api.devnet.solana.com'
+const PUBLIC_LAUNCH_AT_ENV = process.env.SIPHER_BETA_LAUNCH_AT  // ISO timestamp, set when X thread #1 publishes
+const EXCLUDE_PATH = join(process.cwd(), 'scripts/WALLETS_TO_EXCLUDE.json')
+const EVIDENCE_DIR = join(process.cwd(), 'docs/sentinel/evidence')
+
+// Anchor instruction discriminators for sipher_vault — sha256("global:<ix_name>")[..8]
+// Generated via /tmp/print-discriminators.ts; verify against actual TX data on devnet
+const IX_DISCRIMINATORS = {
+  deposit: 'f223c68952e1f2b6',
+  withdraw_private: 'be93840ab9183fd5',
+  refund: '0260b7fb3fd02e2e',
+  authority_refund: '5aef4ed17d0f7d1c',
+  set_paused: '5b3c7dc0b0e1a6da',
+  update_fee: 'e8fdc3f794d449de',
+  collect_fee: '3cadf767045d8230',
+  initialize: 'afaf6d1f0d989bed',
+  create_vault_token: '311005db3dfd3069',
+  create_fee_token: '1e8de72a6a9ba5af',
+}
+
+type Revert = {
+  tx: string
+  error: string
+  classification: 'user_error' | 'unexplained'
+  reason: string
+}
+
+type GateResult = {
+  checkedAt: string
+  checkedAgainstSlot: number
+  publicLaunchAt: string | null
+  criteria: {
+    C1_days_since_launch: { value: number, pass: boolean }
+    C2_deposits: { count: number, distinct_wallets: number, pass: boolean }
+    C3_withdraws: { count: number, distinct_wallets: number, pass: boolean }
+    C4_refunds: { count: number, pass: boolean }
+    C5_reverts: { total: number, user_error: number, unexplained: number, pass: boolean }
+    C6_authority_interventions: { count: number, pass: boolean }
+  }
+  overall: 'PASS' | 'FAIL'
+  wallets_observed: string[]
+  reverts: Revert[]
+}
+
+function classifyError(err: unknown): string {
+  return JSON.stringify(err).slice(0, 200)
+}
+
+async function main(): Promise<void> {
+  console.log('Phase 4a — devnet beta gate check\n')
+  const launchAt = PUBLIC_LAUNCH_AT_ENV ? new Date(PUBLIC_LAUNCH_AT_ENV) : null
+  if (!launchAt) {
+    console.warn('⚠️  SIPHER_BETA_LAUNCH_AT not set — C1 will report 0 days since launch')
+  }
+
+  const conn = new Connection(RPC_URL, 'confirmed')
+  const excludeRaw = JSON.parse(readFileSync(EXCLUDE_PATH, 'utf-8')) as { wallets: string[] }
+  const excludeSet = new Set(excludeRaw.wallets)
+
+  console.log(`Querying TX history for program ${VAULT_PROGRAM_ID.toBase58()} ...`)
+  const sigs = await conn.getSignaturesForAddress(VAULT_PROGRAM_ID, { limit: 1000 })
+  console.log(`Found ${sigs.length} signatures`)
+
+  const txDetails = await Promise.all(
+    sigs.slice(0, 200).map((s) =>
+      conn.getParsedTransaction(s.signature, { maxSupportedTransactionVersion: 0 }).catch(() => null),
+    ),
+  )
+
+  let deposits = 0
+  let withdraws = 0
+  let refunds = 0
+  let authorityInterventions = 0
+  const depositors = new Set<string>()
+  const withdrawSigners = new Set<string>()
+  const reverts: Revert[] = []
+  const allWallets = new Set<string>()
+
+  for (let i = 0; i < txDetails.length; i++) {
+    const tx = txDetails[i]
+    if (!tx) continue
+    const sig = sigs[i].signature
+    const failed = tx.meta?.err !== null && tx.meta?.err !== undefined
+
+    const ixs = tx.transaction.message.instructions.filter(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (ix: any) => ix.programId?.equals?.(VAULT_PROGRAM_ID),
+    )
+    if (ixs.length === 0) continue
+
+    const signer = tx.transaction.message.accountKeys[0].pubkey.toBase58()
+    allWallets.add(signer)
+
+    for (const ix of ixs) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const data = (ix as any).data ?? ''
+      const disc = Buffer.from(data, 'base64').slice(0, 8).toString('hex')
+
+      if (disc === IX_DISCRIMINATORS.deposit) {
+        if (failed) {
+          reverts.push({
+            tx: sig,
+            error: classifyError(tx.meta!.err),
+            classification: 'user_error',
+            reason: 'deposit failed',
+          })
+        } else if (!excludeSet.has(signer)) {
+          deposits++
+          depositors.add(signer)
+        }
+      } else if (disc === IX_DISCRIMINATORS.withdraw_private) {
+        if (failed) {
+          reverts.push({
+            tx: sig,
+            error: classifyError(tx.meta!.err),
+            classification: 'user_error',
+            reason: 'withdraw_private failed',
+          })
+        } else if (!excludeSet.has(signer)) {
+          withdraws++
+          withdrawSigners.add(signer)
+        }
+      } else if (
+        disc === IX_DISCRIMINATORS.refund ||
+        disc === IX_DISCRIMINATORS.authority_refund
+      ) {
+        if (!failed) refunds++
+        if (failed) {
+          reverts.push({
+            tx: sig,
+            error: classifyError(tx.meta!.err),
+            classification: 'user_error',
+            reason: 'refund failed',
+          })
+        }
+      } else if (
+        disc === IX_DISCRIMINATORS.set_paused ||
+        disc === IX_DISCRIMINATORS.update_fee ||
+        disc === IX_DISCRIMINATORS.collect_fee
+      ) {
+        if (!failed) authorityInterventions++
+      }
+    }
+  }
+
+  const userErrorReverts = reverts.filter((r) => r.classification === 'user_error').length
+  const unexplainedReverts = reverts.length - userErrorReverts
+
+  const now = new Date()
+  const daysSinceLaunch = launchAt ? (now.getTime() - launchAt.getTime()) / 86400_000 : 0
+
+  const criteria: GateResult['criteria'] = {
+    C1_days_since_launch: {
+      value: Math.round(daysSinceLaunch * 10) / 10,
+      pass: daysSinceLaunch >= 3,
+    },
+    C2_deposits: {
+      count: deposits,
+      distinct_wallets: depositors.size,
+      pass: deposits >= 5 && depositors.size >= 3,
+    },
+    C3_withdraws: {
+      count: withdraws,
+      distinct_wallets: withdrawSigners.size,
+      pass: withdraws >= 3 && withdrawSigners.size >= 2,
+    },
+    C4_refunds: { count: refunds, pass: refunds >= 1 },
+    C5_reverts: {
+      total: reverts.length,
+      user_error: userErrorReverts,
+      unexplained: unexplainedReverts,
+      pass: unexplainedReverts === 0,
+    },
+    C6_authority_interventions: { count: authorityInterventions, pass: authorityInterventions === 0 },
+  }
+
+  const overall: 'PASS' | 'FAIL' = Object.values(criteria).every((c) => c.pass) ? 'PASS' : 'FAIL'
+
+  const result: GateResult = {
+    checkedAt: now.toISOString(),
+    checkedAgainstSlot: await conn.getSlot('confirmed'),
+    publicLaunchAt: launchAt?.toISOString() ?? null,
+    criteria,
+    overall,
+    wallets_observed: Array.from(allWallets).filter((w) => !excludeSet.has(w)),
+    reverts,
+  }
+
+  mkdirSync(EVIDENCE_DIR, { recursive: true })
+  const outPath = join(EVIDENCE_DIR, `devnet-beta-gate-${now.toISOString().slice(0, 10)}.json`)
+  writeFileSync(outPath, JSON.stringify(result, null, 2))
+  console.log(`\nEvidence written: ${outPath}`)
+  console.log(`Overall: ${overall}`)
+  for (const [k, v] of Object.entries(criteria)) {
+    console.log(`  ${k}: ${JSON.stringify(v)}`)
+  }
+}
+
+main().catch((err) => {
+  console.error('\n✗ Gate check failed:', err.message ?? err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

The sipher-repo half of Phase 4a (Devnet Beta). Adds env-var-driven network configuration so flipping production from devnet→mainnet in Phase 4b becomes a one-line VPS env edit + restart. Adds the BetaBanner UI. Adds the devnet beta gate-check script. Adds gitleaks CI.

## What this PR adds

- **`packages/agent/src/config/network.ts`** + tests — `loadNetworkConfig()` reads `SIPHER_NETWORK` + `SIPHER_HELIUS_API_KEY` at boot, throws if missing
- **`packages/agent/src/routes/config.ts`** + tests — `/api/config` endpoint exposes network metadata to the UI; whitelist asserts no Helius URL/key in response, handler returns 500 on runtime config error
- **`app/src/components/BetaBanner.tsx`** + tests — sticky amber banner visible only when `network=devnet`, dismissible per session, role="status" (polite a11y)
- **`app/src/lib/networkConfig.ts`** + tests — Zustand store fetches `/api/config` at boot via `apiFetch`, caches; UI render-gates on it
- **`app/src/App.tsx`** + **Header.tsx** — render-gates on networkConfig, drops `VITE_SOLANA_NETWORK` + `VITE_SOLANA_RPC_URL` build-time env vars in favor of runtime config
- **`scripts/devnet-beta-gate-check.ts`** + **`WALLETS_TO_EXCLUDE.json`** — gate criteria measurement (C1-C6 per spec), emits structured JSON evidence to `docs/sentinel/evidence/`
- **`.github/workflows/gitleaks.yml`** + **`.gitleaks.toml`** — secret scanning on PRs + nightly cron, allowlist for known test fixtures + .env placeholders
- **`.env.example`** — documented placeholders for `SIPHER_NETWORK` + `SIPHER_HELIUS_API_KEY`, with footgun note about `SOLANA_NETWORK` parity

## Verification

- All unit tests pass: `pnpm test -- --run` (1308 agent + 54 app)
- Typecheck clean: `pnpm typecheck`
- gitleaks local dry-run: 0 leaks across 628 commits
- Gate-check baseline run shows correct schema, FAIL on unmet criteria (expected pre-beta) — `authority_refunds: 1` from Phase 3 evidence, `authority_interventions: 2` from PR-A1 set_paused rehearsal both correctly counted
- BetaBanner renders on devnet, hidden on mainnet (component test)

## Footgun: SOLANA_NETWORK + SIPHER_NETWORK must match

`SOLANA_NETWORK` is read by 11 agent tool files (deposit, send, scan, refund, balance, history, status, privacy-score, viewing-key, etc.) for actual RPC calls. `SIPHER_NETWORK` drives the new UI chrome + `/api/config` endpoint. They must stay in sync until `SOLANA_NETWORK` is migrated to use `loadNetworkConfig()` in a future PR. A mismatch produces a UI/tool divergence (UI says devnet, tools transact on mainnet — or vice versa).

`.env.example` flags this inline. VPS deploy procedure (PR-B2) sets both.

## Spec + plan

- Spec: `docs/superpowers/specs/2026-05-05-phase4-split-devnet-beta-mainnet-design.md`
- Plan: `docs/superpowers/plans/2026-05-05-phase4-split-devnet-beta-mainnet.md` (Task A2.0 - A2.7)

## What this PR explicitly does NOT do

- Does NOT flip the VPS env (still SIPHER_NETWORK unset → boot will fail until env is set on VPS — PR-B2 covers that)
- Does NOT publish the blog post (PR-A3) or X thread #1 (manual ops)
- Does NOT run the gate-check against published-launch state (no public launch yet)
- Does NOT migrate `SOLANA_NETWORK` reads in the 11 agent tool files (deferred to a follow-up)