### PR TITLE
feat(redesign): privacy graph + shielded volume card + 2 backend endpoints

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -19,6 +19,7 @@
     "@tailwindcss/vite": "^4.2.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "reactflow": "^11.11.4",
     "tailwindcss": "^4.2.2",
     "zustand": "^5.0.12"
   },

--- a/app/src/components/PrivacyGraph.tsx
+++ b/app/src/components/PrivacyGraph.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react'
+import { Card } from './ui/Card'
+import { NodeGraph, type GraphNode, type GraphEdge } from './ui/NodeGraph'
+import { apiFetch } from '../api/client'
+import { useAuthState } from '../hooks/useAuthState'
+
+interface StealthNode {
+  index: number
+  derivationPath: string
+  stealthAddress: string
+  parentIndex: number | null
+  createdAt: string
+}
+
+export function PrivacyGraph() {
+  const { token } = useAuthState()
+  const [tree, setTree] = useState<StealthNode[]>([])
+
+  useEffect(() => {
+    if (!token) return
+    const controller = new AbortController()
+    apiFetch<{ tree: StealthNode[]; rootWallet: string }>('/api/stealth/index', {
+      token,
+      signal: controller.signal,
+    })
+      .then((j) => setTree(j.tree))
+      .catch((err) => {
+        if (err instanceof Error && err.name === 'AbortError') return
+        setTree([])
+      })
+    return () => controller.abort()
+  }, [token])
+
+  const nodes: GraphNode[] = tree.map((n, i) => ({
+    id: String(n.index),
+    label: `#${n.index}`,
+    x: i * 140,
+    y: n.parentIndex == null ? 200 : 100,
+    isRoot: n.parentIndex == null,
+  }))
+  const edges: GraphEdge[] = tree
+    .filter((n) => n.parentIndex != null)
+    .map((n) => ({ source: String(n.parentIndex), target: String(n.index) }))
+
+  return (
+    <Card variant="default" sheen className="p-6">
+      <div className="flex items-center justify-between mb-4">
+        <span
+          className="text-2xs text-text-muted"
+          style={{ letterSpacing: 'var(--tracking-widest)' }}
+        >
+          PRIVACY GRAPH · STEALTH ADDRESS TREE
+        </span>
+        <span className="text-xs text-text-muted">
+          {tree.length} {tree.length === 1 ? 'address' : 'addresses'}
+        </span>
+      </div>
+      {tree.length === 0 ? (
+        <div className="h-[400px] flex items-center justify-center text-text-muted text-sm">
+          Connect a wallet to see your privacy graph.
+        </div>
+      ) : (
+        <NodeGraph nodes={nodes} edges={edges} />
+      )}
+    </Card>
+  )
+}

--- a/app/src/components/ShieldedVolumeCard.tsx
+++ b/app/src/components/ShieldedVolumeCard.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react'
+import { Card } from './ui/Card'
+import { apiFetch } from '../api/client'
+
+interface AggregateResponse {
+  totalTvlSol: number
+  chainCount: number
+  liveChainCount: number
+  asOf: string
+}
+
+export function ShieldedVolumeCard() {
+  const [data, setData] = useState<AggregateResponse | null>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    apiFetch<AggregateResponse>('/api/chains/aggregate', { signal: controller.signal })
+      .then(setData)
+      .catch((err) => {
+        if (err instanceof Error && err.name === 'AbortError') return
+        setData(null)
+      })
+    return () => controller.abort()
+  }, [])
+
+  return (
+    <Card variant="default" className="p-6 h-full flex flex-col justify-center">
+      <span
+        className="text-2xs text-text-muted"
+        style={{ letterSpacing: 'var(--tracking-widest)' }}
+      >
+        SHIELDED VOLUME · {data?.liveChainCount ?? 0} CHAINS LIVE
+      </span>
+      <div className="flex items-baseline gap-2 mt-3">
+        <span className="text-4xl font-mono text-text">
+          {data
+            ? data.totalTvlSol.toLocaleString(undefined, { maximumFractionDigits: 2 })
+            : '—'}
+        </span>
+        <span className="text-base text-text-muted">SOL</span>
+      </div>
+      <span className="text-xs text-text-muted mt-1">
+        aggregated across all SIP vault deployments
+      </span>
+    </Card>
+  )
+}

