### PR TITLE
feat(redesign): theme tokens + ui/* primitives (foundation)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -6,7 +6,6 @@ import {
   SolflareWalletAdapter,
 } from '@solana/wallet-adapter-wallets'
 import '@solana/wallet-adapter-react-ui/styles.css'
-import './styles/theme.css'
 
 import Header from './components/Header'
 import BottomNav from './components/BottomNav'

--- a/app/src/components/ui/Card.tsx
+++ b/app/src/components/ui/Card.tsx
@@ -1,0 +1,26 @@
+import { ReactNode, HTMLAttributes } from 'react'
+
+type CardVariant = 'default' | 'elevated' | 'strong'
+
+interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode
+  variant?: CardVariant
+  sheen?: boolean
+}
+
+const VARIANT_CLASS: Record<CardVariant, string> = {
+  default: 'glass-1',
+  elevated: 'glass-2',
+  strong: 'glass-strong',
+}
+
+export function Card({ children, variant = 'default', sheen = false, className = '', ...rest }: CardProps) {
+  const classes = [VARIANT_CLASS[variant], sheen ? 'glass-sheen' : '', className]
+    .filter(Boolean)
+    .join(' ')
+  return (
+    <div className={classes} {...rest}>
+      {children}
+    </div>
+  )
+}

--- a/app/src/components/ui/HashCell.tsx
+++ b/app/src/components/ui/HashCell.tsx
@@ -11,15 +11,25 @@ function truncate(hash: string, head: number, tail: number): string {
   return `${hash.slice(0, head)}…${hash.slice(-tail)}`
 }
 
-export function HashCell({ hash, headChars = 4, tailChars = 4, className = '', ...rest }: HashCellProps) {
+export function HashCell({
+  hash,
+  headChars = 4,
+  tailChars = 4,
+  className = '',
+  'aria-label': ariaLabel,
+  ...rest
+}: HashCellProps) {
   const display = truncate(hash, headChars, tailChars)
   const handleCopy = () => {
-    navigator.clipboard?.writeText(hash).catch(() => { /* clipboard denied — silent */ })
+    navigator.clipboard?.writeText(hash).catch((err) => {
+      console.warn('[HashCell] clipboard write failed', err)
+    })
   }
   return (
     <button
       type="button"
       title={hash}
+      aria-label={ariaLabel ?? `Copy ${hash}`}
       onClick={handleCopy}
       className={`inline-flex items-center font-mono text-xs text-text-secondary hover:text-text transition-colors ${className}`}
       {...rest}

--- a/app/src/components/ui/HashCell.tsx
+++ b/app/src/components/ui/HashCell.tsx
@@ -1,0 +1,30 @@
+import { ButtonHTMLAttributes } from 'react'
+
+interface HashCellProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'type' | 'title'> {
+  hash: string
+  headChars?: number
+  tailChars?: number
+}
+
+function truncate(hash: string, head: number, tail: number): string {
+  if (hash.length <= head + tail) return hash
+  return `${hash.slice(0, head)}…${hash.slice(-tail)}`
+}
+
+export function HashCell({ hash, headChars = 4, tailChars = 4, className = '', ...rest }: HashCellProps) {
+  const display = truncate(hash, headChars, tailChars)
+  const handleCopy = () => {
+    navigator.clipboard?.writeText(hash).catch(() => { /* clipboard denied — silent */ })
+  }
+  return (
+    <button
+      type="button"
+      title={hash}
+      onClick={handleCopy}
+      className={`inline-flex items-center font-mono text-xs text-text-secondary hover:text-text transition-colors ${className}`}
+      {...rest}
+    >
+      {display}
+    </button>
+  )
+}

--- a/app/src/components/ui/MetricBar.tsx
+++ b/app/src/components/ui/MetricBar.tsx
@@ -1,0 +1,38 @@
+interface MetricBarProps {
+  label: string
+  value: number
+  helper?: string
+  max?: number
+  className?: string
+}
+
+export function MetricBar({ label, value, helper, max = 100, className = '' }: MetricBarProps) {
+  const clamped = Math.min(Math.max(value, 0), max)
+  const pct = (clamped / max) * 100
+  return (
+    <div className={`flex flex-col gap-1.5 ${className}`}>
+      <div className="flex items-baseline justify-between">
+        <span className="text-base text-text">{label}</span>
+        <span className="text-base font-mono text-text">{value}</span>
+      </div>
+      <div
+        role="progressbar"
+        aria-label={label}
+        aria-valuenow={clamped}
+        aria-valuemin={0}
+        aria-valuemax={max}
+        className="h-px bg-line rounded-pill overflow-hidden"
+      >
+        <div
+          data-testid="metric-bar-fill"
+          className="h-full rounded-pill transition-[width] duration-base ease-out"
+          style={{
+            width: `${pct}%`,
+            background: 'var(--gradient-progress)',
+          }}
+        />
+      </div>
+      {helper && <span className="text-2xs text-text-muted">{helper}</span>}
+    </div>
+  )
+}

--- a/app/src/components/ui/Pill.tsx
+++ b/app/src/components/ui/Pill.tsx
@@ -1,0 +1,24 @@
+import { ButtonHTMLAttributes } from 'react'
+
+interface PillProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'type'> {
+  label: string
+  active?: boolean
+  size?: 'sm' | 'md'
+}
+
+export function Pill({ label, active = false, size = 'md', className = '', ...rest }: PillProps) {
+  const sizeClass = size === 'sm' ? 'text-2xs px-2 py-0.5' : 'text-xs px-2.5 py-1'
+  const stateClass = active
+    ? 'bg-accent-soft text-text border-line-accent'
+    : 'bg-transparent text-text-muted border-line hover:text-text-secondary hover:border-line-2'
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      className={`inline-flex items-center justify-center gap-1.5 border rounded-pill font-medium tracking-wide uppercase transition-colors ${sizeClass} ${stateClass} ${className}`}
+      {...rest}
+    >
+      {label}
+    </button>
+  )
+}

--- a/app/src/components/ui/Sheet.tsx
+++ b/app/src/components/ui/Sheet.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect } from 'react'
+import { ReactNode, useEffect, useRef } from 'react'
 
 interface SheetProps {
   open: boolean
@@ -8,13 +8,21 @@ interface SheetProps {
 }
 
 export function Sheet({ open, onClose, children, ariaLabel = 'Sheet' }: SheetProps) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
     }
     document.addEventListener('keydown', onKey)
