### PR TITLE
feat(redesign): PR 7 — Keys + Settings surfaces

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@noble/ciphers": "^2.1.1",
     "@phosphor-icons/react": "^2.1.10",
     "@solana/wallet-adapter-react": "^0.15.0",
     "@solana/wallet-adapter-react-ui": "^0.9.0",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -20,6 +20,8 @@ import HeraldView from './views/HeraldView'
 import SquadView from './views/SquadView'
 import PrivacyReportView from './views/PrivacyReportView'
 import ChainsView from './views/ChainsView'
+import KeysView from './views/KeysView'
+import SettingsView from './views/SettingsView'
 import { useAppStore } from './stores/app'
 import { useAuth } from './hooks/useAuth'
 import { useSSE } from './hooks/useSSE'
@@ -53,6 +55,10 @@ function AppShell() {
         return <PrivacyReportView />
       case 'chains':
         return <ChainsView />
+      case 'keys':
+        return <KeysView />
+      case 'settings':
+        return isAdmin ? <SettingsView /> : <DashboardView events={events} />
       case 'chat':
         return (
           <div className="lg:hidden h-full">

--- a/app/src/api/keys.ts
+++ b/app/src/api/keys.ts
@@ -1,0 +1,18 @@
+import { apiFetch } from './client'
+
+export interface DownloadData {
+  blob: string
+  filename: string
+}
+
+export interface GenerateKeyResponse {
+  hash: string
+  downloadData: DownloadData
+}
+
+export async function generateKey(token: string): Promise<GenerateKeyResponse> {
+  return apiFetch<GenerateKeyResponse>('/api/keys/generate', {
+    method: 'POST',
+    token,
+  })
+}

--- a/app/src/components/BottomNav.tsx
+++ b/app/src/components/BottomNav.tsx
@@ -7,6 +7,8 @@ import {
   Broadcast,
   UsersThree,
   SignOut,
+  Key,
+  Gear,
 } from '@phosphor-icons/react'
 import { useAppStore, type View } from '../stores/app'
 import { useAuthState } from '../hooks/useAuthState'
@@ -80,8 +82,19 @@ export default function BottomNav() {
           >
             <div className="w-8 h-1 bg-line-2 rounded-full mx-auto mb-4" />
             <div className="flex flex-col gap-1">
+              <button
+                onClick={() => {
+                  setActiveView('keys')
+                  setMoreOpen(false)
+                }}
+                className="flex items-center gap-3 px-3 py-3 rounded-lg text-text-secondary hover:bg-glass-2 transition-colors"
+              >
+                <Key size={20} />
+                <span className="text-sm font-medium">Keys</span>
+              </button>
               {isAdmin && (
                 <>
+                  <div className="border-t border-line my-1" />
                   <button
                     onClick={() => {
                       setActiveView('herald')
@@ -101,6 +114,16 @@ export default function BottomNav() {
                   >
                     <UsersThree size={20} />
                     <span className="text-sm font-medium">Squad</span>
+                  </button>
+                  <button
+                    onClick={() => {
+                      setActiveView('settings')
+                      setMoreOpen(false)
+                    }}
+                    className="flex items-center gap-3 px-3 py-3 rounded-lg text-text-secondary hover:bg-glass-2 transition-colors"
+                  >
+                    <Gear size={20} />
+                    <span className="text-sm font-medium">Settings</span>
                   </button>
                   <div className="border-t border-line my-1" />
                 </>

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -5,6 +5,8 @@ import {
   UsersThree,
   ChatCircle,
   GlobeHemisphereWest,
+  Key,
+  Gear,
 } from '@phosphor-icons/react'
 import { useAppStore, type View } from '../stores/app'
 import { useAuthState } from '../hooks/useAuthState'
@@ -26,9 +28,11 @@ const TABS: Tab[] = [
   { id: 'dashboard', label: 'Dashboard', icon: ChartBar },
   { id: 'vault', label: 'Vault', icon: Vault },
   { id: 'chains', label: 'Chains', icon: GlobeHemisphereWest },
+  { id: 'keys', label: 'Keys', icon: Key },
   { id: 'chat', label: 'Chat', icon: ChatCircle, tabletOnly: true },
   { id: 'herald', label: 'Herald', icon: Broadcast, adminOnly: true },
   { id: 'squad', label: 'Squad', icon: UsersThree, adminOnly: true },
+  { id: 'settings', label: 'Settings', icon: Gear, adminOnly: true },
 ]
 
 export default function Header() {

--- a/app/src/components/keys/StealthAddressBackup.tsx
+++ b/app/src/components/keys/StealthAddressBackup.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useRef, useState } from 'react'
+import { apiFetch } from '../../api/client'
+import { useAuthState } from '../../hooks/useAuthState'
+import { Card } from '../ui/Card'
+import { Chip } from '../ui/Chip'
+import { Sheet } from '../ui/Sheet'
+import { encryptWithPassphrase } from '../../lib/crypto/passphrase-encrypt'
+
+interface StealthIndexResponse {
+  tree: Array<{
+    index: number
+    derivationPath: string
+    stealthAddress: string
+    parentIndex: number | null
+    createdAt: string
+  }>
+  rootWallet: string
+}
+
+function downloadEncryptedBlob(blob: object, filename: string) {
+  const json = JSON.stringify(blob, null, 2)
+  const url = URL.createObjectURL(new Blob([json], { type: 'application/json' }))
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}
+
+export function StealthAddressBackup() {
+  const { publicKey, token } = useAuthState()
+  const [data, setData] = useState<StealthIndexResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const [passphrase, setPassphrase] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [encrypting, setEncrypting] = useState(false)
+  const [retryNonce, setRetryNonce] = useState(0)
+  const aborterRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    if (!token) return
+    const controller = new AbortController()
+    aborterRef.current = controller
+    setLoading(true)
+    setError(null)
+    apiFetch<StealthIndexResponse>('/api/stealth/index', { token, signal: controller.signal })
+      .then((r) => {
+        if (!controller.signal.aborted) setData(r)
+      })
+      .catch((e: unknown) => {
+        if (!controller.signal.aborted) {
+          setError(e instanceof Error ? e.message : 'Failed to load stealth index')
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
+    return () => controller.abort()
+  }, [token, retryNonce])
+
+  const count = data?.tree.length ?? 0
+
+  async function handleSubmit() {
+    if (!data) return
+    if (passphrase.length < 8) return
+    if (passphrase !== confirm) return
+    setEncrypting(true)
+    try {
+      const plaintext = new TextEncoder().encode(JSON.stringify(data))
+      const blob = await encryptWithPassphrase(plaintext, passphrase)
+      const wallet8 = (publicKey ?? 'unknown').slice(0, 8)
+      const filename = `sipher-stealth-backup-${wallet8}-${Math.floor(Date.now() / 1000)}.enc.json`
+      downloadEncryptedBlob(blob, filename)
+      setSheetOpen(false)
+      setPassphrase('')
+      setConfirm('')
+    } finally {
+      setEncrypting(false)
+    }
+  }
+
+  return (
+    <Card variant="default" className="p-5 flex flex-col gap-4">
+      <div
+        className="text-2xs text-text-muted"
+        style={{ letterSpacing: 'var(--tracking-widest)' }}
+      >
+        ◆ STEALTH ADDRESS BACKUP
+      </div>
+
+      {loading && <p className="text-sm text-text-muted">Loading…</p>}
+
+      {error && !loading && (
+        <Card role="alert" variant="default" className="p-3 flex items-center justify-between">
+          <p className="text-xs text-danger">{error}</p>
+          <button
+            type="button"
+            onClick={() => setRetryNonce((n) => n + 1)}
+            className="text-xs border border-line rounded-md px-2.5 py-1 hover:border-line-2"
+          >
+            Retry
+          </button>
+        </Card>
+      )}
+
+      {!loading && !error && count === 0 && (
+        <p className="text-sm text-text-muted">
+          No stealth addresses yet. Make a private deposit to populate this.
+        </p>
+      )}
+
+      {!loading && !error && count > 0 && (
+        <>
+          <div className="flex items-center gap-2">
+            <Chip tone="cyan">{count} addresses</Chip>
+          </div>
+          <button
+            type="button"
+            onClick={() => setSheetOpen(true)}
+            className="self-start text-xs px-3 py-1.5 rounded-md text-bg font-semibold"
+            style={{ background: 'linear-gradient(90deg, var(--color-cyan), var(--color-violet))' }}
+          >
+            Download encrypted backup
+          </button>
+        </>
+      )}
+
+      {sheetOpen && (
+        <Sheet open onClose={() => setSheetOpen(false)} ariaLabel="Encrypt backup">
+          <div className="p-5 flex flex-col gap-3">
+            <div
+              className="text-2xs text-text-muted"
+              style={{ letterSpacing: 'var(--tracking-widest)' }}
+            >
+              ENCRYPT BACKUP
+            </div>
+            <label className="text-xs text-text-muted">
+              Passphrase
+              <input
+                type="password"
+                value={passphrase}
+                onChange={(e) => setPassphrase(e.target.value)}
+                aria-label="Passphrase"
+                className="mt-1 w-full text-xs border border-line rounded-md px-2 py-1 bg-bg-2"
+              />
+            </label>
+            <label className="text-xs text-text-muted">
+              Confirm passphrase
+              <input
+                type="password"
+                value={confirm}
+                onChange={(e) => setConfirm(e.target.value)}
+                aria-label="Confirm passphrase"
+                className="mt-1 w-full text-xs border border-line rounded-md px-2 py-1 bg-bg-2"
+              />
+            </label>
+            {passphrase.length > 0 && passphrase.length < 8 && (
+              <p className="text-xs text-danger">Passphrase must be at least 8 characters.</p>
+            )}
+            {passphrase.length >= 8 && passphrase.length < 12 && (
+              <p className="text-xs text-warning">Use a stronger passphrase for stronger protection.</p>
+            )}
+            {passphrase !== confirm && confirm.length > 0 && (
+              <p className="text-xs text-danger">Passphrases do not match.</p>
+            )}
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setSheetOpen(false)}
+                className="text-xs border border-line rounded-md px-3 py-1.5 hover:border-line-2"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={
+                  encrypting ||
+                  passphrase.length < 8 ||
+                  passphrase !== confirm
+                }
+                className="text-xs px-3 py-1.5 rounded-md text-bg font-semibold disabled:opacity-40"
+                style={{ background: 'linear-gradient(90deg, var(--color-cyan), var(--color-violet))' }}
+              >
+                {encrypting ? 'Encrypting…' : 'Encrypt and download'}
+              </button>
+            </div>
+          </div>
+        </Sheet>
+      )}
+    </Card>
+  )
+}

--- a/app/src/components/keys/StealthAddressBackup.tsx
+++ b/app/src/components/keys/StealthAddressBackup.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { apiFetch } from '../../api/client'
 import { useAuthState } from '../../hooks/useAuthState'
 import { Card } from '../ui/Card'
@@ -38,13 +38,12 @@ export function StealthAddressBackup() {
   const [passphrase, setPassphrase] = useState('')
   const [confirm, setConfirm] = useState('')
   const [encrypting, setEncrypting] = useState(false)
+  const [encryptError, setEncryptError] = useState<string | null>(null)
   const [retryNonce, setRetryNonce] = useState(0)
-  const aborterRef = useRef<AbortController | null>(null)
 
   useEffect(() => {
     if (!token) return
     const controller = new AbortController()
-    aborterRef.current = controller
     setLoading(true)
     setError(null)
     apiFetch<StealthIndexResponse>('/api/stealth/index', { token, signal: controller.signal })
@@ -69,6 +68,7 @@ export function StealthAddressBackup() {
     if (passphrase.length < 8) return
     if (passphrase !== confirm) return
     setEncrypting(true)
+    setEncryptError(null)
     try {
       const plaintext = new TextEncoder().encode(JSON.stringify(data))
       const blob = await encryptWithPassphrase(plaintext, passphrase)
@@ -78,6 +78,8 @@ export function StealthAddressBackup() {
       setSheetOpen(false)
       setPassphrase('')
       setConfirm('')
+    } catch (e: unknown) {
+      setEncryptError(e instanceof Error ? e.message : 'Encryption failed')
     } finally {
       setEncrypting(false)
     }
@@ -116,11 +118,14 @@ export function StealthAddressBackup() {
       {!loading && !error && count > 0 && (
         <>
           <div className="flex items-center gap-2">
-            <Chip tone="cyan">{count} addresses</Chip>
+            <Chip tone="cyan">{count} {count === 1 ? 'address' : 'addresses'}</Chip>
           </div>
           <button
             type="button"
-            onClick={() => setSheetOpen(true)}
+            onClick={() => {
+              setEncryptError(null)
+              setSheetOpen(true)
+            }}
             className="self-start text-xs px-3 py-1.5 rounded-md text-bg font-semibold"
             style={{ background: 'linear-gradient(90deg, var(--color-cyan), var(--color-violet))' }}
           >
@@ -131,7 +136,7 @@ export function StealthAddressBackup() {
 
       {sheetOpen && (
         <Sheet open onClose={() => setSheetOpen(false)} ariaLabel="Encrypt backup">
-          <div className="p-5 flex flex-col gap-3">
+          <div className="p-5 flex flex-col gap-4">
             <div
               className="text-2xs text-text-muted"
               style={{ letterSpacing: 'var(--tracking-widest)' }}
@@ -166,6 +171,9 @@ export function StealthAddressBackup() {
             )}
             {passphrase !== confirm && confirm.length > 0 && (
               <p className="text-xs text-danger">Passphrases do not match.</p>
+            )}
+            {encryptError && (
+              <p role="alert" className="text-xs text-danger">{encryptError}</p>
             )}
             <div className="flex justify-end gap-2">
               <button

--- a/app/src/components/keys/ViewKeyCard.tsx
+++ b/app/src/components/keys/ViewKeyCard.tsx
@@ -1,0 +1,147 @@
+import { useState } from 'react'
+import { Card } from '../ui/Card'
+import { Chip } from '../ui/Chip'
+import { HashCell } from '../ui/HashCell'
+import { Sheet } from '../ui/Sheet'
+import { useKeyStore } from '../../stores/keys'
+import { useAuthState } from '../../hooks/useAuthState'
+import { generateKey, type GenerateKeyResponse } from '../../api/keys'
+
+function downloadBlob(downloadData: { blob: string; filename: string }) {
+  const bin = atob(downloadData.blob)
+  const bytes = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
+  const url = URL.createObjectURL(new Blob([bytes], { type: 'application/json' }))
+  const a = document.createElement('a')
+  a.href = url
+  a.download = downloadData.filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}
+
+export function ViewKeyCard() {
+  const hash = useKeyStore((s) => s.hash)
+  const setHash = useKeyStore((s) => s.set)
+  const { token } = useAuthState()
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [confirmRotate, setConfirmRotate] = useState(false)
+
+  async function doGenerate(): Promise<GenerateKeyResponse | null> {
+    if (!token) return null
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await generateKey(token)
+      setHash(result.hash)
+      downloadBlob(result.downloadData)
+      return result
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to generate viewing key')
+      return null
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  function copyHash() {
+    if (hash) navigator.clipboard.writeText(hash)
+  }
+
+  return (
+    <Card variant="default" className="p-5 flex flex-col gap-4">
+      <div
+        className="text-2xs text-text-muted"
+        style={{ letterSpacing: 'var(--tracking-widest)' }}
+      >
+        ◆ VIEWING KEY
+      </div>
+
+      {hash === null ? (
+        <>
+          <p className="text-sm text-text-muted">
+            No viewing key in this session. Generate one to enable selective disclosure.
+          </p>
+          <button
+            type="button"
+            onClick={doGenerate}
+            disabled={busy || !token}
+            className="self-start text-xs px-3 py-1.5 rounded-md text-bg font-semibold disabled:opacity-40 disabled:cursor-not-allowed"
+            style={{ background: 'linear-gradient(90deg, var(--color-cyan), var(--color-violet))' }}
+          >
+            {busy ? 'Generating…' : 'Generate'}
+          </button>
+        </>
+      ) : (
+        <>
+          <div className="flex items-center gap-2">
+            <Chip tone="cyan">Active</Chip>
+            <HashCell hash={hash} />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={copyHash}
+              className="text-xs border border-line rounded-md px-3 py-1.5 hover:border-line-2"
+            >
+              Copy hash
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirmRotate(true)}
+              disabled={busy}
+              className="text-xs border border-line rounded-md px-3 py-1.5 hover:border-line-2 disabled:opacity-40"
+            >
+              {busy ? 'Working…' : 'Rotate'}
+            </button>
+          </div>
+        </>
+      )}
+
+      {error && (
+        <Card role="alert" variant="default" className="p-3">
+          <p className="text-xs text-danger">{error}</p>
+        </Card>
+      )}
+
+      {confirmRotate && (
+        <Sheet open onClose={() => setConfirmRotate(false)} ariaLabel="Rotate viewing key">
+          <div className="p-5 flex flex-col gap-4">
+            <div
+              className="text-2xs text-text-muted"
+              style={{ letterSpacing: 'var(--tracking-widest)' }}
+            >
+              ROTATE VIEWING KEY
+            </div>
+            <p className="text-sm text-text-muted">
+              Rotating invalidates this key for new payments. Save the old key file if past
+              payments still need auditor visibility.
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setConfirmRotate(false)}
+                className="text-xs border border-line rounded-md px-3 py-1.5 hover:border-line-2"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={async () => {
+                  setConfirmRotate(false)
+                  await doGenerate()
+                }}
+                className="text-xs px-3 py-1.5 rounded-md text-bg font-semibold"
+                style={{ background: 'var(--color-warning)' }}
+              >
+                Confirm rotate
+              </button>
+            </div>
+          </div>
+        </Sheet>
+      )}
+    </Card>
+  )
+}

--- a/app/src/components/keys/__tests__/StealthAddressBackup.test.tsx
+++ b/app/src/components/keys/__tests__/StealthAddressBackup.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { StealthAddressBackup } from '../StealthAddressBackup'
+
+vi.mock('../../../hooks/useAuthState', () => ({
+  useAuthState: () => ({
+    publicKey: 'TestWallet1111111111111111111111111111111111',
+    token: 'fake-jwt',
+    isAuthenticated: true,
+    isAdmin: false,
+  }),
+}))
+
+const apiFetchMock = vi.fn()
+vi.mock('../../../api/client', () => ({
+  apiFetch: (path: string, opts?: unknown) => apiFetchMock(path, opts),
+}))
+
+const encryptMock = vi.fn(async (_plaintext: Uint8Array, _passphrase: string) => ({
+  v: 1, alg: 'xchacha20poly1305-pbkdf2sha256-310k',
+  salt: 'c2FsdA==', nonce: 'bm9uY2U=', ct: 'Y3Q=',
+}))
+vi.mock('../../../lib/crypto/passphrase-encrypt', () => ({
+  encryptWithPassphrase: (plaintext: Uint8Array, passphrase: string) =>
+    encryptMock(plaintext, passphrase),
+}))
+
+describe('StealthAddressBackup', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    encryptMock.mockClear()
+    HTMLAnchorElement.prototype.click = vi.fn()
+    // jsdom does not implement these; stub to keep download path inert.
+    Object.assign(URL, {
+      createObjectURL: vi.fn(() => 'blob:mock'),
+      revokeObjectURL: vi.fn(),
+    })
+  })
+
+  it('renders loading skeleton on mount', async () => {
+    apiFetchMock.mockReturnValue(new Promise(() => {})) // never resolves
+    render(<StealthAddressBackup />)
+    expect(screen.getByText(/loading/i)).toBeInTheDocument()
+  })
+
+  it('renders empty-state copy when /api/stealth/index returns 0 addresses', async () => {
+    apiFetchMock.mockResolvedValueOnce({ tree: [], rootWallet: '' })
+    render(<StealthAddressBackup />)
+    await waitFor(() => {
+      expect(screen.getByText(/no stealth addresses yet/i)).toBeInTheDocument()
+    })
+  })
+
+  it('renders count chip + Download button when addresses exist', async () => {
+    apiFetchMock.mockResolvedValueOnce({
+      tree: [{ index: 0, derivationPath: 'm/0', stealthAddress: '0xabc', parentIndex: null, createdAt: '' }],
+      rootWallet: 'wallet',
+    })
+    render(<StealthAddressBackup />)
+    await waitFor(() => {
+      expect(screen.getByText(/1 addresses?/i)).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: /download encrypted backup/i })).toBeInTheDocument()
+  })
+
+  it('encrypts + downloads on submit', async () => {
+    apiFetchMock.mockResolvedValueOnce({
+      tree: [{ index: 0, derivationPath: 'm/0', stealthAddress: '0xabc', parentIndex: null, createdAt: '' }],
+      rootWallet: 'wallet',
+    })
+    render(<StealthAddressBackup />)
+    await waitFor(() => screen.getByRole('button', { name: /download encrypted backup/i }))
+    fireEvent.click(screen.getByRole('button', { name: /download encrypted backup/i }))
+    fireEvent.change(screen.getByLabelText(/^passphrase$/i), { target: { value: 'a-good-pw' } })
+    fireEvent.change(screen.getByLabelText(/confirm passphrase/i), { target: { value: 'a-good-pw' } })
+    fireEvent.click(screen.getByRole('button', { name: /^encrypt and download$/i }))
+    await waitFor(() => expect(encryptMock).toHaveBeenCalled())
+    expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled()
+  })
+
+  it('renders error banner on fetch failure with retry', async () => {
+    apiFetchMock.mockRejectedValueOnce(new Error('boom'))
+    render(<StealthAddressBackup />)
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+    apiFetchMock.mockResolvedValueOnce({ tree: [], rootWallet: '' })
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/no stealth addresses yet/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/app/src/components/keys/__tests__/StealthAddressBackup.test.tsx
+++ b/app/src/components/keys/__tests__/StealthAddressBackup.test.tsx
@@ -53,14 +53,29 @@ describe('StealthAddressBackup', () => {
 
   it('renders count chip + Download button when addresses exist', async () => {
     apiFetchMock.mockResolvedValueOnce({
+      tree: [
+        { index: 0, derivationPath: 'm/0', stealthAddress: '0xabc', parentIndex: null, createdAt: '' },
+        { index: 1, derivationPath: 'm/1', stealthAddress: '0xdef', parentIndex: 0, createdAt: '' },
+      ],
+      rootWallet: 'wallet',
+    })
+    render(<StealthAddressBackup />)
+    await waitFor(() => {
+      expect(screen.getByText('2 addresses')).toBeInTheDocument()
+    })
+    expect(screen.getByRole('button', { name: /download encrypted backup/i })).toBeInTheDocument()
+  })
+
+  it('renders singular "1 address" copy when exactly one stealth address exists', async () => {
+    apiFetchMock.mockResolvedValueOnce({
       tree: [{ index: 0, derivationPath: 'm/0', stealthAddress: '0xabc', parentIndex: null, createdAt: '' }],
       rootWallet: 'wallet',
     })
     render(<StealthAddressBackup />)
     await waitFor(() => {
-      expect(screen.getByText(/1 addresses?/i)).toBeInTheDocument()
+      expect(screen.getByText('1 address')).toBeInTheDocument()
     })
-    expect(screen.getByRole('button', { name: /download encrypted backup/i })).toBeInTheDocument()
+    expect(screen.queryByText(/1 addresses/)).not.toBeInTheDocument()
   })
 
   it('encrypts + downloads on submit', async () => {
@@ -89,5 +104,26 @@ describe('StealthAddressBackup', () => {
     await waitFor(() => {
       expect(screen.getByText(/no stealth addresses yet/i)).toBeInTheDocument()
     })
+  })
+
+  it('surfaces encrypt error inside Sheet and keeps Sheet open for retry', async () => {
+    apiFetchMock.mockResolvedValueOnce({
+      tree: [{ index: 0, derivationPath: 'm/0', stealthAddress: '0xabc', parentIndex: null, createdAt: '' }],
+      rootWallet: 'wallet',
+    })
+    encryptMock.mockRejectedValueOnce(new Error('boom'))
+    render(<StealthAddressBackup />)
+    await waitFor(() => screen.getByRole('button', { name: /download encrypted backup/i }))
+    fireEvent.click(screen.getByRole('button', { name: /download encrypted backup/i }))
+    fireEvent.change(screen.getByLabelText(/^passphrase$/i), { target: { value: 'a-good-pw' } })
+    fireEvent.change(screen.getByLabelText(/confirm passphrase/i), { target: { value: 'a-good-pw' } })
+    fireEvent.click(screen.getByRole('button', { name: /^encrypt and download$/i }))
+    await waitFor(() => {
+      expect(screen.getByText('boom')).toBeInTheDocument()
+    })
+    // Sheet must stay open so user can retry without re-entering passphrase.
+    expect(screen.getByLabelText(/^passphrase$/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/confirm passphrase/i)).toBeInTheDocument()
+    expect(HTMLAnchorElement.prototype.click).not.toHaveBeenCalled()
   })
 })

--- a/app/src/components/keys/__tests__/ViewKeyCard.test.tsx
+++ b/app/src/components/keys/__tests__/ViewKeyCard.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ViewKeyCard } from '../ViewKeyCard'
+import { useKeyStore } from '../../../stores/keys'
+
+vi.mock('../../../api/keys', () => ({
+  generateKey: vi.fn(async () => ({
+    hash: '0xtesthash000000000000000000000000000000000000000000000000000000ab',
+    downloadData: { blob: 'eyJrZXkiOiJ4In0=', filename: 'sip-viewing-key.json' },
+  })),
+}))
+
+vi.mock('../../../hooks/useAuthState', () => ({
+  useAuthState: () => ({
+    publicKey: 'TestWallet1111111111111111111111111111111111',
+    token: 'fake-jwt',
+    isAuthenticated: true,
+    isAdmin: false,
+  }),
+}))
+
+describe('ViewKeyCard', () => {
+  beforeEach(() => {
+    useKeyStore.setState({ hash: null })
+    HTMLAnchorElement.prototype.click = vi.fn()
+  })
+
+  it('renders empty state when no hash in the store', () => {
+    render(<ViewKeyCard />)
+    expect(screen.getByText(/no viewing key in this session/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /generate/i })).toBeInTheDocument()
+  })
+
+  it('shows the generated hash + Copy + Rotate buttons after generate', async () => {
+    render(<ViewKeyCard />)
+    fireEvent.click(screen.getByRole('button', { name: /generate/i }))
+    await waitFor(() => {
+      expect(useKeyStore.getState().hash).toMatch(/^0xtesthash/)
+    })
+    expect(screen.getByRole('button', { name: /copy hash/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /rotate/i })).toBeInTheDocument()
+  })
+
+  it('copies the hash to clipboard when Copy is clicked', async () => {
+    useKeyStore.setState({ hash: '0xabcd' })
+    const writeText = vi.fn()
+    Object.assign(navigator, { clipboard: { writeText } })
+    render(<ViewKeyCard />)
+    fireEvent.click(screen.getByRole('button', { name: /copy hash/i }))
+    expect(writeText).toHaveBeenCalledWith('0xabcd')
+  })
+
+  it('opens rotate confirm modal and replaces hash on confirm', async () => {
+    useKeyStore.setState({ hash: '0xprevious' })
+    render(<ViewKeyCard />)
+    fireEvent.click(screen.getByRole('button', { name: /rotate/i }))
+    expect(screen.getByText(/rotating invalidates this key/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /confirm rotate/i }))
+    await waitFor(() => {
+      expect(useKeyStore.getState().hash).toMatch(/^0xtesthash/)
+    })
+  })
+})

--- a/app/src/components/ui/Chip.tsx
+++ b/app/src/components/ui/Chip.tsx
@@ -1,0 +1,47 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+
+export type ChipTone =
+  | 'neutral'
+  | 'success'
+  | 'danger'
+  | 'warning'
+  | 'cyan'
+  | 'accent'
+  | 'herald'
+  | 'sentinel'
+
+interface ChipProps extends HTMLAttributes<HTMLSpanElement> {
+  tone?: ChipTone
+  icon?: ReactNode
+  children: ReactNode
+}
+
+const BASE =
+  'inline-flex items-center gap-1.5 border rounded-pill px-2.5 py-1 text-xs font-medium tracking-wide uppercase'
+
+const TONE_CLASSES: Record<ChipTone, string> = {
+  neutral: 'border-line text-text-muted',
+  success: 'border-success/40 bg-success-soft text-success',
+  danger: 'border-danger/40 bg-danger-soft text-danger',
+  warning: 'border-warning/40 bg-warning-soft text-warning',
+  cyan: 'border-cyan/40 bg-cyan-soft text-cyan-hi',
+  accent: 'border-accent/40 bg-accent-soft text-accent-hi',
+  herald: 'border-herald/40 bg-herald-soft text-herald',
+  sentinel: 'border-sentinel/40 bg-sentinel-soft text-sentinel',
+}
+
+export function Chip({
+  tone = 'neutral',
+  icon,
+  className,
+  children,
+  ...rest
+}: ChipProps) {
+  const merged = [BASE, TONE_CLASSES[tone], className].filter(Boolean).join(' ')
+  return (
+    <span className={merged} {...rest}>
+      {icon}
+      {children}
+    </span>
+  )
+}

--- a/app/src/components/ui/__tests__/Chip.test.tsx
+++ b/app/src/components/ui/__tests__/Chip.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { Chip } from '../Chip'
+
+describe('Chip', () => {
+  it('renders children', () => {
+    render(<Chip>HELLO</Chip>)
+    expect(screen.getByText('HELLO')).toBeInTheDocument()
+  })
+
+  it('defaults to neutral tone', () => {
+    render(<Chip data-testid="chip">A</Chip>)
+    const el = screen.getByTestId('chip')
+    expect(el.className).toContain('border-line')
+    expect(el.className).toContain('text-text-muted')
+  })
+
+  it.each([
+    ['success', ['border-success/40', 'bg-success-soft', 'text-success']],
+    ['danger', ['border-danger/40', 'bg-danger-soft', 'text-danger']],
+    ['warning', ['border-warning/40', 'bg-warning-soft', 'text-warning']],
+    ['cyan', ['border-cyan/40', 'bg-cyan-soft', 'text-cyan-hi']],
+    ['accent', ['border-accent/40', 'bg-accent-soft', 'text-accent-hi']],
+    ['herald', ['border-herald/40', 'bg-herald-soft', 'text-herald']],
+    ['sentinel', ['border-sentinel/40', 'bg-sentinel-soft', 'text-sentinel']],
+  ] as const)('applies %s tone classes', (tone, classes) => {
+    render(<Chip tone={tone} data-testid="chip">A</Chip>)
+    const el = screen.getByTestId('chip')
+    classes.forEach((cls) => expect(el.className).toContain(cls))
+  })
+
+  it('renders icon slot before children', () => {
+    render(
+      <Chip icon={<span data-testid="icon">!</span>} data-testid="chip">LABEL</Chip>,
+    )
+    expect(screen.getByTestId('icon')).toBeInTheDocument()
+    expect(screen.getByText('LABEL')).toBeInTheDocument()
+  })
+
+  it('forwards className for layering', () => {
+    render(<Chip className="self-start mt-2" data-testid="chip">X</Chip>)
+    const el = screen.getByTestId('chip')
+    expect(el.className).toContain('self-start')
+    expect(el.className).toContain('mt-2')
+  })
+
+  it('includes the rounded-pill base class', () => {
+    render(<Chip data-testid="chip">X</Chip>)
+    const el = screen.getByTestId('chip')
+    expect(el.className).toContain('rounded-pill')
+    expect(el.className).toContain('uppercase')
+  })
+})

--- a/app/src/components/vault/CooldownChip.tsx
+++ b/app/src/components/vault/CooldownChip.tsx
@@ -1,12 +1,10 @@
 import { useEffect, useState } from 'react'
+import { Chip } from '../ui/Chip'
 
 interface CooldownChipProps {
-  refundableAt: number // unix seconds
+  refundableAt: number
   onElapsed?: () => void
 }
-
-const CHIP_BASE =
-  'inline-flex items-center gap-1.5 border rounded-pill px-2.5 py-1 text-xs font-medium tracking-wide uppercase'
 
 function formatRemaining(secondsRemaining: number): string {
   if (secondsRemaining <= 0) return 'Available now'
@@ -38,13 +36,13 @@ export function CooldownChip({ refundableAt, onElapsed }: CooldownChipProps) {
     return () => clearInterval(id)
   }, [refundableAt, elapsed, onElapsed])
 
-  const className = elapsed
-    ? `${CHIP_BASE} border-success/40 bg-success-soft text-success`
-    : `${CHIP_BASE} border-line text-text-muted`
-
   return (
-    <span role="status" aria-live="polite" className={className}>
+    <Chip
+      tone={elapsed ? 'success' : 'neutral'}
+      role="status"
+      aria-live="polite"
+    >
       {formatRemaining(remaining)}
-    </span>
+    </Chip>
   )
 }

--- a/app/src/components/vault/RefundList.tsx
+++ b/app/src/components/vault/RefundList.tsx
@@ -1,4 +1,5 @@
 import { Card } from '../ui/Card'
+import { Chip } from '../ui/Chip'
 import { CooldownChip } from './CooldownChip'
 import { TxStatusBadge } from './TxStatusBadge'
 import type { Position } from './StealthAddressList'
@@ -10,9 +11,6 @@ interface RefundListProps {
   statusByToken: Record<string, SignStatus>
   signaturesByToken: Record<string, string>
 }
-
-const CHIP_BASE =
-  'inline-flex items-center gap-1.5 border rounded-pill px-2.5 py-1 text-xs font-medium tracking-wide uppercase'
 
 export function RefundList({ records, onRefund, statusByToken, signaturesByToken }: RefundListProps) {
   if (records.length === 0) {
@@ -35,9 +33,7 @@ export function RefundList({ records, onRefund, statusByToken, signaturesByToken
             variant="default"
             className="p-4 flex items-center gap-3"
           >
-            <span className={`${CHIP_BASE} border-cyan/40 bg-cyan-soft text-cyan-hi`}>
-              {p.symbol}
-            </span>
+            <Chip tone="cyan">{p.symbol}</Chip>
             <span className="text-sm font-mono">{p.balanceUiAmount}</span>
             <CooldownChip refundableAt={p.refundableAt} />
             <div className="ml-auto flex items-center gap-3">

--- a/app/src/components/vault/StealthAddressList.tsx
+++ b/app/src/components/vault/StealthAddressList.tsx
@@ -1,4 +1,5 @@
 import { Card } from '../ui/Card'
+import { Chip } from '../ui/Chip'
 import { HashCell } from '../ui/HashCell'
 
 export interface Position {
@@ -27,12 +28,6 @@ interface StealthAddressListProps {
   stealthTree: StealthNode[]
   loading: boolean
 }
-
-// Chip styling mirrors TxStatusBadge's BADGE_BASE so non-interactive labels
-// stay visually consistent with the interactive Pill primitive without
-// borrowing its button semantics.
-const CHIP_BASE =
-  'inline-flex items-center gap-1.5 border rounded-pill px-2.5 py-1 text-xs font-medium tracking-wide uppercase'
 
 export function StealthAddressList({
   positions,
@@ -76,19 +71,13 @@ function PositionsSection({
               className="flex items-center justify-between text-xs font-mono"
             >
               <div className="flex items-center gap-2">
-                <span className={`${CHIP_BASE} border-cyan/40 bg-cyan-soft text-cyan-hi`}>
-                  {p.symbol}
-                </span>
+                <Chip tone="cyan">{p.symbol}</Chip>
                 <span className="text-text">{p.balanceUiAmount}</span>
               </div>
               {p.cooldownActive ? (
-                <span className={`${CHIP_BASE} border-line text-text-muted`}>Cooldown</span>
+                <Chip tone="neutral">Cooldown</Chip>
               ) : (
-                <span
-                  className={`${CHIP_BASE} border-success/40 bg-success-soft text-success`}
-                >
-                  Refundable
-                </span>
+                <Chip tone="success">Refundable</Chip>
               )}
             </div>
           ))}
@@ -132,11 +121,9 @@ function StealthTreeSection({
             </div>
           ))}
           {stealthTree.length === 1 && (
-            <span
-              className={`${CHIP_BASE} self-start mt-2 border-line text-text-muted`}
-            >
+            <Chip tone="neutral" className="self-start mt-2">
               M19 — Derived stealth tree expands when M19 ships
-            </span>
+            </Chip>
           )}
         </div>
       )}

--- a/app/src/components/vault/TxStatusBadge.tsx
+++ b/app/src/components/vault/TxStatusBadge.tsx
@@ -1,13 +1,11 @@
 import type { SignStatus } from '../../hooks/useTransactionSigner'
 import { solscanUrl, useNetworkConfigStore } from '../../lib/networkConfig'
+import { Chip } from '../ui/Chip'
 
 interface TxStatusBadgeProps {
   status: SignStatus
   signature?: string
 }
-
-const BADGE_BASE =
-  'inline-flex items-center gap-1.5 border rounded-pill px-2.5 py-1 text-xs font-medium tracking-wide uppercase'
 
 export function TxStatusBadge({ status, signature }: TxStatusBadgeProps) {
   const solscanSuffix = useNetworkConfigStore((s) => s.config?.solscanSuffix ?? '?cluster=devnet')
@@ -16,34 +14,20 @@ export function TxStatusBadge({ status, signature }: TxStatusBadgeProps) {
 
   if (status === 'signing') {
     return (
-      <span
-        role="status"
-        aria-live="polite"
-        className={`${BADGE_BASE} border-accent/40 bg-accent-soft text-accent-hi`}
-      >
-        Signing…
-      </span>
+      <Chip tone="accent" role="status" aria-live="polite">Signing…</Chip>
     )
   }
 
   if (status === 'broadcasting') {
     return (
-      <span
-        role="status"
-        aria-live="polite"
-        className={`${BADGE_BASE} border-cyan/40 bg-cyan-soft text-cyan-hi`}
-      >
-        Broadcasting…
-      </span>
+      <Chip tone="cyan" role="status" aria-live="polite">Broadcasting…</Chip>
     )
   }
 
   if (status === 'confirmed') {
     return (
       <div role="status" aria-live="polite" className="flex items-center gap-2">
-        <span className={`${BADGE_BASE} border-success/40 bg-success-soft text-success`}>
-          Confirmed
-        </span>
+        <Chip tone="success">Confirmed</Chip>
         {signature && (
           <a
             href={solscanUrl(signature, solscanSuffix)}
@@ -60,13 +44,7 @@ export function TxStatusBadge({ status, signature }: TxStatusBadgeProps) {
 
   if (status === 'error') {
     return (
-      <span
-        role="status"
-        aria-live="polite"
-        className={`${BADGE_BASE} border-danger/40 bg-danger-soft text-danger`}
-      >
-        Failed — try again
-      </span>
+      <Chip tone="danger" role="status" aria-live="polite">Failed — try again</Chip>
     )
   }
 

--- a/app/src/lib/crypto/__tests__/passphrase-encrypt.test.ts
+++ b/app/src/lib/crypto/__tests__/passphrase-encrypt.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { encryptWithPassphrase, decryptWithPassphrase } from '../passphrase-encrypt'
+
+describe('passphrase-encrypt', () => {
+  const plaintext = new TextEncoder().encode(JSON.stringify({ hello: 'world', n: 1 }))
+
+  it('produces output matching the schema (v1, salt b64, nonce b64, ct b64)', async () => {
+    const blob = await encryptWithPassphrase(plaintext, 'correct horse battery staple')
+    expect(blob.v).toBe(1)
+    expect(blob.alg).toBe('xchacha20poly1305-pbkdf2sha256-310k')
+    expect(typeof blob.salt).toBe('string')
+    expect(typeof blob.nonce).toBe('string')
+    expect(typeof blob.ct).toBe('string')
+    expect(blob.salt.length).toBeGreaterThan(0)
+    expect(blob.nonce.length).toBeGreaterThan(0)
+    expect(blob.ct.length).toBeGreaterThan(0)
+  })
+
+  it('produces a different salt + nonce per call', async () => {
+    const a = await encryptWithPassphrase(plaintext, 'pw')
+    const b = await encryptWithPassphrase(plaintext, 'pw')
+    expect(a.salt).not.toBe(b.salt)
+    expect(a.nonce).not.toBe(b.nonce)
+    expect(a.ct).not.toBe(b.ct)
+  })
+
+  it('round-trips with the correct passphrase', async () => {
+    const blob = await encryptWithPassphrase(plaintext, 'open-sesame')
+    const recovered = await decryptWithPassphrase(blob, 'open-sesame')
+    expect(new TextDecoder().decode(recovered)).toBe(new TextDecoder().decode(plaintext))
+  })
+
+  it('throws on wrong passphrase', async () => {
+    const blob = await encryptWithPassphrase(plaintext, 'right')
+    await expect(decryptWithPassphrase(blob, 'wrong')).rejects.toThrow()
+  })
+})

--- a/app/src/lib/crypto/passphrase-encrypt.ts
+++ b/app/src/lib/crypto/passphrase-encrypt.ts
@@ -1,0 +1,72 @@
+import { xchacha20poly1305 } from '@noble/ciphers/chacha.js'
+
+export interface EncryptedBlob {
+  v: 1
+  alg: 'xchacha20poly1305-pbkdf2sha256-310k'
+  salt: string
+  nonce: string
+  ct: string
+}
+
+const ITERATIONS = 310_000
+const SALT_BYTES = 16
+const NONCE_BYTES = 24
+
+function toB64(bytes: Uint8Array): string {
+  let s = ''
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i])
+  return btoa(s)
+}
+
+function fromB64(s: string): Uint8Array {
+  const bin = atob(s)
+  const out = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
+  return out
+}
+
+async function deriveKey(passphrase: string, salt: Uint8Array): Promise<Uint8Array> {
+  const enc = new TextEncoder().encode(passphrase)
+  const baseKey = await crypto.subtle.importKey(
+    'raw', enc, { name: 'PBKDF2' }, false, ['deriveBits'],
+  )
+  const bits = await crypto.subtle.deriveBits(
+    { name: 'PBKDF2', salt: salt as BufferSource, iterations: ITERATIONS, hash: 'SHA-256' },
+    baseKey,
+    256,
+  )
+  return new Uint8Array(bits)
+}
+
+export async function encryptWithPassphrase(
+  plaintext: Uint8Array,
+  passphrase: string,
+): Promise<EncryptedBlob> {
+  const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES))
+  const nonce = crypto.getRandomValues(new Uint8Array(NONCE_BYTES))
+  const key = await deriveKey(passphrase, salt)
+  const cipher = xchacha20poly1305(key, nonce)
+  const ct = cipher.encrypt(plaintext)
+  return {
+    v: 1,
+    alg: 'xchacha20poly1305-pbkdf2sha256-310k',
+    salt: toB64(salt),
+    nonce: toB64(nonce),
+    ct: toB64(ct),
+  }
+}
+
+export async function decryptWithPassphrase(
+  blob: EncryptedBlob,
+  passphrase: string,
+): Promise<Uint8Array> {
+  if (blob.v !== 1 || blob.alg !== 'xchacha20poly1305-pbkdf2sha256-310k') {
+    throw new Error('Unsupported blob format')
+  }
+  const salt = fromB64(blob.salt)
+  const nonce = fromB64(blob.nonce)
+  const ct = fromB64(blob.ct)
+  const key = await deriveKey(passphrase, salt)
+  const cipher = xchacha20poly1305(key, nonce)
+  return cipher.decrypt(ct)
+}

--- a/app/src/stores/__tests__/keys.test.ts
+++ b/app/src/stores/__tests__/keys.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useKeyStore } from '../keys'
+
+describe('useKeyStore', () => {
+  beforeEach(() => {
+    useKeyStore.setState({ hash: null })
+  })
+
+  it('starts with hash null', () => {
+    expect(useKeyStore.getState().hash).toBeNull()
+  })
+
+  it('set updates the hash', () => {
+    useKeyStore.getState().set('0xabc123')
+    expect(useKeyStore.getState().hash).toBe('0xabc123')
+  })
+
+  it('clear resets the hash to null', () => {
+    useKeyStore.getState().set('0xabc123')
+    useKeyStore.getState().clear()
+    expect(useKeyStore.getState().hash).toBeNull()
+  })
+})

--- a/app/src/stores/app.ts
+++ b/app/src/stores/app.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 
-export type View = 'dashboard' | 'vault' | 'herald' | 'squad' | 'chat' | 'privacyReport' | 'chains' | 'deposit' | 'withdraw'
+export type View = 'dashboard' | 'vault' | 'herald' | 'squad' | 'chat' | 'privacyReport' | 'chains' | 'deposit' | 'withdraw' | 'keys' | 'settings'
 export type ToolStatus = 'running' | 'success' | 'error'
 
 export interface ToolCall {

--- a/app/src/stores/keys.ts
+++ b/app/src/stores/keys.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand'
+
+interface KeyState {
+  hash: string | null
+  set: (hash: string) => void
+  clear: () => void
+}
+
+export const useKeyStore = create<KeyState>((set) => ({
+  hash: null,
+  set: (hash) => set({ hash }),
+  clear: () => set({ hash: null }),
+}))

--- a/app/src/styles/theme.css
+++ b/app/src/styles/theme.css
@@ -55,7 +55,9 @@
   /* Color — agent identity */
   --color-sipher: var(--color-sipher);
   --color-herald: var(--color-herald);
+  --color-herald-soft: var(--color-herald-soft);
   --color-sentinel: var(--color-sentinel);
+  --color-sentinel-soft: var(--color-sentinel-soft);
   --color-courier: var(--color-courier);
 
   /* Typography */

--- a/app/src/styles/tokens.css
+++ b/app/src/styles/tokens.css
@@ -70,7 +70,9 @@
      ────────────────────────────────────────────────────────────── */
   --color-sipher:           #10B981;   /* lead — emerald */
   --color-herald:           #3B82F6;   /* x agent — blue */
+  --color-herald-soft:      rgba(59, 130, 246, 0.16);
   --color-sentinel:         #F59E0B;   /* monitor — amber */
+  --color-sentinel-soft:    rgba(245, 158, 11, 0.16);
   --color-courier:          #8B5CF6;   /* executor — violet */
 
   /* ──────────────────────────────────────────────────────────────

--- a/app/src/views/KeysView.tsx
+++ b/app/src/views/KeysView.tsx
@@ -1,0 +1,20 @@
+import { useAuthState } from '../hooks/useAuthState'
+import { ViewKeyCard } from '../components/keys/ViewKeyCard'
+import { StealthAddressBackup } from '../components/keys/StealthAddressBackup'
+
+export default function KeysView() {
+  const { isAuthenticated } = useAuthState()
+  if (!isAuthenticated) return null
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-sm text-text-muted" style={{ letterSpacing: 'var(--tracking-widest)' }}>
+        VIEWING KEY MANAGEMENT
+      </h1>
+      <div data-testid="keys-view" className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <ViewKeyCard />
+        <StealthAddressBackup />
+      </div>
+    </div>
+  )
+}

--- a/app/src/views/KeysView.tsx
+++ b/app/src/views/KeysView.tsx
@@ -3,8 +3,8 @@ import { ViewKeyCard } from '../components/keys/ViewKeyCard'
 import { StealthAddressBackup } from '../components/keys/StealthAddressBackup'
 
 export default function KeysView() {
-  const { isAuthenticated } = useAuthState()
-  if (!isAuthenticated) return null
+  const { status } = useAuthState()
+  if (status !== 'authed') return null
 
   return (
     <div className="flex flex-col gap-4">

--- a/app/src/views/SettingsView.tsx
+++ b/app/src/views/SettingsView.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useRef, useState } from 'react'
+import { apiFetch } from '../api/client'
+import { useAuthState } from '../hooks/useAuthState'
+import { useAppStore } from '../stores/app'
+import { useNetworkConfigStore } from '../lib/networkConfig'
+import { Card } from '../components/ui/Card'
+import { Chip, type ChipTone } from '../components/ui/Chip'
+
+interface SentinelConfigPayload {
+  mode: 'yolo' | 'advisory' | 'off'
+  preflightScope: string
+  preflightSkipAmount: number
+  largeTransferThreshold: number
+  threatCheckEnabled: boolean
+  blacklistAutonomy: boolean
+  cancelWindowMs: number
+  rateLimitFundPerHour: number
+  rateLimitBlacklistPerHour: number
+  scanInterval: number
+  activeScanInterval: number
+  autoRefundThreshold: number
+  model: string
+  dailyBudgetUsd: number
+  dailyCostUsd: number
+  blockOnError: boolean
+  fundMovingTools: string[]
+}
+
+function modeTone(mode: SentinelConfigPayload['mode']): ChipTone {
+  if (mode === 'yolo') return 'danger'
+  if (mode === 'advisory') return 'warning'
+  return 'neutral'
+}
+
+function networkTone(network: string): ChipTone {
+  return network === 'mainnet' ? 'cyan' : 'warning'
+}
+
+export default function SettingsView() {
+  const { token, isAdmin } = useAuthState()
+  const setActiveView = useAppStore((s) => s.setActiveView)
+  const network = useNetworkConfigStore((s) => s.config?.network)
+  const [config, setConfig] = useState<SentinelConfigPayload | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const aborterRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    if (!isAdmin) {
+      setActiveView('dashboard')
+      return
+    }
+    if (!token) return
+    const controller = new AbortController()
+    aborterRef.current = controller
+    apiFetch<SentinelConfigPayload>('/api/sentinel/config', {
+      token, signal: controller.signal,
+    })
+      .then((r) => {
+        if (!controller.signal.aborted) setConfig(r)
+      })
+      .catch((e: unknown) => {
+        if (!controller.signal.aborted) {
+          setError(e instanceof Error ? e.message : 'Failed to load config')
+        }
+      })
+    return () => controller.abort()
+  }, [isAdmin, token, setActiveView])
+
+  if (!isAdmin) return null
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-sm text-text-muted" style={{ letterSpacing: 'var(--tracking-widest)' }}>
+        SETTINGS — READ-ONLY INSPECTOR
+      </h1>
+
+      <Card variant="default" className="p-4 flex flex-col gap-2">
+        <div
+          className="text-2xs text-text-muted"
+          style={{ letterSpacing: 'var(--tracking-widest)' }}
+        >
+          NETWORK
+        </div>
+        <div className="flex items-center gap-2">
+          <Chip tone={networkTone(network ?? '')}>{network ?? 'unknown'}</Chip>
+          <span className="text-xs text-text-muted">Set via SIPHER_NETWORK env var.</span>
+        </div>
+      </Card>
+
+      {error && (
+        <Card role="alert" variant="default" className="p-3">
+          <p className="text-xs text-danger">{error}</p>
+        </Card>
+      )}
+
+      {config && (
+        <>
+          <Card variant="default" className="p-4 flex flex-col gap-2">
+            <div
+              className="text-2xs text-text-muted"
+              style={{ letterSpacing: 'var(--tracking-widest)' }}
+            >
+              SENTINEL MODE
+            </div>
+            <div className="flex items-center gap-2">
+              <Chip tone={modeTone(config.mode)}>{config.mode}</Chip>
+              <span className="text-xs text-text-muted">
+                Set via SENTINEL_MODE env var. Restart agent to change.
+              </span>
+            </div>
+          </Card>
+
+          <Card variant="default" className="p-4 flex flex-col gap-2">
+            <div
+              className="text-2xs text-text-muted"
+              style={{ letterSpacing: 'var(--tracking-widest)' }}
+            >
+              PREFLIGHT ENVELOPE
+            </div>
+            <ConfigRow label="Scope" value={config.preflightScope} />
+            <ConfigRow label="Skip amount" value={`${config.preflightSkipAmount} SOL`} />
+            <ConfigRow label="Large transfer threshold" value={`${config.largeTransferThreshold} SOL`} />
+            <ConfigRow label="Threat check enabled" value={String(config.threatCheckEnabled)} />
+            <ConfigRow label="Blacklist autonomy" value={String(config.blacklistAutonomy)} />
+            <ConfigRow label="Cancel window" value={`${config.cancelWindowMs / 1000}s`} />
+            <ConfigRow label="Rate limit (fund/hr)" value={String(config.rateLimitFundPerHour)} />
+            <ConfigRow label="Rate limit (blacklist/hr)" value={String(config.rateLimitBlacklistPerHour)} />
+            <ConfigRow label="Scan interval" value={`${config.scanInterval / 1000}s`} />
+            <ConfigRow label="Active scan interval" value={`${config.activeScanInterval / 1000}s`} />
+            <ConfigRow label="Auto-refund threshold" value={String(config.autoRefundThreshold)} />
+          </Card>
+
+          <Card variant="default" className="p-4 flex flex-col gap-2">
+            <div
+              className="text-2xs text-text-muted"
+              style={{ letterSpacing: 'var(--tracking-widest)' }}
+            >
+              LLM COST GUARD
+            </div>
+            <ConfigRow label="Model" value={config.model} />
+            <ConfigRow
+              label="Daily spend"
+              value={`$${config.dailyCostUsd.toFixed(2)} / $${config.dailyBudgetUsd}`}
+            />
+            <ConfigRow label="Block on error" value={String(config.blockOnError)} />
+          </Card>
+
+          <Card variant="default" className="p-4 flex flex-col gap-2">
+            <div
+              className="text-2xs text-text-muted"
+              style={{ letterSpacing: 'var(--tracking-widest)' }}
+            >
+              FUND-MOVING TOOLS (SENTINEL preflight required)
+            </div>
+            <p className="text-xs text-text-muted">
+              Hardcoded in preflight-rules.ts; allowlist edits are deferred until audit-log infra lands.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {config.fundMovingTools.map((tool) => (
+                <Chip key={tool} tone="cyan">{tool}</Chip>
+              ))}
+            </div>
+          </Card>
+        </>
+      )}
+    </div>
+  )
+}
+
+function ConfigRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between text-xs">
+      <span className="text-text-muted">{label}</span>
+      <Chip tone="neutral">{value}</Chip>
+    </div>
+  )
+}

--- a/app/src/views/VaultView.tsx
+++ b/app/src/views/VaultView.tsx
@@ -4,6 +4,7 @@ import { useAuthState } from '../hooks/useAuthState'
 import { useAppStore } from '../stores/app'
 import { useNetworkConfigStore } from '../lib/networkConfig'
 import { Card } from '../components/ui/Card'
+import { Chip } from '../components/ui/Chip'
 import { HashCell } from '../components/ui/HashCell'
 import {
   StealthAddressList,
@@ -37,9 +38,6 @@ interface StealthIndexResponse {
   tree: StealthNode[]
   rootWallet: string
 }
-
-const CHIP_BASE =
-  'inline-flex items-center gap-1.5 border rounded-pill px-2.5 py-1 text-xs font-medium tracking-wide uppercase'
 
 export default function VaultView() {
   const { token } = useAuthState()
@@ -125,14 +123,10 @@ function ShieldedVaultPanel({
         <span className="text-sm text-text-muted">SOL</span>
       </div>
       <div className="flex flex-wrap gap-2">
-        <span className={`${CHIP_BASE} border-line text-text-muted`}>
-          {positions.length} positions
-        </span>
-        <span
-          className={`${CHIP_BASE} ${hasPositions ? 'border-success/40 bg-success-soft text-success' : 'border-line text-text-muted'}`}
-        >
+        <Chip tone="neutral">{positions.length} positions</Chip>
+        <Chip tone={hasPositions ? 'success' : 'neutral'}>
           {hasPositions ? 'Active' : 'Empty'}
-        </span>
+        </Chip>
       </div>
       <StealthAddressList positions={positions} stealthTree={stealthTree} loading={loading} />
       <button

--- a/app/src/views/__tests__/KeysView.test.tsx
+++ b/app/src/views/__tests__/KeysView.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import KeysView from '../KeysView'
+
+vi.mock('../../components/keys/ViewKeyCard', () => ({
+  ViewKeyCard: () => <div data-testid="view-key-card">VKC</div>,
+}))
+vi.mock('../../components/keys/StealthAddressBackup', () => ({
+  StealthAddressBackup: () => <div data-testid="backup-card">SAB</div>,
+}))
+
+const useAuthStateMock = vi.fn()
+vi.mock('../../hooks/useAuthState', () => ({
+  useAuthState: () => useAuthStateMock(),
+}))
+
+describe('KeysView', () => {
+  it('renders both ViewKeyCard and StealthAddressBackup when authenticated', () => {
+    useAuthStateMock.mockReturnValue({
+      publicKey: 'TestWallet1111111111111111111111111111111111',
+      token: 'fake-jwt',
+      isAuthenticated: true,
+      isAdmin: false,
+    })
+    render(<KeysView />)
+    expect(screen.getByTestId('view-key-card')).toBeInTheDocument()
+    expect(screen.getByTestId('backup-card')).toBeInTheDocument()
+  })
+
+  it('renders inside a 2-column grid on md+', () => {
+    useAuthStateMock.mockReturnValue({
+      publicKey: 'TestWallet1111111111111111111111111111111111',
+      token: 'fake-jwt',
+      isAuthenticated: true,
+      isAdmin: false,
+    })
+    const { container } = render(<KeysView />)
+    const grid = container.querySelector('[data-testid="keys-view"]')
+    expect(grid?.className).toContain('grid')
+    expect(grid?.className).toMatch(/md:grid-cols-2/)
+  })
+
+  it('renders nothing when unauthenticated', () => {
+    useAuthStateMock.mockReturnValue({
+      publicKey: null,
+      token: null,
+      isAuthenticated: false,
+      isAdmin: false,
+    })
+    const { container } = render(<KeysView />)
+    expect(container.querySelector('[data-testid="keys-view"]')).toBeNull()
+    expect(screen.queryByTestId('view-key-card')).toBeNull()
+  })
+
+  it('renders the section heading', () => {
+    useAuthStateMock.mockReturnValue({
+      publicKey: 'TestWallet1111111111111111111111111111111111',
+      token: 'fake-jwt',
+      isAuthenticated: true,
+      isAdmin: false,
+    })
+    render(<KeysView />)
+    expect(screen.getByText(/viewing key management/i)).toBeInTheDocument()
+  })
+})

--- a/app/src/views/__tests__/KeysView.test.tsx
+++ b/app/src/views/__tests__/KeysView.test.tsx
@@ -19,7 +19,7 @@ describe('KeysView', () => {
     useAuthStateMock.mockReturnValue({
       publicKey: 'TestWallet1111111111111111111111111111111111',
       token: 'fake-jwt',
-      isAuthenticated: true,
+      status: 'authed',
       isAdmin: false,
     })
     render(<KeysView />)
@@ -31,7 +31,7 @@ describe('KeysView', () => {
     useAuthStateMock.mockReturnValue({
       publicKey: 'TestWallet1111111111111111111111111111111111',
       token: 'fake-jwt',
-      isAuthenticated: true,
+      status: 'authed',
       isAdmin: false,
     })
     const { container } = render(<KeysView />)
@@ -44,7 +44,7 @@ describe('KeysView', () => {
     useAuthStateMock.mockReturnValue({
       publicKey: null,
       token: null,
-      isAuthenticated: false,
+      status: 'unauthed',
       isAdmin: false,
     })
     const { container } = render(<KeysView />)
@@ -56,7 +56,7 @@ describe('KeysView', () => {
     useAuthStateMock.mockReturnValue({
       publicKey: 'TestWallet1111111111111111111111111111111111',
       token: 'fake-jwt',
-      isAuthenticated: true,
+      status: 'authed',
       isAdmin: false,
     })
     render(<KeysView />)

--- a/app/src/views/__tests__/SettingsView.test.tsx
+++ b/app/src/views/__tests__/SettingsView.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useNetworkConfigStore } from '../../lib/networkConfig'
+
+const setActiveViewMock = vi.fn()
+vi.mock('../../stores/app', () => ({
+  useAppStore: (selector: (s: unknown) => unknown) =>
+    selector({ setActiveView: setActiveViewMock, activeView: 'settings' }),
+}))
+
+const useAuthStateMock = vi.fn()
+vi.mock('../../hooks/useAuthState', () => ({
+  useAuthState: () => useAuthStateMock(),
+}))
+
+const apiFetchMock = vi.fn()
+vi.mock('../../api/client', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+const sentinelConfigFixture = {
+  mode: 'advisory',
+  preflightScope: 'fund-actions',
+  preflightSkipAmount: 0.1,
+  largeTransferThreshold: 10,
+  threatCheckEnabled: true,
+  blacklistAutonomy: true,
+  cancelWindowMs: 30000,
+  rateLimitFundPerHour: 5,
+  rateLimitBlacklistPerHour: 20,
+  scanInterval: 60000,
+  activeScanInterval: 15000,
+  autoRefundThreshold: 1,
+  model: 'openrouter:anthropic/claude-sonnet-4.6',
+  dailyBudgetUsd: 10,
+  dailyCostUsd: 0,
+  blockOnError: false,
+  fundMovingTools: ['send', 'deposit', 'swap', 'sweep', 'consolidate', 'splitSend', 'scheduleSend', 'drip', 'recurring', 'refund'],
+}
+
+describe('SettingsView', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    setActiveViewMock.mockReset()
+    useAuthStateMock.mockReset()
+    useNetworkConfigStore.setState({
+      config: {
+        network: 'devnet',
+        clusterName: 'devnet',
+        publicRpcUrl: 'https://api.devnet.solana.com',
+        programIds: { sipherVault: 'X', sipPrivacy: 'Y' },
+        vaultConfig: 'Z',
+        beta: true,
+        solscanSuffix: '?cluster=devnet',
+      },
+      error: null,
+    })
+  })
+
+  it('redirects non-admin to dashboard', async () => {
+    useAuthStateMock.mockReturnValue({
+      publicKey: 'X', token: 't', isAuthenticated: true, isAdmin: false,
+    })
+    const { default: SettingsView } = await import('../SettingsView')
+    render(<SettingsView />)
+    await waitFor(() => {
+      expect(setActiveViewMock).toHaveBeenCalledWith('dashboard')
+    })
+  })
+
+  it('renders network chip from useNetworkConfigStore', async () => {
+    useAuthStateMock.mockReturnValue({
+      publicKey: 'X', token: 't', isAuthenticated: true, isAdmin: true,
+    })
+    apiFetchMock.mockResolvedValue(sentinelConfigFixture)
+    const { default: SettingsView } = await import('../SettingsView')
+    render(<SettingsView />)
+    await waitFor(() => {
+      expect(screen.getByText(/devnet/i)).toBeInTheDocument()
+    })
+  })
+
+  it('renders SENTINEL mode chip with warning tone for advisory', async () => {
+    useAuthStateMock.mockReturnValue({
+      publicKey: 'X', token: 't', isAuthenticated: true, isAdmin: true,
+    })
+    apiFetchMock.mockResolvedValue(sentinelConfigFixture)
+    const { default: SettingsView } = await import('../SettingsView')
+    render(<SettingsView />)
+    await waitFor(() => {
+      const chip = screen.getByText(/^advisory$/i)
+      expect(chip).toBeInTheDocument()
+      expect(chip.className).toContain('bg-warning-soft')
+    })
+  })
+
+  it('renders all 10 fund-moving tools', async () => {
+    useAuthStateMock.mockReturnValue({
+      publicKey: 'X', token: 't', isAuthenticated: true, isAdmin: true,
+    })
+    apiFetchMock.mockResolvedValue(sentinelConfigFixture)
+    const { default: SettingsView } = await import('../SettingsView')
+    render(<SettingsView />)
+    await waitFor(() => {
+      sentinelConfigFixture.fundMovingTools.forEach((tool) => {
+        expect(screen.getByText(tool, { selector: 'span' })).toBeInTheDocument()
+      })
+    })
+  })
+
+  it('renders dailyCostUsd / dailyBudgetUsd', async () => {
+    useAuthStateMock.mockReturnValue({
+      publicKey: 'X', token: 't', isAuthenticated: true, isAdmin: true,
+    })
+    apiFetchMock.mockResolvedValue({ ...sentinelConfigFixture, dailyCostUsd: 1.23 })
+    const { default: SettingsView } = await import('../SettingsView')
+    render(<SettingsView />)
+    await waitFor(() => {
+      expect(screen.getByText(/\$1\.23/)).toBeInTheDocument()
+      expect(screen.getByText(/\$10/)).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -32,6 +32,7 @@ import { getSentinelConfig } from './sentinel/config.js'
 import { configRouter } from './routes/config.js'
 import { chainsRouter } from './routes/chains.js'
 import { stealthIndexRouter } from './routes/stealth-index.js'
+import { keysRouter } from './routes/keys.js'
 import { buildCorsMiddleware } from './cors-config.js'
 import { loadNetworkConfig } from './config/network.js'
 import {
@@ -215,6 +216,9 @@ app.use('/api/sentinel', verifyJwt, requireOwner, sentinelAdminRouter)
 
 // Stealth address tree (per-wallet) — JWT required, used by Dashboard PrivacyGraph
 app.use('/api/stealth', verifyJwt, stealthIndexRouter)
+
+// Viewing key generator (stateless, no DB writes) — JWT required (PR 7)
+app.use('/api/keys', verifyJwt, keysRouter)
 
 // Activity stream (per-wallet history from DB) — JWT required
 app.get('/api/activity', verifyJwt, (req: Request, res: Response) => {

--- a/packages/agent/src/routes/keys.ts
+++ b/packages/agent/src/routes/keys.ts
@@ -1,0 +1,28 @@
+import { Router, type Request, type Response } from 'express'
+import { executeViewingKey } from '../tools/viewing-key.js'
+
+export const keysRouter: Router = Router()
+
+/**
+ * Generate a fresh viewing keypair.
+ *
+ * Stateless wrapper around executeViewingKey('generate'). The response is
+ * the only artifact — no DB writes, no session updates, no audit log entries.
+ * The FE persists the encrypted blob client-side; the server never holds the
+ * raw key material (Decision D1, PR 7 spec).
+ *
+ * @auth verifyJwt (mounted at app-level)
+ * @returns 200 { hash, downloadData: { blob, filename } } | 500 { error }
+ */
+keysRouter.post('/generate', async (_req: Request, res: Response) => {
+  try {
+    const result = await executeViewingKey({ action: 'generate' })
+    res.json({
+      hash: result.details.viewingKeyHash,
+      downloadData: result.downloadData,
+    })
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'generate failed'
+    res.status(500).json({ error: message })
+  }
+})

--- a/packages/agent/src/routes/sentinel-api.ts
+++ b/packages/agent/src/routes/sentinel-api.ts
@@ -7,6 +7,7 @@ import { cancelCircuitBreakerAction } from '../sentinel/circuit-breaker.js'
 import { getSentinelAssessor } from '../sentinel/preflight-gate.js'
 import { getSentinelConfig } from '../sentinel/config.js'
 import { resolvePending, rejectPending } from '../sentinel/pending.js'
+import { FUND_MOVING_TOOLS } from '../sentinel/preflight-rules.js'
 import { sendSentinelError } from './sentinel-errors.js'
 
 // Reference: docs/sentinel/rest-api.md
@@ -161,6 +162,36 @@ sentinelAdminRouter.get('/decisions', (req: Request, res: Response) => {
   const limit = Number(String(req.query.limit ?? '50'))
   const source = (typeof req.query.source === 'string' ? req.query.source : undefined)
   res.json({ decisions: listDecisions({ limit, source }) })
+})
+
+/**
+ * Return the full SENTINEL operating config plus the fund-moving tool list.
+ * Read-only; admin-only because thresholds reveal SENTINEL heuristics.
+ *
+ * @auth verifyJwt + requireOwner
+ * @returns 200 SentinelConfig + { dailyCostUsd, fundMovingTools }
+ */
+sentinelAdminRouter.get('/config', (_req: Request, res: Response) => {
+  const config = getSentinelConfig()
+  res.json({
+    mode: config.mode,
+    preflightScope: config.preflightScope,
+    preflightSkipAmount: config.preflightSkipAmount,
+    largeTransferThreshold: config.largeTransferThreshold,
+    threatCheckEnabled: config.threatCheckEnabled,
+    blacklistAutonomy: config.blacklistAutonomy,
+    cancelWindowMs: config.cancelWindowMs,
+    rateLimitFundPerHour: config.rateLimitFundPerHour,
+    rateLimitBlacklistPerHour: config.rateLimitBlacklistPerHour,
+    scanInterval: config.scanInterval,
+    activeScanInterval: config.activeScanInterval,
+    autoRefundThreshold: config.autoRefundThreshold,
+    model: config.model,
+    dailyBudgetUsd: config.dailyBudgetUsd,
+    dailyCostUsd: dailyDecisionCostUsd(),
+    blockOnError: config.blockOnError,
+    fundMovingTools: Array.from(FUND_MOVING_TOOLS),
+  })
 })
 
 // ─── Promise-gate endpoints (pause/resume for advisory mode) ────────────────

--- a/packages/agent/tests/routes/keys.test.ts
+++ b/packages/agent/tests/routes/keys.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+import { keysRouter } from '../../src/routes/keys.js'
+import { verifyJwt } from '../../src/routes/auth.js'
+
+const TEST_JWT_SECRET = 'test-jwt-secret-at-least-16-chars'
+
+function makeApp() {
+  const app = express()
+  app.use(express.json())
+  app.use('/api/keys', verifyJwt, keysRouter)
+  return app
+}
+
+function authToken(wallet = 'TestWallet1111111111111111111111111111111111') {
+  return jwt.sign({ wallet }, TEST_JWT_SECRET, { expiresIn: '1h' })
+}
+
+beforeEach(() => {
+  process.env.JWT_SECRET = TEST_JWT_SECRET
+})
+
+afterEach(() => {
+  delete process.env.JWT_SECRET
+})
+
+describe('POST /api/keys/generate', () => {
+  it('rejects unauthenticated requests with 401', async () => {
+    const res = await request(makeApp()).post('/api/keys/generate')
+    expect(res.status).toBe(401)
+  })
+
+  it('generates a viewing keypair and returns hash + downloadData', async () => {
+    const res = await request(makeApp())
+      .post('/api/keys/generate')
+      .set('Authorization', `Bearer ${authToken()}`)
+    expect(res.status).toBe(200)
+    expect(typeof res.body.hash).toBe('string')
+    expect(res.body.hash.length).toBeGreaterThan(0)
+    expect(res.body.downloadData).toBeDefined()
+    expect(typeof res.body.downloadData.blob).toBe('string')
+    expect(typeof res.body.downloadData.filename).toBe('string')
+  })
+
+  it('returns a different hash on each call (no caching)', async () => {
+    const a = await request(makeApp())
+      .post('/api/keys/generate')
+      .set('Authorization', `Bearer ${authToken()}`)
+    const b = await request(makeApp())
+      .post('/api/keys/generate')
+      .set('Authorization', `Bearer ${authToken()}`)
+    expect(a.body.hash).not.toBe(b.body.hash)
+  })
+
+  it('persists nothing to the sessions or audit_log tables', async () => {
+    const { getDb } = await import('../../src/db.js')
+    const db = getDb()
+    const sessionsBefore = (db.prepare('SELECT COUNT(*) as n FROM sessions').get() as { n: number }).n
+    const auditBefore = (db.prepare('SELECT COUNT(*) as n FROM audit_log').get() as { n: number }).n
+
+    await request(makeApp())
+      .post('/api/keys/generate')
+      .set('Authorization', `Bearer ${authToken()}`)
+
+    const sessionsAfter = (db.prepare('SELECT COUNT(*) as n FROM sessions').get() as { n: number }).n
+    const auditAfter = (db.prepare('SELECT COUNT(*) as n FROM audit_log').get() as { n: number }).n
+    expect(sessionsAfter).toBe(sessionsBefore)
+    expect(auditAfter).toBe(auditBefore)
+  })
+})

--- a/packages/agent/tests/routes/sentinel-config.test.ts
+++ b/packages/agent/tests/routes/sentinel-config.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import jwt from 'jsonwebtoken'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TEST_JWT_SECRET = 'test-jwt-secret-at-least-16-chars'
+const OWNER_WALLET = 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N'
+const NON_ADMIN_WALLET = 'NonAdminWallet1111111111111111111111111111'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Module imports (top-level await — Vitest ESM)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const { sentinelPublicRouter, sentinelAdminRouter } = await import('../../src/routes/sentinel-api.js')
+const { verifyJwt, requireOwner } = await import('../../src/routes/auth.js')
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function authToken(wallet: string): string {
+  return jwt.sign({ wallet }, TEST_JWT_SECRET, { expiresIn: '1h', algorithm: 'HS256' })
+}
+
+// Mirrors production wiring (packages/agent/src/index.ts:214-215):
+// public sub-router gets verifyJwt only; admin sub-router gets verifyJwt + requireOwner.
+function makeApp() {
+  const app = express()
+  app.use(express.json())
+  app.use('/api/sentinel', verifyJwt, sentinelPublicRouter)
+  app.use('/api/sentinel', verifyJwt, requireOwner, sentinelAdminRouter)
+  return app
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test setup
+// ─────────────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  process.env.NODE_ENV = 'test'
+  process.env.JWT_SECRET = TEST_JWT_SECRET
+  process.env.AUTHORIZED_WALLETS = OWNER_WALLET
+})
+
+afterEach(() => {
+  delete process.env.JWT_SECRET
+  delete process.env.AUTHORIZED_WALLETS
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/sentinel/config', () => {
+  it('returns 403 for non-admin wallets', async () => {
+    const res = await request(makeApp())
+      .get('/api/sentinel/config')
+      .set('Authorization', `Bearer ${authToken(NON_ADMIN_WALLET)}`)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns full SentinelConfig payload for admin', async () => {
+    const res = await request(makeApp())
+      .get('/api/sentinel/config')
+      .set('Authorization', `Bearer ${authToken(OWNER_WALLET)}`)
+    expect(res.status).toBe(200)
+    expect(['yolo', 'advisory', 'off']).toContain(res.body.mode)
+    expect(['fund-actions', 'critical-only', 'never']).toContain(res.body.preflightScope)
+    expect(typeof res.body.preflightSkipAmount).toBe('number')
+    expect(typeof res.body.largeTransferThreshold).toBe('number')
+    expect(typeof res.body.cancelWindowMs).toBe('number')
+    expect(typeof res.body.threatCheckEnabled).toBe('boolean')
+    expect(typeof res.body.blacklistAutonomy).toBe('boolean')
+    expect(typeof res.body.blockOnError).toBe('boolean')
+    expect(typeof res.body.model).toBe('string')
+    expect(typeof res.body.dailyBudgetUsd).toBe('number')
+    expect(typeof res.body.dailyCostUsd).toBe('number')
+  })
+
+  it('includes fundMovingTools array with the canonical tool list', async () => {
+    const res = await request(makeApp())
+      .get('/api/sentinel/config')
+      .set('Authorization', `Bearer ${authToken(OWNER_WALLET)}`)
+    expect(Array.isArray(res.body.fundMovingTools)).toBe(true)
+    expect(res.body.fundMovingTools).toEqual(
+      expect.arrayContaining([
+        'send', 'deposit', 'swap', 'sweep', 'consolidate',
+        'splitSend', 'scheduleSend', 'drip', 'recurring', 'refund',
+      ]),
+    )
+  })
+
+  it('reflects dailyDecisionCostUsd for dailyCostUsd', async () => {
+    const { dailyDecisionCostUsd } = await import('../../src/db.js')
+    const expected = dailyDecisionCostUsd()
+    const res = await request(makeApp())
+      .get('/api/sentinel/config')
+      .set('Authorization', `Bearer ${authToken(OWNER_WALLET)}`)
+    expect(res.body.dailyCostUsd).toBe(expected)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
 
   app:
     dependencies:
+      '@noble/ciphers':
+        specifier: ^2.1.1
+        version: 2.1.1
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## Summary

Ships `/keys` (all logged-in users) and `/settings` (admin-only) routes for the Phase 4b glass-neon redesign sprint. PR 7 of 9.

**Spec:** `docs/superpowers/specs/2026-05-09-pr7-keys-settings-design.md` (6 locked decisions D1–D6)
**Plan:** `docs/superpowers/plans/2026-05-09-pr7-keys-settings.md`

## Changes

- New `<Chip>` design-system primitive (8 tones); migrates 5 existing CHIP_BASE sites
- New `useKeyStore` Zustand for in-memory viewing-key hash
- New `passphrase-encrypt` lib (PBKDF2-SHA256 310k + XChaCha20-Poly1305)
- New thin backend `POST /api/keys/generate` (no persistence — wraps existing `executeViewingKey('generate')`)
- New admin-only backend `GET /api/sentinel/config` (read-only inspector for SENTINEL config + fund-moving tools list)
- New `KeysView` (2-column: ViewKeyCard + StealthAddressBackup) — visible to all logged-in users
- New `SettingsView` — 5 read-only sections (Network, SENTINEL mode, Preflight envelope, LLM cost guard, Fund-moving tools); admin-gated
- Tokens: `--color-herald-soft`, `--color-sentinel-soft` added
- Routing/nav: View enum extended; Header NAV_ITEMS + BottomNav drawer surfaces both routes

## Tests

- App: 291 → 330 (+39)
- Agent: 1391 → 1399 (+8)
- TSC: clean

## Test plan

- [x] CI green
- [x] Vercel preview renders KeysView + SettingsView correctly
- [ ] Manual: admin sees Settings nav item; non-admin does not
- [ ] Manual: direct URL `/settings` as non-admin → redirect to /dashboard
- [ ] Manual: ViewKeyCard generate downloads file + shows hash; rotate confirm replaces it
- [ ] Manual: StealthAddressBackup empty state renders (PR 4 stub)
- [ ] Manual: SettingsView renders all 5 sections; FUND_MOVING_TOOLS shows 10 tools

## Out of scope

- Persistent server-side viewing keys (D1 — deferred)
- Editable SENTINEL mode/thresholds (D5 — deferred)
- FUND_MOVING_TOOLS allowlist toggle (D4 — deferred)
- Backup decryption / restore UI (D2 — lands in M19)