### PR TITLE
feat: split FE to Vercel, backend stays on VPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,6 @@ data/
 .superpowers/
 .worktrees/
 
-# Vercel project link (created by `vercel link`, stays local)
-.vercel/
-
 # Playwright / RTL
 playwright-report/
 test-results/
@@ -27,3 +24,4 @@ e2e/test.db-journal
 # SENTINEL spec-capture artifacts (transient)
 e2e/sentinel-capture/
 .env.spec
+.vercel

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ data/
 .superpowers/
 .worktrees/
 
+# Vercel project link (created by `vercel link`, stays local)
+.vercel/
+
 # Playwright / RTL
 playwright-report/
 test-results/

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,16 +1,19 @@
 # Vercel only builds @sipher/app. Exclude paths that aren't needed
 # for the FE build: backend code, contracts, e2e fixtures, data files.
-# Keep packages/ + pnpm-workspace.yaml + pnpm-lock.yaml + patches/ so
+# Keep packages/, pnpm-workspace.yaml, pnpm-lock.yaml, patches/ so
 # pnpm install can resolve the workspace correctly with --filter.
+# Patterns are anchored to repo root with leading "/" so they don't
+# match nested dirs (critical for app/src/ — without anchoring, a
+# bare `src/` would exclude app/src/ too).
 
-contracts/
-programs/
-sdks/
-e2e/
-docs/
-scripts/
-src/
-data/
+/contracts/
+/programs/
+/sdks/
+/e2e/
+/docs/
+/scripts/
+/src/
+/data/
 *.log
 *.sqlite
 *.sqlite-journal

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,19 +1,20 @@
-# Vercel only deploys app/. Everything else stays on VPS.
-packages/
+# Vercel only builds @sipher/app. Exclude paths that aren't needed
+# for the FE build: backend code, contracts, e2e fixtures, data files.
+# Keep packages/ + pnpm-workspace.yaml + pnpm-lock.yaml + patches/ so
+# pnpm install can resolve the workspace correctly with --filter.
+
 contracts/
 programs/
-docs/
-e2e/
-scripts/
 sdks/
+e2e/
+docs/
+scripts/
 src/
+data/
 *.log
 *.sqlite
-data/
+*.sqlite-journal
+*.tsbuildinfo
 node_modules/