-    return () => document.removeEventListener('keydown', onKey)
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    dialogRef.current?.focus()
+    return () => {
+      document.removeEventListener('keydown', onKey)
+      document.body.style.overflow = previousOverflow
+    }
   }, [open, onClose])
 
   if (!open) return null
@@ -25,13 +33,14 @@ export function Sheet({ open, onClose, children, ariaLabel = 'Sheet' }: SheetPro
         data-testid="sheet-backdrop"
         onClick={onClose}
         className="fixed inset-0 bg-black/40 backdrop-blur-sm z-overlay"
-        style={{ animation: 'pulse-bloom var(--duration-bloom) ease-in-out infinite' }}
       />
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-label={ariaLabel}
-        className="fixed top-0 right-0 h-full w-full max-w-[420px] z-modal glass-strong overflow-y-auto"
+        tabIndex={-1}
+        className="fixed top-0 right-0 h-full w-full max-w-[420px] z-modal glass-strong overflow-y-auto outline-none"
         style={{
           animation: 'drawer-slide-in var(--duration-slow) var(--ease-out-expo) both',
         }}

--- a/app/src/components/ui/Sheet.tsx
+++ b/app/src/components/ui/Sheet.tsx
@@ -1,0 +1,43 @@
+import { ReactNode, useEffect } from 'react'
+
+interface SheetProps {
+  open: boolean
+  onClose: () => void
+  children: ReactNode
+  ariaLabel?: string
+}
+
+export function Sheet({ open, onClose, children, ariaLabel = 'Sheet' }: SheetProps) {
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <>
+      <div
+        data-testid="sheet-backdrop"
+        onClick={onClose}
+        className="fixed inset-0 bg-black/40 backdrop-blur-sm z-overlay"
+        style={{ animation: 'pulse-bloom var(--duration-bloom) ease-in-out infinite' }}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={ariaLabel}
+        className="fixed top-0 right-0 h-full w-full max-w-[420px] z-modal glass-strong overflow-y-auto"
+        style={{
+          animation: 'drawer-slide-in var(--duration-slow) var(--ease-out-expo) both',
+        }}
+      >
+        {children}
+      </div>
+    </>
+  )
+}

--- a/app/src/components/ui/__tests__/Card.test.tsx
+++ b/app/src/components/ui/__tests__/Card.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Card } from '../Card'
+
+describe('Card', () => {
+  it('renders children', () => {
+    render(<Card><span>hello</span></Card>)
+    expect(screen.getByText('hello')).toBeInTheDocument()
+  })
+
+  it('applies glass-1 class by default', () => {
+    const { container } = render(<Card>x</Card>)
+    expect(container.firstChild).toHaveClass('glass-1')
+  })
+
+  it('applies glass-2 class when variant=elevated', () => {
+    const { container } = render(<Card variant="elevated">x</Card>)
+    expect(container.firstChild).toHaveClass('glass-2')
+    expect(container.firstChild).not.toHaveClass('glass-1')
+  })
+
+  it('applies glass-strong class when variant=strong', () => {
+    const { container } = render(<Card variant="strong">x</Card>)
+    expect(container.firstChild).toHaveClass('glass-strong')
+  })
+
+  it('adds glass-sheen class when sheen=true', () => {
+    const { container } = render(<Card sheen>x</Card>)
+    expect(container.firstChild).toHaveClass('glass-sheen')
+  })
+
+  it('forwards className', () => {
+    const { container } = render(<Card className="extra">x</Card>)
+    expect(container.firstChild).toHaveClass('glass-1')
+    expect(container.firstChild).toHaveClass('extra')
+  })
+})

--- a/app/src/components/ui/__tests__/HashCell.test.tsx
+++ b/app/src/components/ui/__tests__/HashCell.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { HashCell } from '../HashCell'
+
+describe('HashCell', () => {
+  it('truncates a long hash to first4...last4 by default', () => {
+    render(<HashCell hash="0x1234567890abcdef1234567890abcdef" />)
+    expect(screen.getByText('0x12…cdef')).toBeInTheDocument()
+  })
+
+  it('respects a custom truncate length', () => {
+    render(<HashCell hash="0x1234567890abcdef1234567890abcdef" headChars={6} tailChars={6} />)
+    expect(screen.getByText('0x1234…abcdef')).toBeInTheDocument()
+  })
+
+  it('shows full hash when shorter than truncate boundary', () => {
+    render(<HashCell hash="0x1234" />)
+    expect(screen.getByText('0x1234')).toBeInTheDocument()
+  })
+
+  it('copies to clipboard on click', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    render(<HashCell hash="0xabcdef" />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(writeText).toHaveBeenCalledWith('0xabcdef')
+  })
+
+  it('exposes the full hash via title attribute', () => {
+    render(<HashCell hash="0xabcdef1234567890" />)
+    expect(screen.getByRole('button')).toHaveAttribute('title', '0xabcdef1234567890')
+  })
+})

