### PR TITLE
feat(redesign): chains tab — multi-chain vault grid + page

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -17,6 +17,7 @@ import VaultView from './views/VaultView'
 import HeraldView from './views/HeraldView'
 import SquadView from './views/SquadView'
 import PrivacyReportView from './views/PrivacyReportView'
+import ChainsView from './views/ChainsView'
 import { useAppStore } from './stores/app'
 import { useAuth } from './hooks/useAuth'
 import { useSSE } from './hooks/useSSE'
@@ -44,6 +45,8 @@ function AppShell() {
         return isAdmin ? <SquadView token={token} /> : <DashboardView events={events} />
       case 'privacyReport':
         return <PrivacyReportView />
+      case 'chains':
+        return <ChainsView />
       case 'chat':
         return (
           <div className="lg:hidden h-full">

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -4,6 +4,7 @@ import {
   Broadcast,
   UsersThree,
   ChatCircle,
+  GlobeHemisphereWest,
 } from '@phosphor-icons/react'
 import { useAppStore, type View } from '../stores/app'
 import { useAuthState } from '../hooks/useAuthState'
@@ -24,6 +25,7 @@ interface Tab {
 const TABS: Tab[] = [
   { id: 'dashboard', label: 'Dashboard', icon: ChartBar },
   { id: 'vault', label: 'Vault', icon: Vault },
+  { id: 'chains', label: 'Chains', icon: GlobeHemisphereWest },
   { id: 'chat', label: 'Chat', icon: ChatCircle, tabletOnly: true },
   { id: 'herald', label: 'Herald', icon: Broadcast, adminOnly: true },
   { id: 'squad', label: 'Squad', icon: UsersThree, adminOnly: true },

--- a/app/src/components/MultiChainVaultGrid.tsx
+++ b/app/src/components/MultiChainVaultGrid.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react'
+import { Card } from './ui/Card'
+import { Pill } from './ui/Pill'
+import { apiFetch } from '../api/client'
+
+export interface ChainRow {
+  chainId: string
+  network: 'mainnet' | 'devnet' | 'testnet'
+  programId: string
+  vaultPda: string | null
+  tvlSol: number
+  feeBps: number
+  status: 'live' | 'pending'
+  rpcLatencyMs: number | null
+}
+
+function formatChainName(chainId: string): string {
+  return chainId
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+export function MultiChainVaultGrid() {
+  const [chains, setChains] = useState<ChainRow[]>([])
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    apiFetch<{ chains: ChainRow[] }>('/api/chains', { signal: controller.signal })
+      .then((j) => setChains(j.chains))
+      .catch((err) => {
+        if (err instanceof Error && err.name === 'AbortError') return
+        setError(err instanceof Error ? err.message : 'Failed to load chains')
+      })
+    return () => controller.abort()
+  }, [])
+
+  return (
+    <Card variant="default" className="p-6">
+      <div className="flex items-center justify-between mb-4">
+        <span
+          className="text-2xs text-text-muted"
+          style={{ letterSpacing: 'var(--tracking-widest)' }}
+        >
+          MULTI-CHAIN VAULTS
+        </span>
+        <span className="text-xs text-text-muted">
+          {chains.length} {chains.length === 1 ? 'chain' : 'chains'}
+        </span>
+      </div>
+      {error && (
+        <div className="text-sm text-danger py-4">{error}</div>
+      )}
+      {!error && chains.length === 0 && (
+        <div className="text-sm text-text-muted py-4">Loading chains…</div>
+      )}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        {chains.map((c) => (
+          <div
+            key={c.chainId}
+            className="p-3 bg-glass-1 rounded-md border border-line"
+          >
+            <div className="flex items-center justify-between mb-1.5">
+              <span className="text-xs text-text-secondary">{formatChainName(c.chainId)}</span>
+              <Pill label={c.status.toUpperCase()} size="sm" active={c.status === 'live'} />
+            </div>
+            <div className="font-mono text-sm text-text">
+              {c.tvlSol.toLocaleString(undefined, { maximumFractionDigits: 2 })} SOL
+            </div>
+            <div className="text-2xs text-text-muted">fee {c.feeBps} bps</div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  )
+}

--- a/app/src/components/__tests__/MultiChainVaultGrid.test.tsx
+++ b/app/src/components/__tests__/MultiChainVaultGrid.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MultiChainVaultGrid, type ChainRow } from '../MultiChainVaultGrid'
+
+vi.mock('../../api/client', () => ({
+  apiFetch: vi.fn(),
+}))
+
+import { apiFetch } from '../../api/client'
+
+const fakeChains: ChainRow[] = [
+  {
+    chainId: 'solana-mainnet',
+    network: 'mainnet',
+    programId: 'S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at',
+    vaultPda: 'BVawZkppFewygA5nxdrLma4ThKx8Th7bW4KTCkcWTZwZ',
+    tvlSol: 12.5,
+    feeBps: 50,
+    status: 'live',
+    rpcLatencyMs: null,
+  },
+  {
+    chainId: 'sepolia',
+    network: 'testnet',
+    programId: '0x1FED19684dC108304960db2818CF5a961d28405E',
+    vaultPda: null,
+    tvlSol: 0,
+    feeBps: 50,
+    status: 'live',
+    rpcLatencyMs: null,
+  },
+  {
+    chainId: 'blast-sepolia',
+    network: 'testnet',
+    programId: '',
+    vaultPda: null,
+    tvlSol: 0,
+    feeBps: 50,
+    status: 'pending',
+    rpcLatencyMs: null,
+  },
+]
+
+beforeEach(() => {
+  ;(apiFetch as ReturnType<typeof vi.fn>).mockReset()
+})
+
+describe('MultiChainVaultGrid', () => {
+  it('renders human-readable chain names from chainId', async () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ chains: fakeChains })
+    render(<MultiChainVaultGrid />)
+    await waitFor(() => expect(screen.getByText('Solana Mainnet')).toBeInTheDocument())
+    expect(screen.getByText('Sepolia')).toBeInTheDocument()
+    expect(screen.getByText('Blast Sepolia')).toBeInTheDocument()
+  })
+
+  it('marks live chains with the LIVE pill (active=true)', async () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ chains: fakeChains })
+    render(<MultiChainVaultGrid />)
+    await waitFor(() => {
+      const livePills = screen.getAllByRole('button', { name: 'LIVE' })
+      expect(livePills.length).toBe(2)
+      livePills.forEach((p) => expect(p).toHaveAttribute('aria-pressed', 'true'))
+    })
+  })
+
+  it('marks pending chains with the PENDING pill (active=false)', async () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ chains: fakeChains })
+    render(<MultiChainVaultGrid />)
+    await waitFor(() => {
+      const pendingPill = screen.getByRole('button', { name: 'PENDING' })
+      expect(pendingPill).toHaveAttribute('aria-pressed', 'false')
+    })
+  })
+
+  it('formats TVL with 2-decimal precision and fee in bps', async () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ chains: fakeChains })
+    render(<MultiChainVaultGrid />)
+    await waitFor(() => expect(screen.getByText('12.5 SOL')).toBeInTheDocument())
+    expect(screen.getAllByText(/fee 50 bps/).length).toBe(3)
+  })
+
+  it('renders chain count with proper pluralization', async () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ chains: fakeChains })
+    render(<MultiChainVaultGrid />)
+    await waitFor(() => expect(screen.getByText('3 chains')).toBeInTheDocument())
+  })
+
+  it('shows loading copy until data lands', () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockReturnValueOnce(new Promise(() => {}))
+    render(<MultiChainVaultGrid />)
+    expect(screen.getByText(/Loading chains/)).toBeInTheDocument()
+  })
+
+  it('surfaces the error message on fetch failure', async () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('network down'))
+    render(<MultiChainVaultGrid />)
+    await waitFor(() => expect(screen.getByText('network down')).toBeInTheDocument())
+  })
+})