-
-# Allow lockfile + workspace config so pnpm can resolve in build
-!pnpm-lock.yaml
-!pnpm-workspace.yaml
-!package.json
-!app/
+.env
+.env.local

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,19 @@
+# Vercel only deploys app/. Everything else stays on VPS.
+packages/
+contracts/
+programs/
+docs/
+e2e/
+scripts/
+sdks/
+src/
+*.log
+*.sqlite
+data/
+node_modules/
+
+# Allow lockfile + workspace config so pnpm can resolve in build
+!pnpm-lock.yaml
+!pnpm-workspace.yaml
+!package.json
+!app/

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ hidden amounts, and compliance viewing keys across 17 chains.**
 [![Express](https://img.shields.io/badge/Express-5-000000?logo=express&logoColor=white)]()
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
-**Colosseum Agent Hackathon** | Agent #274 | [Live API](https://sipher.sip-protocol.org) | [Live Demo](https://sipher.sip-protocol.org/v1/demo) | [API Docs](https://sipher.sip-protocol.org/docs) | [Skill File](https://sipher.sip-protocol.org/skill.md)
+**Colosseum Agent Hackathon** | Agent #274 | [Live App](https://sipher.sip-protocol.org) | [Live API](https://api.sipher.sip-protocol.org) | [Live Demo](https://api.sipher.sip-protocol.org/v1/demo) | [API Docs](https://api.sipher.sip-protocol.org/docs) | [Skill File](https://api.sipher.sip-protocol.org/skill.md)
 
 </div>
 
@@ -161,7 +161,7 @@ No setup, no SDK, no wallet. Just `curl`.
 **Step 1 — Generate a stealth meta-address (recipient side):**
 
 ```bash
-curl -s -X POST https://sipher.sip-protocol.org/v1/stealth/generate \
+curl -s -X POST https://api.sipher.sip-protocol.org/v1/stealth/generate \
   -H "Content-Type: application/json" \
   -H "X-API-Key: your-key" \
   -d '{"chain": "solana"}' | jq '.data.metaAddress'
@@ -172,7 +172,7 @@ Returns spending + viewing public keys (base58 for Solana). Share these with the
 **Step 2 — Derive a one-time stealth address (sender side):**
 
 ```bash
-curl -s -X POST https://sipher.sip-protocol.org/v1/stealth/derive \
+curl -s -X POST https://api.sipher.sip-protocol.org/v1/stealth/derive \
   -H "Content-Type: application/json" \
   -H "X-API-Key: your-key" \
   -d '{
@@ -189,7 +189,7 @@ Returns an unlinkable one-time address. No one can connect it to the recipient.
 **Step 3 — Build a shielded transfer:**
 
 ```bash
-curl -s -X POST https://sipher.sip-protocol.org/v1/transfer/shield \
+curl -s -X POST https://api.sipher.sip-protocol.org/v1/transfer/shield \
   -H "Content-Type: application/json" \
   -H "X-API-Key: your-key" \
   -d '{
@@ -209,7 +209,7 @@ Returns an unsigned transaction + Pedersen commitment. Sign and submit to Solana
 **Or see everything at once (no API key needed):**
 
 ```bash
-curl -s https://sipher.sip-protocol.org/v1/demo | jq '.data.summary'
+curl -s https://api.sipher.sip-protocol.org/v1/demo | jq '.data.summary'
 ```
 
 ---
@@ -219,7 +219,7 @@ curl -s https://sipher.sip-protocol.org/v1/demo | jq '.data.summary'
 25 real cryptographic operations executing live — no mocks, no fakes:
 
 ```bash
-curl https://sipher.sip-protocol.org/v1/demo | jq '.data.summary'
+curl https://api.sipher.sip-protocol.org/v1/demo | jq '.data.summary'
 ```
 
 ```json
@@ -341,7 +341,7 @@ Sipher isn't a human tool with an API bolted on. Every design decision prioritiz
 
 | Pillar | How Sipher Delivers |
 |--------|-------------------|
-| **Discovery** | [`/skill.md`](https://sipher.sip-protocol.org/skill.md) — OpenClaw-compatible skill file. Agents discover, parse, and use all 66 endpoints without human configuration. Self-describing API at `/`, error catalog at `/v1/errors`, full schema at `/v1/openapi.json`. |
+| **Discovery** | [`/skill.md`](https://api.sipher.sip-protocol.org/skill.md) — OpenClaw-compatible skill file. Agents discover, parse, and use all 66 endpoints without human configuration. Self-describing API at `/`, error catalog at `/v1/errors`, full schema at `/v1/openapi.json`. |
 | **Integration** | Pure REST + JSON. No browser, no OAuth, no cookies. 4 auto-generated SDKs (TypeScript, Python, Rust, Go). API key auth via `X-API-Key` header — the simplest auth pattern for agents. |
 | **Autonomy** | [`privacy-demo-agent.ts`](scripts/privacy-demo-agent.ts) runs 20 steps across 34 endpoints with zero human intervention. Sessions (`X-Session-Id`) maintain state across multi-step workflows. No CAPTCHA, no manual verification. |
 | **Reliability** | 11+ mutation endpoints support `Idempotency-Key` for safe retries. Structured error responses with machine-readable codes and retry guidance. Agents can reason about failures, not parse HTML error pages. |
@@ -371,7 +371,7 @@ class SipherStealthGenerate extends StructuredTool {
   schema = z.object({ chain: z.string().optional() })
 
   async _call({ chain }: { chain?: string }) {
-    const res = await fetch('https://sipher.sip-protocol.org/v1/stealth/generate', {
+    const res = await fetch('https://api.sipher.sip-protocol.org/v1/stealth/generate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-API-Key': process.env.SIPHER_KEY! },
       body: JSON.stringify({ chain: chain || 'solana' }),
@@ -483,7 +483,7 @@ curl -X POST http://localhost:5006/v1/viewing-key/generate \
 ### Live Demo (no auth):
 
 ```bash
-curl https://sipher.sip-protocol.org/v1/demo | jq .
+curl https://api.sipher.sip-protocol.org/v1/demo | jq .
 ```
 
 ---
@@ -508,7 +508,7 @@ Sipher is powered by the full SIP Protocol SDK — not a thin wrapper:
 
 ## 🔌 API Endpoints (66 total)
 
-**Base URL:** `https://sipher.sip-protocol.org` | **Auth:** `X-API-Key` header | **Docs:** [`/docs`](https://sipher.sip-protocol.org/docs)
+**Base URL:** `https://api.sipher.sip-protocol.org` | **Auth:** `X-API-Key` header | **Docs:** [`/docs`](https://api.sipher.sip-protocol.org/docs)
 
 All responses follow: `{ success: boolean, data?: T, error?: { code, message, details? } }`
 
@@ -533,7 +533,7 @@ All responses follow: `{ success: boolean, data?: T, error?: { code, message, de
 | **Privacy** | 1 | `/v1/privacy/score` | Wallet privacy analysis (0-100) |
 | **SENTINEL** | 8 | `/v1/sentinel/assess`, `/blacklist`, `/pending`, `/decisions`, `/status` | Risk assessment + threat detection (public + admin) |
 
-Full interactive reference: [`/docs`](https://sipher.sip-protocol.org/docs) | OpenClaw skill: [`/skill.md`](https://sipher.sip-protocol.org/skill.md)
+Full interactive reference: [`/docs`](https://api.sipher.sip-protocol.org/docs) | OpenClaw skill: [`/skill.md`](https://api.sipher.sip-protocol.org/skill.md)
 
 ---
 
@@ -758,8 +758,8 @@ See [`docs/superpowers/specs/2026-04-18-test-infrastructure-design.md`](docs/sup
 | **AI** | Pi SDK (@mariozechner/pi-agent-core + pi-ai) via OpenRouter (AgentCore + SentinelCore) |
 | **Testing** | Vitest + Supertest |
 | **Docs** | OpenAPI 3.1 + Swagger UI |
-| **Deploy** | Docker + GHCR + GitHub Actions |
-| **Domain** | sipher.sip-protocol.org |
+| **Deploy** | Vercel (FE) + Docker + GHCR + GitHub Actions (BE) |
+| **Domains** | sipher.sip-protocol.org (FE on Vercel) · api.sipher.sip-protocol.org (BE on VPS) |
 
 ---
 
@@ -833,6 +833,6 @@ MIT — see [LICENSE](LICENSE)
 
 *Your agent's wallet is a public diary. Sipher closes the book.*
 
-[Live Demo](https://sipher.sip-protocol.org/v1/demo) · [API Docs](https://sipher.sip-protocol.org/docs) · [Skill File](https://sipher.sip-protocol.org/skill.md) · [Report Bug](https://github.com/sip-protocol/sipher/issues)
+[Live Demo](https://api.sipher.sip-protocol.org/v1/demo) · [API Docs](https://api.sipher.sip-protocol.org/docs) · [Skill File](https://api.sipher.sip-protocol.org/skill.md) · [Report Bug](https://github.com/sip-protocol/sipher/issues)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ hidden amounts, and compliance viewing keys across 17 chains.**
 [![Express](https://img.shields.io/badge/Express-5-000000?logo=express&logoColor=white)]()
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
-**Colosseum Agent Hackathon** | Agent #274 | [Live App](https://sipher.sip-protocol.org) | [Live API](https://api.sipher.sip-protocol.org) | [Live Demo](https://api.sipher.sip-protocol.org/v1/demo) | [API Docs](https://api.sipher.sip-protocol.org/docs) | [Skill File](https://api.sipher.sip-protocol.org/skill.md)
+**Colosseum Agent Hackathon** | Agent #274 | [Live App](https://sipher.sip-protocol.org) | [Live API](https://sipher-api.sip-protocol.org) | [Live Demo](https://sipher-api.sip-protocol.org/v1/demo) | [API Docs](https://sipher-api.sip-protocol.org/docs) | [Skill File](https://sipher-api.sip-protocol.org/skill.md)
 
 </div>
 
@@ -161,7 +161,7 @@ No setup, no SDK, no wallet. Just `curl`.
 **Step 1 — Generate a stealth meta-address (recipient side):**
 
 ```bash
-curl -s -X POST https://api.sipher.sip-protocol.org/v1/stealth/generate \
+curl -s -X POST https://sipher-api.sip-protocol.org/v1/stealth/generate \
   -H "Content-Type: application/json" \
   -H "X-API-Key: your-key" \
   -d '{"chain": "solana"}' | jq '.data.metaAddress'
@@ -172,7 +172,7 @@ Returns spending + viewing public keys (base58 for Solana). Share these with the
 **Step 2 — Derive a one-time stealth address (sender side):**
 
 ```bash
-curl -s -X POST https://api.sipher.sip-protocol.org/v1/stealth/derive \
+curl -s -X POST https://sipher-api.sip-protocol.org/v1/stealth/derive \
   -H "Content-Type: application/json" \
   -H "X-API-Key: your-key" \
   -d '{
@@ -189,7 +189,7 @@ Returns an unlinkable one-time address. No one can connect it to the recipient.
 **Step 3 — Build a shielded transfer:**
 
 ```bash
-curl -s -X POST https://api.sipher.sip-protocol.org/v1/transfer/shield \
+curl -s -X POST https://sipher-api.sip-protocol.org/v1/transfer/shield \
   -H "Content-Type: application/json" \
   -H "X-API-Key: your-key" \
   -d '{
@@ -209,7 +209,7 @@ Returns an unsigned transaction + Pedersen commitment. Sign and submit to Solana
 **Or see everything at once (no API key needed):**
 
 ```bash
-curl -s https://api.sipher.sip-protocol.org/v1/demo | jq '.data.summary'
+curl -s https://sipher-api.sip-protocol.org/v1/demo | jq '.data.summary'
 ```
 
 ---
@@ -219,7 +219,7 @@ curl -s https://api.sipher.sip-protocol.org/v1/demo | jq '.data.summary'
 25 real cryptographic operations executing live — no mocks, no fakes:
 
 ```bash
-curl https://api.sipher.sip-protocol.org/v1/demo | jq '.data.summary'
+curl https://sipher-api.sip-protocol.org/v1/demo | jq '.data.summary'
 ```
 
 ```json
@@ -341,7 +341,7 @@ Sipher isn't a human tool with an API bolted on. Every design decision prioritiz
 
 | Pillar | How Sipher Delivers |
 |--------|-------------------|
-| **Discovery** | [`/skill.md`](https://api.sipher.sip-protocol.org/skill.md) — OpenClaw-compatible skill file. Agents discover, parse, and use all 66 endpoints without human configuration. Self-describing API at `/`, error catalog at `/v1/errors`, full schema at `/v1/openapi.json`. |
+| **Discovery** | [`/skill.md`](https://sipher-api.sip-protocol.org/skill.md) — OpenClaw-compatible skill file. Agents discover, parse, and use all 66 endpoints without human configuration. Self-describing API at `/`, error catalog at `/v1/errors`, full schema at `/v1/openapi.json`. |
 | **Integration** | Pure REST + JSON. No browser, no OAuth, no cookies. 4 auto-generated SDKs (TypeScript, Python, Rust, Go). API key auth via `X-API-Key` header — the simplest auth pattern for agents. |
 | **Autonomy** | [`privacy-demo-agent.ts`](scripts/privacy-demo-agent.ts) runs 20 steps across 34 endpoints with zero human intervention. Sessions (`X-Session-Id`) maintain state across multi-step workflows. No CAPTCHA, no manual verification. |
 | **Reliability** | 11+ mutation endpoints support `Idempotency-Key` for safe retries. Structured error responses with machine-readable codes and retry guidance. Agents can reason about failures, not parse HTML error pages. |
@@ -371,7 +371,7 @@ class SipherStealthGenerate extends StructuredTool {
   schema = z.object({ chain: z.string().optional() })
 
   async _call({ chain }: { chain?: string }) {
-    const res = await fetch('https://api.sipher.sip-protocol.org/v1/stealth/generate', {
+    const res = await fetch('https://sipher-api.sip-protocol.org/v1/stealth/generate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-API-Key': process.env.SIPHER_KEY! },
       body: JSON.stringify({ chain: chain || 'solana' }),
@@ -483,7 +483,7 @@ curl -X POST http://localhost:5006/v1/viewing-key/generate \
 ### Live Demo (no auth):
 
 ```bash
-curl https://api.sipher.sip-protocol.org/v1/demo | jq .
+curl https://sipher-api.sip-protocol.org/v1/demo | jq .
 ```
 
 ---
@@ -508,7 +508,7 @@ Sipher is powered by the full SIP Protocol SDK — not a thin wrapper:
 
 ## 🔌 API Endpoints (66 total)
 
-**Base URL:** `https://api.sipher.sip-protocol.org` | **Auth:** `X-API-Key` header | **Docs:** [`/docs`](https://api.sipher.sip-protocol.org/docs)
+**Base URL:** `https://sipher-api.sip-protocol.org` | **Auth:** `X-API-Key` header | **Docs:** [`/docs`](https://sipher-api.sip-protocol.org/docs)
 
 All responses follow: `{ success: boolean, data?: T, error?: { code, message, details? } }`
 
@@ -533,7 +533,7 @@ All responses follow: `{ success: boolean, data?: T, error?: { code, message, de
 | **Privacy** | 1 | `/v1/privacy/score` | Wallet privacy analysis (0-100) |
 | **SENTINEL** | 8 | `/v1/sentinel/assess`, `/blacklist`, `/pending`, `/decisions`, `/status` | Risk assessment + threat detection (public + admin) |
 
-Full interactive reference: [`/docs`](https://api.sipher.sip-protocol.org/docs) | OpenClaw skill: [`/skill.md`](https://api.sipher.sip-protocol.org/skill.md)
+Full interactive reference: [`/docs`](https://sipher-api.sip-protocol.org/docs) | OpenClaw skill: [`/skill.md`](https://sipher-api.sip-protocol.org/skill.md)
 
 ---
 
@@ -759,7 +759,7 @@ See [`docs/superpowers/specs/2026-04-18-test-infrastructure-design.md`](docs/sup
 | **Testing** | Vitest + Supertest |
 | **Docs** | OpenAPI 3.1 + Swagger UI |
 | **Deploy** | Vercel (FE) + Docker + GHCR + GitHub Actions (BE) |
-| **Domains** | sipher.sip-protocol.org (FE on Vercel) · api.sipher.sip-protocol.org (BE on VPS) |
+| **Domains** | sipher.sip-protocol.org (FE on Vercel) · sipher-api.sip-protocol.org (BE on VPS) |
 
 ---
 
@@ -833,6 +833,6 @@ MIT — see [LICENSE](LICENSE)
 
 *Your agent's wallet is a public diary. Sipher closes the book.*
 
-[Live Demo](https://api.sipher.sip-protocol.org/v1/demo) · [API Docs](https://api.sipher.sip-protocol.org/docs) · [Skill File](https://api.sipher.sip-protocol.org/skill.md) · [Report Bug](https://github.com/sip-protocol/sipher/issues)
+[Live Demo](https://sipher-api.sip-protocol.org/v1/demo) · [API Docs](https://sipher-api.sip-protocol.org/docs) · [Skill File](https://sipher-api.sip-protocol.org/skill.md) · [Report Bug](https://github.com/sip-protocol/sipher/issues)
 
 </div>

--- a/app/.env.example
+++ b/app/.env.example
@@ -11,5 +11,5 @@
 #
 # Production (set in Vercel project env vars; .env.production is the
 # committed fallback):
-# VITE_API_URL=https://api.sipher.sip-protocol.org
+# VITE_API_URL=https://sipher-api.sip-protocol.org
 # VITE_SOLANA_NETWORK=mainnet-beta

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,0 +1,15 @@
+# Vite env vars for the Sipher frontend.
+#
+# Local dev defaults live in .env.development (loaded by `vite dev`).
+# Production defaults live in .env.production (loaded by `vite build`).
+# Vercel project env vars override .env.production at build time and
+# are the canonical source for prod values.
+#
+# Local development (used by `vite dev`):
+# VITE_API_URL=http://localhost:5006
+# VITE_SOLANA_NETWORK=devnet
+#
+# Production (set in Vercel project env vars; .env.production is the
+# committed fallback):
+# VITE_API_URL=https://api.sipher.sip-protocol.org
+# VITE_SOLANA_NETWORK=mainnet-beta

--- a/app/.env.production
+++ b/app/.env.production
@@ -1,2 +1,2 @@
-VITE_API_URL=https://sipher.sip-protocol.org
+VITE_API_URL=https://api.sipher.sip-protocol.org
 VITE_SOLANA_NETWORK=mainnet-beta

--- a/app/.env.production
+++ b/app/.env.production
@@ -1,2 +1,2 @@
-VITE_API_URL=https://api.sipher.sip-protocol.org
+VITE_API_URL=https://sipher-api.sip-protocol.org
 VITE_SOLANA_NETWORK=mainnet-beta

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - SOLANA_RPC_URL_FALLBACK=${SOLANA_RPC_URL_FALLBACK:-}
       - SIPHER_HELIUS_API_KEY=${SIPHER_HELIUS_API_KEY:-}
       - RPC_PROVIDER=${RPC_PROVIDER:-generic}
-      - CORS_ORIGINS=${CORS_ORIGINS:-https://sipher.sip-protocol.org,https://sip-protocol.org,https://app.sip-protocol.org}
+      - CORS_ORIGINS=${CORS_ORIGINS:-https://sipher.sip-protocol.org}
       - REDIS_URL=redis://redis:6379
       - TRUST_PROXY=${TRUST_PROXY:-1}
       - LOG_LEVEL=info

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,7 +4,7 @@ Production deployment reference for Sipher on the SIP Protocol VPS.
 
 ## Overview
 
-Sipher's API runs as a Docker container (`sipher` + `sipher-redis`) behind nginx at [api.sipher.sip-protocol.org](https://api.sipher.sip-protocol.org). The frontend is hosted on Vercel at [sipher.sip-protocol.org](https://sipher.sip-protocol.org) and consumes the API cross-origin (CORS allowlist gated). Deployment is GitOps: GitHub Actions builds on push to `main`, publishes to GHCR, then SSHes into the VPS and recreates the container. Vercel auto-deploys on push to `main` and on PR open (preview URLs at `*-sipher.vercel.app`).
+Sipher's API runs as a Docker container (`sipher` + `sipher-redis`) behind nginx at [sipher-api.sip-protocol.org](https://sipher-api.sip-protocol.org). The frontend is hosted on Vercel at [sipher.sip-protocol.org](https://sipher.sip-protocol.org) and consumes the API cross-origin (CORS allowlist gated). Deployment is GitOps: GitHub Actions builds on push to `main`, publishes to GHCR, then SSHes into the VPS and recreates the container. Vercel auto-deploys on push to `main` and on PR open (preview URLs at `sipher-<hash>-rectors-projects.vercel.app`).
 
 ## VPS Layout
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,7 +4,7 @@ Production deployment reference for Sipher on the SIP Protocol VPS.
 
 ## Overview
 
-Sipher runs as a Docker container (`sipher` + `sipher-redis`) behind nginx at [sipher.sip-protocol.org](https://sipher.sip-protocol.org). Deployment is GitOps: GitHub Actions builds on push to `main`, publishes to GHCR, then SSHes into the VPS and recreates the container.
+Sipher's API runs as a Docker container (`sipher` + `sipher-redis`) behind nginx at [api.sipher.sip-protocol.org](https://api.sipher.sip-protocol.org). The frontend is hosted on Vercel at [sipher.sip-protocol.org](https://sipher.sip-protocol.org) and consumes the API cross-origin (CORS allowlist gated). Deployment is GitOps: GitHub Actions builds on push to `main`, publishes to GHCR, then SSHes into the VPS and recreates the container. Vercel auto-deploys on push to `main` and on PR open (preview URLs at `*-sipher.vercel.app`).
 
 ## VPS Layout
 
@@ -40,7 +40,7 @@ SSH access: `ssh sip` (the `sipher` container runs under the `sip` user, there i
 | `RPC_PROVIDER` | `generic` | `helius` / `quicknode` / `triton` / `generic` |
 | `SIPHER_MODEL` | `anthropic/claude-sonnet-4.6` | Default SIPHER LLM model ID (provider `openrouter` hard-coded in `packages/agent/src/pi/provider.ts`) |
 | `SOLANA_NETWORK` | `mainnet-beta` | `mainnet-beta` / `devnet` |
-| `CORS_ORIGINS` | SIP domains | Comma-separated allowlist |
+| `CORS_ORIGINS` | `https://sipher.sip-protocol.org` | Comma-separated allowlist of explicit origins. Vercel preview URLs matching `*-sipher.vercel.app` are accepted in code, not env. |
 | `RATE_LIMIT_MAX` | `100` | Requests per window |
 | `RATE_LIMIT_WINDOW_MS` | `60000` | Rate limit window (ms) |
 | `JUPITER_API_URL` | `https://lite-api.jup.ag` | Jupiter DEX endpoint |

--- a/packages/agent/src/cors-config.ts
+++ b/packages/agent/src/cors-config.ts
@@ -1,0 +1,44 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express'
+
+// Matches any Vercel preview URL for the sipher project:
+//   https://<branch-slug>-sipher.vercel.app
+// Branch slugs are lowercase alphanumeric + hyphens, e.g. "feat-redesign-tokens".
+const VERCEL_PREVIEW_PATTERN = /^https:\/\/[a-z0-9-]+-sipher\.vercel\.app$/
+
+/**
+ * Builds a CORS middleware from a comma-separated origins env string.
+ *
+ * Two allow paths:
+ *   1. Exact match against the explicit allowlist (production + local)
+ *   2. Wildcard match against *-sipher.vercel.app preview deployments
+ *
+ * Returns null when corsOriginsEnv is empty so callers can skip .use() entirely
+ * (preserves same-origin behaviour when CORS_ORIGINS is unset).
+ */
+export function buildCorsMiddleware(corsOriginsEnv: string): RequestHandler | null {
+  const allowedOrigins = corsOriginsEnv.split(',').map((s) => s.trim()).filter(Boolean)
+  if (allowedOrigins.length === 0) return null
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const origin = req.headers.origin
+
+    if (origin) {
+      const allowed =
+        allowedOrigins.includes(origin) || VERCEL_PREVIEW_PATTERN.test(origin)
+
+      if (allowed) {
+        res.setHeader('Access-Control-Allow-Origin', origin)
+        res.setHeader('Access-Control-Allow-Credentials', 'true')
+        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS')
+        res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
+      }
+    }
+
+    if (req.method === 'OPTIONS') {
+      res.status(204).end()
+      return
+    }
+
+    next()
+  }
+}

--- a/packages/agent/src/cors-config.ts
+++ b/packages/agent/src/cors-config.ts
@@ -20,6 +20,12 @@ export function buildCorsMiddleware(corsOriginsEnv: string): RequestHandler | nu
   if (allowedOrigins.length === 0) return null
 
   return (req: Request, res: Response, next: NextFunction): void => {
+    // Set Vary: Origin unconditionally so any shared cache (Cloudflare, CDN,
+    // intermediary proxy) keys the response by the Origin request header and
+    // never serves a cached ACAO from one origin to a request from another.
+    // Required by the Fetch spec when the response varies by Origin.
+    res.setHeader('Vary', 'Origin')
+
     const origin = req.headers.origin
 
     if (origin) {
@@ -35,6 +41,9 @@ export function buildCorsMiddleware(corsOriginsEnv: string): RequestHandler | nu
     }
 
     if (req.method === 'OPTIONS') {
+      // Cache the preflight result for 24h so browsers don't re-handshake on
+      // every request. Matches the cors npm package default.
+      res.setHeader('Access-Control-Max-Age', '86400')
       res.status(204).end()
       return
     }

--- a/packages/agent/src/cors-config.ts
+++ b/packages/agent/src/cors-config.ts
@@ -1,9 +1,16 @@
 import type { Request, Response, NextFunction, RequestHandler } from 'express'
 
-// Matches any Vercel preview URL for the sipher project:
-//   https://<branch-slug>-sipher.vercel.app
-// Branch slugs are lowercase alphanumeric + hyphens, e.g. "feat-redesign-tokens".
-const VERCEL_PREVIEW_PATTERN = /^https:\/\/[a-z0-9-]+-sipher\.vercel\.app$/
+// Matches any Vercel preview URL for the sipher project under the
+// rectors-projects team. Vercel preview URLs follow:
+//   https://<project>-<hash-or-branch>-<team-slug>.vercel.app
+// Examples:
+//   https://sipher-96i1chii4-rectors-projects.vercel.app   (deploy hash)
+//   https://sipher-git-feat-x-rectors-projects.vercel.app  (branch deploy)
+// Anchoring on both the project name AND the team slug means a project
+// named "sipher" under a different team (e.g. an attacker registering
+// "sipher" elsewhere) does not match.
+const VERCEL_PREVIEW_PATTERN =
+  /^https:\/\/sipher-[a-z0-9-]+-rectors-projects\.vercel\.app$/
 
 /**
  * Builds a CORS middleware from a comma-separated origins env string.

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -215,11 +215,9 @@ app.get('/api/activity', verifyJwt, (req: Request, res: Response) => {
   res.json({ activity })
 })
 
-// Serve web chat UI (static files from app/dist)
-// In production: packages/agent/dist/ -> ../../../app/dist
-// Resolved via __dirname so it works regardless of cwd
-const webRoot = path.resolve(__dirname, '../../../app/dist')
-app.use(express.static(webRoot))
+// FE is served by Vercel at sipher.sip-protocol.org. Backend
+// is API-only at api.sipher.sip-protocol.org. CORS_ORIGINS env
+// gates which Vercel preview/prod origins can call us.
 
 // ─── Chat endpoint ──────────────────────────────────────────────────────────
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -208,7 +208,7 @@ app.get('/api/activity', verifyJwt, (req: Request, res: Response) => {
 })
 
 // FE is served by Vercel at sipher.sip-protocol.org. Backend
-// is API-only at api.sipher.sip-protocol.org. CORS_ORIGINS env
+// is API-only at sipher-api.sip-protocol.org. CORS_ORIGINS env
 // gates which Vercel preview/prod origins can call us.
 
 // ─── Chat endpoint ──────────────────────────────────────────────────────────

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -27,6 +27,7 @@ import { performVaultRefund, assertVaultRefundWired } from './sentinel/vault-ref
 import { sentinelPublicRouter, sentinelAdminRouter } from './routes/sentinel-api.js'
 import { getSentinelConfig } from './sentinel/config.js'
 import { configRouter } from './routes/config.js'
+import { buildCorsMiddleware } from './cors-config.js'
 import { loadNetworkConfig } from './config/network.js'
 import {
   getAllPendingActionsWithStatus,
@@ -142,25 +143,16 @@ console.log(`[agent] trust proxy = ${trustProxy} (set TRUST_PROXY env var to ove
 
 app.use(express.json({ limit: '1mb' }))
 
-// ─── CORS — only needed for dev/test (in prod the agent serves the app statically)
+// ─── CORS ────────────────────────────────────────────────────────────────────
 // Reads comma-separated CORS_ORIGINS env. Empty/unset = no CORS headers (same-origin).
-const corsOrigins = (process.env.CORS_ORIGINS ?? '').split(',').map((o) => o.trim()).filter(Boolean)
-if (corsOrigins.length > 0) {
-  app.use((req, res, next) => {
-    const origin = req.headers.origin
-    if (origin && corsOrigins.includes(origin)) {
-      res.setHeader('Access-Control-Allow-Origin', origin)
-      res.setHeader('Access-Control-Allow-Credentials', 'true')
-      res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PATCH, DELETE, OPTIONS')
-      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization')
-    }
-    if (req.method === 'OPTIONS') {
-      res.status(204).end()
-      return
-    }
-    next()
-  })
-  console.log(`  CORS:    enabled for ${corsOrigins.join(', ')}`)
+// In addition to the explicit allowlist, any *-sipher.vercel.app preview URL is
+// accepted automatically so Vercel branch previews work without touching the env.
+const corsOriginsEnv = process.env.CORS_ORIGINS ?? ''
+const corsMw = buildCorsMiddleware(corsOriginsEnv)
+if (corsMw) {
+  app.use(corsMw)
+  const listed = corsOriginsEnv.split(',').map((s) => s.trim()).filter(Boolean)
+  console.log(`  CORS:    enabled for ${listed.join(', ')} + *-sipher.vercel.app previews`)
 }
 
 // ─── Pay and Admin routes ────────────────────────────────────────────────────

--- a/packages/agent/tests/cors-origins.test.ts
+++ b/packages/agent/tests/cors-origins.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import express, { type Request, type Response } from 'express'
 import supertest from 'supertest'
 import { buildCorsMiddleware } from '../src/cors-config.js'
@@ -59,5 +59,40 @@ describe('CORS allowlist', () => {
   it('returns no CORS middleware when corsOriginsEnv is empty', async () => {
     const middleware = buildCorsMiddleware('')
     expect(middleware).toBeNull()
+  })
+
+  it('sets Vary: Origin on every response so shared caches key by origin', async () => {
+    const app = createApp('https://sipher.sip-protocol.org')
+    const res = await supertest(app)
+      .get('/test')
+      .set('Origin', 'https://sipher.sip-protocol.org')
+    expect(res.headers['vary']).toBe('Origin')
+  })
+
+  it('OPTIONS preflight from allowed origin returns 204 with full CORS headers and Max-Age', async () => {
+    const app = createApp('https://sipher.sip-protocol.org')
+    const res = await supertest(app)
+      .options('/test')
+      .set('Origin', 'https://sipher.sip-protocol.org')
+      .set('Access-Control-Request-Method', 'POST')
+    expect(res.status).toBe(204)
+    expect(res.headers['access-control-allow-origin']).toBe('https://sipher.sip-protocol.org')
+    expect(res.headers['access-control-allow-credentials']).toBe('true')
+    expect(res.headers['access-control-allow-methods']).toBe('GET, POST, PATCH, DELETE, OPTIONS')
+    expect(res.headers['access-control-allow-headers']).toBe('Content-Type, Authorization')
+    expect(res.headers['access-control-max-age']).toBe('86400')
+    expect(res.headers['vary']).toBe('Origin')
+  })
+
+  it('OPTIONS preflight from rejected origin returns 204 with no ACAO header', async () => {
+    const app = createApp('https://sipher.sip-protocol.org')
+    const res = await supertest(app)
+      .options('/test')
+      .set('Origin', 'https://evil.example.com')
+      .set('Access-Control-Request-Method', 'POST')
+    expect(res.status).toBe(204)
+    expect(res.headers['access-control-allow-origin']).toBeUndefined()
+    expect(res.headers['access-control-allow-credentials']).toBeUndefined()
+    expect(res.headers['vary']).toBe('Origin')
   })
 })

--- a/packages/agent/tests/cors-origins.test.ts
+++ b/packages/agent/tests/cors-origins.test.ts
@@ -21,13 +21,22 @@ describe('CORS allowlist', () => {
     expect(res.headers['access-control-allow-origin']).toBe('https://sipher.sip-protocol.org')
   })
 
-  it('accepts a Vercel preview origin matching *-sipher.vercel.app', async () => {
+  it('accepts a Vercel preview origin under the rectors-projects team', async () => {
     const app = createApp('https://sipher.sip-protocol.org')
     const res = await supertest(app)
       .get('/test')
-      .set('Origin', 'https://feat-redesign-tokens-sipher.vercel.app')
+      .set('Origin', 'https://sipher-96i1chii4-rectors-projects.vercel.app')
     expect(res.status).toBe(200)
-    expect(res.headers['access-control-allow-origin']).toBe('https://feat-redesign-tokens-sipher.vercel.app')
+    expect(res.headers['access-control-allow-origin']).toBe('https://sipher-96i1chii4-rectors-projects.vercel.app')
+  })
+
+  it('accepts a Vercel branch-deploy origin under the rectors-projects team', async () => {
+    const app = createApp('https://sipher.sip-protocol.org')
+    const res = await supertest(app)
+      .get('/test')
+      .set('Origin', 'https://sipher-git-feat-redesign-rectors-projects.vercel.app')
+    expect(res.status).toBe(200)
+    expect(res.headers['access-control-allow-origin']).toBe('https://sipher-git-feat-redesign-rectors-projects.vercel.app')
   })
 
   it('rejects an unrelated origin not in the allowlist and not a sipher preview', async () => {
@@ -39,11 +48,20 @@ describe('CORS allowlist', () => {
     expect(res.headers['access-control-allow-origin']).toBeUndefined()
   })
 
-  it('rejects a different Vercel project that is not *-sipher.vercel.app', async () => {
+  it('rejects a different Vercel project under any team', async () => {
     const app = createApp('https://sipher.sip-protocol.org')
     const res = await supertest(app)
       .get('/test')
-      .set('Origin', 'https://something-else.vercel.app')
+      .set('Origin', 'https://something-else-rectors-projects.vercel.app')
+    expect(res.status).toBe(200)
+    expect(res.headers['access-control-allow-origin']).toBeUndefined()
+  })
+
+  it('rejects a sipher-named project under a different team', async () => {
+    const app = createApp('https://sipher.sip-protocol.org')
+    const res = await supertest(app)
+      .get('/test')
+      .set('Origin', 'https://sipher-abc-attacker-team.vercel.app')
     expect(res.status).toBe(200)
     expect(res.headers['access-control-allow-origin']).toBeUndefined()
   })

--- a/packages/agent/tests/cors-origins.test.ts
+++ b/packages/agent/tests/cors-origins.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import express, { type Request, type Response } from 'express'
+import supertest from 'supertest'
+import { buildCorsMiddleware } from '../src/cors-config.js'
+
+function createApp(corsOriginsEnv: string) {
+  const app = express()
+  const middleware = buildCorsMiddleware(corsOriginsEnv)
+  if (middleware) app.use(middleware)
+  app.get('/test', (_req: Request, res: Response) => res.json({ ok: true }))
+  return app
+}
+
+describe('CORS allowlist', () => {
+  it('accepts a production origin in the explicit allowlist', async () => {
+    const app = createApp('https://sipher.sip-protocol.org')
+    const res = await supertest(app)
+      .get('/test')
+      .set('Origin', 'https://sipher.sip-protocol.org')
+    expect(res.status).toBe(200)
+    expect(res.headers['access-control-allow-origin']).toBe('https://sipher.sip-protocol.org')
+  })
+
+  it('accepts a Vercel preview origin matching *-sipher.vercel.app', async () => {
+    const app = createApp('https://sipher.sip-protocol.org')
+    const res = await supertest(app)
+      .get('/test')
+      .set('Origin', 'https://feat-redesign-tokens-sipher.vercel.app')
+    expect(res.status).toBe(200)
+    expect(res.headers['access-control-allow-origin']).toBe('https://feat-redesign-tokens-sipher.vercel.app')
+  })
+
+  it('rejects an unrelated origin not in the allowlist and not a sipher preview', async () => {
+    const app = createApp('https://sipher.sip-protocol.org')
+    const res = await supertest(app)
+      .get('/test')
+      .set('Origin', 'https://evil.example.com')
+    expect(res.status).toBe(200) // request still served; CORS headers simply absent
+    expect(res.headers['access-control-allow-origin']).toBeUndefined()
+  })
+
+  it('rejects a different Vercel project that is not *-sipher.vercel.app', async () => {
+    const app = createApp('https://sipher.sip-protocol.org')
+    const res = await supertest(app)
+      .get('/test')
+      .set('Origin', 'https://something-else.vercel.app')
+    expect(res.status).toBe(200)
+    expect(res.headers['access-control-allow-origin']).toBeUndefined()
+  })
+
+  it('passes requests with no Origin header (SSR / curl)', async () => {
+    const app = createApp('https://sipher.sip-protocol.org')
+    const res = await supertest(app).get('/test') // no Origin header
+    expect(res.status).toBe(200)
+    // No Origin on request → no ACAO header emitted (no-cors context)
+    expect(res.headers['access-control-allow-origin']).toBeUndefined()
+  })
+
+  it('returns no CORS middleware when corsOriginsEnv is empty', async () => {
+    const middleware = buildCorsMiddleware('')
+    expect(middleware).toBeNull()
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "cd app && pnpm install --frozen-lockfile && pnpm build",
+  "installCommand": "echo 'install handled in buildCommand'",
+  "outputDirectory": "app/dist",
+  "framework": null,
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" }
+      ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "cd app && pnpm install --frozen-lockfile && pnpm build",
+  "buildCommand": "pnpm install --frozen-lockfile --filter @sipher/app... && pnpm --filter @sipher/app build",
   "installCommand": "echo 'install handled in buildCommand'",
   "outputDirectory": "app/dist",
   "framework": null,


### PR DESCRIPTION
## Summary

PR 0 of the glass-neon redesign + Vercel FE migration sprint. Splits Sipher's FE deployment from the agent backend so each subsequent visual-sprint PR (PRs 1-9) auto-deploys a Vercel preview URL for review.

**Origin split:**
- `https://sipher.sip-protocol.org` → Vercel (FE, `rectors-projects/sipher`)
- `https://sipher-api.sip-protocol.org` → VPS (BE, `sipher` Docker container)

Spec: [`docs/superpowers/specs/2026-05-07-glass-neon-redesign-design.md`](docs/superpowers/specs/2026-05-07-glass-neon-redesign-design.md) · Plan: [`docs/superpowers/plans/2026-05-07-glass-neon-redesign.md`](docs/superpowers/plans/2026-05-07-glass-neon-redesign.md)

## Changes

- `vercel.json` + `.vercelignore` — Vite-only build via `pnpm --filter @sipher/app...`. Anchored ignore patterns at repo root so `app/src/` ships.
- `app/.env.production` + `app/.env.example` — `VITE_API_URL` now points at `sipher-api.sip-protocol.org`.
- `packages/agent/src/index.ts` — removed `app.use(express.static(webRoot))` (FE no longer served from agent); replaced inline CORS handler with `buildCorsMiddleware(corsOriginsEnv)`.
- `packages/agent/src/cors-config.ts` (NEW) — origin allowlist + Vercel preview regex `/^https:\/\/sipher-[a-z0-9-]+-rectors-projects\.vercel\.app$/`. Sets `Vary: Origin` unconditionally for shared-cache safety. `Access-Control-Max-Age: 86400` on OPTIONS.
- `packages/agent/tests/cors-origins.test.ts` (NEW) — 9 supertest cases covering production origin, real Vercel preview pattern, branch-deploy URL, rejection paths, OPTIONS preflight (allowed + rejected), Vary header, no-Origin passthrough, empty-env null return.
- `docker-compose.yml` — `CORS_ORIGINS` narrowed to `https://sipher.sip-protocol.org`. Preview pattern stays in code (no env churn for new branches).
- `README.md` + `docs/deployment.md` — every endpoint URL + Domains row + overview prose updated for the origin split. Deployment docs now describe Vercel + VPS dual deploy paths.
- `.gitignore` — `.vercel` directory excluded.

**Hostname rationale:** I started with `api.sipher.sip-protocol.org` per the original plan, but Cloudflare's free Universal SSL wildcard (`*.sip-protocol.org`) only covers single-level subdomains. Two-level-deep hostnames need Advanced Certificate Manager (paid). Pivoted to `sipher-api.sip-protocol.org` — same naming intent, slides under the free wildcard.

## Acceptance criteria

| Criterion | Status |
|---|---|
| `https://sipher.sip-protocol.org` resolves to Vercel | ✅ `server: Vercel`, `x-vercel-id` header confirmed |
| `https://sipher-api.sip-protocol.org` resolves to VPS | ✅ `/api/health` returns full agent status |
| Cross-origin auth surface preserved | ✅ /api/auth/nonce POST returns SIWS message keyed to `sipher.sip-protocol.org` |
| FE bundle uses sipher-api URL | ✅ grepped bundled JS for `https://sipher-api.sip-protocol.org` |
| CORS preflight from prod origin | ✅ all 4 ACA* headers + Vary: Origin echoed |
| Backend CI green | ✅ tsc / lint / root + agent tests all clean |
| 1348 agent tests | ✅ +9 new (cors-origins) over baseline 1339 |
| 555 root tests | ✅ no regressions |

## Tested against (autonomous)

| Wallet | Connect | SIWS one-popup | JWT refresh | Disconnect | Status |
|---|---|---|---|---|---|
| (no wallet) | n/a | n/a | n/a | n/a | Auth surface code unchanged from PR #176 |
| Cross-origin GET | ✅ | n/a | n/a | n/a | /api/health, /api/config, /v1/demo all 200 |
| Cross-origin POST | ✅ | n/a | n/a | n/a | /api/auth/nonce 200, /api/pay/.../confirm 401 (auth gate) |

> RECTOR to verify Phantom/Solflare/Jupiter wallet sign-in interactively before merging. Auth code paths are unchanged in this PR — only the URL split. The CORS contract was the only audit-relevant surface and is verified end-to-end.

## Rollback

| Failure | Response |
|---|---|
| FE breaks (white screen) | Vercel dashboard → Deployments → "Promote previous deployment" (≤60s) |
| Backend breaks | VPS: `cd ~/sipher && IMAGE_TAG=<previous-sha> docker compose up -d api` |
| DNS revert | Cloudflare API: delete `sipher` CNAME, recreate as A→151.245.137.75 proxied=true; remove `sipher-api` A record (TTL=60s rollback window) |
| CORS broken on previews | Add explicit origin to `CORS_ORIGINS` env on VPS; preview regex is in code |

## Test plan

- [x] `pnpm test -- --run` (root) — 555 tests passing
- [x] `pnpm test -- --run` (packages/agent) — 1348 tests passing (+9 cors-origins)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm build` (app/) — clean
- [x] DNS cut + Vercel SSL provisioned for sipher.sip-protocol.org
- [x] Cloudflare Origin CA cert provisioned for sipher-api.sip-protocol.org
- [x] VPS nginx serves sipher-api; old sipher.sip-protocol.org config removed
- [x] Cross-origin smoke test from sipher.sip-protocol.org against sipher-api.sip-protocol.org (3 endpoints)
- [ ] Wallet sign-in interactive test (Phantom/Solflare/Jupiter) — RECTOR pre-merge

## What this unlocks

PRs 1-9 of the glass-neon redesign sprint can now ship — each pushed branch auto-deploys a Vercel preview at `sipher-<branch>-rectors-projects.vercel.app` for RECTOR review. Backend changes continue to deploy via the existing GitHub Actions → GHCR → VPS pipeline.