--- a/app/src/components/ui/__tests__/HashCell.test.tsx
+++ b/app/src/components/ui/__tests__/HashCell.test.tsx
@@ -1,8 +1,23 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { HashCell } from '../HashCell'
 
 describe('HashCell', () => {
+  let writeText: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    })
+  })
+
+  afterEach(() => {
+    Reflect.deleteProperty(navigator, 'clipboard')
+  })
+
   it('truncates a long hash to first4...last4 by default', () => {
     render(<HashCell hash="0x1234567890abcdef1234567890abcdef" />)
     expect(screen.getByText('0x12…cdef')).toBeInTheDocument()
@@ -19,8 +34,6 @@ describe('HashCell', () => {
   })
 
   it('copies to clipboard on click', () => {
-    const writeText = vi.fn().mockResolvedValue(undefined)
-    Object.assign(navigator, { clipboard: { writeText } })
     render(<HashCell hash="0xabcdef" />)
     fireEvent.click(screen.getByRole('button'))
     expect(writeText).toHaveBeenCalledWith('0xabcdef')
@@ -29,5 +42,25 @@ describe('HashCell', () => {
   it('exposes the full hash via title attribute', () => {
     render(<HashCell hash="0xabcdef1234567890" />)
     expect(screen.getByRole('button')).toHaveAttribute('title', '0xabcdef1234567890')
+  })
+
+  it('exposes a default copy aria-label for screen readers', () => {
+    render(<HashCell hash="0xabcdef1234567890" />)
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Copy 0xabcdef1234567890')
+  })
+
+  it('lets caller override aria-label', () => {
+    render(<HashCell hash="0xabcdef" aria-label="Stealth address" />)
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Stealth address')
+  })
+
+  it('warns to console on clipboard write failure (does not throw)', async () => {
+    writeText.mockRejectedValueOnce(new Error('denied'))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    render(<HashCell hash="0xff" />)
+    fireEvent.click(screen.getByRole('button'))
+    await Promise.resolve()
+    expect(warn).toHaveBeenCalledWith('[HashCell] clipboard write failed', expect.any(Error))
+    warn.mockRestore()
   })
 })

--- a/app/src/components/ui/__tests__/MetricBar.test.tsx
+++ b/app/src/components/ui/__tests__/MetricBar.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MetricBar } from '../MetricBar'
+
+describe('MetricBar', () => {
+  it('renders label + value', () => {
+    render(<MetricBar label="Anonymity set" value={84} />)
+    expect(screen.getByText('Anonymity set')).toBeInTheDocument()
+    expect(screen.getByText('84')).toBeInTheDocument()
+  })
+
+  it('renders helper text below the bar', () => {
+    render(<MetricBar label="Time decay" value={91} helper="Avg dwell 6d 12h" />)
+    expect(screen.getByText('Avg dwell 6d 12h')).toBeInTheDocument()
+  })
+
+  it('clamps values above 100 to 100% width', () => {
+    const { container } = render(<MetricBar label="x" value={150} />)
+    const fill = container.querySelector('[data-testid="metric-bar-fill"]') as HTMLElement
+    expect(fill.style.width).toBe('100%')
+  })
+
+  it('clamps negative values to 0%', () => {
+    const { container } = render(<MetricBar label="x" value={-10} />)
+    const fill = container.querySelector('[data-testid="metric-bar-fill"]') as HTMLElement
+    expect(fill.style.width).toBe('0%')
+  })
+
+  it('uses ARIA progressbar role with proper attrs', () => {
+    render(<MetricBar label="x" value={50} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '50')
+    expect(bar).toHaveAttribute('aria-valuemin', '0')
+    expect(bar).toHaveAttribute('aria-valuemax', '100')
+    expect(bar).toHaveAttribute('aria-label', 'x')
+  })
+})

--- a/app/src/components/ui/__tests__/Pill.test.tsx
+++ b/app/src/components/ui/__tests__/Pill.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Pill } from '../Pill'
+
+describe('Pill', () => {
+  it('renders label', () => {
+    render(<Pill label="ALL" />)
+    expect(screen.getByText('ALL')).toBeInTheDocument()
+  })
+
+  it('shows active state via aria-pressed=true', () => {
+    render(<Pill label="DEPOSIT" active />)
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('shows inactive via aria-pressed=false by default', () => {
+    render(<Pill label="WITHDRAW" />)
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('calls onClick when clicked', () => {
+    let called = false
+    render(<Pill label="X" onClick={() => { called = true }} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(called).toBe(true)
+  })
+
+  it('applies size=sm class', () => {
+    const { container } = render(<Pill label="X" size="sm" />)
+    expect(container.firstChild).toHaveClass('text-2xs')
+  })
+
+  it('applies size=md (default) class', () => {
+    const { container } = render(<Pill label="X" />)
+    expect(container.firstChild).toHaveClass('text-xs')
+  })
+})

--- a/app/src/components/ui/__tests__/Sheet.test.tsx
+++ b/app/src/components/ui/__tests__/Sheet.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Sheet } from '../Sheet'
+
+describe('Sheet', () => {
+  it('renders children when open', () => {
+    render(<Sheet open onClose={() => {}}><span>chat content</span></Sheet>)
+    expect(screen.getByText('chat content')).toBeInTheDocument()
+  })
+
+  it('does not render children when closed', () => {
+    render(<Sheet open={false} onClose={() => {}}><span>chat content</span></Sheet>)
+    expect(screen.queryByText('chat content')).not.toBeInTheDocument()
+  })
+
+  it('calls onClose when backdrop clicked', () => {
+    const onClose = vi.fn()
+    render(<Sheet open onClose={onClose}><span>x</span></Sheet>)
+    fireEvent.click(screen.getByTestId('sheet-backdrop'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('calls onClose when Escape key pressed', () => {
+    const onClose = vi.fn()
+    render(<Sheet open onClose={onClose}><span>x</span></Sheet>)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('uses dialog role with aria-modal=true', () => {
+    render(<Sheet open onClose={() => {}}><span>x</span></Sheet>)
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true')
+  })
+
+  it('exposes a label via aria-label', () => {
+    render(<Sheet open onClose={() => {}} ariaLabel="Ask SIPHER"><span>x</span></Sheet>)
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-label', 'Ask SIPHER')
+  })
+})

--- a/app/src/components/ui/__tests__/Sheet.test.tsx
+++ b/app/src/components/ui/__tests__/Sheet.test.tsx
@@ -1,8 +1,12 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { Sheet } from '../Sheet'
 
 describe('Sheet', () => {
+  beforeEach(() => {
+    document.body.style.overflow = ''
+  })
+
   it('renders children when open', () => {
     render(<Sheet open onClose={() => {}}><span>chat content</span></Sheet>)
     expect(screen.getByText('chat content')).toBeInTheDocument()
@@ -27,6 +31,13 @@ describe('Sheet', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
+  it('does not register Escape listener when closed', () => {
+    const onClose = vi.fn()
+    render(<Sheet open={false} onClose={onClose}><span>x</span></Sheet>)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
   it('uses dialog role with aria-modal=true', () => {
     render(<Sheet open onClose={() => {}}><span>x</span></Sheet>)
     expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true')
@@ -35,5 +46,17 @@ describe('Sheet', () => {
   it('exposes a label via aria-label', () => {
     render(<Sheet open onClose={() => {}} ariaLabel="Ask SIPHER"><span>x</span></Sheet>)
     expect(screen.getByRole('dialog')).toHaveAttribute('aria-label', 'Ask SIPHER')
+  })
+
+  it('locks body scroll when open and restores it on unmount', () => {
+    const { unmount } = render(<Sheet open onClose={() => {}}><span>x</span></Sheet>)
+    expect(document.body.style.overflow).toBe('hidden')
+    unmount()
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('focuses the dialog on open', () => {
+    render(<Sheet open onClose={() => {}}><span>x</span></Sheet>)
+    expect(document.activeElement).toBe(screen.getByRole('dialog'))
   })
 })

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
+import './styles/theme.css'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/app/src/styles/animations.css
+++ b/app/src/styles/animations.css
@@ -1,0 +1,27 @@
+@keyframes pulse-bloom {
+  0%, 100% { opacity: 0.8; }
+  50% { opacity: 1; }
+}
+
+@keyframes shimmer {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+
+@keyframes gauge-fill {
+  0% { stroke-dashoffset: 100%; }
+  100% { stroke-dashoffset: var(--target-offset); }
+}
+
+@keyframes drawer-slide-in {
+  0% { transform: translateX(100%); }
+  100% { transform: translateX(0); }
+}
+
+.animate-pulse-bloom {
+  animation: pulse-bloom var(--duration-pulse) var(--ease-in-out) infinite;
+}
+
+.animate-shimmer {
+  animation: shimmer var(--duration-bloom) var(--ease-linear) infinite;
+}

--- a/app/src/styles/glass.css
+++ b/app/src/styles/glass.css
@@ -1,0 +1,43 @@
+.glass-1 {
+  background: var(--color-glass-1);
+  backdrop-filter: var(--backdrop-glass);
+  -webkit-backdrop-filter: var(--backdrop-glass);
+  border: 1px solid var(--color-line);
+  border-radius: var(--radius-lg);
+}
+
+.glass-2 {
+  background: var(--color-glass-2);
+  backdrop-filter: var(--backdrop-glass-dense);
+  -webkit-backdrop-filter: var(--backdrop-glass-dense);
+  border: 1px solid var(--color-line-2);
+  border-radius: var(--radius-lg);
+}
+
+.glass-strong {
+  background: var(--color-glass-strong);
+  backdrop-filter: var(--backdrop-glass-modal);
+  -webkit-backdrop-filter: var(--backdrop-glass-modal);
+  border: 1px solid var(--color-line-strong);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-xl);
+}
+
+.glass-sheen {
+  position: relative;
+}
+
+.glass-sheen::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--gradient-card-sheen);
+  border-radius: inherit;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.glass-sheen > * {
+  position: relative;
+  z-index: 1;
+}

--- a/app/src/styles/theme.css
+++ b/app/src/styles/theme.css
@@ -114,10 +114,14 @@
   --shadow-glow-focus-ring: var(--glow-focus-ring);
   --shadow-glow-focus-ring-cyan: var(--glow-focus-ring-cyan);
 
-  /* Animation */
+  /* Animation — easings */
   --ease-spring: var(--ease-spring);
   --ease-out-expo: var(--ease-out-expo);
   --ease-out-back: var(--ease-out-back);
+
+  /* Tailwind 4 native @theme namespaces stop here.
+     z-index and transition-duration utilities are NOT in the recognized
+     `--{namespace}-*` set, so they are declared via @utility further below. */
 
   /* Legacy aliases — preserved verbatim for zero visual regression in PR 1.
      Existing components reference bg-card / bg-elevated / border-border /
@@ -166,3 +170,20 @@ body {
     animation-iteration-count: 1 !important;
   }
 }
+
+/* Custom utilities for design-system tokens that Tailwind 4 does not map
+   natively from @theme. Each emits exactly when the class is referenced
+   in source, same scanning model as built-in utilities. */
+@utility z-base { z-index: var(--z-base); }
+@utility z-raised { z-index: var(--z-raised); }
+@utility z-sticky { z-index: var(--z-sticky); }
+@utility z-overlay { z-index: var(--z-overlay); }
+@utility z-modal { z-index: var(--z-modal); }
+@utility z-toast { z-index: var(--z-toast); }
+@utility z-tooltip { z-index: var(--z-tooltip); }
+
+@utility duration-instant { transition-duration: var(--duration-instant); }
+@utility duration-fast { transition-duration: var(--duration-fast); }
+@utility duration-base { transition-duration: var(--duration-base); }
+@utility duration-slow { transition-duration: var(--duration-slow); }
+@utility duration-slower { transition-duration: var(--duration-slower); }

--- a/app/src/styles/theme.css
+++ b/app/src/styles/theme.css
@@ -1,45 +1,168 @@
 @import 'tailwindcss';
+@import './tokens.css';
+@import './glass.css';
+@import './animations.css';
 
 @theme {
-  /* Backgrounds */
-  --color-bg: #111113;
+  /* Color — backgrounds */
+  --color-bg: var(--color-bg);
+  --color-bg-1: var(--color-bg-1);
+  --color-bg-2: var(--color-bg-2);
+  --color-bg-3: var(--color-bg-3);
+  --color-bg-4: var(--color-bg-4);
+
+  /* Color — surfaces */
+  --color-glass-1: var(--color-glass-1);
+  --color-glass-2: var(--color-glass-2);
+  --color-glass-3: var(--color-glass-3);
+  --color-glass-strong: var(--color-glass-strong);
+
+  /* Color — hairlines */
+  --color-line: var(--color-line);
+  --color-line-2: var(--color-line-2);
+  --color-line-strong: var(--color-line-strong);
+  --color-line-accent: var(--color-line-accent);
+
+  /* Color — text */
+  --color-text: var(--color-text);
+  --color-text-secondary: var(--color-text-secondary);
+  --color-text-muted: var(--color-text-muted);
+  --color-text-dim: var(--color-text-dim);
+  --color-text-inverse: var(--color-text-inverse);
+
+  /* Color — brand */
+  --color-accent: var(--color-accent);
+  --color-accent-hi: var(--color-accent-hi);
+  --color-accent-lo: var(--color-accent-lo);
+  --color-accent-soft: var(--color-accent-soft);
+  --color-accent-glow: var(--color-accent-glow);
+  --color-cyan: var(--color-cyan);
+  --color-cyan-hi: var(--color-cyan-hi);
+  --color-cyan-lo: var(--color-cyan-lo);
+  --color-cyan-soft: var(--color-cyan-soft);
+  --color-cyan-glow: var(--color-cyan-glow);
+
+  /* Color — status */
+  --color-success: var(--color-success);
+  --color-success-soft: var(--color-success-soft);
+  --color-warning: var(--color-warning);
+  --color-warning-soft: var(--color-warning-soft);
+  --color-danger: var(--color-danger);
+  --color-danger-soft: var(--color-danger-soft);
+  --color-info: var(--color-info);
+  --color-info-soft: var(--color-info-soft);
+
+  /* Color — agent identity */
+  --color-sipher: var(--color-sipher);
+  --color-herald: var(--color-herald);
+  --color-sentinel: var(--color-sentinel);
+  --color-courier: var(--color-courier);
+
+  /* Typography */
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-mono);
+  --font-display: var(--font-display);
+  --text-2xs: var(--text-2xs);
+  --text-xs: var(--text-xs);
+  --text-sm: var(--text-sm);
+  --text-base: var(--text-base);
+  --text-md: var(--text-md);
+  --text-lg: var(--text-lg);
+  --text-xl: var(--text-xl);
+  --text-2xl: var(--text-2xl);
+  --text-3xl: var(--text-3xl);
+  --text-4xl: var(--text-4xl);
+  --text-5xl: var(--text-5xl);
+  --text-6xl: var(--text-6xl);
+  --tracking-tight: var(--tracking-tight);
+  --tracking-normal: var(--tracking-normal);
+  --tracking-wide: var(--tracking-wide);
+  --tracking-wider: var(--tracking-wider);
+  --tracking-widest: var(--tracking-widest);
+  --tracking-mega: var(--tracking-mega);
+  --leading-none: var(--leading-none);
+  --leading-tight: var(--leading-tight);
+  --leading-snug: var(--leading-snug);
+  --leading-normal: var(--leading-normal);
+  --leading-relaxed: var(--leading-relaxed);
+
+  /* Radius */
+  --radius-xs: var(--radius-xs);
+  --radius-sm: var(--radius-sm);
+  --radius-md: var(--radius-md);
+  --radius-lg: var(--radius-lg);
+  --radius-xl: var(--radius-xl);
+  --radius-2xl: var(--radius-2xl);
+  --radius-3xl: var(--radius-3xl);
+  --radius-pill: var(--radius-pill);
+  --radius-full: var(--radius-full);
+
+  /* Shadow + glow */
+  --shadow-xs: var(--shadow-xs);
+  --shadow-sm: var(--shadow-sm);
+  --shadow-md: var(--shadow-md);
+  --shadow-lg: var(--shadow-lg);
+  --shadow-xl: var(--shadow-xl);
+  --shadow-2xl: var(--shadow-2xl);
+  --shadow-glow-accent-sm: var(--glow-accent-sm);
+  --shadow-glow-accent-md: var(--glow-accent-md);
+  --shadow-glow-accent-lg: var(--glow-accent-lg);
+  --shadow-glow-cyan-md: var(--glow-cyan-md);
+  --shadow-glow-success: var(--glow-success);
+  --shadow-glow-warning: var(--glow-warning);
+  --shadow-glow-danger: var(--glow-danger);
+  --shadow-glow-focus-ring: var(--glow-focus-ring);
+  --shadow-glow-focus-ring-cyan: var(--glow-focus-ring-cyan);
+
+  /* Animation */
+  --ease-spring: var(--ease-spring);
+  --ease-out-expo: var(--ease-out-expo);
+  --ease-out-back: var(--ease-out-back);
+
+  /* Legacy aliases — preserved verbatim for zero visual regression in PR 1.
+     Existing components reference bg-card / bg-elevated / border-border /
+     bg-green / bg-red / bg-yellow utilities derived from these tokens.
+     Each restyle PR (PR 2-8) migrates its components to the new naming
+     (bg-bg-2 / bg-bg-3 / border-line / bg-success / bg-danger / bg-warning).
+     Once all callers migrate, this block disappears. */
   --color-card: #161618;
   --color-elevated: #1E1E22;
   --color-border: #232326;
-
-  /* Text hierarchy */
-  --color-text: #E4E4E7;
-  --color-text-secondary: #A1A1AA;
-  --color-text-muted: #71717A;
-  --color-text-dim: #52525B;
-
-  /* Brand */
-  --color-accent: #7C3AED;
-
-  /* Status */
   --color-green: #22C55E;
-  --color-yellow: #F59E0B;
   --color-red: #EF4444;
+  --color-yellow: #F59E0B;
+}
 
-  /* Agent identity */
-  --color-sipher: #10B981;
-  --color-herald: #3B82F6;
-  --color-sentinel: #F59E0B;
-  --color-courier: #8B5CF6;
-
-  --radius-lg: 8px;
+/* Base resets */
+:root {
+  color-scheme: dark;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
 }
 
 body {
-  background-color: var(--color-bg);
-  color: var(--color-text);
-  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
-  margin: 0;
-  min-height: 100dvh;
+  background: var(--color-bg);
+  background-image: var(--gradient-bloom);
+  background-attachment: fixed;
+  min-height: 100vh;
   -webkit-font-smoothing: antialiased;
+  margin: 0;
   overscroll-behavior-y: none;
 }
 
-.font-mono {
-  font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', monospace;
+*:focus-visible {
+  outline: none;
+  box-shadow: var(--glow-focus-ring);
+  border-radius: var(--radius-sm);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
 }

--- a/app/src/styles/tokens.css
+++ b/app/src/styles/tokens.css
@@ -1,0 +1,301 @@
+:root {
+  /* ──────────────────────────────────────────────────────────────
+     COLOR — BACKGROUND LAYERS
+     Stacked from furthest (page) to nearest (raised surface).
+     ────────────────────────────────────────────────────────────── */
+  --color-bg:               #0A0A0F;   /* page — near-black with violet bias */
+  --color-bg-1:             #111118;   /* base panels, sticky chrome */
+  --color-bg-2:             #161620;   /* card resting */
+  --color-bg-3:             #1C1C28;   /* card hover, raised */
+  --color-bg-4:             #232334;   /* popovers, command palette */
+
+  /* SURFACE — translucent (sit on top of bg w/ backdrop-blur) */
+  --color-glass-1:          rgba(255, 255, 255, 0.025);
+  --color-glass-2:          rgba(255, 255, 255, 0.045);
+  --color-glass-3:          rgba(255, 255, 255, 0.075);
+  --color-glass-strong:     rgba(255, 255, 255, 0.12);
+
+  /* HAIRLINES */
+  --color-line:             rgba(255, 255, 255, 0.06);
+  --color-line-2:           rgba(255, 255, 255, 0.10);
+  --color-line-strong:      rgba(255, 255, 255, 0.16);
+  --color-line-accent:      rgba(124, 58, 237, 0.35);
+
+  /* ──────────────────────────────────────────────────────────────
+     COLOR — TEXT HIERARCHY
+     ────────────────────────────────────────────────────────────── */
+  --color-text:             #F4F4F8;   /* primary */
+  --color-text-secondary:   #B4B4C2;   /* body secondary */
+  --color-text-muted:       #7A7A8C;   /* labels, helper */
+  --color-text-dim:         #4F4F60;   /* dividers in text, captions */
+  --color-text-inverse:     #0A0A0F;   /* on accent fills */
+
+  /* ──────────────────────────────────────────────────────────────
+     COLOR — BRAND ACCENTS
+     Primary = neon violet. Secondary = electric cyan.
+     ────────────────────────────────────────────────────────────── */
+  --color-accent:           #7C3AED;   /* violet 600 — primary brand */
+  --color-accent-hi:        #A78BFA;   /* violet 400 — hover, focus */
+  --color-accent-lo:        #5B21B6;   /* violet 800 — pressed */
+  --color-accent-soft:      rgba(124, 58, 237, 0.18);
+  --color-accent-glow:      rgba(124, 58, 237, 0.55);
+
+  --color-cyan:             #22D3EE;   /* cyan 400 — secondary brand */
+  --color-cyan-hi:          #67E8F9;   /* cyan 300 */
+  --color-cyan-lo:          #0891B2;   /* cyan 600 */
+  --color-cyan-soft:        rgba(34, 211, 238, 0.18);
+  --color-cyan-glow:        rgba(34, 211, 238, 0.50);
+
+  /* ──────────────────────────────────────────────────────────────
+     COLOR — STATUS
+     ────────────────────────────────────────────────────────────── */
+  --color-success:          #22C55E;
+  --color-success-soft:     rgba(34, 197, 94, 0.16);
+  --color-success-glow:     rgba(34, 197, 94, 0.45);
+
+  --color-warning:          #F59E0B;
+  --color-warning-soft:     rgba(245, 158, 11, 0.16);
+  --color-warning-glow:     rgba(245, 158, 11, 0.45);
+
+  --color-danger:           #EF4444;
+  --color-danger-soft:      rgba(239, 68, 68, 0.16);
+  --color-danger-glow:      rgba(239, 68, 68, 0.45);
+
+  --color-info:             #3B82F6;
+  --color-info-soft:        rgba(59, 130, 246, 0.16);
+  --color-info-glow:        rgba(59, 130, 246, 0.45);
+
+  /* ──────────────────────────────────────────────────────────────
+     COLOR — AGENT IDENTITY
+     ────────────────────────────────────────────────────────────── */
+  --color-sipher:           #10B981;   /* lead — emerald */
+  --color-herald:           #3B82F6;   /* x agent — blue */
+  --color-sentinel:         #F59E0B;   /* monitor — amber */
+  --color-courier:          #8B5CF6;   /* executor — violet */
+
+  /* ──────────────────────────────────────────────────────────────
+     COLOR — PRIVACY GRADE
+     A→F gradient, used by gauge + score factor bars.
+     ────────────────────────────────────────────────────────────── */
+  --color-grade-a:          #22C55E;
+  --color-grade-b:          #84CC16;
+  --color-grade-c:          #FACC15;
+  --color-grade-d:          #FB923C;
+  --color-grade-f:          #EF4444;
+
+  /* ──────────────────────────────────────────────────────────────
+     GRADIENTS
+     Cyan→Violet is the signature. Use linear for fills, conic for
+     gauges, radial for ambient bloom.
+     ────────────────────────────────────────────────────────────── */
+  --gradient-brand:         linear-gradient(135deg, #22D3EE 0%, #7C3AED 100%);
+  --gradient-brand-vert:    linear-gradient(180deg, #22D3EE 0%, #7C3AED 100%);
+  --gradient-brand-soft:    linear-gradient(135deg, rgba(34,211,238,0.20) 0%, rgba(124,58,237,0.20) 100%);
+
+  --gradient-cta:           linear-gradient(180deg, #8B5CF6 0%, #6D28D9 100%);
+  --gradient-cta-hover:     linear-gradient(180deg, #A78BFA 0%, #7C3AED 100%);
+  --gradient-cta-pressed:   linear-gradient(180deg, #6D28D9 0%, #4C1D95 100%);
+
+  --gradient-progress:      linear-gradient(90deg, #22D3EE 0%, #7C3AED 100%);
+  --gradient-progress-success: linear-gradient(90deg, #10B981 0%, #22D3EE 100%);
+
+  --gradient-gauge:         conic-gradient(from -90deg, #22D3EE 0%, #7C3AED 100%);
+  --gradient-gauge-track:   conic-gradient(from -90deg, rgba(255,255,255,0.06) 0%, rgba(255,255,255,0.06) 100%);
+
+  --gradient-bloom:
+    radial-gradient(1200px 700px at 85% -10%, rgba(124, 58, 237, 0.18), transparent 60%),
+    radial-gradient(900px 600px at -10% 110%, rgba(34, 211, 238, 0.14), transparent 60%),
+    radial-gradient(600px 400px at 50% 50%, rgba(16, 185, 129, 0.06), transparent 70%);
+
+  --gradient-card-sheen:    linear-gradient(180deg, rgba(255,255,255,0.05) 0%, rgba(255,255,255,0.015) 50%, rgba(255,255,255,0) 100%);
+  --gradient-hairline:      linear-gradient(90deg, transparent, rgba(255,255,255,0.18), transparent);
+
+  /* ──────────────────────────────────────────────────────────────
+     TYPOGRAPHY
+     ────────────────────────────────────────────────────────────── */
+  --font-sans:              'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --font-mono:              'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+  --font-display:           'Inter', ui-sans-serif, system-ui, sans-serif;
+
+  /* font-size — modular scale, base 14 */
+  --text-2xs:               10px;
+  --text-xs:                11px;
+  --text-sm:                12px;
+  --text-base:              14px;
+  --text-md:                15px;
+  --text-lg:                17px;
+  --text-xl:                20px;
+  --text-2xl:               24px;
+  --text-3xl:               32px;
+  --text-4xl:               44px;
+  --text-5xl:               60px;
+  --text-6xl:               84px;   /* hero numerals (gauge value) */
+
+  /* font-weight */
+  --weight-regular:         400;
+  --weight-medium:          500;
+  --weight-semibold:        600;
+  --weight-bold:            700;
+
+  /* letter-spacing */
+  --tracking-tight:         -0.02em;
+  --tracking-normal:        0;
+  --tracking-wide:          0.04em;
+  --tracking-wider:         0.08em;
+  --tracking-widest:        0.16em;   /* eyebrow labels */
+  --tracking-mega:          0.22em;   /* SIPHER wordmark */
+
+  /* line-height */
+  --leading-none:           1;
+  --leading-tight:          1.15;
+  --leading-snug:           1.35;
+  --leading-normal:         1.5;
+  --leading-relaxed:        1.65;
+
+  /* ──────────────────────────────────────────────────────────────
+     SPACING — 4px base
+     ────────────────────────────────────────────────────────────── */
+  --space-0:                0px;
+  --space-px:               1px;
+  --space-0-5:              2px;
+  --space-1:                4px;
+  --space-1-5:              6px;
+  --space-2:                8px;
+  --space-2-5:              10px;
+  --space-3:                12px;
+  --space-4:                16px;
+  --space-5:                20px;
+  --space-6:                24px;
+  --space-7:                28px;
+  --space-8:                32px;
+  --space-10:               40px;
+  --space-12:               48px;
+  --space-14:               56px;
+  --space-16:               64px;
+  --space-20:               80px;
+  --space-24:               96px;
+
+  /* ──────────────────────────────────────────────────────────────
+     BORDER RADIUS
+     ────────────────────────────────────────────────────────────── */
+  --radius-none:            0;
+  --radius-xs:              3px;     /* tags, chips */
+  --radius-sm:              5px;     /* small buttons */
+  --radius-md:              7px;     /* inputs */
+  --radius-lg:              10px;    /* cards, panels */
+  --radius-xl:              14px;    /* hero cards, modals */
+  --radius-2xl:             20px;    /* drawer sheets */
+  --radius-3xl:             28px;    /* showcase blocks */
+  --radius-pill:            999px;   /* pills, dot indicators */
+  --radius-full:            9999px;  /* circular */
+
+  /* ──────────────────────────────────────────────────────────────
+     BLUR — for glass/backdrop layers
+     ────────────────────────────────────────────────────────────── */
+  --blur-none:              0;
+  --blur-xs:                4px;
+  --blur-sm:                8px;
+  --blur-md:                14px;    /* default glass */
+  --blur-lg:                22px;    /* dense glass (chrome) */
+  --blur-xl:                32px;    /* command palette overlay */
+  --blur-2xl:               48px;    /* hero gauge backdrop */
+
+  /* saturation pairs to use with blur in backdrop-filter */
+  --backdrop-glass:         blur(14px) saturate(140%);
+  --backdrop-glass-dense:   blur(22px) saturate(160%);
+  --backdrop-glass-modal:   blur(32px) saturate(180%);
+
+  /* ──────────────────────────────────────────────────────────────
+     SHADOWS — elevation
+     ────────────────────────────────────────────────────────────── */
+  --shadow-xs:              0 1px 2px rgba(0, 0, 0, 0.30);
+  --shadow-sm:              0 2px 6px rgba(0, 0, 0, 0.32);
+  --shadow-md:              0 6px 16px -4px rgba(0, 0, 0, 0.45);
+  --shadow-lg:              0 14px 32px -8px rgba(0, 0, 0, 0.55);
+  --shadow-xl:              0 28px 56px -12px rgba(0, 0, 0, 0.65);
+  --shadow-2xl:             0 40px 80px -16px rgba(0, 0, 0, 0.75);
+  --shadow-inset:           inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  --shadow-inset-strong:    inset 0 1px 0 rgba(255, 255, 255, 0.12);
+
+  /* ──────────────────────────────────────────────────────────────
+     GLOW — neon recipes
+     Use as box-shadow. Layered: inset hairline + outer halo.
+     ────────────────────────────────────────────────────────────── */
+  --glow-accent-sm:
+    0 0 0 1px rgba(124, 58, 237, 0.20) inset,
+    0 4px 12px -4px rgba(124, 58, 237, 0.40);
+
+  --glow-accent-md:                            /* default CTA glow */
+    0 0 0 1px rgba(124, 58, 237, 0.25) inset,
+    0 8px 24px -8px rgba(124, 58, 237, 0.55),
+    0 2px 8px -2px rgba(124, 58, 237, 0.35);
+
+  --glow-accent-lg:                            /* Shield SOL primary CTA */
+    0 0 0 1px rgba(124, 58, 237, 0.30) inset,
+    0 0 24px rgba(124, 58, 237, 0.30),
+    0 12px 32px -8px rgba(124, 58, 237, 0.65),
+    0 4px 12px -2px rgba(34, 211, 238, 0.25);
+
+  --glow-cyan-md:
+    0 0 0 1px rgba(34, 211, 238, 0.25) inset,
+    0 8px 24px -8px rgba(34, 211, 238, 0.55);
+
+  --glow-success:           0 0 16px -4px rgba(34, 197, 94, 0.55);
+  --glow-warning:           0 0 16px -4px rgba(245, 158, 11, 0.55);
+  --glow-danger:            0 0 16px -4px rgba(239, 68, 68, 0.55);
+
+  --glow-focus-ring:        0 0 0 4px rgba(124, 58, 237, 0.22);
+  --glow-focus-ring-cyan:   0 0 0 4px rgba(34, 211, 238, 0.22);
+
+  /* drop-shadow flavors (for filter:, e.g. on conic gauges) */
+  --drop-glow-accent:       drop-shadow(0 0 18px rgba(124, 58, 237, 0.45));
+  --drop-glow-cyan:         drop-shadow(0 0 18px rgba(34, 211, 238, 0.45));
+
+  /* ──────────────────────────────────────────────────────────────
+     ANIMATION — durations + easings
+     ────────────────────────────────────────────────────────────── */
+  --duration-instant:       60ms;
+  --duration-fast:          120ms;
+  --duration-base:          200ms;
+  --duration-slow:          320ms;
+  --duration-slower:        500ms;
+  --duration-pulse:         2000ms;
+  --duration-bloom:         8000ms;
+
+  /* easings */
+  --ease-linear:            linear;
+  --ease-in:                cubic-bezier(0.4, 0, 1, 1);
+  --ease-out:               cubic-bezier(0, 0, 0.2, 1);          /* default UI motion */
+  --ease-in-out:            cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-out-expo:          cubic-bezier(0.16, 1, 0.3, 1);       /* drawer/sheet open */
+  --ease-out-back:          cubic-bezier(0.34, 1.56, 0.64, 1);   /* dot grid pop */
+  --ease-spring:            cubic-bezier(0.5, 1.5, 0.5, 1);      /* gauge fill */
+  --ease-anticipate:        cubic-bezier(0.68, -0.6, 0.32, 1.6);
+
+  /* ──────────────────────────────────────────────────────────────
+     LAYOUT — z-index, breakpoints, container widths
+     ────────────────────────────────────────────────────────────── */
+  --z-base:                 0;
+  --z-raised:               10;
+  --z-sticky:               20;
+  --z-overlay:              40;
+  --z-modal:                50;
+  --z-toast:                60;
+  --z-tooltip:              70;
+
+  --bp-sm:                  640px;
+  --bp-md:                  768px;
+  --bp-lg:                  1024px;
+  --bp-xl:                  1280px;
+  --bp-2xl:                 1536px;
+
+  --container-app:          1440px;
+  --container-readable:     720px;
+
+  /* nav rail / sidebar widths */
+  --width-sidebar:          240px;
+  --width-sidebar-collapsed:64px;
+  --width-chat-rail:        360px;
+  --height-header:          56px;
+  --height-header-mobile:   48px;
+}


### PR DESCRIPTION
## Summary

PR 1 of the glass-neon redesign sprint. Lays the foundation for PRs 2-8 with **zero visual change** to existing screens.

- Drops in designer's 301-line token sheet at `app/src/styles/tokens.css` (17 sections — bg, glass, hairlines, text, brand, status, agent identity, privacy grade, gradients, typography, spacing, radius, blur, shadows, glow, animation, layout). Verbatim, drop-in updateable per spec D4.
- Wires Tailwind 4 `@theme` block at `app/src/styles/theme.css` bridging tokens to utility classes (`bg-bg`, `text-text-muted`, `shadow-glow-accent-lg`, etc.).
- Adds `glass.css` utilities (`.glass-1`, `.glass-2`, `.glass-strong`, `.glass-sheen`).
- Adds `animations.css` keyframes (`pulse-bloom`, `shimmer`, `gauge-fill`, `drawer-slide-in`).
- Ships 5 ui/* primitives with Vitest coverage:
  - `Card` — glass-paneled card with variant + sheen
  - `Pill` — toggle-button status/filter pill with ARIA
  - `HashCell` — mono-truncated hash with copy-on-click + screen-reader label
  - `MetricBar` — labeled progress bar with cyan→violet gradient + ARIA progressbar
  - `Sheet` — right slide-over with backdrop, Escape, body-scroll-lock, dialog autofocus
- Custom `@utility` directives for z-index + duration tokens (Tailwind 4 doesn't map `--z-*`/`--duration-*` from `@theme` natively).
- Legacy color aliases preserved verbatim in `@theme` (`--color-card`, `--color-elevated`, `--color-border`, `--color-green`, `--color-red`, `--color-yellow`) so existing components keep rendering identically. Each later restyle PR migrates its callers; the alias block disappears once empty.

## Acceptance criteria

- [x] Existing UI unchanged (zero visual regression — legacy aliases preserve all referenced color tokens byte-identically)
- [x] 5 primitives covered by tests (Card 6 + Pill 6 + HashCell 8 + MetricBar 5 + Sheet 9 = 34 UI tests)
- [x] Build size delta < 30KB gzipped (actual: **+2.77 KB gz** on the CSS chunk; JS chunk unchanged because primitives aren't yet imported by views)

## Verification

- App tests: 178/178 passing (was 144 on main, +34 new UI primitive tests)
- Lint: clean
- Typecheck: clean
- Build: clean

## Review trail

Spec compliance + code quality reviews ran post-implementation. One **critical** issue caught (z-index + duration utilities silently not emitted from `@theme` self-references — Sheet z-overlay/z-modal had no z-index at runtime; MetricBar transition had no duration), plus 6 **important** improvements (Sheet body-scroll-lock + autofocus + drop infinite backdrop animation; HashCell aria-label + console.warn + per-test clipboard stub hygiene). All addressed in commits 8e52517, 5052ff3, 03fdfe2.

## PR 1 of redesign sprint

Spec: `docs/superpowers/specs/2026-05-07-glass-neon-redesign-design.md` (D4, D5 binding decisions)
Plan: `docs/superpowers/plans/2026-05-07-glass-neon-redesign.md` (PR 1 / Tasks 1-13)
Predecessor handoff: `~/Documents/secret/claude-strategy/sip-protocol/sipher/session-handoff-2026-05-08.md`

## Test plan

- [x] All component tests pass (Card 6, Pill 6, HashCell 8, MetricBar 5, Sheet 9 — 34 UI primitive tests + 144 inherited = 178/178)
- [x] Lint + typecheck clean
- [x] Build clean
- [x] Build size delta < 30KB gz (actual +2.77 KB gz)
- [ ] Vercel preview shows existing UI unchanged (no visual regression) — RECTOR to spot-check Dashboard / Vault / Header / BottomNav