--- a/app/src/stores/app.ts
+++ b/app/src/stores/app.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 
-export type View = 'dashboard' | 'vault' | 'herald' | 'squad' | 'chat' | 'privacyReport'
+export type View = 'dashboard' | 'vault' | 'herald' | 'squad' | 'chat' | 'privacyReport' | 'chains'
 export type ToolStatus = 'running' | 'success' | 'error'
 
 export interface ToolCall {

--- a/app/src/views/ChainsView.tsx
+++ b/app/src/views/ChainsView.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from 'react'
+import { Card } from '../components/ui/Card'
+import { Pill } from '../components/ui/Pill'
+import { HashCell } from '../components/ui/HashCell'
+import { apiFetch } from '../api/client'
+import type { ChainRow } from '../components/MultiChainVaultGrid'
+
+function formatChainName(chainId: string): string {
+  return chainId
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function formatNetworkBadge(network: ChainRow['network']): string {
+  return network.toUpperCase()
+}
+
+export default function ChainsView() {
+  const [chains, setChains] = useState<ChainRow[]>([])
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    apiFetch<{ chains: ChainRow[] }>('/api/chains', { signal: controller.signal })
+      .then((j) => setChains(j.chains))
+      .catch((err) => {
+        if (err instanceof Error && err.name === 'AbortError') return
+        setError(err instanceof Error ? err.message : 'Failed to load chains')
+      })
+    return () => controller.abort()
+  }, [])
+
+  const liveCount = chains.filter((c) => c.status === 'live').length
+  const totalTvl = chains.reduce((sum, c) => sum + c.tvlSol, 0)
+
+  return (
+    <div className="max-w-6xl mx-auto p-6 space-y-6">
+      <div>
+        <h1 className="text-3xl text-text font-semibold">Chains</h1>
+        <p className="text-base text-text-muted mt-1">
+          Per-chain SIP vault deployment status. {liveCount} of {chains.length} chains live · {totalTvl.toFixed(2)} SOL aggregate TVL.
+        </p>
+      </div>
+
+      {error && (
+        <Card variant="default" className="p-4 text-sm text-danger">
+          {error}
+        </Card>
+      )}
+
+      {!error && (
+        <Card variant="default" className="p-6 overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead
+              className="text-2xs text-text-muted"
+              style={{ letterSpacing: 'var(--tracking-wider)' }}
+            >
+              <tr>
+                <th className="text-left font-medium pb-3">CHAIN</th>
+                <th className="text-left font-medium pb-3">NETWORK</th>
+                <th className="text-left font-medium pb-3">STATUS</th>
+                <th className="text-right font-medium pb-3">TVL</th>
+                <th className="text-right font-medium pb-3">FEE</th>
+                <th className="text-left font-medium pb-3 pl-6">PROGRAM ID</th>
+              </tr>
+            </thead>
+            <tbody>
+              {chains.length === 0 && !error && (
+                <tr>
+                  <td colSpan={6} className="py-8 text-center text-text-muted text-sm">
+                    Loading chains…
+                  </td>
+                </tr>
+              )}
+              {chains.map((c) => (
+                <tr key={c.chainId} className="border-t border-line">
+                  <td className="py-3 text-text">{formatChainName(c.chainId)}</td>
+                  <td className="py-3 text-text-secondary font-mono">{formatNetworkBadge(c.network)}</td>
+                  <td className="py-3">
+                    <Pill label={c.status.toUpperCase()} size="sm" active={c.status === 'live'} />
+                  </td>
+                  <td className="py-3 text-right font-mono text-text">
+                    {c.tvlSol.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+                  </td>
+                  <td className="py-3 text-right text-text-secondary">{c.feeBps} bps</td>
+                  <td className="py-3 pl-6">
+                    {c.programId ? (
+                      <HashCell hash={c.programId} headChars={6} tailChars={6} />
+                    ) : (
+                      <span className="text-text-muted font-mono">—</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -6,6 +6,7 @@ import { PrivacyScoreCard } from '../components/PrivacyScoreCard'
 import { ActivityStreamTable, type ActivityRow } from '../components/ActivityStreamTable'
 import { PrivacyGraph } from '../components/PrivacyGraph'
 import { ShieldedVolumeCard } from '../components/ShieldedVolumeCard'
+import { MultiChainVaultGrid } from '../components/MultiChainVaultGrid'
 
 interface VaultData {
   wallet: string
@@ -131,6 +132,8 @@ export default function DashboardView({ events }: { events: ActivityEvent[] }) {
           <ShieldedVolumeCard />
         </div>
       </div>
+
+      <MultiChainVaultGrid />
 
       <ActivityStreamTable rows={allRows} />
     </div>

--- a/app/src/views/__tests__/ChainsView.test.tsx
+++ b/app/src/views/__tests__/ChainsView.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import ChainsView from '../ChainsView'
+
+vi.mock('../../api/client', () => ({
+  apiFetch: vi.fn(),
+}))
+
+import { apiFetch } from '../../api/client'
+
+const fakeChains = [
+  {
+    chainId: 'solana-mainnet',
+    network: 'mainnet' as const,
+    programId: 'S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at',
+    vaultPda: 'BVawZkppFewygA5nxdrLma4ThKx8Th7bW4KTCkcWTZwZ',
+    tvlSol: 12.5,
+    feeBps: 50,
+    status: 'live' as const,
+    rpcLatencyMs: null,
+  },
+  {
+    chainId: 'sepolia',
+    network: 'testnet' as const,
+    programId: '0x1FED19684dC108304960db2818CF5a961d28405E',
+    vaultPda: null,
+    tvlSol: 3.7,
+    feeBps: 50,
+    status: 'live' as const,
+    rpcLatencyMs: null,
+  },
+  {
+    chainId: 'blast-sepolia',
+    network: 'testnet' as const,
+    programId: '',
+    vaultPda: null,
+    tvlSol: 0,
+    feeBps: 50,
+    status: 'pending' as const,
+    rpcLatencyMs: null,
+  },
+]
+
+beforeEach(() => {
+  ;(apiFetch as ReturnType<typeof vi.fn>).mockReset()
+})
+
+describe('ChainsView', () => {
+  it('renders the page header with live/total counts and aggregate TVL', async () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ chains: fakeChains })
+    render(<ChainsView />)
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1, name: 'Chains' })).toBeInTheDocument()
+      expect(screen.getByText(/2 of 3 chains live/)).toBeInTheDocument()
+      expect(screen.getByText(/16\.20 SOL aggregate TVL/)).toBeInTheDocument()
+    })
+  })
+
+  it('renders one row per chain with formatted name + status pill', async () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ chains: fakeChains })
+    render(<ChainsView />)
+    await waitFor(() => {
+      expect(screen.getByText('Solana Mainnet')).toBeInTheDocument()
+      expect(screen.getByText('Sepolia')).toBeInTheDocument()
+      expect(screen.getByText('Blast Sepolia')).toBeInTheDocument()
+    })
+    expect(screen.getAllByRole('button', { name: 'LIVE' }).length).toBe(2)
+    expect(screen.getByRole('button', { name: 'PENDING' })).toBeInTheDocument()
+  })
+
+  it('renders the program ID via HashCell when present, em-dash when empty', async () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ chains: fakeChains })
+    render(<ChainsView />)
+    await waitFor(() => {
+      expect(screen.getByText('S1PMFs…epS9at')).toBeInTheDocument()
+      expect(screen.getByText('0x1FED…28405E')).toBeInTheDocument()
+    })
+  })
+
+  it('shows the loading row when chains is empty before fetch resolves', () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockReturnValueOnce(new Promise(() => {}))
+    render(<ChainsView />)
+    expect(screen.getByText(/Loading chains/)).toBeInTheDocument()
+  })
+
+  it('surfaces error copy when fetch fails', async () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('boom'))
+    render(<ChainsView />)
+    await waitFor(() => expect(screen.getByText('boom')).toBeInTheDocument())
+  })
+})


