### PR TITLE
feat: backend auth surface hardening + mainnet-leak guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,11 @@ SIPHER_ADMIN_PASSWORD=
 # Runtime throws if unset or too short. Generate: openssl rand -hex 32
 JWT_SECRET=
 
+# JWT lifetime. Default 24h in production, 1h in tests. Reduce for higher
+# security, increase for less re-auth churn. Pairs with /api/auth/refresh
+# which auto-renews within the last 5min of the window.
+JWT_EXPIRY=24h
+
 # Admin wallet allowlist (comma-separated base58 pubkeys)
 AUTHORIZED_WALLETS=
 

--- a/.env.example
+++ b/.env.example
@@ -56,7 +56,10 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:5173
 RATE_LIMIT_MAX=100
 RATE_LIMIT_WINDOW_MS=60000
 
-# Proxy
+# Number of reverse-proxy hops in front of the agent (nginx, load balancer, etc.).
+# Required for per-IP rate limiting to read X-Forwarded-For correctly. Default 1
+# matches the VPS production setup (one nginx hop). Set to 0 for local dev without
+# a reverse proxy, or higher if you have multi-hop infrastructure.
 TRUST_PROXY=1
 
 # Graceful Shutdown

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,21 +13,29 @@ services:
       - API_KEYS=${API_KEYS}
       - ADMIN_API_KEY=${ADMIN_API_KEY}
       - SOLANA_RPC_URL=${SOLANA_RPC_URL:-https://api.mainnet-beta.solana.com}
+      - SOLANA_RPC_URL_FALLBACK=${SOLANA_RPC_URL_FALLBACK:-}
       - SIPHER_HELIUS_API_KEY=${SIPHER_HELIUS_API_KEY:-}
       - RPC_PROVIDER=${RPC_PROVIDER:-generic}
       - CORS_ORIGINS=${CORS_ORIGINS:-https://sipher.sip-protocol.org,https://sip-protocol.org,https://app.sip-protocol.org}
       - REDIS_URL=redis://redis:6379
-      - TRUST_PROXY=1
+      - TRUST_PROXY=${TRUST_PROXY:-1}
       - LOG_LEVEL=info
       - RATE_LIMIT_MAX=100
       - RATE_LIMIT_WINDOW_MS=60000
       # Phase 2 — Guardian Command
       - JWT_SECRET=${JWT_SECRET}
+      - JWT_EXPIRY=${JWT_EXPIRY:-24h}
       - SIPHER_ADMIN_PASSWORD=${SIPHER_ADMIN_PASSWORD}
       - AUTHORIZED_WALLETS=${AUTHORIZED_WALLETS:-}
-      - SOLANA_NETWORK=${SOLANA_NETWORK:-mainnet-beta}
-      # SENTINEL
-      - SENTINEL_MODE=${SENTINEL_MODE:-yolo}
+      # Network config — loadNetworkConfig() reads SIPHER_NETWORK at boot and
+      # FATAL-throws if unset (no silent mainnet fallback). The default 'devnet'
+      # below matches the devnet-beta posture we ship with; flip to 'mainnet'
+      # in the operator env when promoting to production.
+      - SIPHER_NETWORK=${SIPHER_NETWORK:-devnet}
+      - SOLANA_NETWORK=${SOLANA_NETWORK:-devnet}
+      # SENTINEL — default 'advisory' is fail-safe; an explicit 'yolo' opts into
+      # autonomous fund-moving operations and emits a startup warning.
+      - SENTINEL_MODE=${SENTINEL_MODE:-advisory}
       - SENTINEL_AUTHORITY_KEYPAIR=${SENTINEL_AUTHORITY_KEYPAIR:-}
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
       - X_BEARER_TOKEN=${X_BEARER_TOKEN:-}

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { mockPrivacyScore } from './fixtures/mocks'
 
 const AUTH_STATE = 'e2e/fixtures/storageState.json'
 
@@ -36,6 +37,7 @@ test.describe('chat sidebar', () => {
           body,
         })
       })
+      await mockPrivacyScore(page)
 
       const errors: string[] = []
       page.on('pageerror', (err) => errors.push(err.message))

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { mockSolanaRpc } from './fixtures/mocks'
+import { mockSolanaRpc, mockPrivacyScore } from './fixtures/mocks'
 
 const AUTH_STATE = 'e2e/fixtures/storageState.json'
 
@@ -13,6 +13,7 @@ test('dashboard view renders without errors', async ({ page }) => {
   })
 
   await mockSolanaRpc(page)
+  await mockPrivacyScore(page)
   await page.goto('/')
 
   await expect(page.locator('[data-testid="dashboard-view"]')).toBeVisible()