--- a/app/src/components/__tests__/PrivacyGraph.test.tsx
+++ b/app/src/components/__tests__/PrivacyGraph.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { PrivacyGraph } from '../PrivacyGraph'
+
+vi.mock('../../api/client', () => ({
+  apiFetch: vi.fn(),
+}))
+
+vi.mock('../../hooks/useAuthState', () => ({
+  useAuthState: () => ({ token: 'tok', isAdmin: false }),
+}))
+
+import { apiFetch } from '../../api/client'
+
+beforeAll(() => {
+  if (!('ResizeObserver' in globalThis)) {
+    ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  }
+})
+
+beforeEach(() => {
+  ;(apiFetch as ReturnType<typeof vi.fn>).mockReset()
+})
+
+describe('PrivacyGraph', () => {
+  it('shows the empty-state copy when the tree is empty', async () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      tree: [],
+      rootWallet: '',
+    })
+    render(<PrivacyGraph />)
+    await waitFor(() => {
+      expect(screen.getByText(/0 addresses/)).toBeInTheDocument()
+      expect(screen.getByText(/Connect a wallet to see your privacy graph/)).toBeInTheDocument()
+    })
+  })
+
+  it('renders the NodeGraph and address count when the API returns nodes', async () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      tree: [
+        {
+          index: 0,
+          derivationPath: "m/0'",
+          stealthAddress: 'rootWallet',
+          parentIndex: null,
+          createdAt: '2026-05-08T00:00:00Z',
+        },
+      ],
+      rootWallet: 'rootWallet',
+    })
+    render(<PrivacyGraph />)
+    await waitFor(() => expect(screen.getByText('1 address')).toBeInTheDocument())
+    expect(screen.getByTestId('node-graph')).toBeInTheDocument()
+  })
+
+  it('falls back to empty state when the fetch errors', async () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('network'))
+    render(<PrivacyGraph />)
+    await waitFor(() => expect(screen.getByText(/0 addresses/)).toBeInTheDocument())
+  })
+})

--- a/app/src/components/__tests__/ShieldedVolumeCard.test.tsx
+++ b/app/src/components/__tests__/ShieldedVolumeCard.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { ShieldedVolumeCard } from '../ShieldedVolumeCard'
+
+vi.mock('../../api/client', () => ({
+  apiFetch: vi.fn(),
+}))
+
+import { apiFetch } from '../../api/client'
+
+beforeEach(() => {
+  ;(apiFetch as ReturnType<typeof vi.fn>).mockReset()
+})
+
+describe('ShieldedVolumeCard', () => {
+  it('renders the formatted TVL once data loads', async () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      totalTvlSol: 1234.567,
+      chainCount: 12,
+      liveChainCount: 9,
+      asOf: '2026-05-08T00:00:00Z',
+    })
+    render(<ShieldedVolumeCard />)
+    await waitFor(() => expect(screen.getByText('1,234.57')).toBeInTheDocument())
+    expect(screen.getByText('SOL')).toBeInTheDocument()
+    expect(screen.getByText(/9 CHAINS LIVE/)).toBeInTheDocument()
+  })
+
+  it('renders an em-dash placeholder before data loads', () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockReturnValueOnce(new Promise(() => {}))
+    render(<ShieldedVolumeCard />)
+    expect(screen.getByText('—')).toBeInTheDocument()
+    expect(screen.getByText(/0 CHAINS LIVE/)).toBeInTheDocument()
+  })
+
+  it('falls back to em-dash when fetch errors', async () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('network'))
+    render(<ShieldedVolumeCard />)
+    await waitFor(() => {
+      expect(screen.getByText('—')).toBeInTheDocument()
+    })
+  })
+})

--- a/app/src/components/ui/NodeGraph.tsx
+++ b/app/src/components/ui/NodeGraph.tsx
@@ -1,0 +1,64 @@
+import { useMemo } from 'react'
+import ReactFlow, { Background, Controls, type Node, type Edge } from 'reactflow'
+import 'reactflow/dist/style.css'
+
+export interface GraphNode {
+  id: string
+  label: string
+  x: number
+  y: number
+  isRoot?: boolean
+}
+
+export interface GraphEdge {
+  source: string
+  target: string
+}
+
+interface NodeGraphProps {
+  nodes: GraphNode[]
+  edges: GraphEdge[]
+  height?: number
+}
+
+export function NodeGraph({ nodes, edges, height = 400 }: NodeGraphProps) {
+  const rfNodes: Node[] = useMemo(
+    () =>
+      nodes.map((n) => ({
+        id: n.id,
+        position: { x: n.x, y: n.y },
+        data: { label: n.label },
+        style: {
+          background: n.isRoot ? 'var(--color-cyan)' : 'var(--color-glass-2)',
+          color: n.isRoot ? 'var(--color-text-inverse)' : 'var(--color-text)',
+          border: '1px solid var(--color-line-accent)',
+          borderRadius: 'var(--radius-pill)',
+          padding: '8px 14px',
+          fontSize: 11,
+          boxShadow: n.isRoot ? 'var(--glow-cyan-md)' : 'var(--glow-accent-sm)',
+        },
+      })),
+    [nodes],
+  )
+
+  const rfEdges: Edge[] = useMemo(
+    () =>
+      edges.map((e, i) => ({
+        id: `e${i}`,
+        source: e.source,
+        target: e.target,
+        style: { stroke: 'var(--color-cyan-soft)', strokeWidth: 1.5 },
+        animated: true,
+      })),
+    [edges],
+  )
+
+  return (
+    <div data-testid="node-graph" style={{ width: '100%', height }}>
+      <ReactFlow nodes={rfNodes} edges={rfEdges} fitView>
+        <Background color="var(--color-line)" gap={24} />
+        <Controls className="bg-bg-2 border border-line rounded-md" />
+      </ReactFlow>
+    </div>
+  )
+}

