### PR TITLE
feat(redesign): shell — Header + BottomNav + ChatSidebar slide-over

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -11,6 +11,7 @@ import Header from './components/Header'
 import BottomNav from './components/BottomNav'
 import ChatSidebar from './components/ChatSidebar'
 import { BetaBanner } from './components/BetaBanner'
+import { Sheet } from './components/ui/Sheet'
 import DashboardView from './views/DashboardView'
 import VaultView from './views/VaultView'
 import HeraldView from './views/HeraldView'
@@ -24,6 +25,8 @@ import { AuthSyncProvider } from './providers/AuthSyncProvider'
 
 function AppShell() {
   const activeView = useAppStore((s) => s.activeView)
+  const chatSheetOpen = useAppStore((s) => s.chatSheetOpen)
+  const setChatSheetOpen = useAppStore((s) => s.setChatSheetOpen)
   const { token, isAdmin } = useAuth()
   const { events } = useSSE()
   const beta = useNetworkConfigStore((s) => s.config?.beta ?? false)
@@ -58,14 +61,17 @@ function AppShell() {
         <main className="flex-1 overflow-y-auto px-4 py-5 lg:px-6">
           {renderView()}
         </main>
-
-        {/* Desktop persistent chat sidebar */}
-        <aside className="hidden lg:flex w-[300px] border-l border-border shrink-0">
-          <ChatSidebar />
-        </aside>
       </div>
 
       <BottomNav />
+
+      <Sheet
+        open={chatSheetOpen}
+        onClose={() => setChatSheetOpen(false)}
+        ariaLabel="Ask SIPHER"
+      >
+        <ChatSidebar />
+      </Sheet>
     </div>
   )
 }

