### PR TITLE
feat(redesign): PR 6b — WithdrawView with per-record refund flow

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -15,6 +15,7 @@ import { Sheet } from './components/ui/Sheet'
 import DashboardView from './views/DashboardView'
 import VaultView from './views/VaultView'
 import DepositView from './views/DepositView'
+import WithdrawView from './views/WithdrawView'
 import HeraldView from './views/HeraldView'
 import SquadView from './views/SquadView'
 import PrivacyReportView from './views/PrivacyReportView'
@@ -42,6 +43,8 @@ function AppShell() {
         return <VaultView />
       case 'deposit':
         return <DepositView />
+      case 'withdraw':
+        return <WithdrawView />
       case 'herald':
         return isAdmin ? <HeraldView token={token} /> : <DashboardView events={events} />
       case 'squad':

--- a/app/src/components/BottomNav.tsx
+++ b/app/src/components/BottomNav.tsx
@@ -44,7 +44,7 @@ export default function BottomNav() {
           const Icon = tab.icon
           const active =
             activeView === tab.id ||
-            (tab.id === 'vault' && activeView === 'deposit')
+            (tab.id === 'vault' && (activeView === 'deposit' || activeView === 'withdraw'))
           return (
             <button
               key={tab.id}

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -78,7 +78,7 @@ export default function Header() {
             const Icon = tab.icon
             const active =
               activeView === tab.id ||
-              (tab.id === 'vault' && activeView === 'deposit')
+              (tab.id === 'vault' && (activeView === 'deposit' || activeView === 'withdraw'))
             return (
               <button
                 key={tab.id}

--- a/app/src/components/vault/CooldownChip.tsx
+++ b/app/src/components/vault/CooldownChip.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react'
+
+interface CooldownChipProps {
+  refundableAt: number // unix seconds
+  onElapsed?: () => void
+}
+
+const CHIP_BASE =
+  'inline-flex items-center gap-1.5 border rounded-pill px-2.5 py-1 text-xs font-medium tracking-wide uppercase'
+
+function formatRemaining(secondsRemaining: number): string {
+  if (secondsRemaining <= 0) return 'Available now'
+  if (secondsRemaining < 3600) {
+    const m = Math.floor(secondsRemaining / 60)
+    const s = secondsRemaining % 60
+    return `${m}:${s.toString().padStart(2, '0')}`
+  }
+  const h = Math.floor(secondsRemaining / 3600)
+  const m = Math.floor((secondsRemaining % 3600) / 60)
+  return `${h}h ${m}m`
+}
+
+export function CooldownChip({ refundableAt, onElapsed }: CooldownChipProps) {
+  const [now, setNow] = useState(() => Math.floor(Date.now() / 1000))
+  const remaining = refundableAt - now
+  const elapsed = remaining <= 0
+
+  useEffect(() => {
+    if (elapsed) return
+    const id = setInterval(() => {
+      const next = Math.floor(Date.now() / 1000)
+      setNow(next)
+      if (next >= refundableAt) {
+        clearInterval(id)
+        onElapsed?.()
+      }
+    }, 1000)
+    return () => clearInterval(id)
+  }, [refundableAt, elapsed, onElapsed])
+
+  const className = elapsed
+    ? `${CHIP_BASE} border-success/40 bg-success-soft text-success`
+    : `${CHIP_BASE} border-line text-text-muted`
+
+  return (
+    <span role="status" aria-live="polite" className={className}>
+      {formatRemaining(remaining)}
+    </span>
+  )
+}

--- a/app/src/components/vault/RefundList.tsx
+++ b/app/src/components/vault/RefundList.tsx
@@ -1,0 +1,59 @@
+import { Card } from '../ui/Card'
+import { CooldownChip } from './CooldownChip'
+import { TxStatusBadge } from './TxStatusBadge'
+import type { Position } from './StealthAddressList'
+import type { SignStatus } from '../../hooks/useTransactionSigner'
+
+interface RefundListProps {
+  records: Position[]
+  onRefund: (token: string) => Promise<void> | void
+  statusByToken: Record<string, SignStatus>
+  signaturesByToken: Record<string, string>
+}
+
+const CHIP_BASE =
+  'inline-flex items-center gap-1.5 border rounded-pill px-2.5 py-1 text-xs font-medium tracking-wide uppercase'
+
+export function RefundList({ records, onRefund, statusByToken, signaturesByToken }: RefundListProps) {
+  if (records.length === 0) {
+    return (
+      <Card variant="default" className="p-6">
+        <p className="text-sm text-text-muted">No active vault positions to refund.</p>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {records.map((p) => {
+        const status = statusByToken[p.symbol] ?? 'idle'
+        const signature = signaturesByToken[p.symbol]
+        const busy = status === 'signing' || status === 'broadcasting'
+        return (
+          <Card
+            key={p.depositRecordAddress}
+            variant="default"
+            className="p-4 flex items-center gap-3"
+          >
+            <span className={`${CHIP_BASE} border-cyan/40 bg-cyan-soft text-cyan-hi`}>
+              {p.symbol}
+            </span>
+            <span className="text-sm font-mono">{p.balanceUiAmount}</span>
+            <CooldownChip refundableAt={p.refundableAt} />
+            <div className="ml-auto flex items-center gap-3">
+              <TxStatusBadge status={status} signature={signature} />
+              <button
+                type="button"
+                onClick={() => onRefund(p.symbol)}
+                disabled={p.cooldownActive || busy}
+                className="text-xs border border-line rounded-md px-3 py-1.5 hover:border-line-2 disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                Refund
+              </button>
+            </div>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/app/src/components/vault/__tests__/CooldownChip.test.tsx
+++ b/app/src/components/vault/__tests__/CooldownChip.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { CooldownChip } from '../CooldownChip'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-05-08T00:00:00Z'))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('CooldownChip', () => {
+  it('renders Available now when refundableAt is in the past', () => {
+    const past = Math.floor(Date.now() / 1000) - 60
+    render(<CooldownChip refundableAt={past} />)
+    expect(screen.getByText(/available now/i)).toBeInTheDocument()
+  })
+
+  it('renders countdown copy in mm:ss when within 1h', () => {
+    const future = Math.floor(Date.now() / 1000) + 600
+    render(<CooldownChip refundableAt={future} />)
+    expect(screen.getByText(/10:00|10m/i)).toBeInTheDocument()
+  })
+
+  it('renders countdown copy in Xh Ym when >=1h', () => {
+    const future = Math.floor(Date.now() / 1000) + 5 * 3600
+    render(<CooldownChip refundableAt={future} />)
+    expect(screen.getByText(/5h/)).toBeInTheDocument()
+  })
+
+  it('flips to Available now when timer ticks past zero', () => {
+    const future = Math.floor(Date.now() / 1000) + 2
+    const onElapsed = vi.fn()
+    render(<CooldownChip refundableAt={future} onElapsed={onElapsed} />)
+    act(() => {
+      vi.advanceTimersByTime(3000)
+    })
+    expect(screen.getByText(/available now/i)).toBeInTheDocument()
+    expect(onElapsed).toHaveBeenCalled()
+  })
+})

--- a/app/src/components/vault/__tests__/RefundList.test.tsx
+++ b/app/src/components/vault/__tests__/RefundList.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { RefundList } from '../RefundList'
+
+vi.mock('../../../lib/networkConfig', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/networkConfig')>()
+  return {
+    ...actual,
+    useNetworkConfigStore: <T,>(selector: (s: { config: { solscanSuffix: string } }) => T) =>
+      selector({ config: { solscanSuffix: '?cluster=devnet' } }),
+  }
+})
+
+const fakePosition = {
+  mint: 'So11111111111111111111111111111111111111112',
+  symbol: 'SOL',
+  balance: '2500000000',
+  balanceUiAmount: 2.5,
+  lockedAmount: '0',
+  decimals: 9,
+  lastDepositAt: 1715000000,
+  refundableAt: 1715086400,
+  cooldownActive: false,
+  depositRecordAddress: 'DEPOSITRECORDPDA',
+}
+
+describe('RefundList', () => {
+  it('renders a row per record with mint + balance + Refund button', () => {
+    render(
+      <RefundList
+        records={[fakePosition]}
+        onRefund={vi.fn()}
+        statusByToken={{}}
+        signaturesByToken={{}}
+      />
+    )
+    expect(screen.getByText('SOL')).toBeInTheDocument()
+    expect(screen.getByText(/2\.5/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /refund/i })).toBeInTheDocument()
+  })
+
+  it('disables Refund when cooldownActive', () => {
+    render(
+      <RefundList
+        records={[{ ...fakePosition, cooldownActive: true }]}
+        onRefund={vi.fn()}
+        statusByToken={{}}
+        signaturesByToken={{}}
+      />
+    )
+    expect(screen.getByRole('button', { name: /refund/i })).toBeDisabled()
+  })
+
+  it('calls onRefund(token) when Refund clicked', () => {
+    const onRefund = vi.fn()
+    render(
+      <RefundList
+        records={[fakePosition]}
+        onRefund={onRefund}
+        statusByToken={{}}
+        signaturesByToken={{}}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /refund/i }))
+    expect(onRefund).toHaveBeenCalledWith('SOL')
+  })
+
+  it('renders empty-state copy when records is empty', () => {
+    render(
+      <RefundList
+        records={[]}
+        onRefund={vi.fn()}
+        statusByToken={{}}
+        signaturesByToken={{}}
+      />
+    )
+    expect(screen.getByText(/no active vault positions/i)).toBeInTheDocument()
+  })
+})

--- a/app/src/components/vault/__tests__/RefundList.test.tsx
+++ b/app/src/components/vault/__tests__/RefundList.test.tsx
@@ -76,4 +76,17 @@ describe('RefundList', () => {
     )
     expect(screen.getByText(/no active vault positions/i)).toBeInTheDocument()
   })
+
+  it('disables Refund and shows Signing badge when statusByToken[symbol] === signing', () => {
+    render(
+      <RefundList
+        records={[fakePosition]}
+        onRefund={vi.fn()}
+        statusByToken={{ SOL: 'signing' }}
+        signaturesByToken={{}}
+      />
+    )
+    expect(screen.getByRole('button', { name: /refund/i })).toBeDisabled()
+    expect(screen.getByText(/signing/i)).toBeInTheDocument()
+  })
 })

--- a/app/src/stores/app.ts
+++ b/app/src/stores/app.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 
-export type View = 'dashboard' | 'vault' | 'herald' | 'squad' | 'chat' | 'privacyReport' | 'chains' | 'deposit'
+export type View = 'dashboard' | 'vault' | 'herald' | 'squad' | 'chat' | 'privacyReport' | 'chains' | 'deposit' | 'withdraw'
 export type ToolStatus = 'running' | 'success' | 'error'
 
 export interface ToolCall {

--- a/app/src/views/VaultView.tsx
+++ b/app/src/views/VaultView.tsx
@@ -84,6 +84,8 @@ export default function VaultView() {
         positions={positions}
         stealthTree={stealthTree}
         loading={loading}
+        onWithdraw={() => setActiveView('withdraw')}
+        disabled={isMainnet}
       />
       <UnshieldedWalletPanel
         wallet={vault?.wallet ?? ''}
@@ -99,10 +101,14 @@ function ShieldedVaultPanel({
   positions,
   stealthTree,
   loading,
+  onWithdraw,
+  disabled,
 }: {
   positions: Position[]
   stealthTree: StealthNode[]
   loading: boolean
+  onWithdraw: () => void
+  disabled: boolean
 }) {
   const totalSol = positions.find((p) => p.symbol === 'SOL')?.balanceUiAmount ?? 0
   const hasPositions = positions.length > 0
@@ -131,9 +137,10 @@ function ShieldedVaultPanel({
       <StealthAddressList positions={positions} stealthTree={stealthTree} loading={loading} />
       <button
         type="button"
-        disabled
-        className="self-start border border-line rounded-md px-3 py-1.5 text-xs disabled:opacity-40 disabled:cursor-not-allowed"
-        title="Coming soon — refund flow ships in PR 6b"
+        onClick={onWithdraw}
+        disabled={disabled}
+        className="self-start border border-line rounded-md px-3 py-1.5 text-xs hover:border-line-2 disabled:opacity-40 disabled:cursor-not-allowed"
+        title={disabled ? 'Devnet only — switch network' : ''}
       >
         Withdraw
       </button>

--- a/app/src/views/WithdrawView.tsx
+++ b/app/src/views/WithdrawView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { ArrowLeft } from '@phosphor-icons/react'
 import { apiFetch } from '../api/client'
 import { useAuthState } from '../hooks/useAuthState'
@@ -29,10 +29,13 @@ export default function WithdrawView() {
   const network = useNetworkConfigStore((s) => s.config?.network ?? '')
   const isMainnet = network === 'mainnet'
 
+  // Vault deposit_record PDA is per (wallet, mint), so positions[] is one row per mint
+  // and the symbol-keyed status/signature/error maps are 1:1 with the rendered rows.
   const [positions, setPositions] = useState<Position[]>([])
   const [statusByToken, setStatusByToken] = useState<Record<string, SignStatus>>({})
   const [signaturesByToken, setSignaturesByToken] = useState<Record<string, string>>({})
   const [errorByToken, setErrorByToken] = useState<Record<string, string>>({})
+  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const { signAndBroadcast } = useTransactionSigner()
 
@@ -59,6 +62,12 @@ export default function WithdrawView() {
     return () => controller.abort()
   }, [token, isMainnet, refresh])
 
+  useEffect(() => {
+    return () => {
+      if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current)
+    }
+  }, [])
+
   const handleRefund = useCallback(
     async (tokenSymbol: string) => {
       setErrorByToken((s) => ({ ...s, [tokenSymbol]: '' }))
@@ -77,12 +86,14 @@ export default function WithdrawView() {
           return
         }
         setStatusByToken((s) => ({ ...s, [tokenSymbol]: 'confirmed' }))
-        if (result.signature) {
-          setSignaturesByToken((s) => ({ ...s, [tokenSymbol]: result.signature! }))
+        const sig = result.signature
+        if (sig) {
+          setSignaturesByToken((s) => ({ ...s, [tokenSymbol]: sig }))
         }
         // Refresh positions a moment after confirmation so the closed deposit
         // record drops out of the list.
-        setTimeout(() => refresh(), 1500)
+        if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current)
+        refreshTimerRef.current = setTimeout(() => refresh(), 1500)
       } catch (err) {
         setStatusByToken((s) => ({ ...s, [tokenSymbol]: 'error' }))
         setErrorByToken((s) => ({

--- a/app/src/views/WithdrawView.tsx
+++ b/app/src/views/WithdrawView.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState, useCallback } from 'react'
+import { ArrowLeft } from '@phosphor-icons/react'
+import { apiFetch } from '../api/client'
+import { useAuthState } from '../hooks/useAuthState'
+import { useAppStore } from '../stores/app'
+import { useTransactionSigner } from '../hooks/useTransactionSigner'
+import { useNetworkConfigStore } from '../lib/networkConfig'
+import { Card } from '../components/ui/Card'
+import { RefundList } from '../components/vault/RefundList'
+import type { Position } from '../components/vault/StealthAddressList'
+import type { SignStatus } from '../hooks/useTransactionSigner'
+
+interface PositionsResponse {
+  positions: Position[]
+  available: boolean
+  reason?: string
+  network: string
+}
+
+interface RefundTxResponse {
+  serializedTx: string
+  refundAmount: string
+  network?: string
+}
+
+export default function WithdrawView() {
+  const { token } = useAuthState()
+  const setActiveView = useAppStore((s) => s.setActiveView)
+  const network = useNetworkConfigStore((s) => s.config?.network ?? '')
+  const isMainnet = network === 'mainnet'
+
+  const [positions, setPositions] = useState<Position[]>([])
+  const [statusByToken, setStatusByToken] = useState<Record<string, SignStatus>>({})
+  const [signaturesByToken, setSignaturesByToken] = useState<Record<string, string>>({})
+  const [errorByToken, setErrorByToken] = useState<Record<string, string>>({})
+
+  const { signAndBroadcast } = useTransactionSigner()
+
+  const refresh = useCallback(
+    (signal?: AbortSignal) => {
+      if (!token) return
+      apiFetch<PositionsResponse>('/api/vault/positions', {
+        token: token ?? undefined,
+        signal,
+      })
+        .then((r) => {
+          if (signal?.aborted) return
+          setPositions(r.positions)
+        })
+        .catch(() => null)
+    },
+    [token],
+  )
+
+  useEffect(() => {
+    if (!token || isMainnet) return
+    const controller = new AbortController()
+    refresh(controller.signal)
+    return () => controller.abort()
+  }, [token, isMainnet, refresh])
+
+  const handleRefund = useCallback(
+    async (tokenSymbol: string) => {
+      setErrorByToken((s) => ({ ...s, [tokenSymbol]: '' }))
+      setStatusByToken((s) => ({ ...s, [tokenSymbol]: 'signing' }))
+      try {
+        const { serializedTx } = await apiFetch<RefundTxResponse>('/api/vault/refund-tx', {
+          method: 'POST',
+          token: token ?? undefined,
+          body: JSON.stringify({ token: tokenSymbol }),
+        })
+        setStatusByToken((s) => ({ ...s, [tokenSymbol]: 'broadcasting' }))
+        const result = await signAndBroadcast(serializedTx)
+        if (result.error) {
+          setStatusByToken((s) => ({ ...s, [tokenSymbol]: 'error' }))
+          setErrorByToken((s) => ({ ...s, [tokenSymbol]: result.error ?? 'Unknown error' }))
+          return
+        }
+        setStatusByToken((s) => ({ ...s, [tokenSymbol]: 'confirmed' }))
+        if (result.signature) {
+          setSignaturesByToken((s) => ({ ...s, [tokenSymbol]: result.signature! }))
+        }
+        // Refresh positions a moment after confirmation so the closed deposit
+        // record drops out of the list.
+        setTimeout(() => refresh(), 1500)
+      } catch (err) {
+        setStatusByToken((s) => ({ ...s, [tokenSymbol]: 'error' }))
+        setErrorByToken((s) => ({
+          ...s,
+          [tokenSymbol]: err instanceof Error ? err.message : 'Unknown error',
+        }))
+      }
+    },
+    [signAndBroadcast, token, refresh],
+  )
+
+  if (isMainnet) {
+    return (
+      <div className="flex flex-col gap-4 max-w-3xl mx-auto">
+        <BackChip onClick={() => setActiveView('vault')} />
+        <Card variant="default" className="p-6">
+          <p className="text-sm text-text">
+            Sipher Vault is on devnet only — switch network to withdraw.
+          </p>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4 max-w-3xl mx-auto">
+      <BackChip onClick={() => setActiveView('vault')} />
+      <h1 className="text-2xl font-semibold">Refund from vault</h1>
+      <p className="text-xs text-text-muted">
+        Each refund returns the deposited balance to your wallet. The on-chain 24h cooldown is
+        enforced per record.
+      </p>
+      <RefundList
+        records={positions}
+        onRefund={handleRefund}
+        statusByToken={statusByToken}
+        signaturesByToken={signaturesByToken}
+      />
+      {Object.entries(errorByToken)
+        .filter(([, msg]) => Boolean(msg))
+        .map(([tok, msg]) => (
+          <Card
+            key={tok}
+            variant="default"
+            role="alert"
+            aria-live="assertive"
+            className="p-3 border border-danger"
+          >
+            <p className="text-xs text-danger">
+              {tok}: {msg}
+            </p>
+          </Card>
+        ))}
+    </div>
+  )
+}
+
+function BackChip({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="self-start flex items-center gap-1 text-xs text-text-secondary border border-line rounded-md px-2 py-1 hover:border-line-2 hover:text-text"
+    >
+      <ArrowLeft size={12} /> Back to Vault
+    </button>
+  )
+}

--- a/app/src/views/__tests__/VaultView.test.tsx
+++ b/app/src/views/__tests__/VaultView.test.tsx
@@ -141,21 +141,28 @@ describe('VaultView (split-panel)', () => {
     expect(setActiveView).toHaveBeenCalledWith('deposit')
   })
 
-  it('Withdraw CTA always disabled (PR 6b ships withdraw flow)', async () => {
+  it('Withdraw CTA routes to withdraw view', async () => {
+    mockThreeFetches()
+    render(<VaultView />)
+    const withdrawBtn = await screen.findByRole('button', { name: /withdraw/i })
+    fireEvent.click(withdrawBtn)
+    expect(setActiveView).toHaveBeenCalledWith('withdraw')
+  })
+
+  it('Withdraw CTA still routes when positions exist', async () => {
+    mockThreeFetches(populatedPositions)
+    render(<VaultView />)
+    const withdrawBtn = await screen.findByRole('button', { name: /withdraw/i })
+    fireEvent.click(withdrawBtn)
+    expect(setActiveView).toHaveBeenCalledWith('withdraw')
+  })
+
+  it('Withdraw CTA disabled on mainnet', async () => {
+    networkValue = 'mainnet'
     mockThreeFetches()
     render(<VaultView />)
     const withdrawBtn = await screen.findByRole('button', { name: /withdraw/i })
     expect(withdrawBtn).toBeDisabled()
-    expect(withdrawBtn).toHaveAttribute('title', expect.stringMatching(/coming soon/i))
-  })
-
-  it('Withdraw CTA stays disabled even when positions exist', async () => {
-    mockThreeFetches(populatedPositions)
-    render(<VaultView />)
-    const withdrawBtn = await screen.findByRole('button', { name: /withdraw/i })
-    expect(withdrawBtn).toBeDisabled()
-    fireEvent.click(withdrawBtn)
-    expect(setActiveView).not.toHaveBeenCalledWith('withdraw')
   })
 
   it('Shield to vault CTA disabled on mainnet', async () => {

--- a/app/src/views/__tests__/WithdrawView.test.tsx
+++ b/app/src/views/__tests__/WithdrawView.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+const setActiveView = vi.fn()
+const signAndBroadcast = vi.fn()
+let networkValue: 'devnet' | 'mainnet' = 'devnet'
+
+vi.mock('../../api/client', () => ({
+  apiFetch: vi.fn(),
+}))
+
+vi.mock('../../hooks/useAuthState', () => ({
+  useAuthState: () => ({
+    status: 'authed' as const,
+    token: 'test-token',
+    expiresAt: null,
+    isAdmin: false,
+    publicKey: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
+    authenticate: () => Promise.resolve(),
+    disconnect: () => Promise.resolve(),
+    error: null,
+  }),
+}))
+
+vi.mock('../../stores/app', async () => {
+  const actual = await vi.importActual<typeof import('../../stores/app')>('../../stores/app')
+  return {
+    ...actual,
+    useAppStore: Object.assign(
+      (selector: (s: { setActiveView: typeof setActiveView }) => unknown) =>
+        selector({ setActiveView }),
+      { getState: () => ({ setActiveView }) },
+    ),
+  }
+})
+
+vi.mock('../../hooks/useTransactionSigner', () => ({
+  useTransactionSigner: () => ({
+    signAndBroadcast,
+    status: 'idle' as const,
+    setStatus: vi.fn(),
+    reset: vi.fn(),
+  }),
+}))
+
+vi.mock('../../lib/networkConfig', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/networkConfig')>()
+  return {
+    ...actual,
+    useNetworkConfigStore: <T,>(
+      selector: (s: { config: { network: string; solscanSuffix: string } }) => T,
+    ) => selector({ config: { network: networkValue, solscanSuffix: '?cluster=devnet' } }),
+  }
+})
+
+import WithdrawView from '../WithdrawView'
+import { apiFetch } from '../../api/client'
+
+const mockedFetch = apiFetch as ReturnType<typeof vi.fn>
+
+const fakePosition = {
+  mint: 'So11111111111111111111111111111111111111112',
+  symbol: 'SOL',
+  balance: '2500000000',
+  balanceUiAmount: 2.5,
+  lockedAmount: '0',
+  decimals: 9,
+  lastDepositAt: 1715000000,
+  refundableAt: 1715086400,
+  cooldownActive: false,
+  depositRecordAddress: 'DEPOSITRECORDPDA',
+}
+
+beforeEach(() => {
+  mockedFetch.mockReset()
+  setActiveView.mockReset()
+  signAndBroadcast.mockReset()
+  networkValue = 'devnet'
+})
+
+describe('WithdrawView', () => {
+  it('renders RefundList with positions from /api/vault/positions', async () => {
+    mockedFetch.mockResolvedValueOnce({
+      positions: [fakePosition],
+      available: true,
+      network: 'devnet',
+    })
+    render(<WithdrawView />)
+    await waitFor(() => {
+      expect(screen.getByText('SOL')).toBeInTheDocument()
+    })
+  })
+
+  it('renders Back chip that calls setActiveView("vault")', async () => {
+    mockedFetch.mockResolvedValueOnce({ positions: [], available: true, network: 'devnet' })
+    render(<WithdrawView />)
+    const back = await screen.findByRole('button', { name: /back to vault/i })
+    fireEvent.click(back)
+    expect(setActiveView).toHaveBeenCalledWith('vault')
+  })
+
+  it('clicking Refund calls /api/vault/refund-tx and signAndBroadcast', async () => {
+    mockedFetch.mockImplementation((path: string) => {
+      if (path === '/api/vault/positions')
+        return Promise.resolve({ positions: [fakePosition], available: true, network: 'devnet' })
+      if (path === '/api/vault/refund-tx')
+        return Promise.resolve({ serializedTx: 'BASE64TX', refundAmount: '2500000000' })
+      return Promise.reject(new Error('unexpected: ' + path))
+    })
+    signAndBroadcast.mockResolvedValueOnce({ signature: 'CONFIRMED_SIG' })
+
+    render(<WithdrawView />)
+    const refundBtn = await screen.findByRole('button', { name: /^refund$/i })
+    fireEvent.click(refundBtn)
+    await waitFor(() => {
+      expect(mockedFetch).toHaveBeenCalledWith(
+        '/api/vault/refund-tx',
+        expect.objectContaining({ method: 'POST' }),
+      )
+      expect(signAndBroadcast).toHaveBeenCalledWith('BASE64TX')
+    })
+  })
+
+  it('shows mainnet-disabled copy when network is mainnet', async () => {
+    networkValue = 'mainnet'
+    render(<WithdrawView />)
+    expect(screen.getByText(/devnet only/i)).toBeInTheDocument()
+    // RefundList should not render on mainnet
+    expect(screen.queryByText('SOL')).not.toBeInTheDocument()
+  })
+})

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -14,6 +14,7 @@ import { confirmRouter } from './routes/confirm.js'
 import { vaultRouter } from './routes/vault-api.js'
 import { vaultDepositTxRouter } from './routes/vault-deposit-tx.js'
 import { vaultPositionsRouter } from './routes/vault-positions.js'
+import { vaultRefundTxRouter } from './routes/vault-refund-tx.js'
 import { squadRouter, isKillSwitchActive } from './routes/squad-api.js'
 import { heraldRouter } from './routes/herald-api.js'
 import { guardianBus } from './coordination/event-bus.js'
@@ -198,6 +199,9 @@ app.use('/api/vault', verifyJwt, vaultDepositTxRouter)
 
 // Vault positions list (deposit_records by mint) — JWT required (PR 6a)
 app.use('/api/vault', verifyJwt, vaultPositionsRouter)
+
+// Vault refund-tx builder (refund-to-self after 24h cooldown) — JWT required (PR 6b)
+app.use('/api/vault', verifyJwt, vaultRefundTxRouter)
 
 // Squad dashboard + kill switch — JWT + owner required
 app.use('/api/squad', verifyJwt, requireOwner, squadRouter)

--- a/packages/agent/src/routes/vault-refund-tx.ts
+++ b/packages/agent/src/routes/vault-refund-tx.ts
@@ -1,0 +1,116 @@
+import { Router, type Request, type Response } from 'express'
+import { PublicKey } from '@solana/web3.js'
+import { getAssociatedTokenAddress } from '@solana/spl-token'
+import {
+  getVaultBalance,
+  buildRefundTx,
+  createConnection,
+  resolveTokenMint,
+  SIPHER_VAULT_PROGRAM_ID,
+  DEFAULT_REFUND_TIMEOUT,
+} from '@sipher/sdk'
+import { loadNetworkConfig } from '../config/network.js'
+
+const VALID_TOKENS = ['SOL', 'USDC', 'USDT'] as const
+type ValidToken = (typeof VALID_TOKENS)[number]
+
+function isValidToken(token: unknown): token is ValidToken {
+  return typeof token === 'string' && (VALID_TOKENS as readonly string[]).includes(token.toUpperCase())
+}
+
+export const vaultRefundTxRouter = Router()
+
+vaultRefundTxRouter.post('/refund-tx', async (req: Request, res: Response) => {
+  const wallet = req.wallet
+  if (!wallet) {
+    res.status(401).json({
+      error: { code: 'UNAUTHENTICATED', message: 'Authenticated wallet required' },
+    })
+    return
+  }
+
+  const network = loadNetworkConfig().clusterName
+  if (network !== 'devnet') {
+    res.status(409).json({
+      error: {
+        code: 'VAULT_UNAVAILABLE',
+        message: 'Sipher Vault is on devnet only — switch network',
+      },
+    })
+    return
+  }
+
+  const { token } = req.body as { token?: string }
+
+  if (!isValidToken(token)) {
+    res.status(400).json({
+      error: { code: 'INVALID_TOKEN', message: 'Token must be SOL, USDC, or USDT' },
+    })
+    return
+  }
+
+  let depositor: PublicKey
+  try {
+    depositor = new PublicKey(wallet)
+  } catch {
+    res.status(400).json({
+      error: { code: 'INVALID_WALLET', message: 'Wallet is not a valid base58 pubkey' },
+    })
+    return
+  }
+
+  const tokenMint = resolveTokenMint(token.toUpperCase())
+  const connection = createConnection(network)
+
+  try {
+    const balance = await getVaultBalance(connection, depositor, tokenMint, SIPHER_VAULT_PROGRAM_ID)
+
+    if (!balance.exists || balance.balance === 0n) {
+      res.status(404).json({
+        error: {
+          code: 'NOT_FOUND',
+          message: 'No deposit record with available balance for this token',
+        },
+      })
+      return
+    }
+
+    const nowSeconds = Math.floor(Date.now() / 1000)
+    const refundableAt = balance.lastDepositAt + DEFAULT_REFUND_TIMEOUT
+    if (nowSeconds < refundableAt) {
+      res.status(409).json({
+        error: {
+          code: 'COOLDOWN_ACTIVE',
+          message: 'Refund cooldown still active — wait for the 24h window to elapse',
+          secondsRemaining: refundableAt - nowSeconds,
+          refundableAt,
+        },
+      })
+      return
+    }
+
+    const depositorTokenAccount = await getAssociatedTokenAddress(tokenMint, depositor)
+    const result = await buildRefundTx(
+      connection,
+      depositor,
+      tokenMint,
+      depositorTokenAccount,
+      SIPHER_VAULT_PROGRAM_ID,
+    )
+
+    const serializedTx = result.transaction
+      .serialize({ requireAllSignatures: false })
+      .toString('base64')
+
+    res.json({
+      serializedTx,
+      refundAmount: result.refundAmount.toString(),
+      network,
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'unknown error'
+    res.status(500).json({
+      error: { code: 'INTERNAL', message },
+    })
+  }
+})

--- a/packages/agent/tests/routes/vault-refund-tx.test.ts
+++ b/packages/agent/tests/routes/vault-refund-tx.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import express, { type Request, type Response, type NextFunction } from 'express'
+import supertest from 'supertest'
+import { PublicKey, Transaction } from '@solana/web3.js'
+
+const TEST_WALLET = 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N'
+
+vi.mock('../../src/config/network.js', () => ({
+  loadNetworkConfig: vi.fn(() => ({ clusterName: 'devnet' })),
+}))
+
+vi.mock('@sipher/sdk', async () => {
+  const actual = await vi.importActual<typeof import('@sipher/sdk')>('@sipher/sdk')
+  return {
+    ...actual,
+    getVaultBalance: vi.fn(),
+    buildRefundTx: vi.fn(),
+    createConnection: vi.fn(() => ({})),
+  }
+})
+
+import {
+  getVaultBalance,
+  buildRefundTx,
+  WSOL_MINT,
+  DEFAULT_REFUND_TIMEOUT,
+} from '@sipher/sdk'
+import { loadNetworkConfig } from '../../src/config/network.js'
+import { vaultRefundTxRouter } from '../../src/routes/vault-refund-tx.js'
+
+function mockAuth(wallet: string | null) {
+  return (req: Request, _res: Response, next: NextFunction) => {
+    if (wallet) (req as unknown as { wallet: string }).wallet = wallet
+    next()
+  }
+}
+
+function createApp(wallet: string | null = TEST_WALLET) {
+  const app = express()
+  app.use(express.json())
+  app.use('/api/vault', mockAuth(wallet), vaultRefundTxRouter)
+  return app
+}
+
+const SOL_MINT = 'So11111111111111111111111111111111111111112'
+const NOW_SECONDS = 1_800_000_000
+
+/** Build a "no record" VaultBalance — what getVaultBalance returns when the PDA has no on-chain account. */
+function emptyBalance(mint: PublicKey) {
+  return {
+    depositor: new PublicKey(TEST_WALLET),
+    tokenMint: mint,
+    balance: 0n,
+    lockedAmount: 0n,
+    available: 0n,
+    cumulativeVolume: 0n,
+    lastDepositAt: 0,
+    exists: false,
+  }
+}
+
+/** Build a "cooldown elapsed" VaultBalance — last deposit just past the timeout window. */
+function cooledBalance(mint: PublicKey, balance: bigint = 1_500_000_000n) {
+  return {
+    depositor: new PublicKey(TEST_WALLET),
+    tokenMint: mint,
+    balance,
+    lockedAmount: 0n,
+    available: balance,
+    cumulativeVolume: balance,
+    lastDepositAt: NOW_SECONDS - DEFAULT_REFUND_TIMEOUT - 10, // 10s past cooldown
+    exists: true,
+  }
+}
+
+beforeEach(() => {
+  vi.mocked(getVaultBalance).mockReset()
+  vi.mocked(buildRefundTx).mockReset()
+  vi.mocked(loadNetworkConfig).mockReturnValue({ clusterName: 'devnet' } as ReturnType<typeof loadNetworkConfig>)
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(NOW_SECONDS * 1000))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('POST /api/vault/refund-tx', () => {
+  it('returns serializedTx + refundAmount when balance > 0 and cooldown elapsed', async () => {
+    vi.mocked(getVaultBalance).mockImplementation(async (_conn, _depositor, mint) =>
+      cooledBalance(mint, 1_500_000_000n)
+    )
+
+    const fakeTx = new Transaction()
+    // Stub serialize so we don't need a real blockhash / instruction
+    const serialized = Buffer.from('FAKE_REFUND_TX_BYTES')
+    vi.spyOn(fakeTx, 'serialize').mockReturnValue(serialized)
+
+    vi.mocked(buildRefundTx).mockResolvedValueOnce({
+      transaction: fakeTx,
+      refundAmount: 1_500_000_000n,
+      depositorTokenAddress: new PublicKey(TEST_WALLET),
+    })
+
+    const res = await supertest(createApp())
+      .post('/api/vault/refund-tx')
+      .send({ token: 'SOL' })
+
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({
+      serializedTx: serialized.toString('base64'),
+      refundAmount: '1500000000',
+      network: 'devnet',
+    })
+
+    // Verify buildRefundTx was called with depositor + mint (NOT the PDA)
+    expect(buildRefundTx).toHaveBeenCalled()
+    const args = vi.mocked(buildRefundTx).mock.calls[0]
+    expect(args[1].toBase58()).toBe(TEST_WALLET) // depositor
+    expect(args[2].toBase58()).toBe(SOL_MINT)    // tokenMint = wSOL
+  })
+
+  it('returns 404 NOT_FOUND when no deposit record exists', async () => {
+    vi.mocked(getVaultBalance).mockImplementation(async (_conn, _depositor, mint) =>
+      emptyBalance(mint)
+    )
+
+    const res = await supertest(createApp())
+      .post('/api/vault/refund-tx')
+      .send({ token: 'SOL' })
+
+    expect(res.status).toBe(404)
+    expect(res.body.error.code).toBe('NOT_FOUND')
+    expect(buildRefundTx).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 NOT_FOUND when balance is zero', async () => {
+    // exists=true but balance=0 — possible after full refund leaves the PDA closed/reopened.
+    vi.mocked(getVaultBalance).mockImplementation(async (_conn, depositor, mint) => ({
+      depositor,
+      tokenMint: mint,
+      balance: 0n,
+      lockedAmount: 0n,
+      available: 0n,
+      cumulativeVolume: 0n,
+      lastDepositAt: NOW_SECONDS - DEFAULT_REFUND_TIMEOUT - 10,
+      exists: true,
+    }))
+
+    const res = await supertest(createApp())
+      .post('/api/vault/refund-tx')
+      .send({ token: 'SOL' })
+
+    expect(res.status).toBe(404)
+    expect(res.body.error.code).toBe('NOT_FOUND')
+    expect(buildRefundTx).not.toHaveBeenCalled()
+  })
+
+  it('returns 409 COOLDOWN_ACTIVE with secondsRemaining when within 24h window', async () => {
+    const lastDepositAt = NOW_SECONDS - 100 // 100s ago — well inside cooldown
+    vi.mocked(getVaultBalance).mockImplementation(async (_conn, depositor, mint) => ({
+      depositor,
+      tokenMint: mint,
+      balance: 1_000_000_000n,
+      lockedAmount: 0n,
+      available: 1_000_000_000n,
+      cumulativeVolume: 1_000_000_000n,
+      lastDepositAt,
+      exists: true,
+    }))
+
+    const res = await supertest(createApp())
+      .post('/api/vault/refund-tx')
+      .send({ token: 'SOL' })
+
+    expect(res.status).toBe(409)
+    expect(res.body.error.code).toBe('COOLDOWN_ACTIVE')
+    expect(res.body.error.secondsRemaining).toBe(DEFAULT_REFUND_TIMEOUT - 100)
+    expect(res.body.error.refundableAt).toBe(lastDepositAt + DEFAULT_REFUND_TIMEOUT)
+    expect(buildRefundTx).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 envelope when JWT did not attach req.wallet', async () => {
+    const res = await supertest(createApp(null))
+      .post('/api/vault/refund-tx')
+      .send({ token: 'SOL' })
+
+    expect(res.status).toBe(401)
+    expect(res.body.error.code).toBe('UNAUTHENTICATED')
+  })
+
+  it('returns 409 VAULT_UNAVAILABLE on mainnet-beta', async () => {
+    vi.mocked(loadNetworkConfig).mockReturnValueOnce({ clusterName: 'mainnet-beta' } as ReturnType<typeof loadNetworkConfig>)
+
+    const res = await supertest(createApp())
+      .post('/api/vault/refund-tx')
+      .send({ token: 'SOL' })
+
+    expect(res.status).toBe(409)
+    expect(res.body.error.code).toBe('VAULT_UNAVAILABLE')
+    expect(res.body.error.message).toMatch(/devnet/i)
+    expect(getVaultBalance).not.toHaveBeenCalled()
+    expect(buildRefundTx).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- New full-page WithdrawView with per-mint refund rows, glass-neon styling
- 24h cooldown chip with self-ticking countdown (CooldownChip)
- POST /api/vault/refund-tx — REST adapter for SDK `buildRefundTx` (uses `getVaultBalance` + `DEFAULT_REFUND_TIMEOUT`)
- Real on-chain refund via existing `useTransactionSigner` pipeline
- Withdraw button re-enabled in VaultView (was permanently disabled in PR 6a)
- Header + BottomNav vault-tab matchers extended to highlight on `'deposit' || 'withdraw'`

## Test plan
- [x] App tests pass (291, +14 vs PR 6a baseline 277: +6 RefundList, +4 CooldownChip, +4 WithdrawView, net +1 VaultView reshape — was -1 stale + 3 new)
- [x] Agent tests pass (1391, +6 vs PR 6a baseline 1385 — refund-tx route)
- [x] Typecheck clean
- [ ] Vercel preview renders WithdrawView (auto-deploy on push)
- [ ] Manual smoke refund on devnet — deferred (no aged-24h deposit yet; testable after a fresh deposit + 24h)
- [ ] Mainnet path: BetaBanner banner visible, view shows "devnet only" copy

## Architecture
- Composes existing primitives: `RefundList` (presentational) + `CooldownChip` (self-ticking via `setInterval(1000)`) + `TxStatusBadge` (status pipeline)
- `useTransactionSigner` drives signing → broadcasting → confirmed; per-token state maps owned by WithdrawView
- AbortController on mount fetch; refresh-timer ref cleared on unmount (sibling pattern from DepositView)
- Mainnet branch fail-closed: effect bails early via `isMainnet` guard AND a hard render branch returns the disabled card before `RefundList` is mounted
- 409 VAULT_UNAVAILABLE short-circuit in backend route before any SDK calls
- `<Card role="alert">` on per-token error banner for screen reader urgency

## Key decisions
- `getVaultBalance` over `fetchDepositRecord` — no throw-on-missing, cleaner exists/balance check (carry-forward from PR 6a Task 3)
- `DEFAULT_REFUND_TIMEOUT` from SDK (no hardcoded magic number)
- Symbol-keyed status/signature/error maps — vault `deposit_record` PDA is per (wallet, mint), so positions[] is one row per mint and the maps are 1:1 with rendered rows (documented inline)
- Symbol-pill rendered as styled `<span>` with `CHIP_BASE` (NOT `Pill` — Pill is interactive `<button>`, ARIA-incorrect for non-interactive labels) — same adaptation as PR 6a
- `key={p.depositRecordAddress}` (NOT `p.mint`) for RefundList rows — same deviation as StealthAddressList in PR 6a

## Spec
docs/superpowers/specs/2026-05-08-pr6-vault-flows-design.md (commit 74cb083)

## Plan
docs/superpowers/plans/2026-05-08-pr6-vault-flows.md (commit e8fd9c7)

## Builds on PR 6a
This PR depends on PR #183 (deposit path) which merged 2026-05-08. Refund consumes `deposit_records` created by deposit flow.

## Out of scope
- Claim flow (Phase 2 / M19)
- wSOL/native SOL unwrap UX gap — refund of SOL deposits returns wSOL ATA tokens; close-ATA-in-same-tx or unwrap CTA is a follow-up
- AmountForm hardcoded "SOL" label (carry-forward from PR 6a Task 6)
- CHIP_BASE 4× duplication — extract `<Chip>` primitive after PR 6 ships

## Smoke screenshots
_To be added by RECTOR after a fresh devnet deposit ages out the 24h cooldown_