--- a/app/src/components/ui/__tests__/NodeGraph.test.tsx
+++ b/app/src/components/ui/__tests__/NodeGraph.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { NodeGraph, type GraphNode, type GraphEdge } from '../NodeGraph'
+
+beforeAll(() => {
+  // reactflow uses ResizeObserver; jsdom doesn't ship one.
+  if (!('ResizeObserver' in globalThis)) {
+    ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  }
+  // reactflow also pokes at DOMRect on layout; jsdom returns zeroes which is fine.
+})
+
+const nodes: GraphNode[] = [
+  { id: '0', label: '#0', x: 0, y: 200, isRoot: true },
+  { id: '1', label: '#1', x: 140, y: 100 },
+]
+const edges: GraphEdge[] = [{ source: '0', target: '1' }]
+
+describe('NodeGraph', () => {
+  it('renders a sized container around the react-flow instance', () => {
+    render(<NodeGraph nodes={nodes} edges={edges} />)
+    const container = screen.getByTestId('node-graph')
+    expect(container).toBeInTheDocument()
+    expect(container.style.width).toBe('100%')
+    expect(container.style.height).toBe('400px')
+  })
+
+  it('respects a custom height prop', () => {
+    render(<NodeGraph nodes={nodes} edges={edges} height={600} />)
+    expect(screen.getByTestId('node-graph').style.height).toBe('600px')
+  })
+
+  it('renders empty graph without throwing', () => {
+    expect(() => render(<NodeGraph nodes={[]} edges={[]} />)).not.toThrow()
+  })
+})

--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -2,9 +2,10 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { apiFetch } from '../api/client'
 import { type ActivityEvent } from '../hooks/useSSE'
 import { useAuthState } from '../hooks/useAuthState'
-import { Card } from '../components/ui/Card'
 import { PrivacyScoreCard } from '../components/PrivacyScoreCard'
 import { ActivityStreamTable, type ActivityRow } from '../components/ActivityStreamTable'