--- a/app/src/components/BottomNav.tsx
+++ b/app/src/components/BottomNav.tsx
@@ -39,7 +39,7 @@ export default function BottomNav() {
 
   return (
     <>
-      <nav className="flex md:hidden border-t border-border bg-bg pb-[env(safe-area-inset-bottom)]">
+      <nav className="flex md:hidden border-t border-line bg-bg pb-[env(safe-area-inset-bottom)]">
         {TABS.map((tab) => {
           const Icon = tab.icon
           const active = activeView === tab.id
@@ -52,7 +52,7 @@ export default function BottomNav() {
               }`}
             >
               <Icon size={20} weight={active ? 'fill' : 'regular'} />
-              <span className="text-[10px] font-medium tracking-wide">{tab.label}</span>
+              <span className="text-2xs font-medium tracking-wide">{tab.label}</span>
             </button>
           )
         })}
@@ -63,20 +63,20 @@ export default function BottomNav() {
           }`}
         >
           <DotsThree size={20} weight="bold" />
-          <span className="text-[10px] font-medium tracking-wide">More</span>
+          <span className="text-2xs font-medium tracking-wide">More</span>
         </button>
       </nav>
 
       {moreOpen && (
         <div
-          className="fixed inset-0 z-50 bg-black/60 md:hidden"
+          className="fixed inset-0 z-modal bg-black/60 md:hidden"
           onClick={() => setMoreOpen(false)}
         >
           <div
-            className="absolute bottom-0 inset-x-0 bg-card border-t border-border rounded-t-2xl p-4 pb-[calc(1rem+env(safe-area-inset-bottom))]"
+            className="glass-strong absolute bottom-0 inset-x-0 rounded-t-2xl p-4 pb-[calc(1rem+env(safe-area-inset-bottom))]"
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="w-8 h-1 bg-border rounded-full mx-auto mb-4" />
+            <div className="w-8 h-1 bg-line-2 rounded-full mx-auto mb-4" />
             <div className="flex flex-col gap-1">
               {isAdmin && (
                 <>
@@ -85,7 +85,7 @@ export default function BottomNav() {
                       setActiveView('herald')
                       setMoreOpen(false)
                     }}
-                    className="flex items-center gap-3 px-3 py-3 rounded-lg text-text-secondary hover:bg-elevated transition-colors"
+                    className="flex items-center gap-3 px-3 py-3 rounded-lg text-text-secondary hover:bg-glass-2 transition-colors"
                   >
                     <Broadcast size={20} />
                     <span className="text-sm font-medium">Herald</span>
@@ -95,17 +95,17 @@ export default function BottomNav() {
                       setActiveView('squad')
                       setMoreOpen(false)
                     }}
-                    className="flex items-center gap-3 px-3 py-3 rounded-lg text-text-secondary hover:bg-elevated transition-colors"
+                    className="flex items-center gap-3 px-3 py-3 rounded-lg text-text-secondary hover:bg-glass-2 transition-colors"
                   >
                     <UsersThree size={20} />
                     <span className="text-sm font-medium">Squad</span>
                   </button>
-                  <div className="border-t border-border my-1" />
+                  <div className="border-t border-line my-1" />
                 </>
               )}
               <button
                 onClick={handleDisconnect}
-                className="flex items-center gap-3 px-3 py-3 rounded-lg text-red hover:bg-red/10 transition-colors"
+                className="flex items-center gap-3 px-3 py-3 rounded-lg text-danger hover:bg-danger-soft transition-colors"
               >
                 <SignOut size={20} />
                 <span className="text-sm font-medium">Disconnect Wallet</span>

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -33,6 +33,7 @@ export default function Header() {
   const { show: showToast } = useToast()
   const activeView = useAppStore((s) => s.activeView)
   const setActiveView = useAppStore((s) => s.setActiveView)
+  const setChatSheetOpen = useAppStore((s) => s.setChatSheetOpen)
   const network = useNetworkConfigStore((s) => s.config?.network ?? 'mainnet')
 
   const visibleTabs = TABS.filter((t) => {
@@ -59,12 +60,16 @@ export default function Header() {
   }
 
   return (
-    <header className="hidden md:flex h-12 border-b border-border items-center justify-between px-4 bg-bg shrink-0 z-10">
-      <div className="flex items-center gap-1">
-        <span className="font-semibold text-[13px] tracking-widest uppercase text-text mr-4">
-          Sipher
+    <header className="hidden md:flex h-12 border-b border-line items-center justify-between px-4 bg-bg shrink-0 z-sticky">
+      <div className="flex items-center gap-3">
+        <span
+          className="font-semibold text-sm text-text"
+          style={{ letterSpacing: 'var(--tracking-mega)' }}
+        >
+          SIPHER
         </span>
-        <nav className="flex items-center">
+        <span className="text-2xs text-text-muted font-mono uppercase">{network}</span>
+        <nav className="flex items-center ml-3">
           {visibleTabs.map((tab) => {
             const Icon = tab.icon
             const active = activeView === tab.id
@@ -73,9 +78,9 @@ export default function Header() {
                 key={tab.id}
                 onClick={() => setActiveView(tab.id)}
                 className={[
-                  'flex items-center gap-1.5 px-3 py-1.5 rounded-md text-[12px] font-medium transition-colors',
+                  'flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors',
                   tab.tabletOnly ? 'lg:hidden' : '',
-                  active ? 'text-text bg-elevated' : 'text-text-muted hover:text-text-secondary',
+                  active ? 'text-text bg-glass-2' : 'text-text-muted hover:text-text-secondary',
                 ].join(' ')}
               >
                 <Icon size={14} weight={active ? 'fill' : 'regular'} />
@@ -87,15 +92,20 @@ export default function Header() {
       </div>
 
       <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => setChatSheetOpen(true)}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs text-text-secondary border border-line rounded-md hover:border-line-2 hover:text-text transition-colors"
+        >
+          <ChatCircle size={14} />
+          Ask SIPHER
+        </button>
+
         <div className="flex items-center gap-1.5">
           <AgentDot agent="sipher" size={5} />
           <AgentDot agent="herald" size={5} />
           <AgentDot agent="sentinel" size={5} />
         </div>
-
-        <span className="text-[10px] font-mono text-text-muted bg-elevated px-1.5 py-0.5 rounded">
-          {network}
-        </span>
 
         {status === 'authed' && publicKey ? (
           <WalletDropdown

--- a/app/src/components/__tests__/BottomNav.test.tsx
+++ b/app/src/components/__tests__/BottomNav.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import BottomNav from '../BottomNav'
+import type { AuthState } from '../../hooks/useAuthState'
+import { useAppStore } from '../../stores/app'
+
+const mockDisconnect = vi.fn()
+const mockToastShow = vi.fn(() => 'toast-id')
+
+let currentAuth: AuthState = {
+  status: 'unauthed',
+  token: null,
+  expiresAt: null,
+  isAdmin: false,
+  publicKey: null,
+  authenticate: vi.fn(),
+  disconnect: mockDisconnect,
+  error: null,
+}
+
+vi.mock('../../hooks/useAuthState', () => ({
+  useAuthState: () => currentAuth,
+}))
+
+vi.mock('../../providers/ToastProvider', () => ({
+  useToast: () => ({ show: mockToastShow, dismiss: vi.fn() }),
+}))
+
+beforeEach(() => {
+  mockDisconnect.mockReset()
+  mockDisconnect.mockResolvedValue(undefined)
+  mockToastShow.mockReset()
+  useAppStore.setState({ activeView: 'dashboard' }, false)
+  currentAuth = { ...currentAuth, isAdmin: false }
+})
+
+describe('BottomNav', () => {
+  it('renders three primary tabs (Home, Vault, Chat) plus More', () => {
+    render(<BottomNav />)
+    expect(screen.getByRole('button', { name: /Home/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Vault/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Chat/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /More/ })).toBeInTheDocument()
+  })
+
+  it('clicking Vault sets activeView via the store', () => {
+    render(<BottomNav />)
+    fireEvent.click(screen.getByRole('button', { name: /Vault/ }))
+    expect(useAppStore.getState().activeView).toBe('vault')
+  })
+
+  it('More opens drawer; admin sees Herald + Squad entries when isAdmin=true', () => {
+    currentAuth = { ...currentAuth, isAdmin: true }
+    render(<BottomNav />)
+    fireEvent.click(screen.getByRole('button', { name: /More/ }))
+    expect(screen.getByRole('button', { name: /Herald/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Squad/ })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Disconnect Wallet/ })).toBeInTheDocument()
+  })
+
+  it('non-admins do NOT see Herald/Squad in the More drawer', () => {
+    currentAuth = { ...currentAuth, isAdmin: false }
+    render(<BottomNav />)
+    fireEvent.click(screen.getByRole('button', { name: /More/ }))
+    expect(screen.queryByRole('button', { name: /Herald/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Squad/ })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Disconnect Wallet/ })).toBeInTheDocument()
+  })
+
+  it('Disconnect Wallet calls disconnect + shows toast', async () => {
+    render(<BottomNav />)
+    fireEvent.click(screen.getByRole('button', { name: /More/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Disconnect Wallet/ }))
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(mockDisconnect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/src/components/__tests__/Header.test.tsx
+++ b/app/src/components/__tests__/Header.test.tsx
@@ -54,7 +54,7 @@ beforeEach(() => {
   Object.assign(navigator, {
     clipboard: { writeText: mockClipboardWrite.mockResolvedValue(undefined) },
   })
-  useAppStore.setState({ activeView: 'dashboard' }, false)
+  useAppStore.setState({ activeView: 'dashboard', chatSheetOpen: false }, false)
   setAuth({ status: 'unauthed', publicKey: null, isAdmin: false })
 })
 
@@ -109,6 +109,30 @@ describe('Header — auth pill', () => {
     fireEvent.click(screen.getByText('Copy address'))
     await Promise.resolve()
     expect(mockClipboardWrite).toHaveBeenCalledWith(FULL)
+  })
+})
+
+describe('Header — wordmark + Ask SIPHER trigger', () => {
+  it('renders the SIPHER wordmark', () => {
+    render(<Header />)
+    expect(screen.getByText('SIPHER')).toBeInTheDocument()
+  })
+
+  it('exposes Ask SIPHER trigger button', () => {
+    render(<Header />)
+    expect(screen.getByRole('button', { name: /ask sipher/i })).toBeInTheDocument()
+  })
+
+  it('Ask SIPHER click opens chat sheet via store', () => {
+    render(<Header />)
+    expect(useAppStore.getState().chatSheetOpen).toBe(false)
+    fireEvent.click(screen.getByRole('button', { name: /ask sipher/i }))
+    expect(useAppStore.getState().chatSheetOpen).toBe(true)
+  })
+
+  it('renders the active network identifier', () => {
+    render(<Header />)
+    expect(screen.getByText('devnet')).toBeInTheDocument()
   })
 })
 

--- a/app/src/stores/__tests__/app.test.ts
+++ b/app/src/stores/__tests__/app.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useAppStore } from '../app'
+
+describe('app store — chatSheetOpen slice', () => {
+  beforeEach(() => {
+    useAppStore.setState({ chatSheetOpen: false }, false)
+  })
+
+  it('defaults to closed', () => {
+    expect(useAppStore.getState().chatSheetOpen).toBe(false)
+  })
+
+  it('toggles via setChatSheetOpen', () => {
+    useAppStore.getState().setChatSheetOpen(true)
+    expect(useAppStore.getState().chatSheetOpen).toBe(true)
+    useAppStore.getState().setChatSheetOpen(false)
+    expect(useAppStore.getState().chatSheetOpen).toBe(false)
+  })
+
+  it('is excluded from persisted partialize (in-memory only)', () => {
+    useAppStore.getState().setChatSheetOpen(true)
+    const persisted = JSON.parse(localStorage.getItem('sipher-auth') ?? '{}')
+    expect(persisted.state).not.toHaveProperty('chatSheetOpen')
+  })
+})

--- a/app/src/stores/app.ts
+++ b/app/src/stores/app.ts
@@ -49,6 +49,9 @@ interface AppState {
   setChatOpen: (open: boolean) => void
   pendingPrompt: string | null
   consumePendingPrompt: () => string | null
+
+  chatSheetOpen: boolean
+  setChatSheetOpen: (open: boolean) => void
 }
 
 export const useAppStore = create<AppState>()(
@@ -122,6 +125,9 @@ export const useAppStore = create<AppState>()(
         set({ pendingPrompt: null })
         return p
       },
+
+      chatSheetOpen: false,
+      setChatSheetOpen: (chatSheetOpen) => set({ chatSheetOpen }),
     }),
     {
       name: 'sipher-auth',

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -3,11 +3,20 @@ import { mockPrivacyScore } from './fixtures/mocks'
 
 const AUTH_STATE = 'e2e/fixtures/storageState.json'
 
-test.describe('chat sidebar', () => {
+test.describe('Ask SIPHER sheet', () => {
   test.describe('unauthenticated', () => {
     test.use({ storageState: { cookies: [], origins: [] } })
 
-    test('input is disabled and shows connect-wallet placeholder', async ({ page }) => {
+    test('Ask SIPHER opens the sheet; Escape closes it', async ({ page }) => {
+      await page.goto('/')
+      await expect(page.getByRole('dialog', { name: /ask sipher/i })).toHaveCount(0)
+      await page.getByRole('button', { name: /ask sipher/i }).click()
+      await expect(page.getByRole('dialog', { name: /ask sipher/i })).toBeVisible()
+      await page.keyboard.press('Escape')
+      await expect(page.getByRole('dialog', { name: /ask sipher/i })).toHaveCount(0)
+    })
+
+    test('chat input is disabled inside the sheet when unauthenticated', async ({ page }) => {
       const errors: string[] = []
       page.on('pageerror', (err) => errors.push(err.message))
       page.on('console', (msg) => {
@@ -15,6 +24,7 @@ test.describe('chat sidebar', () => {
       })
 
       await page.goto('/')
+      await page.getByRole('button', { name: /ask sipher/i }).click()
       const input = page.getByPlaceholder('Connect wallet first')
       await expect(input).toBeVisible()
       await expect(input).toBeDisabled()
@@ -46,6 +56,7 @@ test.describe('chat sidebar', () => {
       })
 
       await page.goto('/')
+      await page.getByRole('button', { name: /ask sipher/i }).click()
       const input = page.getByPlaceholder('Message SIPHER...')
       await expect(input).toBeEnabled()
       await input.fill('hi')


### PR DESCRIPTION
## Summary

PR 2 of the glass-neon redesign sprint. Restyles the app frame and reshapes the chat IA.

- **Store** — adds in-memory `chatSheetOpen` slice (excluded from `partialize`, in-memory only).
- **Header** — wordmark goes from \"Sipher\" to **SIPHER** with `--tracking-mega` (0.22em). Network indicator (devnet/mainnet) moves next to the wordmark; the standalone right-side network pill is removed. New \"Ask SIPHER\" trigger button on the right opens the chat sheet. Active tab background swaps from solid `bg-elevated` to `glass-2` for the new visual language. Frame styles adopt `border-line` / `z-sticky`.
- **BottomNav** — frame and More-drawer swap to new tokens. Drawer surface goes from solid `bg-card` to `glass-strong` (matches Sheet primitive). Destructive actions migrate to `text-danger` / `bg-danger-soft`.
- **ChatSidebar → Sheet** — removes the persistent right-rail aside (was `hidden lg:flex w-[300px]`) and wraps `<ChatSidebar />` in the new `Sheet` primitive at AppShell root. On lg+ desktop the main canvas reclaims ~360px of horizontal width. Mobile chat tab unchanged.

## Acceptance criteria

- [x] New shell language visible on Vercel preview (Header wordmark, glass-2 active tab, Ask SIPHER trigger)
- [x] Chat input behaviorally identical (same SSE stream, same auth gate, same SENTINEL flow) — just opened via Sheet now
- [x] a11y validated — Sheet uses `dialog` role + `aria-modal=\"true\"` + `aria-label=\"Ask SIPHER\"`, body scroll-locks on open, dialog autofocuses, Escape and backdrop close

## Verification

- App tests: **190/190** passing (was 178 on PR 1; +3 store, +4 Header, +5 BottomNav)
- Typecheck: clean
- Lint: clean
- Build: clean (CSS 47.83 KB / 10.52 KB gz, JS 776.10 KB / 230.75 KB gz — net +3.21 KB gz vs main)
- e2e `chat.spec.ts` updated: existing two tests now click \"Ask SIPHER\" before interacting with the input; one new test asserts \"Ask SIPHER opens the sheet; Escape closes it\"

## PR 2 of redesign sprint

Spec: \`docs/superpowers/specs/2026-05-07-glass-neon-redesign-design.md\` (D9 binding decision)
Plan: \`docs/superpowers/plans/2026-05-07-glass-neon-redesign.md\` (PR 2 / Tasks 1-6)
Builds on: #178 (PR 1 — theme tokens + ui/* primitives)

## Test plan

- [x] All app unit tests pass (190/190)
- [x] Typecheck + lint + build clean
- [ ] Vercel preview manual check — Header wordmark renders with mega tracking, Ask SIPHER button visible on lg+ viewport, chat opens in Sheet on click, Escape + backdrop close, BottomNav More-drawer admin gating still works, chat input streams replies (RECTOR to spot-check)
- [ ] Tablet path — confirm chat tab in Header still works alongside Ask SIPHER (intentional dual-path on md viewport)