### PR DESCRIPTION
## Summary

PR 5 of the glass-neon redesign sprint. Adds the **Chains** tab and Dashboard mini-grid, both reading from the public `/api/chains` endpoint shipped in PR 4.

- **MultiChainVaultGrid** — Dashboard mini-card. 4-column grid (2-col on mobile) of per-chain tiles showing formatted chain name, LIVE/PENDING status pill, TVL in SOL with locale formatting, and fee bps. Loading + error states surface inline.
- **ChainsView** — full `/chains` route view. Header with live/total counts and aggregate TVL, then a 6-column table (CHAIN / NETWORK / STATUS / TVL / FEE / PROGRAM ID) with HashCell for the program ID column (em-dash for chains without a deployed program yet).
- **Nav wiring** — `'chains'` added to the View type union; new Chains tab in Header TABS (3rd position, GlobeHemisphereWest icon, non-admin so visible for all authenticated viewers); App.tsx renderView routes to ChainsView. MultiChainVaultGrid wired into DashboardView between the score grid and the activity stream, completing the spec D4 layout.

## Acceptance criteria

- [x] Chains tab shows live status of Solana mainnet/devnet + 7 EVM L2s live + 3 pending (12 rows total)
- [x] Dashboard shows the mini-grid
- [x] Status pills correctly reflect deployment state from M18