+import { PrivacyGraph } from '../components/PrivacyGraph'
+import { ShieldedVolumeCard } from '../components/ShieldedVolumeCard'
 
 interface VaultData {
   wallet: string
@@ -120,21 +121,14 @@ export default function DashboardView({ events }: { events: ActivityEvent[] }) {
 
   return (
     <div data-testid="dashboard-view" className="space-y-6 p-6">
+      <PrivacyGraph />
+
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2">
           <PrivacyScoreCard data={privacyData} delta={4} />
         </div>
         <div>
-          <Card variant="default" className="p-6 h-full flex flex-col justify-center items-center">
-            <span
-              className="text-2xs text-text-muted"
-              style={{ letterSpacing: 'var(--tracking-widest)' }}
-            >
-              SHIELDED VOLUME · 24H
-            </span>
-            <span className="text-4xl font-mono text-text mt-2">—</span>
-            <span className="text-xs text-text-muted mt-1">aggregator endpoint lands in PR 4</span>
-          </Card>
+          <ShieldedVolumeCard />
         </div>
       </div>
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -27,6 +27,7 @@ import { performVaultRefund, assertVaultRefundWired } from './sentinel/vault-ref
 import { sentinelPublicRouter, sentinelAdminRouter } from './routes/sentinel-api.js'
 import { getSentinelConfig } from './sentinel/config.js'
 import { configRouter } from './routes/config.js'
+import { chainsRouter } from './routes/chains.js'
 import { buildCorsMiddleware } from './cors-config.js'
 import { loadNetworkConfig } from './config/network.js'
 import {
@@ -167,6 +168,9 @@ app.use('/api/auth', authRouter)
 
 // Public network metadata (read by UI before auth) — never returns RPC URL or API key
 app.use('/api/config', configRouter)
+
+// Public chain registry + TVL aggregator (read by UI Shielded Volume + Chains views)
+app.use('/api/chains', chainsRouter)
 
 // Activity SSE stream — JWT required (EventSource passes ?token=)
 app.get('/api/stream', verifyJwt, streamHandler)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -28,6 +28,7 @@ import { sentinelPublicRouter, sentinelAdminRouter } from './routes/sentinel-api
 import { getSentinelConfig } from './sentinel/config.js'
 import { configRouter } from './routes/config.js'
 import { chainsRouter } from './routes/chains.js'
+import { stealthIndexRouter } from './routes/stealth-index.js'
 import { buildCorsMiddleware } from './cors-config.js'
 import { loadNetworkConfig } from './config/network.js'
 import {
@@ -199,6 +200,9 @@ app.use('/api/herald', verifyJwt, requireOwner, heraldRouter)
 // SENTINEL decision log + status + query — JWT required (public) or JWT + owner (admin)
 app.use('/api/sentinel', verifyJwt, sentinelPublicRouter)
 app.use('/api/sentinel', verifyJwt, requireOwner, sentinelAdminRouter)
+
+// Stealth address tree (per-wallet) — JWT required, used by Dashboard PrivacyGraph
+app.use('/api/stealth', verifyJwt, stealthIndexRouter)
 
 // Activity stream (per-wallet history from DB) — JWT required
 app.get('/api/activity', verifyJwt, (req: Request, res: Response) => {

--- a/packages/agent/src/routes/chains.ts
+++ b/packages/agent/src/routes/chains.ts
@@ -1,0 +1,152 @@
+import { Router, Request, Response } from 'express'
+
+export const chainsRouter = Router()
+
+interface ChainStatus {
+  chainId: string
+  network: 'mainnet' | 'devnet' | 'testnet'
+  programId: string
+  vaultPda: string | null
+  tvlSol: number
+  feeBps: number
+  status: 'live' | 'pending'
+  rpcLatencyMs: number | null
+}
+
+const CHAINS: ChainStatus[] = [
+  {
+    chainId: 'solana-mainnet',
+    network: 'mainnet',
+    programId: 'S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at',
+    vaultPda: 'BVawZkppFewygA5nxdrLma4ThKx8Th7bW4KTCkcWTZwZ',
+    tvlSol: 0,
+    feeBps: 50,
+    status: 'live',
+    rpcLatencyMs: null,
+  },
+  {
+    chainId: 'solana-devnet',
+    network: 'devnet',
+    programId: 'S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB',
+    vaultPda: 'CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u',
+    tvlSol: 0,
+    feeBps: 10,
+    status: 'live',
+    rpcLatencyMs: null,
+  },
+  {
+    chainId: 'sepolia',
+    network: 'testnet',
+    programId: '0x1FED19684dC108304960db2818CF5a961d28405E',
+    vaultPda: null,
+    tvlSol: 0,
+    feeBps: 50,
+    status: 'live',
+    rpcLatencyMs: null,
+  },
+  {
+    chainId: 'arbitrum-sepolia',
+    network: 'testnet',
+    programId: '0x0B0d06D6B5136d63Bd0817414E2D318999e50339',
+    vaultPda: null,
+    tvlSol: 0,
+    feeBps: 50,
+    status: 'live',
+    rpcLatencyMs: null,
+  },
+  {
+    chainId: 'base-sepolia',
+    network: 'testnet',
+    programId: '0x0B0d06D6B5136d63Bd0817414E2D318999e50339',
+    vaultPda: null,
+    tvlSol: 0,
+    feeBps: 50,
+    status: 'live',
+    rpcLatencyMs: null,
+  },
+  {
+    chainId: 'op-sepolia',
+    network: 'testnet',
+    programId: '0x0B0d06D6B5136d63Bd0817414E2D318999e50339',
+    vaultPda: null,
+    tvlSol: 0,
+    feeBps: 50,
+    status: 'live',
+    rpcLatencyMs: null,
+  },
+  {
+    chainId: 'scroll-sepolia',
+    network: 'testnet',
+    programId: '0x0B0d06D6B5136d63Bd0817414E2D318999e50339',
+    vaultPda: null,
+    tvlSol: 0,
+    feeBps: 50,
+    status: 'live',
+    rpcLatencyMs: null,
+  },
+  {
+    chainId: 'linea-sepolia',
+    network: 'testnet',
+    programId: '0x0B0d06D6B5136d63Bd0817414E2D318999e50339',
+    vaultPda: null,
+    tvlSol: 0,
+    feeBps: 50,
+    status: 'live',
+    rpcLatencyMs: null,
+  },
+  {
+    chainId: 'mode-sepolia',
+    network: 'testnet',
+    programId: '0x0B0d06D6B5136d63Bd0817414E2D318999e50339',
+    vaultPda: null,
+    tvlSol: 0,
+    feeBps: 50,
+    status: 'live',
+    rpcLatencyMs: null,
+  },
+  {
+    chainId: 'blast-sepolia',
+    network: 'testnet',
+    programId: '',
+    vaultPda: null,
+    tvlSol: 0,
+    feeBps: 50,
+    status: 'pending',
+    rpcLatencyMs: null,
+  },
+  {
+    chainId: 'mantle-sepolia',
+    network: 'testnet',
+    programId: '',
+    vaultPda: null,
+    tvlSol: 0,
+    feeBps: 50,
+    status: 'pending',
+    rpcLatencyMs: null,
+  },
+  {
+    chainId: 'zksync-era-sepolia',
+    network: 'testnet',
+    programId: '',
+    vaultPda: null,
+    tvlSol: 0,
+    feeBps: 50,
+    status: 'pending',
+    rpcLatencyMs: null,
+  },
+]
+
+chainsRouter.get('/', (_req: Request, res: Response) => {
+  res.json({ chains: CHAINS })
+})
+
+chainsRouter.get('/aggregate', (_req: Request, res: Response) => {
+  const totalTvlSol = CHAINS.reduce((sum, c) => sum + c.tvlSol, 0)
+  const liveChains = CHAINS.filter((c) => c.status === 'live').length
+  res.json({
+    totalTvlSol,
+    chainCount: CHAINS.length,
+    liveChainCount: liveChains,
+    asOf: new Date().toISOString(),
+  })
+})

--- a/packages/agent/src/routes/stealth-index.ts
+++ b/packages/agent/src/routes/stealth-index.ts
@@ -1,0 +1,36 @@
+import { Router, Request, Response } from 'express'
+
+export const stealthIndexRouter = Router()
+
+interface StealthNode {
+  index: number
+  derivationPath: string
+  stealthAddress: string
+  parentIndex: number | null
+  createdAt: string
+}
+
+stealthIndexRouter.get('/index', (req: Request, res: Response) => {
+  const wallet = req.wallet
+  if (!wallet) {
+    res.status(500).json({
+      error: { code: 'INTERNAL', message: 'auth middleware did not attach wallet' },
+    })
+    return
+  }
+
+  // Stub tree -- real derivation lands when the SDK viewing-key index is wired.
+  // For now return the wallet itself as the root node so the FE Privacy Graph
+  // can render a one-node tree without throwing on missing data.
+  const tree: StealthNode[] = [
+    {
+      index: 0,
+      derivationPath: "m/0'",
+      stealthAddress: wallet,
+      parentIndex: null,
+      createdAt: new Date().toISOString(),
+    },
+  ]
+
+  res.json({ tree, rootWallet: wallet })
+})

--- a/packages/agent/tests/routes/chains.test.ts
+++ b/packages/agent/tests/routes/chains.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import express from 'express'
+import supertest from 'supertest'
+import { chainsRouter } from '../../src/routes/chains.js'
+
+function createApp() {
+  const app = express()
+  app.use('/api/chains', chainsRouter)
+  return app
+}
+
+describe('GET /api/chains', () => {
+  it('returns the full chain registry', async () => {
+    const res = await supertest(createApp()).get('/api/chains')
+    expect(res.status).toBe(200)
+    expect(Array.isArray(res.body.chains)).toBe(true)
+    expect(res.body.chains.length).toBeGreaterThan(0)
+  })
+
+  it('each chain row carries chainId / network / programId / status', async () => {
+    const res = await supertest(createApp()).get('/api/chains')
+    const first = res.body.chains[0]
+    expect(first).toHaveProperty('chainId')
+    expect(first).toHaveProperty('network')
+    expect(first).toHaveProperty('programId')
+    expect(first).toHaveProperty('status')
+    expect(['live', 'pending']).toContain(first.status)
+  })
+
+  it('includes Solana mainnet vault deployment as a live row', async () => {
+    const res = await supertest(createApp()).get('/api/chains')
+    const mainnet = res.body.chains.find((c: { chainId: string }) => c.chainId === 'solana-mainnet')
+    expect(mainnet).toBeDefined()
+    expect(mainnet.status).toBe('live')
+    expect(mainnet.programId).toBe('S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at')
+  })
+
+  it('does not require authentication (public endpoint)', async () => {
+    const res = await supertest(createApp()).get('/api/chains')
+    expect(res.status).not.toBe(401)
+    expect(res.status).not.toBe(403)
+  })
+})
+
+describe('GET /api/chains/aggregate', () => {
+  it('returns sum TVL across chains plus chainCount + liveChainCount + asOf', async () => {
+    const res = await supertest(createApp()).get('/api/chains/aggregate')
+    expect(res.status).toBe(200)
+    expect(typeof res.body.totalTvlSol).toBe('number')
+    expect(typeof res.body.chainCount).toBe('number')
+    expect(res.body.chainCount).toBeGreaterThan(0)
+    expect(typeof res.body.liveChainCount).toBe('number')
+    expect(res.body.liveChainCount).toBeGreaterThanOrEqual(0)
+    expect(res.body.liveChainCount).toBeLessThanOrEqual(res.body.chainCount)
+    expect(typeof res.body.asOf).toBe('string')
+    expect(() => new Date(res.body.asOf)).not.toThrow()
+  })
+
+  it('does not require authentication (public endpoint)', async () => {
+    const res = await supertest(createApp()).get('/api/chains/aggregate')
+    expect(res.status).not.toBe(401)
+    expect(res.status).not.toBe(403)
+  })
+})

--- a/packages/agent/tests/routes/stealth-index.test.ts
+++ b/packages/agent/tests/routes/stealth-index.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import express, { type Request, type Response, type NextFunction } from 'express'
+import supertest from 'supertest'
+import { stealthIndexRouter } from '../../src/routes/stealth-index.js'
+
+const TEST_WALLET = 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N'
+
+function mockAuth(wallet: string | null) {
+  return (req: Request, _res: Response, next: NextFunction) => {
+    if (wallet) {
+      ;(req as unknown as { wallet: string }).wallet = wallet
+    }
+    next()
+  }
+}
+
+function createApp(wallet: string | null = TEST_WALLET) {
+  const app = express()
+  app.use('/api/stealth', mockAuth(wallet), stealthIndexRouter)
+  return app
+}
+
+describe('GET /api/stealth/index', () => {
+  it('returns a stub tree containing the caller wallet as the root node', async () => {
+    const res = await supertest(createApp()).get('/api/stealth/index')
+    expect(res.status).toBe(200)
+    expect(res.body.rootWallet).toBe(TEST_WALLET)
+    expect(Array.isArray(res.body.tree)).toBe(true)
+    expect(res.body.tree).toHaveLength(1)
+
+    const root = res.body.tree[0]
+    expect(root.index).toBe(0)
+    expect(root.parentIndex).toBeNull()
+    expect(root.stealthAddress).toBe(TEST_WALLET)
+    expect(root.derivationPath).toBe("m/0'")
+    expect(typeof root.createdAt).toBe('string')
+    expect(() => new Date(root.createdAt)).not.toThrow()
+  })
+
+  it('returns a 500 INTERNAL error if upstream auth did not attach req.wallet', async () => {
+    const res = await supertest(createApp(null)).get('/api/stealth/index')
+    expect(res.status).toBe(500)
+    expect(res.body.error.code).toBe('INTERNAL')
+    expect(res.body.error.message).toMatch(/wallet/)
+  })
+
+  it('does not leak any wallet other than the authenticated caller', async () => {
+    const otherWallet = 'OtherWallet111111111111111111111111111111111'
+    const res = await supertest(createApp(otherWallet)).get('/api/stealth/index')
+    expect(res.body.rootWallet).toBe(otherWallet)
+    expect(res.body.tree[0].stealthAddress).toBe(otherWallet)
+    const bodyStr = JSON.stringify(res.body)
+    expect(bodyStr).not.toContain(TEST_WALLET)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
         version: 1.8.0
       '@sip-protocol/sdk':
         specifier: ^0.7.4
-        version: 0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))
+        version: 0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))
       '@sip-protocol/types':
         specifier: ^0.2.2
         version: 0.2.2
@@ -155,12 +155,15 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      reactflow:
+        specifier: ^11.11.4
+        version: 11.11.4(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
       zustand:
         specifier: ^5.0.12
-        version: 5.0.12(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.2.0(react@19.2.4))
+        version: 5.0.12(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.9.1
@@ -1594,6 +1597,42 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@reactflow/background@11.3.14':
+    resolution: {integrity: sha512-Gewd7blEVT5Lh6jqrvOgd4G6Qk17eGKQfsDXgyRSqM+CTwDqRldG2LsWN4sNeno6sbqVIC2fZ+rAUBFA9ZEUDA==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/controls@11.2.14':
+    resolution: {integrity: sha512-MiJp5VldFD7FrqaBNIrQ85dxChrG6ivuZ+dcFhPQUwOK3HfYgX2RHdBua+gx+40p5Vw5It3dVNp/my4Z3jF0dw==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/core@11.11.4':
+    resolution: {integrity: sha512-H4vODklsjAq3AMq6Np4LE12i1I4Ta9PrDHuBR9GmL8uzTt2l2jh4CiQbEMpvMDcp7xi4be0hgXj+Ysodde/i7Q==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/minimap@11.7.14':
+    resolution: {integrity: sha512-mpwLKKrEAofgFJdkhwR5UQ1JYWlcAAL/ZU/bctBkuNTT1yqV+y0buoNVImsRehVYhJwffSWeSHaBR5/GJjlCSQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/node-resizer@2.2.14':
+    resolution: {integrity: sha512-fwqnks83jUlYr6OHcdFEedumWKChTHRGw/kbCxj0oqBd+ekfs+SIp4ddyNU0pdx96JIm5iNFS0oNrmEiJbbSaA==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/node-toolbar@1.3.14':
+    resolution: {integrity: sha512-rbynXQnH/xFNu4P9H+hVqlEUafDCkEoCy0Dg9mG22Sg+rY/0ck6KkrAQrYrTgXusd+cEJOMK0uOOFCK2/5rSGQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
 
   '@reown/appkit-common@1.7.2':
     resolution: {integrity: sha512-DZkl3P5+Iw3TmsitWmWxYbuSCox8iuzngNp/XhbNDJd7t4Cj4akaIUxSEeCajNDiGHlu4HZnfyM1swWsOJ0cOw==}
@@ -3383,6 +3422,99 @@ packages:
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -3397,6 +3529,9 @@ packages:
 
   '@types/express@5.0.6':
     resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
@@ -4147,6 +4282,9 @@ packages:
     resolution: {integrity: sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==}
     engines: {node: '>= 0.10'}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
@@ -4317,6 +4455,44 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -6323,6 +6499,12 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  reactflow@11.11.4:
+    resolution: {integrity: sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
@@ -7069,6 +7251,11 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   utf-8-validate@5.0.10:
     resolution: {integrity: sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==}
     engines: {node: '>=6.14.2'}
@@ -7452,6 +7639,21 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
   zustand@5.0.12:
     resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
@@ -8620,14 +8822,14 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))':
+  '@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.3.87(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      langsmith: 0.3.87(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -8660,26 +8862,26 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
 
-  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))':
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@langchain/langgraph-sdk@1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       p-queue: 9.1.0
       p-retry: 7.1.1
       uuid: 13.0.0
     optionalDependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)':
+  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
-      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 3.25.76
@@ -8689,11 +8891,11 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)':
+  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
-      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 3.25.76
@@ -8703,20 +8905,9 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      js-tiktoken: 1.0.21
-      openai: 4.104.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
-    transitivePeerDependencies:
-      - encoding
-      - ws
-
-  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       js-tiktoken: 1.0.21
       openai: 4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       zod: 3.25.76
@@ -9063,6 +9254,84 @@ snapshots:
       react-native: 0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@5.0.10)
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@reactflow/background@11.3.14(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@reactflow/core': 11.11.4(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      classcat: 5.0.5
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.14)(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/controls@11.2.14(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@reactflow/core': 11.11.4(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      classcat: 5.0.5
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.14)(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/core@11.11.4(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@types/d3': 7.4.3
+      '@types/d3-drag': 3.0.7
+      '@types/d3-selection': 3.0.11
+      '@types/d3-zoom': 3.0.8
+      classcat: 5.0.5
+      d3-drag: 3.0.0
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.14)(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/minimap@11.7.14(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@reactflow/core': 11.11.4(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@types/d3-selection': 3.0.11
+      '@types/d3-zoom': 3.0.8
+      classcat: 5.0.5
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.14)(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/node-resizer@2.2.14(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@reactflow/core': 11.11.4(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      classcat: 5.0.5
+      d3-drag: 3.0.0
+      d3-selection: 3.0.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.14)(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/node-toolbar@1.3.14(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@reactflow/core': 11.11.4(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      classcat: 5.0.5
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.14)(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
 
   '@reown/appkit-common@1.7.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
     dependencies:
@@ -9431,13 +9700,13 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@sip-protocol/sdk@0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))':
+  '@sip-protocol/sdk@0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
       '@aztec/bb.js': 3.0.2
       '@ethereumjs/rlp': 10.1.1
       '@jup-ag/api': 6.0.48
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@magicblock-labs/ephemeral-rollups-sdk': 0.8.5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
       '@noble/ciphers': 2.1.1
       '@noble/curves': 1.9.7
@@ -9456,7 +9725,7 @@ snapshots:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@triton-one/yellowstone-grpc': 4.0.2(patch_hash=3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a)
-      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))
+      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))
       pino: 10.3.0
       zod: 4.3.6
     optionalDependencies:
@@ -9484,7 +9753,7 @@ snapshots:
       '@ethereumjs/rlp': 10.1.1
       '@jup-ag/api': 6.0.48
       '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@magicblock-labs/ephemeral-rollups-sdk': 0.8.5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
       '@noble/ciphers': 2.1.1
       '@noble/curves': 1.9.7
@@ -9503,7 +9772,7 @@ snapshots:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@triton-one/yellowstone-grpc': 4.0.2(patch_hash=3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a)
-      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))
+      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))
       pino: 10.3.0
       zod: 4.3.6
     optionalDependencies:
@@ -11869,6 +12138,123 @@ snapshots:
     dependencies:
       '@types/node': 25.2.0
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
@@ -11887,6 +12273,8 @@ snapshots:
       '@types/body-parser': 1.19.6
       '@types/express-serve-static-core': 5.1.1
       '@types/serve-static': 2.2.0
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/graceful-fs@4.1.9':
     dependencies:
@@ -13209,6 +13597,8 @@ snapshots:
       safe-buffer: 5.2.1
       to-buffer: 1.2.2
 
+  classcat@5.0.5: {}
+
   cliui@6.0.0:
     dependencies:
       string-width: 4.2.3
@@ -13408,6 +13798,42 @@ snapshots:
       rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   data-uri-to-buffer@4.0.1: {}
 
@@ -14551,12 +14977,12 @@ snapshots:
 
   keyvaluestorage-interface@1.0.0: {}
 
-  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76)):
+  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76)):
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
-      langsmith: 0.4.12(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      langsmith: 0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       uuid: 10.0.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -14568,11 +14994,11 @@ snapshots:
       - react-dom
       - zod-to-json-schema
 
-  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6)):
+  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6)):
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
       langsmith: 0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
       uuid: 10.0.0
       zod: 3.25.76