--- a/e2e/fixtures/mocks.ts
+++ b/e2e/fixtures/mocks.ts
@@ -22,8 +22,10 @@ export async function mockSolanaRpc(page: Page): Promise<void> {
 // that CI does not build. Without this mock, DashboardView's privacy-score
 // fetch fires once /api/vault returns the wallet field and the browser logs
 // a 404 — which the "renders without errors" smoke specs assert against.
-// Stub a minimal valid PrivacyData envelope so the FE's catch path doesn't
-// trip and the network layer stays quiet.
+// The factors map MUST include addressReuse / amountPatterns /
+// timingCorrelation / counterpartyExposure since DashboardView destructures
+// those keys without optional-chaining; an empty {} crashes the render and
+// the chat input detaches mid-test.
 export async function mockPrivacyScore(page: Page): Promise<void> {
   await page.route('**/v1/privacy/score', async (route: Route) => {
     await route.fulfill({
@@ -31,7 +33,12 @@ export async function mockPrivacyScore(page: Page): Promise<void> {
         data: {
           score: 0,
           grade: 'N/A',
-          factors: {},
+          factors: {
+            addressReuse: { score: 0, detail: '' },
+            amountPatterns: { score: 0, detail: '' },
+            timingCorrelation: { score: 0, detail: '' },
+            counterpartyExposure: { score: 0, detail: '' },
+          },
           recommendations: [],
           transactionsAnalyzed: 0,
         },

--- a/e2e/fixtures/mocks.ts
+++ b/e2e/fixtures/mocks.ts
@@ -18,6 +18,28 @@ export async function mockSolanaRpc(page: Page): Promise<void> {
   })
 }
 
+// Mode 2 (`/v1/*`) endpoints are served from a separate `dist/app.js` bundle
+// that CI does not build. Without this mock, DashboardView's privacy-score
+// fetch fires once /api/vault returns the wallet field and the browser logs
+// a 404 — which the "renders without errors" smoke specs assert against.
+// Stub a minimal valid PrivacyData envelope so the FE's catch path doesn't
+// trip and the network layer stays quiet.
+export async function mockPrivacyScore(page: Page): Promise<void> {
+  await page.route('**/v1/privacy/score', async (route: Route) => {
+    await route.fulfill({
+      json: {
+        data: {
+          score: 0,
+          grade: 'N/A',
+          factors: {},
+          recommendations: [],
+          transactionsAnalyzed: 0,
+        },
+      },
+    })
+  })
+}
+
 export async function mockJupiter(page: Page): Promise<void> {
   await page.route('**/quote**', async (route: Route) => {
     await route.fulfill({

--- a/e2e/herald.spec.ts
+++ b/e2e/herald.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { mockPrivacyScore } from './fixtures/mocks'
 
 const AUTH_STATE = 'e2e/fixtures/storageState.json'
 
@@ -21,6 +22,7 @@ test('herald view renders with admin budget visible', async ({ page }) => {
       },
     })
   })
+  await mockPrivacyScore(page)
 
   await page.goto('/')
   await page.getByRole('button', { name: /herald/i }).first().click()

--- a/e2e/squad.spec.ts
+++ b/e2e/squad.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { mockPrivacyScore } from './fixtures/mocks'
 
 const AUTH_STATE = 'e2e/fixtures/storageState.json'
 
@@ -11,6 +12,7 @@ test('squad view renders', async ({ page }) => {
     if (msg.type() === 'error') errors.push(msg.text())
   })
 
+  await mockPrivacyScore(page)
   await page.goto('/')
   await page.getByRole('button', { name: /squad/i }).first().click()
   await expect(page.locator('[data-testid="squad-view"]')).toBeVisible()

--- a/e2e/vault.spec.ts
+++ b/e2e/vault.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { mockSolanaRpc } from './fixtures/mocks'
+import { mockSolanaRpc, mockPrivacyScore } from './fixtures/mocks'
 
 const AUTH_STATE = 'e2e/fixtures/storageState.json'
 
@@ -13,6 +13,7 @@ test('vault view renders', async ({ page }) => {
   })
 
   await mockSolanaRpc(page)
+  await mockPrivacyScore(page)
   await page.goto('/')
   await page.getByRole('button', { name: /vault/i }).first().click()
   await expect(page.locator('[data-testid="vault-view"]')).toBeVisible()

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,60 @@
+// ESLint flat config (v9+).
+//
+// Scope: only enforces a single guard rule across the agent package, banning
+// direct reads of process.env.SOLANA_NETWORK and process.env.SOLANA_RPC_URL
+// outside the canonical site `packages/agent/src/config/network.ts`. This is
+// the rule that prevents the silent-mainnet-leak class of bugs from coming
+// back after the B12/B13 migrations.
+//
+// We deliberately don't enable typescript-eslint rules yet — the project's
+// existing style is enforced by tsc + Prettier at the file level, and dragging
+// in lots of rules would create a wave of drive-by changes the
+// auth-surface-hardening PR shouldn't carry. The plugin IS registered so that
+// existing `// eslint-disable-next-line @typescript-eslint/no-explicit-any`
+// comments scattered through herald/tools/*.ts validate (referencing a rule
+// from an unregistered plugin would itself error).
+
+import tsParser from '@typescript-eslint/parser'
+import tseslint from 'typescript-eslint'
+
+export default [
+  {
+    files: ['packages/agent/src/**/*.ts'],
+    ignores: [
+      'packages/agent/src/config/network.ts',
+      'packages/agent/src/**/__tests__/**',
+      'packages/agent/src/**/*.test.ts',
+      'packages/agent/src/**/*.spec.ts',
+    ],
+    linterOptions: {
+      // Pre-existing `// eslint-disable-next-line @typescript-eslint/no-explicit-any`
+      // comments live across herald/tools/* from before any ESLint setup. We
+      // load the plugin (so the rule name resolves) but don't enable the rule
+      // — the disable directives are no-ops, and we suppress the warning that
+      // otherwise screams about every one of them. Dropping the dead
+      // directives is a separate cleanup.
+      reportUnusedDisableDirectives: false,
+    },
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint.plugin,
+    },
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "MemberExpression[object.object.name='process'][object.property.name='env'][property.name=/^(SOLANA_NETWORK|SOLANA_RPC_URL)$/]",
+          message:
+            'Use loadNetworkConfig() instead of reading process.env.SOLANA_NETWORK / SOLANA_RPC_URL directly. See packages/agent/src/config/network.ts.',
+        },
+      ],
+    },
+  },
+]

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,21 @@ import tsParser from '@typescript-eslint/parser'
 import tseslint from 'typescript-eslint'
 
 export default [
+  // Global ignores — build artifacts, node_modules, and any generated dist
+  // output anywhere in the workspace. Without this, `pnpm build` populates
+  // `packages/agent/dist/` and a subsequent `pnpm lint` scans those .js
+  // files (which carry the same disable-directive scaffolding as src) and
+  // errors on the unregistered plugin reference (no flat-config block
+  // matches them, so the typescript-eslint plugin isn't loaded for that
+  // scan path).
+  {
+    ignores: [
+      '**/dist/**',
+      '**/node_modules/**',
+      '**/build/**',
+      'packages/agent/coverage/**',
+    ],
+  },
   {
     files: ['packages/agent/src/**/*.ts'],
     ignores: [

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "tsup",
     "test": "vitest",
     "typecheck": "tsc --noEmit",
+    "lint": "eslint",
     "clean": "rm -rf dist",
     "colosseum": "tsx scripts/colosseum.ts",
     "demo": "tsx scripts/demo-flow.ts",
@@ -62,11 +63,14 @@
     "@types/node": "^25.2.0",
     "@types/supertest": "^6.0.3",
     "@types/swagger-ui-express": "^4.1.8",
+    "@typescript-eslint/parser": "^8.59.2",
+    "eslint": "^10.3.0",
     "pino-pretty": "^13.0.0",
     "supertest": "^7.1.0",
     "tsup": "^8.3.6",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
+    "typescript-eslint": "^8.59.2",
     "vitest": "^3.0.5"
   },
   "keywords": [

--- a/packages/agent/src/adapters/web.ts
+++ b/packages/agent/src/adapters/web.ts
@@ -53,10 +53,15 @@ function chunkToSSE(chunk: ResponseChunk): Record<string, unknown> {
 }
 
 /**
- * Extract the wallet address set by JWT middleware.
+ * Extract the wallet address set by JWT middleware. Throws if absent
+ * (catches middleware-order bugs that would otherwise be silent NPEs).
  */
 function getWallet(req: Request): string {
-  return (req as unknown as Record<string, unknown>).wallet as string
+  const wallet = req.wallet
+  if (!wallet) {
+    throw new Error('getWallet called before verifyJwt middleware attached req.wallet')
+  }
+  return wallet
 }
 
 /**

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -129,6 +129,16 @@ setInterval(() => {
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const app = express()
+
+// Trust proxy: required so req.ip resolves to the client X-Forwarded-For
+// value behind nginx instead of nginx's IP. Without this, per-IP rate
+// limiters degrade into single global counters. Default 1 hop = nginx; set
+// TRUST_PROXY=0 for local dev without a reverse proxy, or higher for
+// multi-hop topologies.
+const trustProxy = Number.parseInt(process.env.TRUST_PROXY ?? '1', 10)
+app.set('trust proxy', trustProxy)
+console.log(`[agent] trust proxy = ${trustProxy} (set TRUST_PROXY env var to override)`)
+
 app.use(express.json({ limit: '1mb' }))
 
 // ─── CORS — only needed for dev/test (in prod the agent serves the app statically)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -22,6 +22,7 @@ import { SentinelCore } from './sentinel/core.js'
 import { SentinelAdapter } from './sentinel/adapter.js'
 import { restorePendingActions, registerActionExecutor } from './sentinel/circuit-breaker.js'
 import { setSentinelAssessor } from './sentinel/preflight-gate.js'
+import { FUND_MOVING_TOOLS } from './sentinel/preflight-rules.js'
 import { performVaultRefund, assertVaultRefundWired } from './sentinel/vault-refund.js'
 import { sentinelPublicRouter, sentinelAdminRouter } from './routes/sentinel-api.js'
 import { getSentinelConfig } from './sentinel/config.js'
@@ -248,13 +249,13 @@ app.post('/api/chat/stream', verifyJwt, async (req, res) => {
 
 // ─── Tool execution endpoint (for direct tool calls from the UI) ────────────
 
-// Fund-moving tools blocked from direct execution — must go through /api/command confirmation flow
-const BLOCKED_TOOLS = new Set(['send', 'deposit', 'refund', 'sweep', 'consolidate', 'swap', 'splitSend', 'scheduleSend', 'drip', 'recurring'])
-
+// Fund-moving tools blocked from direct execution — must go through /api/command
+// confirmation flow. Single source of truth lives in preflight-rules.ts so the
+// SENTINEL preflight gate and this guard never drift.
 app.post('/api/tools/:name', verifyJwt, async (req, res) => {
   const name = req.params.name as string
 
-  if (BLOCKED_TOOLS.has(name)) {
+  if (FUND_MOVING_TOOLS.has(name)) {
     res.status(403).json({ success: false, error: `tool '${name}' requires confirmation flow — use /api/command instead` })
     return
   }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -195,7 +195,11 @@ app.use('/api/sentinel', verifyJwt, requireOwner, sentinelAdminRouter)
 
 // Activity stream (per-wallet history from DB) — JWT required
 app.get('/api/activity', verifyJwt, (req: Request, res: Response) => {
-  const wallet = (req as unknown as Record<string, unknown>).wallet as string
+  const wallet = req.wallet
+  if (!wallet) {
+    res.status(500).json({ error: { code: 'INTERNAL', message: 'JWT middleware did not attach wallet' } })
+    return
+  }
   const activity = getActivity(wallet)
   res.json({ activity })
 })
@@ -245,7 +249,11 @@ app.post('/api/tools/:name', verifyJwt, async (req, res) => {
     return
   }
 
-  const wallet = (req as unknown as Record<string, unknown>).wallet as string
+  const wallet = req.wallet
+  if (!wallet) {
+    res.status(500).json({ success: false, error: { code: 'INTERNAL', message: 'JWT middleware did not attach wallet' } })
+    return
+  }
   const input = { ...req.body, wallet }
 
   try {

--- a/packages/agent/src/routes/admin.ts
+++ b/packages/agent/src/routes/admin.ts
@@ -7,21 +7,26 @@ import {
 } from '../db.js'
 import { renderLoginPage, renderDashboardPage } from '../views/admin-page.js'
 import type { DashboardStats } from '../views/admin-page.js'
+import { createStore } from '../state/ephemeral.js'
 
 export const adminRouter = Router()
 
-const adminTokens = new Map<string, number>() // token → expiresAt
+// token → expiresAt epoch-ms. Backed by the centralized ephemeral store —
+// the value type is a plain number so it round-trips through any future
+// Redis backend without surgery.
+const adminTokens = createStore<number>('adminTokens', { maxSize: 1_000 })
 const COOKIE_NAME = 'sipher_admin'
 const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000
+const TWENTY_FOUR_HOURS_SECONDS = 24 * 60 * 60
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Auth helpers
 // ─────────────────────────────────────────────────────────────────────────────
 
-function isValidAdminToken(token: string): boolean {
-  const expiresAt = adminTokens.get(token)
+async function isValidAdminToken(token: string): Promise<boolean> {
+  const expiresAt = await adminTokens.get(token)
   if (!expiresAt || expiresAt < Date.now()) {
-    adminTokens.delete(token)
+    await adminTokens.delete(token)
     return false
   }
   return true
@@ -42,13 +47,13 @@ function getCookie(req: { headers: { cookie?: string } }, name: string): string 
   return match ? match.split('=')[1].trim() : null
 }
 
-function requireAuth(
+async function requireAuth(
   req: { headers: { cookie?: string } },
   res: { status: (code: number) => { json: (body: unknown) => void } },
   next: () => void,
-): void {
+): Promise<void> {
   const token = getCookie(req, COOKIE_NAME)
-  if (!token || !isValidAdminToken(token)) {
+  if (!token || !(await isValidAdminToken(token))) {
     res.status(401).json({ error: 'Unauthorized' })
     return
   }
@@ -71,23 +76,23 @@ function buildStats(): DashboardStats {
 // Public routes (no auth required)
 // ─────────────────────────────────────────────────────────────────────────────
 
-adminRouter.get('/', (req, res) => {
+adminRouter.get('/', async (req, res) => {
   const token = getCookie(req, COOKIE_NAME)
-  if (token && adminTokens.has(token)) {
+  if (token && (await isValidAdminToken(token))) {
     res.redirect('/admin/dashboard')
     return
   }
   res.type('html').send(renderLoginPage())
 })
 
-adminRouter.post('/login', (req, res) => {
+adminRouter.post('/login', async (req, res) => {
   const { password } = req.body
   if (!password || !checkPassword(password)) {
     res.status(401).type('html').send(renderLoginPage('Invalid password'))
     return
   }
   const token = randomBytes(32).toString('hex')
-  adminTokens.set(token, Date.now() + TWENTY_FOUR_HOURS)
+  await adminTokens.set(token, Date.now() + TWENTY_FOUR_HOURS, TWENTY_FOUR_HOURS_SECONDS)
   res.setHeader(
     'Set-Cookie',
     `${COOKIE_NAME}=${token}; Path=/admin; HttpOnly; Secure; SameSite=Strict; Max-Age=${TWENTY_FOUR_HOURS / 1000}`,
@@ -95,9 +100,9 @@ adminRouter.post('/login', (req, res) => {
   res.redirect('/admin/dashboard')
 })
 
-adminRouter.post('/logout', (req, res) => {
+adminRouter.post('/logout', async (req, res) => {
   const token = getCookie(req, COOKIE_NAME)
-  if (token) adminTokens.delete(token)
+  if (token) await adminTokens.delete(token)
   res.setHeader('Set-Cookie', `${COOKIE_NAME}=; Path=/admin; HttpOnly; Max-Age=0`)
   res.redirect('/admin/')
 })
@@ -116,13 +121,5 @@ adminRouter.get('/api/stats', requireAuth as any, (_req, res) => {
   ;(res as any).json(stats)
 })
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Background cleanup — expire stale admin tokens
-// ─────────────────────────────────────────────────────────────────────────────
-
-setInterval(() => {
-  const now = Date.now()
-  for (const [token, expiresAt] of adminTokens) {
-    if (expiresAt < now) adminTokens.delete(token)
-  }
-}, 60 * 60 * 1000).unref()
+// Background cleanup is centralized in the ephemeral store (sweep loop +
+// lazy expiration on get); no per-map setInterval needed.

--- a/packages/agent/src/routes/auth.ts
+++ b/packages/agent/src/routes/auth.ts
@@ -11,11 +11,38 @@ const NONCE_TTL = 5 * 60 * 1000 // 5 minutes
 // JWT lifetime. 24h default keeps users from re-signing every hour during
 // normal browsing; 1h in tests preserves existing TTL-shape assertions.
 // Operator can override via env (e.g. shorten to '4h' for higher security).
-const JWT_EXPIRY = process.env.JWT_EXPIRY ?? (process.env.NODE_ENV === 'test' ? '1h' : '24h')
+// Type-cast at module load: jwt.sign's expiresIn is `number | StringValue`
+// (an `ms`-style template literal) rather than plain `string`, and the env
+// var is plain `string | undefined`. Validation is operator-trust here —
+// jwt.sign throws at runtime on malformed values.
+const JWT_EXPIRY = (process.env.JWT_EXPIRY ?? (process.env.NODE_ENV === 'test' ? '1h' : '24h')) as jwt.SignOptions['expiresIn']
 
 // Solana wallet base58 shape: 32-44 characters, Bitcoin/Solana base58 alphabet
 // (digits 1-9 + uppercase A-Z minus I, O + lowercase a-z minus l).
 const BASE58_REGEX = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/
+
+// SIWS message domain allow-list. The first line of a SIWS-shaped signedMessage
+// is `${domain} wants you to sign in...` — we require ${domain} to be one of
+// these entries followed by a space or colon (so `localhost.attacker.com` does
+// not match an allow-list entry of `localhost`).
+const SIWS_ALLOWED_DOMAINS = ((): string[] => {
+  const env = process.env.SIPHER_ALLOWED_DOMAINS
+  if (env) return env.split(',').map((d) => d.trim()).filter(Boolean)
+  return ['sipher.sip-protocol.org', 'localhost']
+})()
+
+function siwsMessageStartsWithAllowedDomain(messageText: string): boolean {
+  return SIWS_ALLOWED_DOMAINS.some((d) => messageText.startsWith(`${d} `) || messageText.startsWith(`${d}:`))
+}
+
+function decodeBase64ToBytes(input: string): Uint8Array | null {
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(input)) return null
+  try {
+    return new Uint8Array(Buffer.from(input, 'base64'))
+  } catch {
+    return null
+  }
+}
 
 // In-memory store: nonce → { wallet, expires }
 const pendingNonces = new Map<string, { wallet: string; expires: number }>()
@@ -180,10 +207,17 @@ authRouter.post('/verify', (req: Request, res: Response) => {
     return
   }
 
-  const { wallet, nonce, signature } = req.body as {
+  const { wallet, nonce, signature, signedMessage } = req.body as {
     wallet?: string
     nonce?: string
     signature?: string
+    /**
+     * Optional base64-encoded raw bytes the wallet actually signed. Set when
+     * the wallet supports the SIWS Wallet-Standard feature (one popup combines
+     * connect + sign-in). When absent, the server falls back to reconstructing
+     * the legacy `signMessage()`-style nonce string and verifying against that.
+     */
+    signedMessage?: string
   }
 
   if (!wallet || !nonce || !signature) {
@@ -216,9 +250,36 @@ authRouter.post('/verify', (req: Request, res: Response) => {
       return
     }
 
-    // The message the wallet signed (must match what /nonce returns)
-    const message = `sipher.sip-protocol.org wants you to sign in.\n\nNonce: ${nonce}`
-    const messageBytes = new TextEncoder().encode(message)
+    let messageBytes: Uint8Array
+    if (typeof signedMessage === 'string' && signedMessage.length > 0) {
+      // SIWS path — verify the actual bytes the wallet signed (we cannot
+      // reconstruct them, since the SIWS message format includes per-wallet
+      // fields like Issued At, Domain, Statement, etc.). Bind the signed
+      // bytes to OUR nonce + an allowed domain before trusting the signature.
+      const decoded = decodeBase64ToBytes(signedMessage)
+      if (!decoded) {
+        pendingNonces.delete(nonce)
+        res.status(401).json({ error: 'invalid signedMessage encoding' })
+        return
+      }
+      const messageText = new TextDecoder('utf-8', { fatal: false }).decode(decoded)
+      if (!siwsMessageStartsWithAllowedDomain(messageText)) {
+        pendingNonces.delete(nonce)
+        res.status(401).json({ error: 'signedMessage domain not in allow-list' })
+        return
+      }
+      if (!messageText.includes(`Nonce: ${nonce}`)) {
+        pendingNonces.delete(nonce)
+        res.status(401).json({ error: 'signedMessage does not bind to nonce' })
+        return
+      }
+      messageBytes = decoded
+    } else {
+      // Legacy signMessage() path — reconstruct the nonce string the wallet
+      // signed via its signMessage(bytes) primitive.
+      const message = `sipher.sip-protocol.org wants you to sign in.\n\nNonce: ${nonce}`
+      messageBytes = new TextEncoder().encode(message)
+    }
 
     const valid = ed25519.verify(signatureBytes, messageBytes, publicKeyBytes)
     if (!valid) {

--- a/packages/agent/src/routes/auth.ts
+++ b/packages/agent/src/routes/auth.ts
@@ -10,6 +10,10 @@ import { ed25519 } from '@noble/curves/ed25519'
 const NONCE_TTL = 5 * 60 * 1000 // 5 minutes
 const JWT_EXPIRY = '1h'
 
+// Solana wallet base58 shape: 32-44 characters, Bitcoin/Solana base58 alphabet
+// (digits 1-9 + uppercase A-Z minus I, O + lowercase a-z minus l).
+const BASE58_REGEX = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/
+
 // In-memory store: nonce → { wallet, expires }
 const pendingNonces = new Map<string, { wallet: string; expires: number }>()
 
@@ -108,10 +112,21 @@ export const authRouter = Router()
  * Issues a one-time nonce tied to a wallet address.
  */
 authRouter.post('/nonce', (req: Request, res: Response) => {
-  const { wallet } = req.body as { wallet?: string }
+  const { wallet } = req.body as { wallet?: unknown }
 
-  if (!wallet || typeof wallet !== 'string') {
-    res.status(400).json({ error: 'wallet required' })
+  // Shape validation — reject non-strings, oversize input, non-base58 strings.
+  // Without this, an attacker can: (a) fill pendingNonces with 64KB string keys,
+  // (b) force /verify to amplify ed25519 work on garbage inputs.
+  if (typeof wallet !== 'string') {
+    res.status(400).json({ error: { code: 'VALIDATION_FAILED', message: 'wallet must be a string' } })
+    return
+  }
+  if (wallet.length > 64) {
+    res.status(400).json({ error: { code: 'VALIDATION_FAILED', message: 'wallet too long' } })
+    return
+  }
+  if (!BASE58_REGEX.test(wallet)) {
+    res.status(400).json({ error: { code: 'VALIDATION_FAILED', message: 'wallet must be a valid base58 Solana pubkey (32-44 chars)' } })
     return
   }
 

--- a/packages/agent/src/routes/auth.ts
+++ b/packages/agent/src/routes/auth.ts
@@ -242,6 +242,54 @@ authRouter.post('/verify', (req: Request, res: Response) => {
   res.json({ token, expiresIn: JWT_EXPIRY, isAdmin })
 })
 
+/**
+ * POST /auth/refresh
+ * Issues a fresh JWT when the bearer token is valid and within the last 5min
+ * of its lifetime. Token issued during refresh inherits the original wallet +
+ * isAdmin claims.
+ *
+ * Status codes:
+ *  - 200: new token issued
+ *  - 401 UNAUTHENTICATED: missing or malformed Authorization header
+ *  - 401 INVALID_TOKEN: token signature/structure invalid, or already expired
+ *  - 425 TOO_EARLY: token still has > 5min remaining
+ */
+const REFRESH_WINDOW_SECONDS = 5 * 60
+
+authRouter.post('/refresh', (req: Request, res: Response) => {
+  const authHeader = req.headers.authorization
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    res.status(401).json({ error: { code: 'UNAUTHENTICATED', message: 'Missing or malformed Authorization header' } })
+    return
+  }
+  const token = authHeader.slice(7)
+
+  let payload: jwt.JwtPayload & { wallet?: string; isAdmin?: boolean }
+  try {
+    payload = jwt.verify(token, getSecret(), { algorithms: ['HS256'] }) as jwt.JwtPayload & { wallet?: string; isAdmin?: boolean }
+  } catch {
+    res.status(401).json({ error: { code: 'INVALID_TOKEN', message: 'Token invalid or expired' } })
+    return
+  }
+
+  const now = Math.floor(Date.now() / 1000)
+  const exp = payload.exp ?? 0
+  if (exp - now > REFRESH_WINDOW_SECONDS) {
+    res.status(425).json({ error: { code: 'TOO_EARLY', message: 'Refresh allowed within 5min of expiry' } })
+    return
+  }
+
+  const wallet = payload.wallet
+  if (typeof wallet !== 'string') {
+    res.status(401).json({ error: { code: 'INVALID_TOKEN', message: 'Token missing wallet claim' } })
+    return
+  }
+  const isAdmin = payload.isAdmin === true
+
+  const newToken = jwt.sign({ wallet, isAdmin }, getSecret(), { expiresIn: JWT_EXPIRY, algorithm: 'HS256' })
+  res.json({ token: newToken, expiresIn: JWT_EXPIRY })
+})
+
 // ─── SSE Ticket Exchange ─────────────────────────────────────────────────────
 // Short-lived one-time tickets for SSE connections (avoids JWT in URL)
 

--- a/packages/agent/src/routes/auth.ts
+++ b/packages/agent/src/routes/auth.ts
@@ -8,7 +8,10 @@ import { ed25519 } from '@noble/curves/ed25519'
 // ─────────────────────────────────────────────────────────────────────────────
 
 const NONCE_TTL = 5 * 60 * 1000 // 5 minutes
-const JWT_EXPIRY = '1h'
+// JWT lifetime. 24h default keeps users from re-signing every hour during
+// normal browsing; 1h in tests preserves existing TTL-shape assertions.
+// Operator can override via env (e.g. shorten to '4h' for higher security).
+const JWT_EXPIRY = process.env.JWT_EXPIRY ?? (process.env.NODE_ENV === 'test' ? '1h' : '24h')
 
 // Solana wallet base58 shape: 32-44 characters, Bitcoin/Solana base58 alphabet
 // (digits 1-9 + uppercase A-Z minus I, O + lowercase a-z minus l).

--- a/packages/agent/src/routes/auth.ts
+++ b/packages/agent/src/routes/auth.ts
@@ -33,6 +33,30 @@ function checkVerifyRateLimit(ip: string): boolean {
   return entry.count <= VERIFY_RATE_LIMIT
 }
 
+// Per-IP rate limiter for /nonce (anonymous endpoint — without this, one
+// attacker can fill pendingNonces and DoS legitimate sign-ins, even after
+// the input-validation cap).
+const nonceAttempts = new Map<string, { count: number; firstAt: number }>()
+const NONCE_RATE_LIMIT_MAX = 5
+const NONCE_RATE_LIMIT_WINDOW_MS = 60_000
+
+function nonceRateLimit(req: Request, res: Response, next: NextFunction): void {
+  const ip = req.ip ?? 'unknown'
+  const now = Date.now()
+  const entry = nonceAttempts.get(ip)
+  if (!entry || now - entry.firstAt > NONCE_RATE_LIMIT_WINDOW_MS) {
+    nonceAttempts.set(ip, { count: 1, firstAt: now })
+    next()
+    return
+  }
+  if (entry.count >= NONCE_RATE_LIMIT_MAX) {
+    res.status(429).json({ error: { code: 'RATE_LIMITED', message: 'Too many nonce requests, slow down' } })
+    return
+  }
+  entry.count += 1
+  next()
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────────────────────────────────────
@@ -111,7 +135,7 @@ export const authRouter = Router()
  * POST /auth/nonce
  * Issues a one-time nonce tied to a wallet address.
  */
-authRouter.post('/nonce', (req: Request, res: Response) => {
+authRouter.post('/nonce', nonceRateLimit, (req: Request, res: Response) => {
   const { wallet } = req.body as { wallet?: unknown }
 
   // Shape validation — reject non-strings, oversize input, non-base58 strings.
@@ -363,9 +387,17 @@ setInterval(() => {
   }
 }, 30_000).unref()
 
+setInterval(() => {
+  const now = Date.now()
+  for (const [ip, entry] of nonceAttempts) {
+    if (now - entry.firstAt > NONCE_RATE_LIMIT_WINDOW_MS) nonceAttempts.delete(ip)
+  }
+}, NONCE_RATE_LIMIT_WINDOW_MS).unref()
+
 /** Clear in-memory auth state (nonces, rate-limit counters, SSE tickets). Tests only. */
 export function _resetAuthStateForTests(): void {
   pendingNonces.clear()
   verifyAttempts.clear()
   sseTickets.clear()
+  nonceAttempts.clear()
 }

--- a/packages/agent/src/routes/auth.ts
+++ b/packages/agent/src/routes/auth.ts
@@ -272,7 +272,7 @@ export function verifyJwt(req: Request, res: Response, next: NextFunction): void
       res.status(401).json({ error: 'invalid or expired SSE ticket' })
       return
     }
-    ;(req as unknown as Record<string, unknown>).wallet = wallet
+    req.wallet = wallet
     next()
     return
   }
@@ -290,7 +290,7 @@ export function verifyJwt(req: Request, res: Response, next: NextFunction): void
 
   try {
     const decoded = jwt.verify(token, getSecret(), { algorithms: ['HS256'] }) as { wallet: string }
-    ;(req as unknown as Record<string, unknown>).wallet = decoded.wallet
+    req.wallet = decoded.wallet
     next()
   } catch {
     res.status(401).json({ error: 'invalid or expired token' })
@@ -302,7 +302,11 @@ export function verifyJwt(req: Request, res: Response, next: NextFunction): void
  * Must be placed AFTER verifyJwt in the middleware chain.
  */
 export function requireOwner(req: Request, res: Response, next: NextFunction): void {
-  const wallet = (req as unknown as Record<string, unknown>).wallet as string
+  const wallet = req.wallet
+  if (!wallet) {
+    res.status(500).json({ error: { code: 'INTERNAL', message: 'JWT middleware did not attach wallet' } })
+    return
+  }
   const allowed = (process.env.AUTHORIZED_WALLETS ?? '').split(',').map(w => w.trim()).filter(Boolean)
 
   // If no wallets configured, deny all — fail closed

--- a/packages/agent/src/routes/auth.ts
+++ b/packages/agent/src/routes/auth.ts
@@ -44,6 +44,27 @@ function decodeBase64ToBytes(input: string): Uint8Array | null {
   }
 }
 
+// AUTHORIZED_WALLETS allowlist — cached parse with env-mtime invalidation.
+// Production: env never changes after boot → one parse, all subsequent
+// requests hit the cache. Tests that mutate process.env.AUTHORIZED_WALLETS
+// per-test still see the new value because the cache reparses on env-string
+// drift (no test-helper export needed).
+let _cachedAuthEnv: string | undefined
+let _cachedAuthSet = new Set<string>()
+
+function authorizedWalletsSet(): Set<string> {
+  const cur = process.env.AUTHORIZED_WALLETS
+  if (cur !== _cachedAuthEnv) {
+    _cachedAuthEnv = cur
+    _cachedAuthSet = new Set(
+      (cur ?? '').split(',').map((w) => w.trim()).filter(Boolean)
+    )
+  }
+  return _cachedAuthSet
+}
+
+console.log(`[agent] AUTHORIZED_WALLETS: ${authorizedWalletsSet().size} entries`)
+
 // In-memory store: nonce → { wallet, expires }
 const pendingNonces = new Map<string, { wallet: string; expires: number }>()
 
@@ -296,8 +317,8 @@ authRouter.post('/verify', (req: Request, res: Response) => {
   // One-time use — consume before responding
   pendingNonces.delete(nonce)
 
-  const allowed = (process.env.AUTHORIZED_WALLETS ?? '').split(',').map((w) => w.trim()).filter(Boolean)
-  const isAdmin = allowed.length > 0 && allowed.includes(wallet)
+  const allowed = authorizedWalletsSet()
+  const isAdmin = allowed.size > 0 && allowed.has(wallet)
 
   const token = jwt.sign({ wallet }, getSecret(), { expiresIn: JWT_EXPIRY, algorithm: 'HS256' })
   res.json({ token, expiresIn: JWT_EXPIRY, isAdmin })
@@ -458,15 +479,15 @@ export function requireOwner(req: Request, res: Response, next: NextFunction): v
     res.status(500).json({ error: { code: 'INTERNAL', message: 'JWT middleware did not attach wallet' } })
     return
   }
-  const allowed = (process.env.AUTHORIZED_WALLETS ?? '').split(',').map(w => w.trim()).filter(Boolean)
+  const allowed = authorizedWalletsSet()
 
   // If no wallets configured, deny all — fail closed
-  if (allowed.length === 0) {
+  if (allowed.size === 0) {
     res.status(403).json({ error: 'no authorized wallets configured' })
     return
   }
 
-  if (!allowed.includes(wallet)) {
+  if (!allowed.has(wallet)) {
     res.status(403).json({ error: 'wallet not authorized for admin operations' })
     return
   }

--- a/packages/agent/src/routes/auth.ts
+++ b/packages/agent/src/routes/auth.ts
@@ -2,12 +2,13 @@ import { Router, type Request, type Response, type NextFunction } from 'express'
 import jwt from 'jsonwebtoken'
 import crypto from 'node:crypto'
 import { ed25519 } from '@noble/curves/ed25519'
+import { createStore } from '../state/ephemeral.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Constants
 // ─────────────────────────────────────────────────────────────────────────────
 
-const NONCE_TTL = 5 * 60 * 1000 // 5 minutes
+const NONCE_TTL_SECONDS = 5 * 60 // 5 minutes
 // JWT lifetime. 24h default keeps users from re-signing every hour during
 // normal browsing; 1h in tests preserves existing TTL-shape assertions.
 // Operator can override via env (e.g. shorten to '4h' for higher security).
@@ -65,38 +66,41 @@ function authorizedWalletsSet(): Set<string> {
 
 console.log(`[agent] AUTHORIZED_WALLETS: ${authorizedWalletsSet().size} entries`)
 
-// In-memory store: nonce → { wallet, expires }
-const pendingNonces = new Map<string, { wallet: string; expires: number }>()
+// Pending nonces: nonce → { wallet, expires }. TTL = 5 min.
+const pendingNonces = createStore<{ wallet: string; expires: number }>('pendingNonces', { maxSize: 10_000 })
 
-// Per-IP rate limiter for /verify (prevents ed25519 CPU amplification)
-const verifyAttempts = new Map<string, { count: number; resetAt: number }>()
+// Per-IP rate limiter for /verify (prevents ed25519 CPU amplification).
+const verifyAttempts = createStore<{ count: number; resetAt: number }>('verifyAttempts', { maxSize: 1_000 })
 const VERIFY_RATE_LIMIT = 10  // per minute
 const VERIFY_WINDOW_MS = 60_000
+const VERIFY_WINDOW_SECONDS = VERIFY_WINDOW_MS / 1000
 
-function checkVerifyRateLimit(ip: string): boolean {
+async function checkVerifyRateLimit(ip: string): Promise<boolean> {
   const now = Date.now()
-  const entry = verifyAttempts.get(ip)
+  const entry = await verifyAttempts.get(ip)
   if (!entry || entry.resetAt < now) {
-    verifyAttempts.set(ip, { count: 1, resetAt: now + VERIFY_WINDOW_MS })
+    await verifyAttempts.set(ip, { count: 1, resetAt: now + VERIFY_WINDOW_MS }, VERIFY_WINDOW_SECONDS)
     return true
   }
-  entry.count++
-  return entry.count <= VERIFY_RATE_LIMIT
+  const nextCount = entry.count + 1
+  await verifyAttempts.set(ip, { count: nextCount, resetAt: entry.resetAt }, VERIFY_WINDOW_SECONDS)
+  return nextCount <= VERIFY_RATE_LIMIT
 }
 
 // Per-IP rate limiter for /nonce (anonymous endpoint — without this, one
 // attacker can fill pendingNonces and DoS legitimate sign-ins, even after
 // the input-validation cap).
-const nonceAttempts = new Map<string, { count: number; firstAt: number }>()
+const nonceAttempts = createStore<{ count: number; firstAt: number }>('nonceAttempts', { maxSize: 1_000 })
 const NONCE_RATE_LIMIT_MAX = 5
 const NONCE_RATE_LIMIT_WINDOW_MS = 60_000
+const NONCE_RATE_LIMIT_WINDOW_SECONDS = NONCE_RATE_LIMIT_WINDOW_MS / 1000
 
-function nonceRateLimit(req: Request, res: Response, next: NextFunction): void {
+async function nonceRateLimit(req: Request, res: Response, next: NextFunction): Promise<void> {
   const ip = req.ip ?? 'unknown'
   const now = Date.now()
-  const entry = nonceAttempts.get(ip)
+  const entry = await nonceAttempts.get(ip)
   if (!entry || now - entry.firstAt > NONCE_RATE_LIMIT_WINDOW_MS) {
-    nonceAttempts.set(ip, { count: 1, firstAt: now })
+    await nonceAttempts.set(ip, { count: 1, firstAt: now }, NONCE_RATE_LIMIT_WINDOW_SECONDS)
     next()
     return
   }
@@ -104,7 +108,7 @@ function nonceRateLimit(req: Request, res: Response, next: NextFunction): void {
     res.status(429).json({ error: { code: 'RATE_LIMITED', message: 'Too many nonce requests, slow down' } })
     return
   }
-  entry.count += 1
+  await nonceAttempts.set(ip, { count: entry.count + 1, firstAt: entry.firstAt }, NONCE_RATE_LIMIT_WINDOW_SECONDS)
   next()
 }
 
@@ -186,7 +190,7 @@ export const authRouter = Router()
  * POST /auth/nonce
  * Issues a one-time nonce tied to a wallet address.
  */
-authRouter.post('/nonce', nonceRateLimit, (req: Request, res: Response) => {
+authRouter.post('/nonce', nonceRateLimit, async (req: Request, res: Response) => {
   const { wallet } = req.body as { wallet?: unknown }
 
   // Shape validation — reject non-strings, oversize input, non-base58 strings.
@@ -205,13 +209,11 @@ authRouter.post('/nonce', nonceRateLimit, (req: Request, res: Response) => {
     return
   }
 
-  if (pendingNonces.size >= 10_000) {
-    res.status(429).json({ error: 'too many pending nonces — try again later' })
-    return
-  }
-
+  // The store enforces maxSize via FIFO eviction internally — no explicit
+  // size check needed here; the legacy "too many pending nonces" 429 went
+  // away with the per-IP rate limiter (B5) anyway.
   const nonce = crypto.randomBytes(32).toString('hex')
-  pendingNonces.set(nonce, { wallet, expires: Date.now() + NONCE_TTL })
+  await pendingNonces.set(nonce, { wallet, expires: Date.now() + NONCE_TTL_SECONDS * 1000 }, NONCE_TTL_SECONDS)
 
   res.json({ nonce, message: `sipher.sip-protocol.org wants you to sign in.\n\nNonce: ${nonce}` })
 })
@@ -221,9 +223,9 @@ authRouter.post('/nonce', nonceRateLimit, (req: Request, res: Response) => {
  * Verifies a signed nonce via ed25519 and returns a JWT.
  * The wallet must cryptographically prove ownership by signing the nonce message.
  */
-authRouter.post('/verify', (req: Request, res: Response) => {
+authRouter.post('/verify', async (req: Request, res: Response) => {
   const ip = req.ip ?? req.socket.remoteAddress ?? 'unknown'
-  if (!checkVerifyRateLimit(ip)) {
+  if (!(await checkVerifyRateLimit(ip))) {
     res.status(429).json({ error: 'too many verify attempts — try again later' })
     return
   }
@@ -246,11 +248,11 @@ authRouter.post('/verify', (req: Request, res: Response) => {
     return
   }
 
-  const pending = pendingNonces.get(nonce)
+  const pending = await pendingNonces.get(nonce)
 
   if (!pending || pending.wallet !== wallet || pending.expires < Date.now()) {
     // Always clean up — prevents probing expired entries
-    pendingNonces.delete(nonce)
+    await pendingNonces.delete(nonce)
     res.status(401).json({ error: 'invalid or expired nonce' })
     return
   }
@@ -259,14 +261,14 @@ authRouter.post('/verify', (req: Request, res: Response) => {
   try {
     const publicKeyBytes = decodePublicKey(wallet)
     if (publicKeyBytes.length !== 32) {
-      pendingNonces.delete(nonce)
+      await pendingNonces.delete(nonce)
       res.status(401).json({ error: 'invalid wallet address: expected 32-byte ed25519 public key' })
       return
     }
 
     const signatureBytes = decodeSignature(signature)
     if (signatureBytes.length !== 64) {
-      pendingNonces.delete(nonce)
+      await pendingNonces.delete(nonce)
       res.status(401).json({ error: 'invalid signature: expected 64-byte ed25519 signature' })
       return
     }
@@ -279,18 +281,18 @@ authRouter.post('/verify', (req: Request, res: Response) => {
       // bytes to OUR nonce + an allowed domain before trusting the signature.
       const decoded = decodeBase64ToBytes(signedMessage)
       if (!decoded) {
-        pendingNonces.delete(nonce)
+        await pendingNonces.delete(nonce)
         res.status(401).json({ error: 'invalid signedMessage encoding' })
         return
       }
       const messageText = new TextDecoder('utf-8', { fatal: false }).decode(decoded)
       if (!siwsMessageStartsWithAllowedDomain(messageText)) {
-        pendingNonces.delete(nonce)
+        await pendingNonces.delete(nonce)
         res.status(401).json({ error: 'signedMessage domain not in allow-list' })
         return
       }
       if (!messageText.includes(`Nonce: ${nonce}`)) {
-        pendingNonces.delete(nonce)
+        await pendingNonces.delete(nonce)
         res.status(401).json({ error: 'signedMessage does not bind to nonce' })
         return
       }
@@ -304,18 +306,18 @@ authRouter.post('/verify', (req: Request, res: Response) => {
 
     const valid = ed25519.verify(signatureBytes, messageBytes, publicKeyBytes)
     if (!valid) {
-      pendingNonces.delete(nonce)
+      await pendingNonces.delete(nonce)
       res.status(401).json({ error: 'signature verification failed' })
       return
     }
   } catch {
-    pendingNonces.delete(nonce)
+    await pendingNonces.delete(nonce)
     res.status(401).json({ error: 'signature verification failed' })
     return
   }
 
   // One-time use — consume before responding
-  pendingNonces.delete(nonce)
+  await pendingNonces.delete(nonce)
 
   const allowed = authorizedWalletsSet()
   const isAdmin = allowed.size > 0 && allowed.has(wallet)
@@ -375,15 +377,15 @@ authRouter.post('/refresh', (req: Request, res: Response) => {
 // ─── SSE Ticket Exchange ─────────────────────────────────────────────────────
 // Short-lived one-time tickets for SSE connections (avoids JWT in URL)
 
-const SSE_TICKET_TTL = 30_000 // 30 seconds
-const sseTickets = new Map<string, { wallet: string; expires: number }>()
+const SSE_TICKET_TTL_SECONDS = 30
+const sseTickets = createStore<{ wallet: string; expires: number }>('sseTickets', { maxSize: 10_000 })
 
 /**
  * POST /auth/sse-ticket
  * Exchanges a valid JWT for a short-lived, one-time SSE connection ticket.
  * The ticket is a random string (not a JWT), safe to appear in URLs.
  */
-authRouter.post('/sse-ticket', (req: Request, res: Response) => {
+authRouter.post('/sse-ticket', async (req: Request, res: Response) => {
   const authHeader = req.headers.authorization
   const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined
 
@@ -395,15 +397,12 @@ authRouter.post('/sse-ticket', (req: Request, res: Response) => {
   try {
     const decoded = jwt.verify(token, getSecret(), { algorithms: ['HS256'] }) as { wallet: string }
     const ticket = crypto.randomBytes(32).toString('hex')
-    sseTickets.set(ticket, { wallet: decoded.wallet, expires: Date.now() + SSE_TICKET_TTL })
-
-    // Cap ticket store — evict oldest entry on overflow
-    if (sseTickets.size > 10_000) {
-      const oldest = sseTickets.keys().next().value
-      if (oldest) sseTickets.delete(oldest)
-    }
-
-    res.json({ ticket, expiresIn: SSE_TICKET_TTL / 1000 })
+    await sseTickets.set(
+      ticket,
+      { wallet: decoded.wallet, expires: Date.now() + SSE_TICKET_TTL_SECONDS * 1000 },
+      SSE_TICKET_TTL_SECONDS,
+    )
+    res.json({ ticket, expiresIn: SSE_TICKET_TTL_SECONDS })
   } catch {
     res.status(401).json({ error: 'invalid or expired token' })
   }
@@ -413,13 +412,13 @@ authRouter.post('/sse-ticket', (req: Request, res: Response) => {
  * Validate and consume an SSE ticket. Returns the wallet if valid, null otherwise.
  * Tickets are one-time use — deleted after first validation.
  */
-export function consumeSseTicket(ticket: string): string | null {
-  const entry = sseTickets.get(ticket)
+export async function consumeSseTicket(ticket: string): Promise<string | null> {
+  const entry = await sseTickets.get(ticket)
   if (!entry || entry.expires < Date.now()) {
-    sseTickets.delete(ticket)
+    await sseTickets.delete(ticket)
     return null
   }
-  sseTickets.delete(ticket) // one-time use
+  await sseTickets.delete(ticket) // one-time use
   return entry.wallet
 }
 
@@ -435,11 +434,11 @@ export function consumeSseTicket(ticket: string): string | null {
  *
  * On success, attaches `wallet` to the request object and calls next().
  */
-export function verifyJwt(req: Request, res: Response, next: NextFunction): void {
+export async function verifyJwt(req: Request, res: Response, next: NextFunction): Promise<void> {
   // SSE ticket (preferred — no JWT in URL)
   const ticket = req.query.ticket as string | undefined
   if (ticket) {
-    const wallet = consumeSseTicket(ticket)
+    const wallet = await consumeSseTicket(ticket)
     if (!wallet) {
       res.status(401).json({ error: 'invalid or expired SSE ticket' })
       return
@@ -495,42 +494,10 @@ export function requireOwner(req: Request, res: Response, next: NextFunction): v
   next()
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Background cleanup — prevent unbounded nonce accumulation
-// ─────────────────────────────────────────────────────────────────────────────
-
-setInterval(() => {
-  const now = Date.now()
-  for (const [nonce, data] of pendingNonces) {
-    if (data.expires < now) pendingNonces.delete(nonce)
-  }
-}, 5 * 60 * 1000).unref()
-
-setInterval(() => {
-  const now = Date.now()
-  for (const [ip, entry] of verifyAttempts) {
-    if (entry.resetAt < now) verifyAttempts.delete(ip)
-  }
-}, 5 * 60 * 1000).unref()
-
-setInterval(() => {
-  const now = Date.now()
-  for (const [ticket, data] of sseTickets) {
-    if (data.expires < now) sseTickets.delete(ticket)
-  }
-}, 30_000).unref()
-
-setInterval(() => {
-  const now = Date.now()
-  for (const [ip, entry] of nonceAttempts) {
-    if (now - entry.firstAt > NONCE_RATE_LIMIT_WINDOW_MS) nonceAttempts.delete(ip)
-  }
-}, NONCE_RATE_LIMIT_WINDOW_MS).unref()
-
 /** Clear in-memory auth state (nonces, rate-limit counters, SSE tickets). Tests only. */
-export function _resetAuthStateForTests(): void {
-  pendingNonces.clear()
-  verifyAttempts.clear()
-  sseTickets.clear()
-  nonceAttempts.clear()
+export async function _resetAuthStateForTests(): Promise<void> {
+  await pendingNonces._clear()
+  await verifyAttempts._clear()
+  await sseTickets._clear()
+  await nonceAttempts._clear()
 }

--- a/packages/agent/src/routes/confirm.ts
+++ b/packages/agent/src/routes/confirm.ts
@@ -26,7 +26,11 @@ confirmRouter.post('/:id', (req: Request, res: Response) => {
     return
   }
 
-  const wallet = (req as unknown as Record<string, unknown>).wallet as string
+  const wallet = req.wallet
+  if (!wallet) {
+    res.status(500).json({ error: { code: 'INTERNAL', message: 'JWT middleware did not attach wallet' } })
+    return
+  }
   if (entry.wallet !== wallet) {
     res.status(403).json({ error: 'confirmation belongs to a different wallet' })
     return

--- a/packages/agent/src/routes/herald-api.ts
+++ b/packages/agent/src/routes/herald-api.ts
@@ -43,7 +43,11 @@ heraldRouter.patch('/queue/:id', (req: Request, res: Response): void => {
   try {
     const updated = updateContent(id, parsed.data.content)
     if (oldItem) {
-      const wallet = (req as unknown as Record<string, unknown>).wallet as string
+      const wallet = req.wallet
+      if (!wallet) {
+        res.status(500).json({ error: { code: 'INTERNAL', message: 'JWT middleware did not attach wallet' } })
+        return
+      }
       guardianBus.emit({
         source: 'herald',
         type: 'herald:edited',
@@ -82,7 +86,11 @@ heraldRouter.post('/approve/:id', (req: Request, res: Response) => {
     return
   }
 
-  const wallet = (req as unknown as Record<string, unknown>).wallet as string
+  const wallet = req.wallet
+  if (!wallet) {
+    res.status(500).json({ error: { code: 'INTERNAL', message: 'JWT middleware did not attach wallet' } })
+    return
+  }
 
   switch (action) {
     case 'approve':

--- a/packages/agent/src/routes/pay.ts
+++ b/packages/agent/src/routes/pay.ts
@@ -2,6 +2,8 @@ import { Router } from 'express'
 import { Connection, LAMPORTS_PER_SOL } from '@solana/web3.js'
 import { getPaymentLink, markPaymentLinkPaid } from '../db.js'
 import { loadNetworkConfig } from '../config/network.js'
+import { guardianBus } from '../coordination/event-bus.js'
+import { createStore } from '../state/ephemeral.js'
 import {
   renderPaymentPage,
   renderExpiredPage,
@@ -12,64 +14,154 @@ import {
 export const payRouter = Router()
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Per-link confirmation rate limit
+// ─────────────────────────────────────────────────────────────────────────────
+// 3 confirmation attempts per minute per payment-link id. Window-based (not
+// pure TTL) — first attempt sets `firstAt`, subsequent attempts inside the
+// 60s window increment the counter. After 60s of inactivity the entry's TTL
+// will have lapsed and the next attempt starts a fresh budget. Mirrors the
+// pattern in routes/auth.ts:nonceRateLimit so behavior is consistent across
+// surfaces.
+
+const PAY_CONFIRM_RATE_LIMIT_MAX = 3
+const PAY_CONFIRM_RATE_LIMIT_WINDOW_MS = 60_000
+const PAY_CONFIRM_RATE_LIMIT_WINDOW_SECONDS = PAY_CONFIRM_RATE_LIMIT_WINDOW_MS / 1000
+
+const linkConfirmAttempts = createStore<{ count: number; firstAt: number }>(
+  'linkConfirmAttempts',
+  { maxSize: 10_000 },
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
 // On-chain transaction verification
 // ─────────────────────────────────────────────────────────────────────────────
 
+const errMessage = (e: unknown): string => (e instanceof Error ? e.message : String(e))
+
+/**
+ * Run on-chain verification against a single Connection. Returns a verifier
+ * verdict (`{ valid: true }` or `{ valid: false, error }`) for the four
+ * inspected conditions: tx not found, tx failed, recipient mismatch,
+ * insufficient amount. Throws on actual RPC errors so the caller can decide
+ * whether to fall back to a secondary endpoint.
+ */
+async function verifyOnConnection(
+  connection: Connection,
+  txSignature: string,
+  expectedAddress: string,
+  expectedAmount: number | null,
+): Promise<{ valid: boolean; error?: string }> {
+  const tx = await connection.getTransaction(txSignature, {
+    maxSupportedTransactionVersion: 0,
+  })
+
+  if (!tx) {
+    return { valid: false, error: 'transaction not found on-chain' }
+  }
+
+  if (tx.meta?.err) {
+    return { valid: false, error: 'transaction failed on-chain' }
+  }
+
+  // Check the stealth address received funds
+  const accountKeys = tx.transaction.message.getAccountKeys()
+  const targetIndex = accountKeys.staticAccountKeys.findIndex(
+    key => key.toBase58() === expectedAddress,
+  )
+
+  if (targetIndex === -1) {
+    return { valid: false, error: 'transaction does not involve the expected address' }
+  }
+
+  // Verify amount if specified (1% tolerance for rounding)
+  if (expectedAmount !== null && tx.meta) {
+    const preBalance = tx.meta.preBalances[targetIndex] ?? 0
+    const postBalance = tx.meta.postBalances[targetIndex] ?? 0
+    const receivedLamports = postBalance - preBalance
+    const receivedSol = receivedLamports / LAMPORTS_PER_SOL
+
+    if (receivedSol < expectedAmount * 0.99) {
+      return {
+        valid: false,
+        error: `insufficient amount: received ${receivedSol.toFixed(4)} SOL, expected ${expectedAmount} SOL`,
+      }
+    }
+  }
+
+  return { valid: true }
+}
+
 /**
  * Verify a Solana transaction on-chain before accepting payment confirmation.
- * Checks: tx exists, tx succeeded, recipient matches, amount matches.
- * Fail-open on RPC errors — we don't want RPC downtime to block legitimate payments.
+ * Tries the primary RPC first; on RPC error tries the fallback RPC
+ * (`SOLANA_RPC_URL_FALLBACK`, wired into compose by B15). Throws if both
+ * fail (or if no fallback is configured and the primary errors). Verifier
+ * verdicts (`{ valid: false, error: ... }`) are NOT errors and never
+ * trigger fallback — they're valid "no, this signature doesn't pay this
+ * link" answers.
+ *
+ * Emits two `guardianBus` events for operator visibility:
+ *   - `pay:rpc-fallback-used` (important) — primary failed, fallback succeeded
+ *   - `pay:rpc-all-failed` (critical) — primary + fallback both failed,
+ *     OR primary failed with no fallback configured
  */
 export async function verifyTransaction(
   txSignature: string,
   expectedAddress: string,
   expectedAmount: number | null,
 ): Promise<{ valid: boolean; error?: string }> {
-  const connection = new Connection(loadNetworkConfig().rpcUrl, 'confirmed')
+  const primary = new Connection(loadNetworkConfig().rpcUrl, 'confirmed')
 
   try {
-    const tx = await connection.getTransaction(txSignature, {
-      maxSupportedTransactionVersion: 0,
-    })
-
-    if (!tx) {
-      return { valid: false, error: 'transaction not found on-chain' }
+    return await verifyOnConnection(primary, txSignature, expectedAddress, expectedAmount)
+  } catch (primaryErr) {
+    const fallbackUrl = process.env.SOLANA_RPC_URL_FALLBACK
+    if (!fallbackUrl) {
+      guardianBus.emit({
+        source: 'sipher',
+        type: 'pay:rpc-all-failed',
+        level: 'critical',
+        data: {
+          txSignature,
+          primaryErr: errMessage(primaryErr),
+          fallbackUrl: 'unset',
+        },
+        wallet: null,
+        timestamp: new Date().toISOString(),
+      })
+      throw primaryErr
     }
 
-    if (tx.meta?.err) {
-      return { valid: false, error: 'transaction failed on-chain' }
+    const fallback = new Connection(fallbackUrl, 'confirmed')
+    try {
+      const result = await verifyOnConnection(fallback, txSignature, expectedAddress, expectedAmount)
+      guardianBus.emit({
+        source: 'sipher',
+        type: 'pay:rpc-fallback-used',
+        level: 'important',
+        data: {
+          txSignature,
+          primaryErr: errMessage(primaryErr),
+        },
+        wallet: null,
+        timestamp: new Date().toISOString(),
+      })
+      return result
+    } catch (fallbackErr) {
+      guardianBus.emit({
+        source: 'sipher',
+        type: 'pay:rpc-all-failed',
+        level: 'critical',
+        data: {
+          txSignature,
+          primaryErr: errMessage(primaryErr),
+          fallbackErr: errMessage(fallbackErr),
+        },
+        wallet: null,
+        timestamp: new Date().toISOString(),
+      })
+      throw fallbackErr
     }
-
-    // Check the stealth address received funds
-    const accountKeys = tx.transaction.message.getAccountKeys()
-    const targetIndex = accountKeys.staticAccountKeys.findIndex(
-      key => key.toBase58() === expectedAddress,
-    )
-
-    if (targetIndex === -1) {
-      return { valid: false, error: 'transaction does not involve the expected address' }
-    }
-
-    // Verify amount if specified (1% tolerance for rounding)
-    if (expectedAmount !== null && tx.meta) {
-      const preBalance = tx.meta.preBalances[targetIndex] ?? 0
-      const postBalance = tx.meta.postBalances[targetIndex] ?? 0
-      const receivedLamports = postBalance - preBalance
-      const receivedSol = receivedLamports / LAMPORTS_PER_SOL
-
-      if (receivedSol < expectedAmount * 0.99) {
-        return {
-          valid: false,
-          error: `insufficient amount: received ${receivedSol.toFixed(4)} SOL, expected ${expectedAmount} SOL`,
-        }
-      }
-    }
-
-    return { valid: true }
-  } catch (err) {
-    // RPC failures should not block payment — log and allow with warning
-    console.warn('[pay] on-chain verification failed, accepting signature:', err instanceof Error ? err.message : err)
-    return { valid: true }
   }
 }
 
@@ -119,12 +211,54 @@ payRouter.post('/:id/confirm', async (req, res) => {
     return
   }
 
-  // On-chain verification: tx exists, succeeded, correct recipient & amount
-  const verification = await verifyTransaction(
-    txSignature,
-    link.stealth_address,
-    link.amount,
-  )
+  // Per-link rate limit (3/min/link). Sits between status checks and
+  // verifier so a flood of bad signatures can't burn unbounded RPC budget
+  // against a single link.
+  const linkId = req.params.id
+  const now = Date.now()
+  const entry = await linkConfirmAttempts.get(linkId)
+  if (!entry || now - entry.firstAt > PAY_CONFIRM_RATE_LIMIT_WINDOW_MS) {
+    await linkConfirmAttempts.set(
+      linkId,
+      { count: 1, firstAt: now },
+      PAY_CONFIRM_RATE_LIMIT_WINDOW_SECONDS,
+    )
+  } else if (entry.count >= PAY_CONFIRM_RATE_LIMIT_MAX) {
+    res.status(429).json({
+      error: {
+        code: 'RATE_LIMITED',
+        message: 'Too many confirmation attempts on this link, slow down',
+      },
+    })
+    return
+  } else {
+    await linkConfirmAttempts.set(
+      linkId,
+      { count: entry.count + 1, firstAt: entry.firstAt },
+      PAY_CONFIRM_RATE_LIMIT_WINDOW_SECONDS,
+    )
+  }
+
+  // On-chain verification with primary→fallback RPC. Throws only on RPC
+  // errors (not verifier verdicts) — caught and surfaced as a structured
+  // 503 so clients can retry. Critically, we do NOT mark the link paid in
+  // this branch: an RPC outage must not auto-confirm payments.
+  let verification: { valid: boolean; error?: string }
+  try {
+    verification = await verifyTransaction(
+      txSignature,
+      link.stealth_address,
+      link.amount,
+    )
+  } catch {
+    res.status(503).json({
+      error: {
+        code: 'RPC_UNAVAILABLE',
+        message: 'On-chain verification temporarily unavailable, please retry shortly',
+      },
+    })
+    return
+  }
 
   if (!verification.valid) {
     res.status(400).json({ error: verification.error ?? 'transaction verification failed' })
@@ -134,3 +268,8 @@ payRouter.post('/:id/confirm', async (req, res) => {
   markPaymentLinkPaid(req.params.id, txSignature)
   res.json({ success: true, message: 'Payment confirmed' })
 })
+
+/** Test helper — clears the per-link rate-limit counter store. */
+export async function _resetPayRateLimitForTests(): Promise<void> {
+  await linkConfirmAttempts._clear()
+}

--- a/packages/agent/src/routes/pay.ts
+++ b/packages/agent/src/routes/pay.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import { Connection, LAMPORTS_PER_SOL } from '@solana/web3.js'
 import { getPaymentLink, markPaymentLinkPaid } from '../db.js'
+import { loadNetworkConfig } from '../config/network.js'
 import {
   renderPaymentPage,
   renderExpiredPage,
@@ -24,8 +25,7 @@ export async function verifyTransaction(
   expectedAddress: string,
   expectedAmount: number | null,
 ): Promise<{ valid: boolean; error?: string }> {
-  const rpcUrl = process.env.SOLANA_RPC_URL ?? 'https://api.mainnet-beta.solana.com'
-  const connection = new Connection(rpcUrl, 'confirmed')
+  const connection = new Connection(loadNetworkConfig().rpcUrl, 'confirmed')
 
   try {
     const tx = await connection.getTransaction(txSignature, {

--- a/packages/agent/src/routes/sentinel-api.ts
+++ b/packages/agent/src/routes/sentinel-api.ts
@@ -101,7 +101,7 @@ sentinelAdminRouter.post('/blacklist', (req: Request, res: Response) => {
     sendSentinelError(res, 'VALIDATION_FAILED', 'address, reason, severity required')
     return
   }
-  const wallet = (req as unknown as Record<string, unknown>).wallet as string | undefined
+  const wallet = req.wallet
   const id = insertBlacklist({
     address, reason, severity,
     addedBy: wallet ? `admin:${wallet}` : 'admin',
@@ -119,10 +119,9 @@ sentinelAdminRouter.post('/blacklist', (req: Request, res: Response) => {
  * @see docs/sentinel/rest-api.md#delete-apisentinelblacklistid
  */
 sentinelAdminRouter.delete('/blacklist/:id', (req: Request, res: Response) => {
-  const w = (req as unknown as Record<string, unknown>).wallet
-  const wallet = (typeof w === 'string' ? w : undefined)
+  const wallet = req.wallet
   const reason = (req.body?.reason as string) ?? 'manual removal'
-  const by = typeof wallet === 'string' ? `admin:${wallet}` : 'admin'
+  const by = wallet ? `admin:${wallet}` : 'admin'
   const id = (typeof req.params.id === 'string' ? req.params.id : String(req.params.id))
   softRemoveBlacklist(id, by, reason)
   res.json({ success: true })
@@ -140,9 +139,8 @@ sentinelAdminRouter.delete('/blacklist/:id', (req: Request, res: Response) => {
  */
 sentinelAdminRouter.post('/circuit-breaker/:id/cancel', (req: Request, res: Response) => {
   const reason = (req.body?.reason as string) ?? 'manual cancel'
-  const w = (req as unknown as Record<string, unknown>).wallet
-  const wallet = (typeof w === 'string' ? w : undefined)
-  const by = typeof wallet === 'string' ? `user:${wallet}` : 'admin'
+  const wallet = req.wallet
+  const by = wallet ? `user:${wallet}` : 'admin'
   const id = (typeof req.params.id === 'string' ? req.params.id : String(req.params.id))
   const ok = cancelCircuitBreakerAction(id, by, reason)
   if (!ok) {

--- a/packages/agent/src/routes/stream.ts
+++ b/packages/agent/src/routes/stream.ts
@@ -13,7 +13,11 @@ function sseEventName(type: string): string {
 }
 
 export function streamHandler(req: Request, res: Response): void {
-  const wallet = (req as unknown as Record<string, unknown>).wallet as string
+  const wallet = req.wallet
+  if (!wallet) {
+    res.status(500).json({ error: { code: 'INTERNAL', message: 'JWT middleware did not attach wallet' } })
+    return
+  }
 
   // SSE headers
   res.setHeader('Content-Type', 'text/event-stream')

--- a/packages/agent/src/routes/vault-api.ts
+++ b/packages/agent/src/routes/vault-api.ts
@@ -3,6 +3,7 @@ import { PublicKey, LAMPORTS_PER_SOL } from '@solana/web3.js'
 import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
 import { createConnection, WSOL_MINT, USDC_MINT, USDT_MINT } from '@sipher/sdk'
 import { getActivity } from '../db.js'
+import { loadNetworkConfig } from '../config/network.js'
 
 export const vaultRouter = Router()
 
@@ -39,7 +40,7 @@ vaultRouter.get('/', async (req: Request, res: Response) => {
     res.status(500).json({ error: { code: 'INTERNAL', message: 'JWT middleware did not attach wallet' } })
     return
   }
-  const network = (process.env.SOLANA_NETWORK ?? 'mainnet-beta') as 'devnet' | 'mainnet-beta'
+  const network = loadNetworkConfig().clusterName
   const connection = createConnection(network)
 
   let solBalance = 0

--- a/packages/agent/src/routes/vault-api.ts
+++ b/packages/agent/src/routes/vault-api.ts
@@ -34,7 +34,11 @@ interface TokenBalance {
  * Requires verifyJwt middleware upstream — wallet is attached to req by it.
  */
 vaultRouter.get('/', async (req: Request, res: Response) => {
-  const wallet = (req as unknown as Record<string, unknown>).wallet as string
+  const wallet = req.wallet
+  if (!wallet) {
+    res.status(500).json({ error: { code: 'INTERNAL', message: 'JWT middleware did not attach wallet' } })
+    return
+  }
   const network = (process.env.SOLANA_NETWORK ?? 'mainnet-beta') as 'devnet' | 'mainnet-beta'
   const connection = createConnection(network)
 

--- a/packages/agent/src/sentinel/config.ts
+++ b/packages/agent/src/sentinel/config.ts
@@ -112,9 +112,15 @@ export interface SentinelConfig {
 }
 
 function parseMode(raw: string | undefined): SentinelMode {
-  if (raw === 'advisory' || raw === 'off') return raw
-  return 'yolo'
+  if (raw === 'yolo') return 'yolo'
+  if (raw === 'off') return 'off'
+  // 'advisory' is the safe default for both unset and unknown values —
+  // an operator dropping the env var should NOT silently flip SENTINEL
+  // into autonomous fund-moving mode.
+  return 'advisory'
 }
+
+let _yoloWarnEmitted = false
 
 function parseScope(raw: string | undefined): PreflightScope {
   if (raw === 'critical-only' || raw === 'never') return raw
@@ -128,6 +134,13 @@ function parseScope(raw: string | undefined): PreflightScope {
  * @see docs/sentinel/config.md
  */
 export function getSentinelConfig(): SentinelConfig {
+  const mode = parseMode(process.env.SENTINEL_MODE)
+  if (mode === 'yolo' && !_yoloWarnEmitted) {
+    _yoloWarnEmitted = true
+    console.warn(
+      "[sentinel] SENTINEL_MODE=yolo — autonomous fund-moving operations enabled. Confirm this is intentional.",
+    )
+  }
   return {
     scanInterval: Number(process.env.SENTINEL_SCAN_INTERVAL ?? '60000'),
     activeScanInterval: Number(process.env.SENTINEL_ACTIVE_SCAN_INTERVAL ?? '15000'),
@@ -137,7 +150,7 @@ export function getSentinelConfig(): SentinelConfig {
     maxRpcPerWallet: 5,
     maxWalletsPerCycle: 20,
     backoffMax: 600_000,
-    mode: parseMode(process.env.SENTINEL_MODE),
+    mode,
     preflightScope: parseScope(process.env.SENTINEL_PREFLIGHT_SCOPE),
     preflightSkipAmount: Number(process.env.SENTINEL_PREFLIGHT_SKIP_AMOUNT ?? '0.1'),
     blacklistAutonomy: process.env.SENTINEL_BLACKLIST_AUTONOMY !== 'false',

--- a/packages/agent/src/sentinel/preflight-rules.ts
+++ b/packages/agent/src/sentinel/preflight-rules.ts
@@ -1,7 +1,7 @@
 import { getDb, getActiveBlacklistEntry } from '../db.js'
 import { getSentinelConfig } from './config.js'
 
-const FUND_MOVING_TOOLS = new Set([
+export const FUND_MOVING_TOOLS: ReadonlySet<string> = new Set([
   'send', 'deposit', 'swap', 'sweep', 'consolidate',
   'splitSend', 'scheduleSend', 'drip', 'recurring', 'refund',
 ])

--- a/packages/agent/src/sentinel/scanner.ts
+++ b/packages/agent/src/sentinel/scanner.ts
@@ -8,6 +8,7 @@ import {
 import type { ScanParams } from '@sipher/sdk'
 import { type Detection, detectUnclaimedPayment, detectBalanceChange } from './detector.js'
 import { getSentinelConfig } from './config.js'
+import { loadNetworkConfig } from '../config/network.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -83,8 +84,7 @@ export async function scanWallet(
   let rpcCalls = 0
 
   // Build connection — local only, no RPC call consumed
-  const envNetwork = process.env.SOLANA_NETWORK ?? 'mainnet-beta'
-  const network = (envNetwork === 'devnet' ? 'devnet' : 'mainnet-beta') as 'devnet' | 'mainnet-beta'
+  const network = loadNetworkConfig().clusterName
   const connection = createConnection(network)
 
   // ── Step 1: Vault balance ──────────────────────────────────────────────────

--- a/packages/agent/src/sentinel/tools/get-deposit-status.ts
+++ b/packages/agent/src/sentinel/tools/get-deposit-status.ts
@@ -1,5 +1,6 @@
 import type { AnthropicTool } from '../../pi/tool-adapter.js'
 import { Connection, PublicKey } from '@solana/web3.js'
+import { loadNetworkConfig } from '../../config/network.js'
 
 // Reference: docs/sentinel/tools.md
 
@@ -30,8 +31,7 @@ export const getDepositStatusTool: AnthropicTool = {
 export async function executeGetDepositStatus(
   params: GetDepositStatusParams,
 ): Promise<GetDepositStatusResult> {
-  const rpc = process.env.SOLANA_RPC_URL ?? 'https://api.mainnet-beta.solana.com'
-  const conn = new Connection(rpc, 'confirmed')
+  const conn = new Connection(loadNetworkConfig().rpcUrl, 'confirmed')
   const acct = await conn.getAccountInfo(new PublicKey(params.pda))
   if (!acct) {
     return { status: 'refunded', amount: null, createdAt: null, expiresAt: null }

--- a/packages/agent/src/sentinel/tools/get-on-chain-signatures.ts
+++ b/packages/agent/src/sentinel/tools/get-on-chain-signatures.ts
@@ -1,5 +1,6 @@
 import type { AnthropicTool } from '../../pi/tool-adapter.js'
 import { Connection, PublicKey } from '@solana/web3.js'
+import { loadNetworkConfig } from '../../config/network.js'
 
 // Reference: docs/sentinel/tools.md
 
@@ -42,8 +43,7 @@ export async function executeGetOnChainSignatures(
   params: GetOnChainSignaturesParams,
 ): Promise<GetOnChainSignaturesResult> {
   const limit = Math.min(params.limit ?? 10, 50)
-  const rpc = process.env.SOLANA_RPC_URL ?? 'https://api.mainnet-beta.solana.com'
-  const conn = new Connection(rpc, 'confirmed')
+  const conn = new Connection(loadNetworkConfig().rpcUrl, 'confirmed')
   const pubkey = new PublicKey(params.address)
   const raw = await conn.getSignaturesForAddress(pubkey, { limit })
   const signatures: OnChainSignature[] = raw.map((s) => {

--- a/packages/agent/src/sentinel/tools/get-vault-balance.ts
+++ b/packages/agent/src/sentinel/tools/get-vault-balance.ts
@@ -1,5 +1,6 @@
 import type { AnthropicTool } from '../../pi/tool-adapter.js'
 import { Connection, PublicKey } from '@solana/web3.js'
+import { loadNetworkConfig } from '../../config/network.js'
 
 // Reference: docs/sentinel/tools.md
 
@@ -28,8 +29,7 @@ export const getVaultBalanceTool: AnthropicTool = {
 export async function executeGetVaultBalance(
   params: GetVaultBalanceParams,
 ): Promise<GetVaultBalanceResult> {
-  const rpc = process.env.SOLANA_RPC_URL ?? 'https://api.mainnet-beta.solana.com'
-  const conn = new Connection(rpc, 'confirmed')
+  const conn = new Connection(loadNetworkConfig().rpcUrl, 'confirmed')
   const pubkey = new PublicKey(params.wallet)
   const lamports = await conn.getBalance(pubkey)
   const tokenAccounts = await conn.getParsedTokenAccountsByOwner(pubkey, {

--- a/packages/agent/src/sentinel/vault-refund.ts
+++ b/packages/agent/src/sentinel/vault-refund.ts
@@ -6,6 +6,7 @@ import {
   fetchDepositRecord,
   createConnection,
 } from '@sipher/sdk'
+import { loadNetworkConfig } from '../config/network.js'
 
 /**
  * Load a Solana keypair from a JSON file (standard CLI format: [u8; 64]).
@@ -34,7 +35,7 @@ export async function performVaultRefund(
     throw new Error('SENTINEL_AUTHORITY_KEYPAIR env not set — cannot sign authority refund')
   }
   const authority = loadKeypairFromFile(keypairPath)
-  const network = (process.env.SOLANA_NETWORK ?? 'mainnet-beta') as 'devnet' | 'mainnet-beta'
+  const network = loadNetworkConfig().clusterName
   const connection = createConnection(network)
 
   // Fetch deposit record to get depositor + tokenMint

--- a/packages/agent/src/state/ephemeral.ts
+++ b/packages/agent/src/state/ephemeral.ts
@@ -1,0 +1,91 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Centralized ephemeral state factory
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Single in-memory backend for short-lived security state (nonces, rate-limit
+// counters, SSE tickets, pending confirmations, circuit-breaker flags, etc).
+// Replaces ad-hoc module-scope `Map`s scattered across the codebase.
+//
+// A future commit can swap `createStore` for a Redis-backed implementation
+// behind the same interface, so call-sites do not need to change when we move
+// to multi-replica deployments.
+
+interface MemEntry<T> {
+  value: T
+  expiresAt: number
+}
+
+export interface EphemeralStore<T> {
+  set(key: string, value: T, ttlSeconds: number): Promise<void>
+  get(key: string): Promise<T | null>
+  delete(key: string): Promise<void>
+  size(): Promise<number>
+  /** Test helper — clears all entries. */
+  _clear(): Promise<void>
+}
+
+export interface CreateStoreOptions {
+  /** Max number of entries; oldest evicted FIFO. */
+  maxSize?: number
+  /** Sweep interval for expired entries (default 60s). */
+  sweepIntervalMs?: number
+}
+
+/**
+ * Create an in-memory ephemeral store with TTL-based expiration and FIFO
+ * eviction once `maxSize` is reached. The `name` is reserved for telemetry
+ * and is not currently used by the in-memory backend.
+ */
+export function createStore<T>(name: string, opts: CreateStoreOptions = {}): EphemeralStore<T> {
+  void name
+
+  const map = new Map<string, MemEntry<T>>()
+  const maxSize = opts.maxSize ?? 10_000
+  const sweepIntervalMs = opts.sweepIntervalMs ?? 60_000
+
+  const sweep = (): void => {
+    const now = Date.now()
+    for (const [k, entry] of map) {
+      if (entry.expiresAt <= now) map.delete(k)
+    }
+  }
+
+  const interval = setInterval(sweep, sweepIntervalMs)
+  // Don't keep the Node process alive just for sweeping. `setInterval` on Node
+  // returns a `Timeout` object exposing `.unref()`; in non-Node hosts (browser
+  // workers, edge runtimes) it returns a number — guard before calling.
+  if (typeof interval === 'object' && 'unref' in interval) {
+    (interval as { unref: () => void }).unref()
+  }
+
+  return {
+    async set(key, value, ttlSeconds) {
+      const expiresAt = Date.now() + ttlSeconds * 1000
+      // Evict oldest only when adding a *new* key past the cap. Re-setting an
+      // existing key just updates in place — no eviction.
+      if (map.size >= maxSize && !map.has(key)) {
+        const oldest = map.keys().next().value
+        if (oldest !== undefined) map.delete(oldest)
+      }
+      map.set(key, { value, expiresAt })
+    },
+    async get(key) {
+      const entry = map.get(key)
+      if (!entry) return null
+      if (entry.expiresAt <= Date.now()) {
+        map.delete(key)
+        return null
+      }
+      return entry.value
+    },
+    async delete(key) {
+      map.delete(key)
+    },
+    async size() {
+      return map.size
+    },
+    async _clear() {
+      map.clear()
+    },
+  }
+}

--- a/packages/agent/src/tools/balance.ts
+++ b/packages/agent/src/tools/balance.ts
@@ -7,6 +7,7 @@ import {
   getTokenDecimals,
   fromBaseUnits,
 } from '@sipher/sdk'
+import { loadNetworkConfig } from '../config/network.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Balance tool — Check vault balance for a depositor
@@ -75,7 +76,7 @@ export async function executeBalance(params: BalanceParams): Promise<BalanceTool
     throw new Error(`Invalid wallet address: ${params.wallet}`)
   }
 
-  const network = (process.env.SOLANA_NETWORK ?? 'mainnet-beta') as 'devnet' | 'mainnet-beta'
+  const network = loadNetworkConfig().clusterName
   const connection = createConnection(network)
   const vaultBalance = await getVaultBalance(connection, depositor, tokenMint)
 

--- a/packages/agent/src/tools/consolidate.ts
+++ b/packages/agent/src/tools/consolidate.ts
@@ -1,6 +1,7 @@
 import type { AnthropicTool } from '../pi/tool-adapter.js'
 import { createScheduledOp, getOrCreateSession } from '../db.js'
 import { createConnection, scanForPayments } from '@sipher/sdk'
+import { loadNetworkConfig } from '../config/network.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // consolidate tool — Merge multiple unclaimed stealth balances with staggered
@@ -60,7 +61,7 @@ export async function executeConsolidate(
     throw new Error('Spending key is required for claiming')
   }
 
-  const network = (process.env.SOLANA_NETWORK ?? 'mainnet-beta') as 'devnet' | 'mainnet-beta'
+  const network = loadNetworkConfig().clusterName
   const connection = createConnection(network)
 
   // Parse hex keys → Uint8Array (strip optional 0x prefix)

--- a/packages/agent/src/tools/deposit.ts
+++ b/packages/agent/src/tools/deposit.ts
@@ -9,6 +9,7 @@ import {
   toBaseUnits,
   SIPHER_VAULT_PROGRAM_ID,
 } from '@sipher/sdk'
+import { loadNetworkConfig } from '../config/network.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Deposit tool — Fund the Sipher privacy vault
@@ -111,7 +112,7 @@ export async function executeDeposit(params: DepositParams): Promise<DepositTool
   }
 
   const depositorTokenAccount = await getAssociatedTokenAddress(tokenMint, depositor)
-  const network = (process.env.SOLANA_NETWORK ?? 'mainnet-beta') as 'devnet' | 'mainnet-beta'
+  const network = loadNetworkConfig().clusterName
   const connection = createConnection(network)
 
   const result = await buildDepositTx(

--- a/packages/agent/src/tools/history.ts
+++ b/packages/agent/src/tools/history.ts
@@ -6,6 +6,7 @@ import {
   resolveTokenMint,
 } from '@sipher/sdk'
 import type { VaultEvent } from '@sipher/sdk'
+import { loadNetworkConfig } from '../config/network.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // History tool — Transaction history from on-chain vault events
@@ -92,7 +93,7 @@ export async function executeHistory(params: HistoryParams): Promise<HistoryTool
     }
   }
 
-  const network = (process.env.SOLANA_NETWORK ?? 'mainnet-beta') as 'devnet' | 'mainnet-beta'
+  const network = loadNetworkConfig().clusterName
   const connection = createConnection(network)
   const { events, hasMore } = await getVaultHistory(
     connection,

--- a/packages/agent/src/tools/privacy-score.ts
+++ b/packages/agent/src/tools/privacy-score.ts
@@ -2,6 +2,7 @@ import type { AnthropicTool } from '../pi/tool-adapter.js'
 import { PublicKey } from '@solana/web3.js'
 import { createConnection } from '@sipher/sdk'
 import { classifyAddress } from '../data/known-addresses.js'
+import { loadNetworkConfig } from '../config/network.js'
 
 export interface PrivacyScoreParams {
   wallet: string
@@ -54,7 +55,7 @@ export async function executePrivacyScore(
   }
 
   const limit = Math.min(Math.max(params.limit ?? 50, 1), 200)
-  const network = (process.env.SOLANA_NETWORK ?? 'mainnet-beta') as 'devnet' | 'mainnet-beta'
+  const network = loadNetworkConfig().clusterName
   const connection = createConnection(network)
 
   let walletPubkey: PublicKey

--- a/packages/agent/src/tools/refund.ts
+++ b/packages/agent/src/tools/refund.ts
@@ -9,6 +9,7 @@ import {
   fromBaseUnits,
   SIPHER_VAULT_PROGRAM_ID,
 } from '@sipher/sdk'
+import { loadNetworkConfig } from '../config/network.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Refund tool — Withdraw available balance back to depositor
@@ -93,7 +94,7 @@ export async function executeRefund(params: RefundParams): Promise<RefundToolRes
   }
 
   const depositorTokenAccount = await getAssociatedTokenAddress(tokenMint, depositor)
-  const network = (process.env.SOLANA_NETWORK ?? 'mainnet-beta') as 'devnet' | 'mainnet-beta'
+  const network = loadNetworkConfig().clusterName
   const connection = createConnection(network)
 
   const result = await buildRefundTx(

--- a/packages/agent/src/tools/scan.ts
+++ b/packages/agent/src/tools/scan.ts
@@ -4,6 +4,7 @@ import {
   scanForPayments,
   fromBaseUnits,
 } from '@sipher/sdk'
+import { loadNetworkConfig } from '../config/network.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Scan tool — Scan for incoming stealth payments
@@ -99,7 +100,7 @@ export async function executeScan(params: ScanParams): Promise<ScanToolResult> {
     throw new Error(`Spending key must be 32 bytes (64 hex chars), got ${spendingPrivateKey.length} bytes`)
   }
 
-  const network = (process.env.SOLANA_NETWORK ?? 'mainnet-beta') as 'devnet' | 'mainnet-beta'
+  const network = loadNetworkConfig().clusterName
   const connection = createConnection(network)
 
   const result = await scanForPayments({

--- a/packages/agent/src/tools/send.ts
+++ b/packages/agent/src/tools/send.ts
@@ -19,6 +19,7 @@ import {
   getVaultConfig,
   DEFAULT_FEE_BPS,
 } from '@sipher/sdk'
+import { loadNetworkConfig } from '../config/network.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Private Send tool — Withdraw from vault to a stealth address
@@ -100,7 +101,7 @@ export async function executeSend(params: SendParams): Promise<SendToolResult> {
   }
 
   const token = params.token.toUpperCase()
-  const network = (process.env.SOLANA_NETWORK ?? 'mainnet-beta') as 'devnet' | 'mainnet-beta'
+  const network = loadNetworkConfig().clusterName
   const connection = createConnection(network)
 
   // Fetch live fee_bps from on-chain config

--- a/packages/agent/src/tools/status.ts
+++ b/packages/agent/src/tools/status.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_FEE_BPS,
   DEFAULT_REFUND_TIMEOUT,
 } from '@sipher/sdk'
+import { loadNetworkConfig } from '../config/network.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Status tool — Read-only vault status from on-chain VaultConfig PDA
@@ -42,7 +43,7 @@ export const statusTool: AnthropicTool = {
 }
 
 export async function executeStatus(): Promise<StatusToolResult> {
-  const network = (process.env.SOLANA_NETWORK ?? 'mainnet-beta') as 'devnet' | 'mainnet-beta'
+  const network = loadNetworkConfig().clusterName
   const connection = createConnection(network)
   const config = await getVaultConfig(connection)
 

--- a/packages/agent/src/tools/viewing-key.ts
+++ b/packages/agent/src/tools/viewing-key.ts
@@ -3,6 +3,7 @@ import { generateViewingKey, deriveViewingKey } from '@sip-protocol/sdk'
 import { sha256 } from '@noble/hashes/sha256'
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils'
 import { createConnection } from '@sipher/sdk'
+import { loadNetworkConfig } from '../config/network.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Viewing Key tool — Generate, export, and verify viewing keys
@@ -182,7 +183,7 @@ export async function executeViewingKey(params: ViewingKeyParams): Promise<Viewi
     }
 
     case 'verify': {
-      const network = (process.env.SOLANA_NETWORK ?? 'mainnet-beta') as 'devnet' | 'mainnet-beta'
+      const network = loadNetworkConfig().clusterName
       const connection = createConnection(network)
       const tx = await connection.getParsedTransaction(
         params.txSignature!,

--- a/packages/agent/src/types/express-request.d.ts
+++ b/packages/agent/src/types/express-request.d.ts
@@ -1,0 +1,10 @@
+import 'express-serve-static-core'
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    /** Wallet pubkey extracted from JWT by verifyJwt middleware. */
+    wallet?: string
+    /** True if the wallet is in AUTHORIZED_WALLETS. Set by requireOwner middleware. */
+    isAdmin?: boolean
+  }
+}

--- a/packages/agent/src/types/express-request.d.ts
+++ b/packages/agent/src/types/express-request.d.ts
@@ -1,10 +1,18 @@
-import 'express-serve-static-core'
+// Augment the Express Request type with auth fields populated by middleware.
+//
+// `wallet` is set by `verifyJwt` (from JWT decode or SSE ticket lookup).
+// `isAdmin` is reserved for future use; currently `requireOwner` rejects
+// non-admin requests at the middleware boundary rather than tagging the
+// request, but the field is part of the typed surface so route handlers
+// can read it once that pattern lands.
 
-declare module 'express-serve-static-core' {
-  interface Request {
-    /** Wallet pubkey extracted from JWT by verifyJwt middleware. */
-    wallet?: string
-    /** True if the wallet is in AUTHORIZED_WALLETS. Set by requireOwner middleware. */
-    isAdmin?: boolean
+declare global {
+  namespace Express {
+    interface Request {
+      wallet?: string
+      isAdmin?: boolean
+    }
   }
 }
+
+export {}

--- a/packages/agent/tests/pay-route.test.ts
+++ b/packages/agent/tests/pay-route.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import express from 'express'
 import supertest from 'supertest'
-import { PublicKey, LAMPORTS_PER_SOL } from '@solana/web3.js'
+import { LAMPORTS_PER_SOL } from '@solana/web3.js'
 import { closeDb, createPaymentLink, getPaymentLink, markPaymentLinkPaid } from '../src/db.js'
+import { guardianBus, type GuardianEvent } from '../src/coordination/event-bus.js'
 
-// Mock @solana/web3.js Connection to prevent real RPC calls
+// Mock @solana/web3.js Connection to prevent real RPC calls.
+// Each `new Connection(...)` returns a fresh object whose `getTransaction`
+// points at the same `mockGetTransaction` fn, so chained
+// `mockResolvedValueOnce`/`mockRejectedValueOnce` calls drive primary then
+// fallback verifyOnConnection invocations in order.
 const mockGetTransaction = vi.fn()
 vi.mock('@solana/web3.js', async (importOriginal) => {
   const mod = await importOriginal<typeof import('@solana/web3.js')>()
@@ -16,18 +21,21 @@ vi.mock('@solana/web3.js', async (importOriginal) => {
   }
 })
 
-beforeEach(() => {
+beforeEach(async () => {
   process.env.DB_PATH = ':memory:'
   // Default: tx found, succeeded, correct address — tests override as needed
   mockGetTransaction.mockReset()
+  delete process.env.SOLANA_RPC_URL_FALLBACK
+  await _resetPayRateLimitForTests()
 })
 
 afterEach(() => {
   closeDb()
   delete process.env.DB_PATH
+  delete process.env.SOLANA_RPC_URL_FALLBACK
 })
 
-const { payRouter, verifyTransaction } = await import('../src/routes/pay.js')
+const { payRouter, verifyTransaction, _resetPayRateLimitForTests } = await import('../src/routes/pay.js')
 
 function createApp() {
   const app = express()
@@ -293,7 +301,7 @@ describe('POST /pay/:id/confirm', () => {
     expect(getPaymentLink('any-amount')!.status).toBe('paid')
   })
 
-  it('fails open when RPC is unreachable', async () => {
+  it('fails closed with 503 when RPC is unreachable and no fallback is configured', async () => {
     createPaymentLink({
       id: 'rpc-down',
       stealth_address: 'StEaLtH1111',
@@ -302,19 +310,17 @@ describe('POST /pay/:id/confirm', () => {
     })
     // Simulate RPC failure
     mockGetTransaction.mockRejectedValueOnce(new Error('fetch failed'))
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const app = createApp()
     const res = await supertest(app)
       .post('/pay/rpc-down/confirm')
       .send({ txSignature: 'rpc-down-sig' })
-    expect(res.status).toBe(200)
-    expect(res.body.success).toBe(true)
-    expect(getPaymentLink('rpc-down')!.status).toBe('paid')
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[pay] on-chain verification failed'),
-      expect.stringContaining('fetch failed'),
-    )
-    consoleSpy.mockRestore()
+    expect(res.status).toBe(503)
+    expect(res.body.error).toEqual({
+      code: 'RPC_UNAVAILABLE',
+      message: 'On-chain verification temporarily unavailable, please retry shortly',
+    })
+    // Critical: must NOT mark paid on RPC error — that was the money-at-risk bug.
+    expect(getPaymentLink('rpc-down')!.status).toBe('pending')
   })
 })
 
@@ -358,11 +364,235 @@ describe('verifyTransaction (unit)', () => {
     expect(result.error).toMatch(/insufficient amount/)
   })
 
-  it('fails open on RPC error', async () => {
+  it('throws on RPC error when no fallback is configured', async () => {
     mockGetTransaction.mockRejectedValueOnce(new Error('network timeout'))
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const result = await verifyTransaction('sig', 'Addr', 1.0)
-    expect(result).toEqual({ valid: true })
-    consoleSpy.mockRestore()
+    await expect(verifyTransaction('sig', 'Addr', 1.0)).rejects.toThrow('network timeout')
+  })
+})
+
+describe('POST /pay/:id/confirm — RPC fallback + rate limit', () => {
+  /**
+   * Capture guardianBus events of a given type for the duration of a test.
+   * Returns the array of captured events plus a cleanup fn that removes the
+   * listener. Always call `cleanup()` (even on assertion failure paths) so
+   * the bus doesn't leak listeners between tests.
+   */
+  function captureBusEvents(eventType: string): { events: GuardianEvent[]; cleanup: () => void } {
+    const events: GuardianEvent[] = []
+    const handler = (event: GuardianEvent): void => {
+      events.push(event)
+    }
+    guardianBus.on(eventType, handler)
+    return {
+      events,
+      cleanup: () => guardianBus.off(eventType, handler),
+    }
+  }
+
+  it('falls back to secondary RPC when primary fails', async () => {
+    process.env.SOLANA_RPC_URL_FALLBACK = 'https://fallback.example.com'
+    createPaymentLink({
+      id: 'fallback-success',
+      stealth_address: 'StEaLtH1111',
+      ephemeral_pubkey: '0xeph',
+      expires_at: Date.now() + 3600_000,
+    })
+    // Primary throws; fallback returns a valid tx to the correct address.
+    mockGetTransaction
+      .mockRejectedValueOnce(new Error('primary down'))
+      .mockResolvedValueOnce(mockSolanaTx('StEaLtH1111', 0, 1_000_000))
+
+    const fallbackCapture = captureBusEvents('pay:rpc-fallback-used')
+    const allFailedCapture = captureBusEvents('pay:rpc-all-failed')
+
+    try {
+      const app = createApp()
+      const res = await supertest(app)
+        .post('/pay/fallback-success/confirm')
+        .send({ txSignature: 'sig-fallback' })
+
+      expect(res.status).toBe(200)
+      expect(res.body.success).toBe(true)
+      expect(getPaymentLink('fallback-success')!.status).toBe('paid')
+      expect(getPaymentLink('fallback-success')!.paid_tx).toBe('sig-fallback')
+
+      // Operator visibility: fallback used → important event emitted, no critical.
+      expect(fallbackCapture.events).toHaveLength(1)
+      expect(fallbackCapture.events[0]).toMatchObject({
+        source: 'sipher',
+        type: 'pay:rpc-fallback-used',
+        level: 'important',
+        wallet: null,
+      })
+      expect(fallbackCapture.events[0].data).toMatchObject({
+        txSignature: 'sig-fallback',
+        primaryErr: 'primary down',
+      })
+      expect(fallbackCapture.events[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+      expect(allFailedCapture.events).toHaveLength(0)
+    } finally {
+      fallbackCapture.cleanup()
+      allFailedCapture.cleanup()
+    }
+  })
+
+  it('returns 503 RPC_UNAVAILABLE when both primary and fallback fail', async () => {
+    process.env.SOLANA_RPC_URL_FALLBACK = 'https://fallback.example.com'
+    createPaymentLink({
+      id: 'both-down',
+      stealth_address: 'StEaLtH1111',
+      ephemeral_pubkey: '0xeph',
+      expires_at: Date.now() + 3600_000,
+    })
+    mockGetTransaction
+      .mockRejectedValueOnce(new Error('primary down'))
+      .mockRejectedValueOnce(new Error('fallback down'))
+
+    const allFailedCapture = captureBusEvents('pay:rpc-all-failed')
+    const fallbackCapture = captureBusEvents('pay:rpc-fallback-used')
+
+    try {
+      const app = createApp()
+      const res = await supertest(app)
+        .post('/pay/both-down/confirm')
+        .send({ txSignature: 'sig-both-down' })
+
+      expect(res.status).toBe(503)
+      expect(res.body.error).toEqual({
+        code: 'RPC_UNAVAILABLE',
+        message: 'On-chain verification temporarily unavailable, please retry shortly',
+      })
+      // Link must NOT be marked paid — that's the money-at-risk invariant.
+      expect(getPaymentLink('both-down')!.status).toBe('pending')
+
+      expect(allFailedCapture.events).toHaveLength(1)
+      expect(allFailedCapture.events[0]).toMatchObject({
+        source: 'sipher',
+        type: 'pay:rpc-all-failed',
+        level: 'critical',
+        wallet: null,
+      })
+      expect(allFailedCapture.events[0].data).toMatchObject({
+        txSignature: 'sig-both-down',
+        primaryErr: 'primary down',
+        fallbackErr: 'fallback down',
+      })
+      expect(allFailedCapture.events[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+      expect(fallbackCapture.events).toHaveLength(0)
+    } finally {
+      allFailedCapture.cleanup()
+      fallbackCapture.cleanup()
+    }
+  })
+
+  it('returns 503 with fallbackUrl=unset when primary fails and no fallback configured', async () => {
+    // SOLANA_RPC_URL_FALLBACK is deleted in beforeEach.
+    createPaymentLink({
+      id: 'no-fallback',
+      stealth_address: 'StEaLtH1111',
+      ephemeral_pubkey: '0xeph',
+      expires_at: Date.now() + 3600_000,
+    })
+    mockGetTransaction.mockRejectedValueOnce(new Error('primary nuked'))
+
+    const allFailedCapture = captureBusEvents('pay:rpc-all-failed')
+
+    try {
+      const app = createApp()
+      const res = await supertest(app)
+        .post('/pay/no-fallback/confirm')
+        .send({ txSignature: 'sig-no-fallback' })
+
+      expect(res.status).toBe(503)
+      expect(res.body.error.code).toBe('RPC_UNAVAILABLE')
+      expect(getPaymentLink('no-fallback')!.status).toBe('pending')
+
+      expect(allFailedCapture.events).toHaveLength(1)
+      expect(allFailedCapture.events[0].data).toMatchObject({
+        txSignature: 'sig-no-fallback',
+        primaryErr: 'primary nuked',
+        fallbackUrl: 'unset',
+      })
+    } finally {
+      allFailedCapture.cleanup()
+    }
+  })
+
+  it('per-link rate limit returns 429 on the 4th attempt within a minute', async () => {
+    createPaymentLink({
+      id: 'rate-limited',
+      stealth_address: 'StEaLtH1111',
+      ephemeral_pubkey: '0xeph',
+      expires_at: Date.now() + 3600_000,
+    })
+    // Verifier returns "tx not found" → 400, link stays pending, rate counter ticks.
+    mockGetTransaction.mockResolvedValue(null)
+    const app = createApp()
+
+    for (let i = 0; i < 3; i++) {
+      const res = await supertest(app)
+        .post('/pay/rate-limited/confirm')
+        .send({ txSignature: `attempt-${i}` })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toMatch(/not found on-chain/i)
+    }
+    expect(getPaymentLink('rate-limited')!.status).toBe('pending')
+
+    // Pre-load the verifier mock to fail loudly if the 4th request reaches it.
+    // It MUST be short-circuited at the rate-limit gate before verifyTransaction runs.
+    mockGetTransaction.mockImplementationOnce(() => {
+      throw new Error('rate-limit gate failed to short-circuit')
+    })
+    const fourth = await supertest(app)
+      .post('/pay/rate-limited/confirm')
+      .send({ txSignature: 'attempt-4' })
+
+    expect(fourth.status).toBe(429)
+    expect(fourth.body.error).toEqual({
+      code: 'RATE_LIMITED',
+      message: 'Too many confirmation attempts on this link, slow down',
+    })
+    expect(getPaymentLink('rate-limited')!.status).toBe('pending')
+  })
+
+  it('per-link rate limit isolates different links (link-A exhausted, link-B succeeds)', async () => {
+    createPaymentLink({
+      id: 'link-A',
+      stealth_address: 'StEaLtH1111',
+      ephemeral_pubkey: '0xeph',
+      expires_at: Date.now() + 3600_000,
+    })
+    createPaymentLink({
+      id: 'link-B',
+      stealth_address: 'StEaLtH1111',
+      ephemeral_pubkey: '0xeph',
+      expires_at: Date.now() + 3600_000,
+    })
+    const app = createApp()
+
+    // Burn link-A's budget — 3 attempts that each fail at the verifier (400).
+    mockGetTransaction.mockResolvedValue(null)
+    for (let i = 0; i < 3; i++) {
+      const res = await supertest(app)
+        .post('/pay/link-A/confirm')
+        .send({ txSignature: `link-A-attempt-${i}` })
+      expect(res.status).toBe(400)
+    }
+
+    // 4th attempt on link-A is 429 (budget exhausted).
+    const fourth = await supertest(app)
+      .post('/pay/link-A/confirm')
+      .send({ txSignature: 'link-A-attempt-3' })
+    expect(fourth.status).toBe(429)
+
+    // link-B has its own independent budget — first attempt succeeds with a valid tx.
+    mockGetTransaction.mockReset()
+    mockGetTransaction.mockResolvedValueOnce(mockSolanaTx('StEaLtH1111', 0, 1_000_000))
+    const linkB = await supertest(app)
+      .post('/pay/link-B/confirm')
+      .send({ txSignature: 'link-B-sig' })
+    expect(linkB.status).toBe(200)
+    expect(linkB.body.success).toBe(true)
+    expect(getPaymentLink('link-B')!.status).toBe('paid')
   })
 })

--- a/packages/agent/tests/routes/auth.test.ts
+++ b/packages/agent/tests/routes/auth.test.ts
@@ -371,6 +371,87 @@ describe('POST /auth/verify', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
+// POST /auth/refresh
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /auth/refresh', () => {
+  it('returns a fresh JWT when current token is within 5min of expiry', async () => {
+    const app = createApp()
+    const wallet = 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr'
+    const oldToken = jwt.sign({ wallet, isAdmin: false }, JWT_SECRET, { expiresIn: '4m' })
+
+    const res = await supertest(app)
+      .post('/auth/refresh')
+      .set('Authorization', `Bearer ${oldToken}`)
+      .send()
+    expect(res.status).toBe(200)
+    expect(typeof res.body.token).toBe('string')
+    expect(res.body.expiresIn).toBeDefined()
+
+    // Refresh must preserve the wallet + isAdmin claims
+    const decoded = jwt.verify(res.body.token, JWT_SECRET) as { wallet: string; isAdmin: boolean }
+    expect(decoded.wallet).toBe(wallet)
+    expect(decoded.isAdmin).toBe(false)
+  })
+
+  it('returns 425 TOO_EARLY when current token has more than 5min remaining', async () => {
+    const app = createApp()
+    const wallet = 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr'
+    const newToken = jwt.sign({ wallet, isAdmin: false }, JWT_SECRET, { expiresIn: '20m' })
+
+    const res = await supertest(app)
+      .post('/auth/refresh')
+      .set('Authorization', `Bearer ${newToken}`)
+      .send()
+    expect(res.status).toBe(425)
+    expect(res.body.error?.code).toBe('TOO_EARLY')
+  })
+
+  it('returns 401 INVALID_TOKEN when current token is expired', async () => {
+    const app = createApp()
+    const wallet = 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr'
+    const expiredToken = jwt.sign({ wallet, isAdmin: false }, JWT_SECRET, { expiresIn: '-1s' })
+
+    const res = await supertest(app)
+      .post('/auth/refresh')
+      .set('Authorization', `Bearer ${expiredToken}`)
+      .send()
+    expect(res.status).toBe(401)
+    expect(res.body.error?.code).toBe('INVALID_TOKEN')
+  })
+
+  it('returns 401 INVALID_TOKEN when token signed with wrong secret', async () => {
+    const app = createApp()
+    const wallet = 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr'
+    const badToken = jwt.sign({ wallet, isAdmin: false }, 'a-different-secret-16-chars', { expiresIn: '4m' })
+
+    const res = await supertest(app)
+      .post('/auth/refresh')
+      .set('Authorization', `Bearer ${badToken}`)
+      .send()
+    expect(res.status).toBe(401)
+    expect(res.body.error?.code).toBe('INVALID_TOKEN')
+  })
+
+  it('returns 401 UNAUTHENTICATED when no Authorization header is sent', async () => {
+    const app = createApp()
+    const res = await supertest(app).post('/auth/refresh').send()
+    expect(res.status).toBe(401)
+    expect(res.body.error?.code).toBe('UNAUTHENTICATED')
+  })
+
+  it('returns 401 UNAUTHENTICATED when Authorization header is malformed', async () => {
+    const app = createApp()
+    const res = await supertest(app)
+      .post('/auth/refresh')
+      .set('Authorization', 'NotBearer some-token')
+      .send()
+    expect(res.status).toBe(401)
+    expect(res.body.error?.code).toBe('UNAUTHENTICATED')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
 // verifyJwt middleware
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/packages/agent/tests/routes/auth.test.ts
+++ b/packages/agent/tests/routes/auth.test.ts
@@ -368,6 +368,156 @@ describe('POST /auth/verify', () => {
       .send({ wallet, nonce, signature })
     expect(res.status).toBe(401)
   })
+
+  describe('SIWS one-popup (signedMessage field)', () => {
+    function buildSiwsMessage(domain: string, wallet: string, nonce: string): string {
+      return `${domain} wants you to sign in with your Solana account:\n${wallet}\n\nNonce: ${nonce}\nIssued At: 2026-05-07T00:00:00Z`
+    }
+
+    it('accepts SIWS signedMessage and verifies the actual signed bytes', async () => {
+      const app = createApp()
+      const { privateKey, wallet } = generateTestWallet()
+
+      const nonceRes = await supertest(app)
+        .post('/auth/nonce')
+        .send({ wallet })
+      const { nonce } = nonceRes.body
+
+      const siws = buildSiwsMessage('sipher.sip-protocol.org', wallet, nonce)
+      const messageBytes = new TextEncoder().encode(siws)
+      const sigBytes = ed25519.sign(messageBytes, privateKey)
+      const signature = encodeBase58(sigBytes)
+      const signedMessage = Buffer.from(messageBytes).toString('base64')
+
+      const res = await supertest(app)
+        .post('/auth/verify')
+        .send({ wallet, nonce, signature, signedMessage })
+      expect(res.status).toBe(200)
+      expect(res.body.token).toBeDefined()
+    })
+
+    it('rejects signedMessage that does not bind to the issued nonce', async () => {
+      const app = createApp()
+      const { privateKey, wallet } = generateTestWallet()
+
+      const nonceRes = await supertest(app)
+        .post('/auth/nonce')
+        .send({ wallet })
+      const { nonce } = nonceRes.body
+
+      // Sign a message with a DIFFERENT nonce — attacker reuses an old SIWS msg
+      const siws = buildSiwsMessage('sipher.sip-protocol.org', wallet, 'forged-nonce-not-real')
+      const messageBytes = new TextEncoder().encode(siws)
+      const sigBytes = ed25519.sign(messageBytes, privateKey)
+      const signature = encodeBase58(sigBytes)
+      const signedMessage = Buffer.from(messageBytes).toString('base64')
+
+      const res = await supertest(app)
+        .post('/auth/verify')
+        .send({ wallet, nonce, signature, signedMessage })
+      expect(res.status).toBe(401)
+    })
+
+    it('rejects signedMessage from a domain not in the allow-list', async () => {
+      const app = createApp()
+      const { privateKey, wallet } = generateTestWallet()
+
+      const nonceRes = await supertest(app)
+        .post('/auth/nonce')
+        .send({ wallet })
+      const { nonce } = nonceRes.body
+
+      const siws = buildSiwsMessage('evil.example.com', wallet, nonce)
+      const messageBytes = new TextEncoder().encode(siws)
+      const sigBytes = ed25519.sign(messageBytes, privateKey)
+      const signature = encodeBase58(sigBytes)
+      const signedMessage = Buffer.from(messageBytes).toString('base64')
+
+      const res = await supertest(app)
+        .post('/auth/verify')
+        .send({ wallet, nonce, signature, signedMessage })
+      expect(res.status).toBe(401)
+    })
+
+    it('rejects signedMessage that prefix-matches but is not the allowed domain', async () => {
+      const app = createApp()
+      const { privateKey, wallet } = generateTestWallet()
+
+      const nonceRes = await supertest(app)
+        .post('/auth/nonce')
+        .send({ wallet })
+      const { nonce } = nonceRes.body
+
+      // Attacker registers a domain that prefix-matches "localhost" via "localhost.attacker.com".
+      // Allow-list entry "localhost" must NOT match this.
+      const siws = buildSiwsMessage('localhost.attacker.com', wallet, nonce)
+      const messageBytes = new TextEncoder().encode(siws)
+      const sigBytes = ed25519.sign(messageBytes, privateKey)
+      const signature = encodeBase58(sigBytes)
+      const signedMessage = Buffer.from(messageBytes).toString('base64')
+
+      const res = await supertest(app)
+        .post('/auth/verify')
+        .send({ wallet, nonce, signature, signedMessage })
+      expect(res.status).toBe(401)
+    })
+
+    it('rejects signedMessage whose signature does not match the wallet pubkey', async () => {
+      const app = createApp()
+      const { wallet } = generateTestWallet()
+      const attacker = generateTestWallet()
+
+      const nonceRes = await supertest(app)
+        .post('/auth/nonce')
+        .send({ wallet })
+      const { nonce } = nonceRes.body
+
+      // Attacker signs the SIWS bytes with their own key but claims victim's wallet
+      const siws = buildSiwsMessage('sipher.sip-protocol.org', wallet, nonce)
+      const messageBytes = new TextEncoder().encode(siws)
+      const sigBytes = ed25519.sign(messageBytes, attacker.privateKey)
+      const signature = encodeBase58(sigBytes)
+      const signedMessage = Buffer.from(messageBytes).toString('base64')
+
+      const res = await supertest(app)
+        .post('/auth/verify')
+        .send({ wallet, nonce, signature, signedMessage })
+      expect(res.status).toBe(401)
+    })
+
+    it('rejects malformed base64 signedMessage', async () => {
+      const app = createApp()
+      const { privateKey, wallet } = generateTestWallet()
+
+      const nonceRes = await supertest(app)
+        .post('/auth/nonce')
+        .send({ wallet })
+      const { nonce, message } = nonceRes.body
+      const signature = signMessage(message, privateKey)
+
+      const res = await supertest(app)
+        .post('/auth/verify')
+        .send({ wallet, nonce, signature, signedMessage: 'not-valid-base64-!!!@#$' })
+      expect(res.status).toBe(401)
+    })
+
+    it('legacy signMessage path still works when signedMessage is absent', async () => {
+      const app = createApp()
+      const { privateKey, wallet } = generateTestWallet()
+
+      const nonceRes = await supertest(app)
+        .post('/auth/nonce')
+        .send({ wallet })
+      const { nonce, message } = nonceRes.body
+      const signature = signMessage(message, privateKey)
+
+      const res = await supertest(app)
+        .post('/auth/verify')
+        .send({ wallet, nonce, signature })
+      expect(res.status).toBe(200)
+      expect(res.body.token).toBeDefined()
+    })
+  })
 })
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/agent/tests/routes/auth.test.ts
+++ b/packages/agent/tests/routes/auth.test.ts
@@ -46,9 +46,9 @@ function signMessage(message: string, privateKey: Uint8Array): string {
 
 const { authRouter, verifyJwt, _resetAuthStateForTests } = await import('../../src/routes/auth.js')
 
-beforeEach(() => {
+beforeEach(async () => {
   process.env.JWT_SECRET = JWT_SECRET
-  _resetAuthStateForTests()
+  await _resetAuthStateForTests()
 })
 
 afterEach(() => {

--- a/packages/agent/tests/routes/auth.test.ts
+++ b/packages/agent/tests/routes/auth.test.ts
@@ -57,11 +57,14 @@ afterEach(() => {
 
 function createApp() {
   const app = express()
+  // Mirror prod: trust proxy so req.ip honours X-Forwarded-For (per-IP
+  // rate limiter assertions depend on this).
+  app.set('trust proxy', 1)
   app.use(express.json())
   app.use('/auth', authRouter)
   // Protected test endpoint
   app.get('/protected', verifyJwt, (req, res) => {
-    res.json({ wallet: (req as unknown as Record<string, unknown>).wallet })
+    res.json({ wallet: req.wallet })
   })
   return app
 }
@@ -158,6 +161,42 @@ describe('POST /auth/nonce', () => {
         .send({ wallet: 'l'.repeat(32) })
       expect(res.status).toBe(400)
       expect(res.body.error?.code).toBe('VALIDATION_FAILED')
+    })
+  })
+
+  describe('per-IP rate limit', () => {
+    it('returns 429 after 5 requests/min from same IP', async () => {
+      const app = createApp()
+      const { wallet } = generateTestWallet()
+      for (let i = 0; i < 5; i++) {
+        const res = await supertest(app)
+          .post('/auth/nonce')
+          .set('X-Forwarded-For', '1.2.3.4')
+          .send({ wallet })
+        expect(res.status).toBe(200)
+      }
+      const sixth = await supertest(app)
+        .post('/auth/nonce')
+        .set('X-Forwarded-For', '1.2.3.4')
+        .send({ wallet })
+      expect(sixth.status).toBe(429)
+      expect(sixth.body.error?.code).toBe('RATE_LIMITED')
+    })
+
+    it('different IP gets an independent budget', async () => {
+      const app = createApp()
+      const { wallet } = generateTestWallet()
+      for (let i = 0; i < 5; i++) {
+        await supertest(app)
+          .post('/auth/nonce')
+          .set('X-Forwarded-For', '1.2.3.4')
+          .send({ wallet })
+      }
+      const fromOtherIp = await supertest(app)
+        .post('/auth/nonce')
+        .set('X-Forwarded-For', '5.6.7.8')
+        .send({ wallet })
+      expect(fromOtherIp.status).toBe(200)
     })
   })
 })

--- a/packages/agent/tests/routes/auth.test.ts
+++ b/packages/agent/tests/routes/auth.test.ts
@@ -73,9 +73,10 @@ function createApp() {
 describe('POST /auth/nonce', () => {
   it('returns nonce and message for valid wallet', async () => {
     const app = createApp()
+    const { wallet } = generateTestWallet()
     const res = await supertest(app)
       .post('/auth/nonce')
-      .send({ wallet: 'wallet123abc' })
+      .send({ wallet })
     expect(res.status).toBe(200)
     expect(res.body.nonce).toBeDefined()
     expect(typeof res.body.nonce).toBe('string')
@@ -89,7 +90,7 @@ describe('POST /auth/nonce', () => {
       .post('/auth/nonce')
       .send({})
     expect(res.status).toBe(400)
-    expect(res.body.error).toMatch(/wallet/i)
+    expect(res.body.error?.code).toBe('VALIDATION_FAILED')
   })
 
   it('rejects non-string wallet', async () => {
@@ -98,16 +99,66 @@ describe('POST /auth/nonce', () => {
       .post('/auth/nonce')
       .send({ wallet: 12345 })
     expect(res.status).toBe(400)
-    expect(res.body.error).toMatch(/wallet/i)
+    expect(res.body.error?.code).toBe('VALIDATION_FAILED')
+    expect(res.body.error?.message).toMatch(/wallet/i)
   })
 
   it('generates unique nonces per request', async () => {
     const app = createApp()
+    const { wallet } = generateTestWallet()
     const [r1, r2] = await Promise.all([
-      supertest(app).post('/auth/nonce').send({ wallet: 'wallet123' }),
-      supertest(app).post('/auth/nonce').send({ wallet: 'wallet123' }),
+      supertest(app).post('/auth/nonce').send({ wallet }),
+      supertest(app).post('/auth/nonce').send({ wallet }),
     ])
     expect(r1.body.nonce).not.toBe(r2.body.nonce)
+  })
+
+  describe('input validation', () => {
+    it('rejects wallet longer than 64 chars', async () => {
+      const app = createApp()
+      const res = await supertest(app)
+        .post('/auth/nonce')
+        .send({ wallet: 'A'.repeat(65) })
+      expect(res.status).toBe(400)
+      expect(res.body.error?.code).toBe('VALIDATION_FAILED')
+    })
+
+    it('rejects wallet with non-base58 chars', async () => {
+      const app = createApp()
+      const res = await supertest(app)
+        .post('/auth/nonce')
+        .send({ wallet: 'has spaces and !@#' })
+      expect(res.status).toBe(400)
+      expect(res.body.error?.code).toBe('VALIDATION_FAILED')
+    })
+
+    it('rejects wallet shorter than 32 chars', async () => {
+      const app = createApp()
+      const res = await supertest(app)
+        .post('/auth/nonce')
+        .send({ wallet: 'A'.repeat(31) })
+      expect(res.status).toBe(400)
+      expect(res.body.error?.code).toBe('VALIDATION_FAILED')
+    })
+
+    it('accepts valid base58 Solana pubkey (32-44 chars)', async () => {
+      const app = createApp()
+      const res = await supertest(app)
+        .post('/auth/nonce')
+        .send({ wallet: 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr' })
+      expect(res.status).toBe(200)
+      expect(res.body.nonce).toBeDefined()
+    })
+
+    it('rejects wallet containing the forbidden base58 character "l"', async () => {
+      const app = createApp()
+      // 32-char string with lowercase 'l' (Bitcoin/Solana base58 omits 0OIl)
+      const res = await supertest(app)
+        .post('/auth/nonce')
+        .send({ wallet: 'l'.repeat(32) })
+      expect(res.status).toBe(400)
+      expect(res.body.error?.code).toBe('VALIDATION_FAILED')
+    })
   })
 })
 

--- a/packages/agent/tests/routes/herald-api.test.ts
+++ b/packages/agent/tests/routes/herald-api.test.ts
@@ -29,6 +29,13 @@ const { heraldRouter } = await import('../../src/routes/herald-api.js')
 function createApp() {
   const app = express()
   app.use(express.json())
+  // Stub verifyJwt: production attaches req.wallet from a decoded JWT.
+  // Unit tests mount the router directly, so we attach a fixed test wallet
+  // to match the middleware contract.
+  app.use((req, _res, next) => {
+    req.wallet = 'test-wallet'
+    next()
+  })
   app.use('/api/herald', heraldRouter)
   return app
 }

--- a/packages/agent/tests/sentinel/circuit-breaker.test.ts
+++ b/packages/agent/tests/sentinel/circuit-breaker.test.ts
@@ -3,9 +3,19 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 describe('circuit breaker', () => {
   beforeEach(() => {
     process.env.DB_PATH = ':memory:'
+    // Tests assert the execution path (executor runs, status flips to
+    // 'executed', etc.). With SENTINEL_MODE defaulting to 'advisory' (B16),
+    // gate-3 in circuit-breaker would cancel refunds with reason
+    // 'mode-change'. Pin to 'yolo' here so the circuit breaker actually
+    // runs the executor — that's the surface these tests cover.
+    process.env.SENTINEL_MODE = 'yolo'
     vi.resetModules()  // ensure each test gets fresh module instances
   })
-  afterEach(() => { delete process.env.DB_PATH; vi.useRealTimers() })
+  afterEach(() => {
+    delete process.env.DB_PATH
+    delete process.env.SENTINEL_MODE
+    vi.useRealTimers()
+  })
 
   async function freshDb() {
     const { closeDb, getDb } = await import('../../src/db.js')

--- a/packages/agent/tests/sentinel/config.test.ts
+++ b/packages/agent/tests/sentinel/config.test.ts
@@ -58,21 +58,23 @@ describe('getSentinelConfig', () => {
     expect(config.threatCheckEnabled).toBe(true)
   })
 
-  it('returns default mode=yolo when SENTINEL_MODE unset', () => {
+  it('returns default mode=advisory when SENTINEL_MODE unset (fail-safe)', () => {
     delete process.env.SENTINEL_MODE
-    expect(getSentinelConfig().mode).toBe('yolo')
+    expect(getSentinelConfig().mode).toBe('advisory')
   })
 
-  it('accepts mode=advisory and mode=off', () => {
+  it('accepts mode=advisory, mode=off, and mode=yolo', () => {
     process.env.SENTINEL_MODE = 'advisory'
     expect(getSentinelConfig().mode).toBe('advisory')
     process.env.SENTINEL_MODE = 'off'
     expect(getSentinelConfig().mode).toBe('off')
+    process.env.SENTINEL_MODE = 'yolo'
+    expect(getSentinelConfig().mode).toBe('yolo')
   })
 
-  it('falls back to yolo on unknown mode value', () => {
+  it('falls back to advisory on unknown mode value', () => {
     process.env.SENTINEL_MODE = 'chaos'
-    expect(getSentinelConfig().mode).toBe('yolo')
+    expect(getSentinelConfig().mode).toBe('advisory')
   })
 
   it('returns default preflight knobs', () => {

--- a/packages/agent/tests/sentinel/pause-event.test.ts
+++ b/packages/agent/tests/sentinel/pause-event.test.ts
@@ -223,7 +223,9 @@ describe('executeTool onPause callback', () => {
 
   it('does NOT invoke onPause when mode !== advisory (yolo allows silently)', async () => {
     await freshDb()
-    // SENTINEL_MODE unset → defaults to 'yolo'
+    // Pin SENTINEL_MODE=yolo here — after B16 the default is 'advisory' which
+    // would invoke onPause; this test deliberately covers the yolo path.
+    process.env.SENTINEL_MODE = 'yolo'
     const { setSentinelAssessor } = await import('../../src/sentinel/preflight-gate.js')
     setSentinelAssessor(vi.fn().mockResolvedValue({
       risk: 'medium',

--- a/packages/agent/tests/sentinel/tools/get-deposit-status.test.ts
+++ b/packages/agent/tests/sentinel/tools/get-deposit-status.test.ts
@@ -74,26 +74,15 @@ describe('executeGetDepositStatus — branches', () => {
 })
 
 describe('executeGetDepositStatus — service interaction', () => {
-  it('uses default mainnet RPC when SOLANA_RPC_URL is unset', async () => {
+  it('uses loadNetworkConfig().rpcUrl for the connection', async () => {
+    // Test env (vitest.config.ts) → SIPHER_NETWORK=devnet + Helius test key.
     mockGetAccountInfo.mockResolvedValueOnce(null)
 
     await executeGetDepositStatus({ pda: VALID_PDA })
 
     expect(mockConnectionCtor).toHaveBeenCalledTimes(1)
     expect(mockConnectionCtor).toHaveBeenCalledWith(
-      'https://api.mainnet-beta.solana.com',
-      'confirmed',
-    )
-  })
-
-  it('honors SOLANA_RPC_URL when set', async () => {
-    process.env.SOLANA_RPC_URL = 'https://api.devnet.solana.com'
-    mockGetAccountInfo.mockResolvedValueOnce(null)
-
-    await executeGetDepositStatus({ pda: VALID_PDA })
-
-    expect(mockConnectionCtor).toHaveBeenCalledWith(
-      'https://api.devnet.solana.com',
+      expect.stringContaining('helius-rpc.com'),
       'confirmed',
     )
   })

--- a/packages/agent/tests/sentinel/tools/get-on-chain-signatures.test.ts
+++ b/packages/agent/tests/sentinel/tools/get-on-chain-signatures.test.ts
@@ -151,22 +151,12 @@ describe('executeGetOnChainSignatures — service interaction', () => {
     )
   })
 
-  it('uses default mainnet RPC when SOLANA_RPC_URL is unset', async () => {
+  it('uses loadNetworkConfig().rpcUrl for the connection', async () => {
+    // Test env (vitest.config.ts) → SIPHER_NETWORK=devnet + Helius test key.
     await executeGetOnChainSignatures({ address: VALID_TARGET_ADDRESS })
 
     expect(mockConnectionCtor).toHaveBeenCalledWith(
-      'https://api.mainnet-beta.solana.com',
-      'confirmed',
-    )
-  })
-
-  it('honors SOLANA_RPC_URL when set', async () => {
-    process.env.SOLANA_RPC_URL = 'https://api.devnet.solana.com'
-
-    await executeGetOnChainSignatures({ address: VALID_TARGET_ADDRESS })
-
-    expect(mockConnectionCtor).toHaveBeenCalledWith(
-      'https://api.devnet.solana.com',
+      expect.stringContaining('helius-rpc.com'),
       'confirmed',
     )
   })

--- a/packages/agent/tests/sentinel/tools/get-vault-balance.test.ts
+++ b/packages/agent/tests/sentinel/tools/get-vault-balance.test.ts
@@ -109,27 +109,19 @@ describe('executeGetVaultBalance — branches', () => {
 })
 
 describe('executeGetVaultBalance — service interaction', () => {
-  it('uses default mainnet RPC when SOLANA_RPC_URL is unset', async () => {
+  it('uses loadNetworkConfig().rpcUrl for the connection', async () => {
+    // The test env (vitest.config.ts) sets SIPHER_NETWORK=devnet +
+    // SIPHER_HELIUS_API_KEY=test-key, so loadNetworkConfig() resolves to a
+    // keyed devnet Helius URL. The exact host can shift if Helius changes
+    // their endpoint shape, so we match on the substring.
     mockGetBalance.mockResolvedValueOnce(0)
     mockGetParsedTokenAccountsByOwner.mockResolvedValueOnce({ value: [] })
 
     await executeGetVaultBalance({ wallet: VALID_WALLET })
 
+    expect(mockConnectionCtor).toHaveBeenCalledTimes(1)
     expect(mockConnectionCtor).toHaveBeenCalledWith(
-      'https://api.mainnet-beta.solana.com',
-      'confirmed',
-    )
-  })
-
-  it('honors SOLANA_RPC_URL when set', async () => {
-    process.env.SOLANA_RPC_URL = 'https://api.devnet.solana.com'
-    mockGetBalance.mockResolvedValueOnce(0)
-    mockGetParsedTokenAccountsByOwner.mockResolvedValueOnce({ value: [] })
-
-    await executeGetVaultBalance({ wallet: VALID_WALLET })
-
-    expect(mockConnectionCtor).toHaveBeenCalledWith(
-      'https://api.devnet.solana.com',
+      expect.stringContaining('helius-rpc.com'),
       'confirmed',
     )
   })

--- a/packages/agent/tests/state/ephemeral.test.ts
+++ b/packages/agent/tests/state/ephemeral.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { createStore } from '../../src/state/ephemeral.js'
+
+describe('ephemeral createStore — in-memory backend', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('set/get round-trips', async () => {
+    const store = createStore<string>('test1', { maxSize: 100 })
+    await store.set('k', 'v', 60)
+    expect(await store.get('k')).toBe('v')
+  })
+
+  it('delete removes entry', async () => {
+    const store = createStore<string>('test2', { maxSize: 100 })
+    await store.set('k', 'v', 60)
+    await store.delete('k')
+    expect(await store.get('k')).toBeNull()
+  })
+
+  it('expires after TTL (lazy on get)', async () => {
+    const store = createStore<string>('test3', { maxSize: 100 })
+    await store.set('k', 'v', 1)
+    vi.advanceTimersByTime(2000)
+    expect(await store.get('k')).toBeNull()
+  })
+
+  it('respects maxSize cap (oldest evicted FIFO)', async () => {
+    const store = createStore<string>('test4', { maxSize: 2 })
+    await store.set('a', '1', 60)
+    await store.set('b', '2', 60)
+    await store.set('c', '3', 60)
+    expect(await store.get('a')).toBeNull()
+    expect(await store.get('b')).toBe('2')
+    expect(await store.get('c')).toBe('3')
+  })
+
+  it('size() returns current count', async () => {
+    const store = createStore<string>('test5', { maxSize: 100 })
+    await store.set('a', '1', 60)
+    await store.set('b', '2', 60)
+    expect(await store.size()).toBe(2)
+  })
+
+  it('updating an existing key does not trigger eviction', async () => {
+    // At cap, re-setting an existing key should not evict the oldest entry.
+    const store = createStore<string>('test6', { maxSize: 2 })
+    await store.set('a', '1', 60)
+    await store.set('b', '2', 60)
+    await store.set('a', '1-updated', 60)
+    expect(await store.size()).toBe(2)
+    expect(await store.get('a')).toBe('1-updated')
+    expect(await store.get('b')).toBe('2')
+  })
+
+  it('_clear() empties the store', async () => {
+    const store = createStore<string>('test7', { maxSize: 100 })
+    await store.set('a', '1', 60)
+    await store.set('b', '2', 60)
+    await store._clear()
+    expect(await store.size()).toBe(0)
+    expect(await store.get('a')).toBeNull()
+    expect(await store.get('b')).toBeNull()
+  })
+
+  it('background sweep removes expired entries without get', async () => {
+    // Without a get, lazy expiration never fires. The interval sweeper must
+    // catch up and reduce size() to 0 once all entries are past expiresAt.
+    const store = createStore<string>('test8', { maxSize: 100, sweepIntervalMs: 1000 })
+    await store.set('a', '1', 1)
+    await store.set('b', '2', 1)
+    expect(await store.size()).toBe(2)
+    vi.advanceTimersByTime(1500)
+    expect(await store.size()).toBe(0)
+  })
+})

--- a/packages/agent/tests/status.test.ts
+++ b/packages/agent/tests/status.test.ts
@@ -114,29 +114,11 @@ describe('executeStatus — config not found', () => {
 })
 
 describe('executeStatus — service interaction', () => {
-  it('respects SOLANA_NETWORK env var', async () => {
-    const original = process.env.SOLANA_NETWORK
-    process.env.SOLANA_NETWORK = 'devnet'
-    try {
-      mockGetVaultConfig.mockResolvedValueOnce(makeVaultConfig())
-      await executeStatus()
-      expect(mockCreateConnection).toHaveBeenCalledWith('devnet')
-    } finally {
-      if (original !== undefined) process.env.SOLANA_NETWORK = original
-      else delete process.env.SOLANA_NETWORK
-    }
-  })
-
-  it('defaults to mainnet-beta when SOLANA_NETWORK unset', async () => {
-    const original = process.env.SOLANA_NETWORK
-    delete process.env.SOLANA_NETWORK
-    try {
-      mockGetVaultConfig.mockResolvedValueOnce(makeVaultConfig())
-      await executeStatus()
-      expect(mockCreateConnection).toHaveBeenCalledWith('mainnet-beta')
-    } finally {
-      if (original !== undefined) process.env.SOLANA_NETWORK = original
-    }
+  it('uses cluster name from loadNetworkConfig (SIPHER_NETWORK=devnet in test env)', async () => {
+    mockGetVaultConfig.mockResolvedValueOnce(makeVaultConfig())
+    await executeStatus()
+    // vitest.config.ts sets SIPHER_NETWORK=devnet globally → clusterName === 'devnet'
+    expect(mockCreateConnection).toHaveBeenCalledWith('devnet')
   })
 
   it('propagates getVaultConfig errors', async () => {

--- a/packages/agent/vitest.config.ts
+++ b/packages/agent/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config'
+
+// Tests run with SIPHER_NETWORK=devnet + SIPHER_HELIUS_API_KEY=test-key
+// pre-set so any tool that goes through loadNetworkConfig() (post-B12/B13
+// migration) gets a deterministic config instead of FATAL on unset env.
+// Tests that exercise loadNetworkConfig itself (config/network.test.ts)
+// mutate these freely — vitest restores process.env between worker forks.
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        maxForks: 4,
+      },
+    },
+    env: {
+      SIPHER_NETWORK: 'devnet',
+      SIPHER_HELIUS_API_KEY: 'test-key',
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,12 @@ importers:
       '@types/swagger-ui-express':
         specifier: ^4.1.8
         version: 4.1.8
+      '@typescript-eslint/parser':
+        specifier: ^8.59.2
+        version: 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
+      eslint:
+        specifier: ^10.3.0
+        version: 10.3.0(jiti@2.6.1)
       pino-pretty:
         specifier: ^13.0.0
         version: 13.1.3
@@ -116,6 +122,9 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.59.2
+        version: 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^3.0.5
         version: 3.2.4(@types/node@25.2.0)(jiti@2.6.1)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
@@ -975,6 +984,36 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.5.5':
+    resolution: {integrity: sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.1':
+    resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   '@ethereumjs/common@10.1.1':
     resolution: {integrity: sha512-NefPzPlrJ9w+NWVe06P+sHZQU98E1AEU9vhiHJEVT2wEcNBC1YX6hON9+smrfbn86C4U1pb2zbvjhkF+n/LKBw==}
 
@@ -1029,6 +1068,26 @@ packages:
     resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
     engines: {node: '>=6'}
     hasBin: true
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
@@ -3327,6 +3386,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -3354,6 +3416,9 @@ packages:
 
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
@@ -3437,6 +3502,65 @@ packages:
 
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@typescript-eslint/eslint-plugin@8.59.2':
+    resolution: {integrity: sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.59.2
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.59.2':
+    resolution: {integrity: sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.59.2':
+    resolution: {integrity: sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.59.2':
+    resolution: {integrity: sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.59.2':
+    resolution: {integrity: sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.59.2':
+    resolution: {integrity: sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.59.2':
+    resolution: {integrity: sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.59.2':
+    resolution: {integrity: sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.59.2':
+    resolution: {integrity: sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.59.2':
+    resolution: {integrity: sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -3630,8 +3754,18 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -3650,6 +3784,9 @@ packages:
     peerDependenciesMeta:
       ajv:
         optional: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -3751,6 +3888,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base-x@3.0.11:
     resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
 
@@ -3838,6 +3979,10 @@ packages:
 
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -4231,6 +4376,9 @@ packages:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
 
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
@@ -4428,10 +4576,44 @@ packages:
     engines: {node: '>=6.0'}
     hasBin: true
 
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.3.0:
+    resolution: {integrity: sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
 
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
@@ -4521,6 +4703,9 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
   fast-redact@3.5.0:
     resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
     engines: {node: '>=6'}
@@ -4568,6 +4753,10 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
@@ -4591,8 +4780,19 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   flow-enums-runtime@0.0.6:
     resolution: {integrity: sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==}
@@ -4705,6 +4905,10 @@ packages:
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -4815,6 +5019,14 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
   image-size@1.2.1:
     resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
     engines: {node: '>=16.x'}
@@ -4879,6 +5091,10 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -4886,6 +5102,10 @@ packages:
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
 
   is-nan@1.3.2:
     resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
@@ -5048,12 +5268,21 @@ packages:
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
 
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
   json-stable-stringify@1.3.0:
     resolution: {integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==}
@@ -5086,6 +5315,9 @@ packages:
   jwt-decode@4.0.0:
     resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
     engines: {node: '>=18'}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
   keyvaluestorage-interface@1.0.0:
     resolution: {integrity: sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==}
@@ -5133,6 +5365,10 @@ packages:
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
@@ -5234,6 +5470,10 @@ packages:
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
 
   lodash-es@4.17.23:
     resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
@@ -5467,6 +5707,10 @@ packages:
   minimalistic-crypto-utils@1.0.1:
     resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
@@ -5517,6 +5761,9 @@ packages:
 
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
   negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
@@ -5677,6 +5924,10 @@ packages:
       zod:
         optional: true
 
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
   ox@0.14.7:
     resolution: {integrity: sha512-zSQ/cfBdolj7U4++NAvH7sI+VG0T3pEohITCgcQj8KlawvTDY4vGVhDT64Atsm0d6adWfIYHDpu88iUBMMp+AQ==}
     peerDependencies:
@@ -5701,9 +5952,17 @@ packages:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
 
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
 
   p-queue@6.6.2:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
@@ -5885,6 +6144,10 @@ packages:
     engines: {node: '>=10'}
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -6593,6 +6856,12 @@ packages:
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -6635,6 +6904,10 @@ packages:
   twitter-api-v2@1.29.0:
     resolution: {integrity: sha512-v473q5bwme4N+DWSg6qY+JCvfg1nSJRWwui3HUALafxfqCvVkKiYmS/5x/pVeJwTmyeBxexMbzHwnzrH4h6oYQ==}
 
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
   type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
@@ -6653,6 +6926,13 @@ packages:
 
   typeforce@1.18.0:
     resolution: {integrity: sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==}
+
+  typescript-eslint@8.59.2:
+    resolution: {integrity: sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -6773,6 +7053,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   urijs@1.19.11:
     resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
@@ -7039,6 +7322,10 @@ packages:
   wif@5.0.0:
     resolution: {integrity: sha512-iFzrC/9ne740qFbNjTZ2FciSRJlHIXoxqk/Y5EnE08QOXu1WjJyCCswwDTYbohAOEnlCtLaAAQBhyaLRFh2hMA==}
 
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -7147,6 +7434,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
@@ -8012,6 +8303,36 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.3.0(jiti@2.6.1))':
+    dependencies:
+      eslint: 10.3.0(jiti@2.6.1)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.5.5':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.1':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
+
   '@ethereumjs/common@10.1.1':
     dependencies:
       '@ethereumjs/util': 10.1.1
@@ -8082,6 +8403,22 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.5.4
       yargs: 17.7.2
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:
@@ -11534,6 +11871,8 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/express-serve-static-core@5.1.1':
@@ -11570,6 +11909,8 @@ snapshots:
   '@types/istanbul-reports@3.0.4':
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/jsonwebtoken@9.0.10':
     dependencies:
@@ -11660,6 +12001,97 @@ snapshots:
   '@types/yargs@17.0.35':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.59.2
+      '@typescript-eslint/type-utils': 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.2
+      eslint: 10.3.0(jiti@2.6.1)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.2
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.2
+      debug: 4.4.3
+      eslint: 10.3.0(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.59.2(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.2
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.59.2':
+    dependencies:
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/visitor-keys': 8.59.2
+
+  '@typescript-eslint/tsconfig-utils@8.59.2(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 10.3.0(jiti@2.6.1)
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.59.2': {}
+
+  '@typescript-eslint/typescript-estree@8.59.2(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/visitor-keys': 8.59.2
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.3
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0(jiti@2.6.1))
+      '@typescript-eslint/scope-manager': 8.59.2
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      eslint: 10.3.0(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.59.2':
+    dependencies:
+      '@typescript-eslint/types': 8.59.2
+      eslint-visitor-keys: 5.0.1
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -12318,7 +12750,13 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn@8.15.0: {}
+
+  acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
 
@@ -12329,6 +12767,13 @@ snapshots:
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
 
   ajv@8.18.0:
     dependencies:
@@ -12467,6 +12912,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   base-x@3.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -12554,6 +13001,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -12993,6 +13444,8 @@ snapshots:
 
   deep-extend@0.6.0: {}
 
+  deep-is@0.1.4: {}
+
   define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.1
@@ -13240,7 +13693,69 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.8
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.3.0(jiti@2.6.1):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0(jiti@2.6.1))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.5.5
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.6.1
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 5.0.1
+
   esprima@4.0.1: {}
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
 
   estraverse@5.3.0: {}
 
@@ -13338,6 +13853,8 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
+  fast-levenshtein@2.0.6: {}
+
   fast-redact@3.5.0: {}
 
   fast-safe-stringify@2.1.1: {}
@@ -13377,6 +13894,10 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
   file-uri-to-path@1.0.0: {}
 
   fill-range@7.1.1:
@@ -13413,11 +13934,23 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
       magic-string: 0.30.21
       mlly: 1.8.0
       rollup: 4.57.1
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
 
   flow-enums-runtime@0.0.6: {}
 
@@ -13527,6 +14060,10 @@ snapshots:
       - supports-color
 
   github-from-package@0.0.0: {}
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
 
   glob@7.2.3:
     dependencies:
@@ -13665,6 +14202,10 @@ snapshots:
 
   ieee754@1.2.1: {}
 
+  ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
+
   image-size@1.2.1:
     dependencies:
       queue: 6.0.2
@@ -13721,6 +14262,8 @@ snapshots:
 
   is-docker@2.2.1: {}
 
+  is-extglob@2.1.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
   is-generator-function@1.1.2:
@@ -13730,6 +14273,10 @@ snapshots:
       get-proto: 1.0.1
       has-tostringtag: 1.0.2
       safe-regex-test: 1.1.0
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
 
   is-nan@1.3.2:
     dependencies:
@@ -13943,12 +14490,18 @@ snapshots:
     dependencies:
       bignumber.js: 9.3.1
 
+  json-buffer@3.0.1: {}
+
   json-schema-to-ts@3.1.1:
     dependencies:
       '@babel/runtime': 7.28.6
       ts-algebra: 2.0.0
 
+  json-schema-traverse@0.4.1: {}
+
   json-schema-traverse@1.0.0: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
 
   json-stable-stringify@1.3.0:
     dependencies:
@@ -13991,6 +14544,10 @@ snapshots:
       safe-buffer: 5.2.1
 
   jwt-decode@4.0.0: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
 
   keyvaluestorage-interface@1.0.0: {}
 
@@ -14074,6 +14631,11 @@ snapshots:
 
   leven@3.1.0: {}
 
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
   lighthouse-logger@1.4.2:
     dependencies:
       debug: 2.6.9
@@ -14155,6 +14717,10 @@ snapshots:
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
 
   lodash-es@4.17.23: {}
 
@@ -14457,6 +15023,10 @@ snapshots:
 
   minimalistic-crypto-utils@1.0.1: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.13
@@ -14509,6 +15079,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   napi-build-utils@2.0.0: {}
+
+  natural-compare@1.4.0: {}
 
   negotiator@0.6.4: {}
 
@@ -14666,6 +15238,15 @@ snapshots:
       zod: 4.3.6
     optional: true
 
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
   ox@0.14.7(typescript@5.9.3)(zod@3.22.4):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -14716,9 +15297,17 @@ snapshots:
     dependencies:
       p-try: 2.2.0
 
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
 
   p-queue@6.6.2:
     dependencies:
@@ -14943,6 +15532,8 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
+
+  prelude-ls@1.2.1: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -15833,6 +16424,10 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
   ts-interface-checker@0.1.13: {}
 
   ts-mixer@6.0.4: {}
@@ -15882,6 +16477,10 @@ snapshots:
 
   twitter-api-v2@1.29.0: {}
 
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
   type-detect@4.0.8: {}
 
   type-fest@0.7.1: {}
@@ -15899,6 +16498,17 @@ snapshots:
       is-typed-array: 1.1.15
 
   typeforce@1.18.0: {}
+
+  typescript-eslint@8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 10.3.0(jiti@2.6.1)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@5.9.3: {}
 
@@ -15957,6 +16567,10 @@ snapshots:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   urijs@1.19.11: {}
 
@@ -16233,6 +16847,8 @@ snapshots:
     dependencies:
       bs58check: 4.0.0
 
+  word-wrap@1.2.5: {}
+
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -16332,6 +16948,8 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yocto-queue@0.1.0: {}
 
   zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
## Summary

Phase 4a auth + security proper-fix Phase B — backend hardening of the auth
surface, ephemeral state centralization, mainnet-leak guard, SENTINEL fail-safe
defaults, and `/pay/:id/confirm` fail-closed. Companion to PR #175 (frontend
AuthSync, merged 2026-05-07).

## Changes (20 commits)

| Task | Commit | Description |
|------|--------|-------------|
| B1   | `52b9277` | Express Request augmentation (`req.wallet`, `req.isAdmin`) |
| B2   | `170c79a` | Drop 13 `(req as Record).wallet` casts across 8 files + defensive 500 |
| B3   | `71a7598` | `app.set('trust proxy', N)` + TRUST_PROXY env (default 1) |
| B4   | `fd7e905` | Input validation on `/api/auth/nonce` (BASE58_REGEX + length cap) |
| B5   | `3e3920c` | Per-IP rate limit on `/api/auth/nonce` (5/min, structured 429) |
| B6   | `dcce507` | JWT_EXPIRY env-configurable, default 24h prod / 1h test |
| B7   | `ed1a850` | New `POST /api/auth/refresh` endpoint (200 / 425 TOO_EARLY / 401) |
| B7.5 | `63c2803` | `/auth/verify` accepts SIWS `signedMessage` field — Phantom/Solflare collapse from 2 popups to 1 |
| B8   | `f46f84a` | AUTHORIZED_WALLETS parsed once with env-mtime invalidation |
| B9   | `4f9b66a` | Centralized `createStore<T>` ephemeral state factory + 8 tests |
| B10  | `7859b90` | auth.ts: 4 Maps → ephemeral store; handlers become async |
| B11  | `8cf502e` | adminTokens → ephemeral store (confirm.ts/circuit-breaker.ts kept as-is — non-serializable values) |
| B13  | `f0f76f2` | 3 SENTINEL tools migrated from `process.env.SOLANA_RPC_URL` to `loadNetworkConfig().rpcUrl` |
| B12  | `61e5b5c` | 13 files migrated from `process.env.SOLANA_NETWORK` to `loadNetworkConfig().clusterName` |
| B15  | `0c33e1c` | docker-compose.yml hardened: SIPHER_NETWORK, JWT_EXPIRY, TRUST_PROXY, SOLANA_RPC_URL_FALLBACK, SENTINEL_MODE=advisory |
| B16  | `aa47aa3` | SENTINEL_MODE code-side default flips from 'yolo' to 'advisory' (fail-safe) + boot warn log when 'yolo' active |
| B17  | `6f98da6` | FUND_MOVING_TOOLS single source of truth (`ReadonlySet<string>` exported from preflight-rules.ts) |
| B14  | `d94f376` | ESLint setup + `no-restricted-syntax` rule banning direct env reads (catches future regressions) |
| B18  | `52c8a38` | `/pay/:id/confirm` fail-closed: primary→fallback RPC retry, both fail → 503 RPC_UNAVAILABLE, per-link 3/min rate limit, guardianBus events |
| B19  | `0854318` | ESLint global ignore for dist/, node_modules/, build/ (B14 follow-up surfaced by B19 build smoke) |

## Resolves

- **BE H-1** trust proxy missing
- **BE H-2** no input validation on /api/auth/nonce
- **BE H-3** no rate limit on /api/auth/nonce
- **BE H-4** /pay/:id/confirm fail-open (money-at-risk)
- **BE H-5** 13 files leaking SOLANA_NETWORK
- **BE H-6** SIPHER_NETWORK missing in docker-compose.yml
- **BE H-7** /pay/:id/confirm has no per-link rate limit
- **BE R-3** JWT TTL hardcoded + no refresh endpoint
- **BE R-4** AUTHORIZED_WALLETS parsed per request
- **BE R-7** FUND_MOVING_TOOLS duplicated
- **BE R-8** SENTINEL_MODE default 'yolo' (now fail-safe 'advisory')
- **BE X-1** module-state pattern (5 sites migrated to centralized store)
- **BE X-2** SOLANA_NETWORK drift pattern (ESLint guard added)
- **BE X-3** Express Request cast pattern
- **D5** SIWS one-popup auth (FE shipped in #175 + BE wired in B7.5)
- **D7** /pay/:id/confirm fail-closed
- **D8** ESLint guard rail
- **D9** SENTINEL_MODE 'advisory' default
- **D10** Centralized ephemeral state

## Test plan

- [x] Full agent suite: 1337/1337 passing across 107 files
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm lint` clean (new ESLint rule active, dist/ ignored)
- [x] `pnpm build` clean
- [x] New tests for /api/auth/nonce input validation + rate limit (5)
- [x] New tests for /api/auth/refresh (6 cases — 200, 425, 401x3, malformed-header)
- [x] New tests for /auth/verify SIWS signedMessage path (7 cases — happy / nonce-mismatch / wrong-domain / prefix-attack / wrong-key / malformed-base64 / legacy-fallback)
- [x] New tests for /pay/:id/confirm fail-closed + per-link rate limit (5)
- [x] Ephemeral store tests (8 cases — set/get round-trip, delete, TTL expiration, FIFO eviction, size, update-no-eviction, _clear, sweep)

## Behaviour-change notes for reviewers

1. **`SENTINEL_MODE` default flipped from 'yolo' to 'advisory'.** VPS already has `SENTINEL_MODE=advisory` set explicitly (verified pre-flight), so no production behaviour change. Tests covering the execution path (circuit-breaker, pause-event) were pinned to `'yolo'` in `beforeEach`.
2. **`/api/auth/nonce` error envelope migrated** from legacy `{ error: string }` to structured `{ error: { code: 'VALIDATION_FAILED' | 'RATE_LIMITED', message: string } }`. Other auth.ts routes keep the legacy shape until PR 3 (envelope unification).
3. **`/pay/:id/confirm` no longer fail-opens on RPC errors.** Primary→fallback retry, then 503 with `RPC_UNAVAILABLE`. Operator MUST configure `SOLANA_RPC_URL_FALLBACK` for retry coverage; with no fallback set, single RPC error → 503 (still better than auto-marking-paid).
4. **JWT_EXPIRY default extends to 24h** (was 1h). Pairs with new `/api/auth/refresh` endpoint that auto-renews within the final 5min.
5. **`req.wallet` typed via `declare global { namespace Express { interface Request { wallet?: string; isAdmin?: boolean } } }`.** All protected routes drop their `(req as unknown as Record<...>).wallet` casts.
6. **ESLint added as workspace dev dep.** `eslint`, `@typescript-eslint/parser`, `typescript-eslint`. `pnpm-lock.yaml` updated. RECTOR pre-confirmed via AskUserQuestion that this lockfile change is part of legitimate PR 2 scope (not a separate PR).

## Spec

`docs/superpowers/specs/2026-05-06-phase4a-auth-and-security-fix-design.md`

## Predecessors (merged)

- Docs PR #174 (spec + plan committed)
- PR #175 (frontend AuthSync provider — D3, D4 frontend, D5 frontend, D6)

## Next

Phase C verification (manual auth flow on Phantom/Solflare/Jupiter, /quality:qa Phase 1 re-run, VPS deploy boot smoke) before publishing X thread #1.

🌙 InshaAllah.