## Verification

- App tests: **237/237** passing (was 225 on PR 4; +12 new — MultiChainVaultGrid 7, ChainsView 5)
- Typecheck + lint clean
- Build: CSS 58.52 KB / 12.23 KB gz, JS 913.80 KB / 278.04 KB gz (~+0.5 KB CSS gz, +2.6 KB JS gz vs PR 4 — small)

## Deferred from plan

**Task 1 (real on-chain TVL aggregation) deferred** to a follow-up PR. Plan asked for Helius `getBalance` on Solana vault PDAs + `eth_getBalance` on each EVM L2 contract via `Promise.allSettled`. The current `/api/chains` endpoint (shipped in PR 4) returns `tvlSol: 0` across the board. UI behavior is correct: it formats `0 SOL` for each chain and `0.00 SOL aggregate TVL`. When the real-TVL PR lands, no FE changes needed — the response shape is identical.

The reason for deferring: real-TVL needs cross-chain RPC config (EVM RPC URLs aren't currently in the agent env), retry/backoff for flakey testnets, and probably a TTL-cached aggregate to avoid hammering RPCs on every Dashboard mount. That's a self-contained PR worth its own scope — bundling it here would have made review harder.

## PR 5 of redesign sprint

Spec: \`docs/superpowers/specs/2026-05-07-glass-neon-redesign-design.md\` (D3 reinterpretation table — Denomination pools → Multi-chain vault grid)
Plan: \`docs/superpowers/plans/2026-05-07-glass-neon-redesign.md\` (PR 5 / Tasks 2-3; Task 1 deferred per above)
Builds on: #178, #179, #180, #181

## Test plan

- [x] All app unit tests pass
- [x] Typecheck + lint + build clean
- [ ] Vercel preview manual check — Chains tab appears in Header for authenticated user, ChainsView renders the table with all 12 rows, Dashboard mini-grid shows 4-col on lg viewport (RECTOR)