@@ -14585,7 +15011,7 @@ snapshots:
       - react-dom
       - zod-to-json-schema
 
-  langsmith@0.3.87(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
+  langsmith@0.3.87(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -14594,7 +15020,7 @@ snapshots:
       semver: 7.7.3
       uuid: 10.0.0
     optionalDependencies:
-      openai: 6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
 
   langsmith@0.3.87(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)):
     dependencies:
@@ -14607,7 +15033,7 @@ snapshots:
     optionalDependencies:
       openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
 
-  langsmith@0.4.12(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
+  langsmith@0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -14616,7 +15042,7 @@ snapshots:
       semver: 7.7.3
       uuid: 10.0.0
     optionalDependencies:
-      openai: 6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
 
   langsmith@0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)):
     dependencies:
@@ -15191,21 +15617,6 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@4.104.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
-    dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0
-    optionalDependencies:
-      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - encoding
-
   openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
@@ -15220,12 +15631,6 @@ snapshots:
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
-
-  openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
-    optionalDependencies:
-      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      zod: 3.25.76
-    optional: true
 
   openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
     optionalDependencies:
@@ -15797,6 +16202,20 @@ snapshots:
 
   react@19.2.4: {}
 
+  reactflow@11.11.4(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@reactflow/background': 11.3.14(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@reactflow/controls': 11.2.14(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@reactflow/core': 11.11.4(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@reactflow/minimap': 11.7.14(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@reactflow/node-resizer': 2.2.14(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@reactflow/node-toolbar': 1.3.14(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
   readable-stream@2.3.8:
     dependencies:
       core-util-is: 1.0.3
@@ -16331,7 +16750,7 @@ snapshots:
   terser@5.46.1:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.15.0
+      acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -16581,6 +17000,10 @@ snapshots:
       node-gyp-build: 4.8.4
 
   use-sync-external-store@1.2.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
+  use-sync-external-store@1.6.0(react@19.2.4):
     dependencies:
       react: 19.2.4
 
@@ -16966,8 +17389,15 @@ snapshots:
 
   zod@4.3.6: {}
 
-  zustand@5.0.12(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.2.0(react@19.2.4)):
+  zustand@4.5.7(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       react: 19.2.4
-      use-sync-external-store: 1.2.0(react@19.2.4)
+
+  zustand@5.0.12(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)


### PR DESCRIPTION
## Summary

PR 4 of the glass-neon redesign sprint. Replaces the (since-PR-3) Shielded Volume placeholder with a real card and adds the Privacy Graph hero — both wired to two new backend endpoints.

### Backend (agent)

- **GET /api/chains** — public chain registry (12 rows: Solana mainnet + devnet, 7 EVM L2 testnets live, 3 pending). Each row has `chainId`, `network`, `programId`, `vaultPda`, `feeBps`, `status` (live | pending), `tvlSol` (stub at 0), `rpcLatencyMs`.
- **GET /api/chains/aggregate** — public TVL aggregator. Returns `{ totalTvlSol, chainCount, liveChainCount, asOf }`.
- **GET /api/stealth/index** — JWT-gated. Returns `{ tree: StealthNode[], rootWallet }` for the authenticated caller. Stub returns root-only tree (the wallet itself); real SDK viewing-key derivation lands in M19.

Both new routes mounted in `index.ts` next to the existing public/JWT-gated patterns. Tests cover row shape, aggregate response shape, public access, INTERNAL fail-closed when `req.wallet` missing, and no cross-wallet leakage.

### Frontend

- **NodeGraph primitive** — wraps `reactflow@11.11.4` (the v11 line, before the @xyflow/react rename). Token-styled nodes (cyan root with glow, glass-2 children with accent glow) and edges (cyan-soft animated dash). Background grid with `--color-line` dots. Glass-styled controls panel.
- **PrivacyGraph** — fetches `/api/stealth/index`, transforms tree → NodeGraph nodes/edges, renders inside a sheen Card. Empty-state copy when wallet not connected. Pluralizes address count correctly.
- **ShieldedVolumeCard** — fetches `/api/chains/aggregate`, displays summed TVL + live chain count. Em-dash placeholder while loading or on fetch error.
- **DashboardView wire-in** — `<PrivacyGraph />` renders above the score grid as a full-width hero; `<ShieldedVolumeCard />` replaces the PR 3 placeholder card next to PrivacyScoreCard.

## Acceptance criteria

- [x] Dashboard hero shows the user's actual stealth-address tree (currently root-only stub; real derivation lands in M19)
- [x] Shielded Volume card shows real summed TVL across chains (currently 0 SOL across stub data; real on-chain TVL lands in PR 5)

## Verification

- App tests: **225/225** passing (was 216 on PR 3; +9 new — NodeGraph 3, PrivacyGraph 3, ShieldedVolumeCard 3)
- Agent tests: **1357/1357** passing (was 1348; +6 chains, +3 stealth-index)
- Typecheck + lint clean
- Build delta vs main: CSS +4.46 KB gz, JS +45 KB gz (reactflow). Total +49.5 KB gz — over the 30 KB sprint budget but ResizeObserver-aware code-splitting is a candidate for a follow-up PR.

## Deviations from plan

- **Two stub endpoints, not real implementations.** Plan flagged both as stubs (chains TVL placeholder, stealth tree as root-only); PR 5 wires real on-chain TVL aggregation, M19 wires real SDK viewing-key derivation.
- **reactflow@11, not v12 / @xyflow/react.** Plan said `reactflow@latest` which today resolves to v11.11.4 (v12 was the rename). Sticking with v11 to keep the import surface in `'reactflow'`; v12 migration is a one-line drop-in if/when needed.

## PR 4 of redesign sprint

Spec: \`docs/superpowers/specs/2026-05-07-glass-neon-redesign-design.md\` (D3 reinterpretation table — Network atlas → Privacy graph; Anonymity set → Shielded volume)
Plan: \`docs/superpowers/plans/2026-05-07-glass-neon-redesign.md\` (PR 4 / Tasks 1-6)
Builds on: #178, #179, #180

## Test plan

- [x] All app + agent unit tests pass
- [x] Typecheck + lint + build clean
- [ ] Vercel preview manual check — Dashboard renders Privacy Graph hero + Shielded Volume card with live data; empty-state shows for unauthenticated visitors (RECTOR)