### PR TITLE
chore(app): drop deprecated wallet adapter explicit imports — closes #205

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useMemo } from 'react'
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react'
 import { WalletModalProvider } from '@solana/wallet-adapter-react-ui'
-import {
-  PhantomWalletAdapter,
-  SolflareWalletAdapter,
-} from '@solana/wallet-adapter-wallets'
 import '@solana/wallet-adapter-react-ui/styles.css'
 
 import Header from './components/Header'
@@ -102,10 +98,12 @@ export default function App() {
     fetchNetworkConfig()
   }, [])
 
-  const wallets = useMemo(
-    () => [new PhantomWalletAdapter(), new SolflareWalletAdapter()],
-    [],
-  )
+  // Wallet Standard auto-discovers Phantom, Solflare, and other
+  // wallet-standard wallets the user has installed. Explicit adapter
+  // instantiation has been deprecated since
+  // @solana/wallet-adapter-wallets@0.19 and emits a console warning per
+  // page load — clearing it here.
+  const wallets = useMemo(() => [], [])
 
   if (error) {
     return (


### PR DESCRIPTION
## Summary

Closes #205. Removes `PhantomWalletAdapter` + `SolflareWalletAdapter`
instantiation in `App.tsx`. Wallet Standard auto-discovers them; the
legacy explicit adapter API has been deprecated since
`@solana/wallet-adapter-wallets@0.19`.

## Why

Console showed 14 deprecation warnings per page load
(`Phantom was registered as a Standard Wallet. The Wallet Adapter
for Phantom can be removed from your app.`) — noise for anyone in
DevTools and signal of stale dependencies.

## Verification

- `pnpm exec tsc --noEmit` clean
- `pnpm test --run` green (60 files / 352 tests, no regression)
- Vercel preview will surface the cleaned console + verify Phantom +
  Solflare still appear in the wallet selector via Wallet Standard

Spec: `docs/superpowers/specs/2026-05-10-qa-sweep-tier-0-1-design.md`