### PR TITLE
feat(app): add onAuthClear registry + 5 component consumers — closes #202, #189

### DIFF
--- a/app/src/components/PrivacyGraph.tsx
+++ b/app/src/components/PrivacyGraph.tsx
@@ -3,6 +3,7 @@ import { Card } from './ui/Card'
 import { NodeGraph, type GraphNode, type GraphEdge } from './ui/NodeGraph'
 import { apiFetch } from '../api/client'
 import { useAuthState } from '../hooks/useAuthState'
+import { useOnAuthClear } from '../store/useOnAuthClear'
 
 interface StealthNode {
   index: number
@@ -15,6 +16,8 @@ interface StealthNode {
 export function PrivacyGraph() {
   const { token } = useAuthState()
   const [tree, setTree] = useState<StealthNode[]>([])
+
+  useOnAuthClear(() => setTree([]))
 
   useEffect(() => {
     if (!token) return

--- a/app/src/components/__tests__/PrivacyGraph.test.tsx
+++ b/app/src/components/__tests__/PrivacyGraph.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, act } from '@testing-library/react'
 import { PrivacyGraph } from '../PrivacyGraph'
+import { onAuthClear } from '../../store/onAuthClear'
 
 vi.mock('../../api/client', () => ({
   apiFetch: vi.fn(),
@@ -24,6 +25,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   ;(apiFetch as ReturnType<typeof vi.fn>).mockReset()
+  onAuthClear._resetForTests()
 })
 
 describe('PrivacyGraph', () => {
@@ -61,5 +63,30 @@ describe('PrivacyGraph', () => {
     ;(apiFetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('network'))
     render(<PrivacyGraph />)
     await waitFor(() => expect(screen.getByText(/0 addresses/)).toBeInTheDocument())
+  })
+
+  it('clears the tree when onAuthClear.clearAll fires', async () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      tree: [
+        {
+          index: 0,
+          derivationPath: 'm/0',
+          stealthAddress: 'X',
+          parentIndex: null,
+          createdAt: 't',
+        },
+      ],
+      rootWallet: 'W',
+    })
+    render(<PrivacyGraph />)
+    await waitFor(() => {
+      expect(screen.getByText('1 address')).toBeInTheDocument()
+    })
+
+    act(() => onAuthClear.clearAll())
+
+    await waitFor(() => {
+      expect(screen.getByText(/0 addresses/)).toBeInTheDocument()
+    })
   })
 })

--- a/app/src/components/keys/StealthAddressBackup.tsx
+++ b/app/src/components/keys/StealthAddressBackup.tsx
@@ -49,6 +49,7 @@ export function StealthAddressBackup() {
     setPassphrase('')
     setConfirm('')
     setEncryptError(null)
+    setEncrypting(false)
     setLoading(true)
   })
 

--- a/app/src/components/keys/StealthAddressBackup.tsx
+++ b/app/src/components/keys/StealthAddressBackup.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { apiFetch } from '../../api/client'
 import { useAuthState } from '../../hooks/useAuthState'
+import { useOnAuthClear } from '../../store/useOnAuthClear'
 import { Card } from '../ui/Card'
 import { Chip } from '../ui/Chip'
 import { Sheet } from '../ui/Sheet'
@@ -40,6 +41,16 @@ export function StealthAddressBackup() {
   const [encrypting, setEncrypting] = useState(false)
   const [encryptError, setEncryptError] = useState<string | null>(null)
   const [retryNonce, setRetryNonce] = useState(0)
+
+  useOnAuthClear(() => {
+    setData(null)
+    setError(null)
+    setSheetOpen(false)
+    setPassphrase('')
+    setConfirm('')
+    setEncryptError(null)
+    setLoading(true)
+  })
 
   useEffect(() => {
     if (!token) return

--- a/app/src/components/keys/__tests__/StealthAddressBackup.test.tsx
+++ b/app/src/components/keys/__tests__/StealthAddressBackup.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { StealthAddressBackup } from '../StealthAddressBackup'
+import { onAuthClear } from '../../../store/onAuthClear'
 
 vi.mock('../../../hooks/useAuthState', async () => {
   const { makeFakeAuthState } = await import('../../../test-utils/makeFakeAuthState')
@@ -32,6 +33,7 @@ describe('StealthAddressBackup', () => {
   beforeEach(() => {
     apiFetchMock.mockReset()
     encryptMock.mockClear()
+    onAuthClear._resetForTests()
     HTMLAnchorElement.prototype.click = vi.fn()
     // jsdom does not implement these; stub to keep download path inert.
     Object.assign(URL, {
@@ -106,6 +108,23 @@ describe('StealthAddressBackup', () => {
     fireEvent.click(screen.getByRole('button', { name: /retry/i }))
     await waitFor(() => {
       expect(screen.getByText(/no stealth addresses yet/i)).toBeInTheDocument()
+    })
+  })
+
+  it('clears data state when onAuthClear.clearAll fires', async () => {
+    apiFetchMock.mockResolvedValueOnce({
+      tree: [
+        { index: 0, derivationPath: 'm/0', stealthAddress: '0xabc', parentIndex: null, createdAt: '' },
+      ],
+      rootWallet: 'wallet',
+    })
+    render(<StealthAddressBackup />)
+    await waitFor(() => {
+      expect(screen.getByText('1 address')).toBeInTheDocument()
+    })
+    act(() => onAuthClear.clearAll())
+    await waitFor(() => {
+      expect(screen.queryByText('1 address')).not.toBeInTheDocument()
     })
   })
 

--- a/app/src/hooks/__tests__/useSSE.test.ts
+++ b/app/src/hooks/__tests__/useSSE.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { connectSSE } from '../../api/sse'
+import { useSSE } from '../useSSE'
+import { onAuthClear } from '../../store/onAuthClear'
+
+vi.mock('../../api/sse', () => ({
+  connectSSE: vi.fn(),
+}))
+
+vi.mock('../useAuthState', async () => {
+  const { makeFakeAuthState } = await import('../../test-utils/makeFakeAuthState')
+  return {
+    useAuthState: () => makeFakeAuthState({ status: 'authed', token: 'tok' }),
+  }
+})
+
+beforeEach(() => {
+  onAuthClear._resetForTests()
+  ;(connectSSE as ReturnType<typeof vi.fn>).mockReset()
+})
+
+describe('useSSE', () => {
+  it('clears events when onAuthClear.clearAll fires', async () => {
+    let onMessageCb: ((e: MessageEvent) => void) | null = null
+    ;(connectSSE as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_token, onMessage) => {
+        onMessageCb = onMessage
+        return { close: vi.fn(), onerror: null } as unknown as EventSource
+      },
+    )
+
+    const { result } = renderHook(() => useSSE())
+
+    // Wait for the async connectSSE to resolve and capture the callback.
+    await waitFor(() => expect(onMessageCb).not.toBeNull())
+
+    // Inject an event so events.length > 0 before the clear.
+    act(() => {
+      onMessageCb?.({
+        data: JSON.stringify({
+          id: '1',
+          agent: 'a',
+          type: 't',
+          level: 'info',
+          data: {},
+          timestamp: 'x',
+        }),
+      } as MessageEvent)
+    })
+    await waitFor(() => expect(result.current.events).toHaveLength(1))
+
+    // Fire auth-clear and assert the events array drained.
+    act(() => onAuthClear.clearAll())
+    await waitFor(() => expect(result.current.events).toHaveLength(0))
+  })
+})

--- a/app/src/hooks/useSSE.ts
+++ b/app/src/hooks/useSSE.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { connectSSE } from '../api/sse'
 import { useAuthState } from './useAuthState'
+import { useOnAuthClear } from '../store/useOnAuthClear'
 
 export interface ActivityEvent {
   id: string
@@ -16,6 +17,13 @@ export function useSSE() {
   const [events, setEvents] = useState<ActivityEvent[]>([])
   const [connected, setConnected] = useState(false)
   const sourceRef = useRef<EventSource | null>(null)
+
+  useOnAuthClear(() => {
+    setEvents([])
+    setConnected(false)
+    sourceRef.current?.close()
+    sourceRef.current = null
+  })
 
   useEffect(() => {
     if (!token) { setConnected(false); return }

--- a/app/src/store/__tests__/onAuthClear.test.ts
+++ b/app/src/store/__tests__/onAuthClear.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { onAuthClear } from '../onAuthClear'
+
+describe('onAuthClear registry', () => {
+  beforeEach(() => {
+    onAuthClear._resetForTests()
+  })
+
+  it('register returns an unsubscribe function', () => {
+    const unsubscribe = onAuthClear.register(() => {})
+    expect(typeof unsubscribe).toBe('function')
+  })
+
+  it('clearAll fires every registered callback', () => {
+    const a = vi.fn()
+    const b = vi.fn()
+    onAuthClear.register(a)
+    onAuthClear.register(b)
+    onAuthClear.clearAll()
+    expect(a).toHaveBeenCalledOnce()
+    expect(b).toHaveBeenCalledOnce()
+  })
+
+  it('unsubscribed callbacks are not fired', () => {
+    const a = vi.fn()
+    const b = vi.fn()
+    const unsubA = onAuthClear.register(a)
+    onAuthClear.register(b)
+    unsubA()
+    onAuthClear.clearAll()
+    expect(a).not.toHaveBeenCalled()
+    expect(b).toHaveBeenCalledOnce()
+  })
+
+  it('clearAll is idempotent — second call after a clear with no new registrations is a noop', () => {
+    const a = vi.fn()
+    onAuthClear.register(a)
+    onAuthClear.clearAll()
+    onAuthClear.clearAll()
+    expect(a).toHaveBeenCalledTimes(2)
+  })
+
+  it('a callback that throws does not block subsequent callbacks', () => {
+    const a = vi.fn(() => { throw new Error('boom') })
+    const b = vi.fn()
+    onAuthClear.register(a)
+    onAuthClear.register(b)
+    expect(() => onAuthClear.clearAll()).not.toThrow()
+    expect(b).toHaveBeenCalledOnce()
+  })
+})

--- a/app/src/store/__tests__/useOnAuthClear.test.tsx
+++ b/app/src/store/__tests__/useOnAuthClear.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useOnAuthClear } from '../useOnAuthClear'
+import { onAuthClear } from '../onAuthClear'
+
+describe('useOnAuthClear', () => {
+  beforeEach(() => {
+    onAuthClear._resetForTests()
+  })
+
+  it('registers the callback on mount', () => {
+    const cb = vi.fn()
+    renderHook(() => useOnAuthClear(cb))
+    onAuthClear.clearAll()
+    expect(cb).toHaveBeenCalledOnce()
+  })
+
+  it('unregisters the callback on unmount', () => {
+    const cb = vi.fn()
+    const { unmount } = renderHook(() => useOnAuthClear(cb))
+    unmount()
+    onAuthClear.clearAll()
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('uses the latest callback identity across renders', () => {
+    const a = vi.fn()
+    const b = vi.fn()
+    const { rerender } = renderHook(({ cb }) => useOnAuthClear(cb), {
+      initialProps: { cb: a },
+    })
+    rerender({ cb: b })
+    onAuthClear.clearAll()
+    expect(a).not.toHaveBeenCalled()
+    expect(b).toHaveBeenCalledOnce()
+  })
+})

--- a/app/src/store/onAuthClear.ts
+++ b/app/src/store/onAuthClear.ts
@@ -1,0 +1,53 @@
+type ClearCallback = () => void
+
+interface OnAuthClearRegistry {
+  register(cb: ClearCallback): () => void
+  clearAll(): void
+  /**
+   * Test-only helper. Drops all callbacks. Production code should never call
+   * this — production cleanup happens via the unsubscribe returned by
+   * `register`.
+   */
+  _resetForTests(): void
+}
+
+function createRegistry(): OnAuthClearRegistry {
+  const callbacks = new Set<ClearCallback>()
+
+  return {
+    register(cb) {
+      callbacks.add(cb)
+      return () => {
+        callbacks.delete(cb)
+      }
+    },
+    clearAll() {
+      // Snapshot to a list so a callback that registers/unregisters during
+      // iteration does not skew the loop.
+      const snapshot = Array.from(callbacks)
+      for (const cb of snapshot) {
+        try {
+          cb()
+        } catch {
+          // A consumer's cleanup throwing should not block other consumers.
+          // Swallow; auth-clear is best-effort UI cleanup.
+        }
+      }
+    },
+    _resetForTests() {
+      callbacks.clear()
+    },
+  }
+}
+
+/**
+ * Module-singleton registry of "clear cached UI state on auth boundary"
+ * callbacks. The auth store calls `clearAll()` from inside `clearAuth()` —
+ * outside React render — so the registry must be callable without a hook
+ * context.
+ *
+ * Component consumers should use the `useOnAuthClear` thin hook (in
+ * `app/src/store/useOnAuthClear.ts`) instead of calling `register` directly,
+ * so unsubscribe is wired to component unmount via `useEffect` cleanup.
+ */
+export const onAuthClear: OnAuthClearRegistry = createRegistry()

--- a/app/src/store/useOnAuthClear.ts
+++ b/app/src/store/useOnAuthClear.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from 'react'
+import { onAuthClear } from './onAuthClear'
+
+/**
+ * Register a cleanup callback that fires when the auth boundary transitions
+ * (`'authed' → 'unauthed' | 'expired'`). The callback is unregistered on
+ * unmount. The latest callback identity wins across renders — useful for
+ * closures over component state that change between renders.
+ *
+ * Usage:
+ *   useOnAuthClear(() => setTree([]))
+ */
+export function useOnAuthClear(callback: () => void): void {
+  const ref = useRef(callback)
+
+  useEffect(() => {
+    ref.current = callback
+  }, [callback])
+
+  useEffect(() => {
+    return onAuthClear.register(() => ref.current())
+  }, [])
+}

--- a/app/src/stores/__tests__/app.test.ts
+++ b/app/src/stores/__tests__/app.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useAppStore } from '../app'
+import { onAuthClear } from '../../store/onAuthClear'
 
 describe('app store — chatSheetOpen slice', () => {
   beforeEach(() => {
@@ -21,5 +22,29 @@ describe('app store — chatSheetOpen slice', () => {
     useAppStore.getState().setChatSheetOpen(true)
     const persisted = JSON.parse(localStorage.getItem('sipher-auth') ?? '{}')
     expect(persisted.state).not.toHaveProperty('chatSheetOpen')
+  })
+})
+
+describe('useAppStore.clearAuth', () => {
+  beforeEach(() => {
+    onAuthClear._resetForTests()
+  })
+
+  it('fires onAuthClear.clearAll after store reset', () => {
+    const cb = vi.fn()
+    onAuthClear.register(cb)
+    useAppStore.getState().setAuth('test-token', false, null)
+    useAppStore.getState().clearAuth()
+    expect(cb).toHaveBeenCalledOnce()
+  })
+
+  it('clears token before firing onAuthClear (consumers see empty state)', () => {
+    let observedToken: string | null | undefined
+    onAuthClear.register(() => {
+      observedToken = useAppStore.getState().token
+    })
+    useAppStore.getState().setAuth('test-token', false, null)
+    useAppStore.getState().clearAuth()
+    expect(observedToken).toBeNull()
   })
 })

--- a/app/src/stores/app.ts
+++ b/app/src/stores/app.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
+import { onAuthClear } from '../store/onAuthClear'
 
 export type View = 'dashboard' | 'vault' | 'herald' | 'squad' | 'chat' | 'privacyReport' | 'chains' | 'deposit' | 'withdraw' | 'keys' | 'settings'
 export type ToolStatus = 'running' | 'success' | 'error'
@@ -64,8 +65,10 @@ export const useAppStore = create<AppState>()(
       isAdmin: false,
       expiresAt: null,
       setAuth: (token, isAdmin, expiresAt = null) => set({ token, isAdmin, expiresAt }),
-      clearAuth: () =>
-        set({ token: null, isAdmin: false, expiresAt: null, messages: [], activeView: 'dashboard' }),
+      clearAuth: () => {
+        set({ token: null, isAdmin: false, expiresAt: null, messages: [], activeView: 'dashboard' })
+        onAuthClear.clearAll()
+      },
 
       messages: [],
       chatLoading: false,

--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { apiFetch } from '../api/client'
 import { type ActivityEvent } from '../hooks/useSSE'
 import { useAuthState } from '../hooks/useAuthState'
+import { useOnAuthClear } from '../store/useOnAuthClear'
 import { PrivacyScoreCard } from '../components/PrivacyScoreCard'
 import { ActivityStreamTable, type ActivityRow } from '../components/ActivityStreamTable'
 import { PrivacyGraph } from '../components/PrivacyGraph'
@@ -52,6 +53,17 @@ export default function DashboardView({ events }: { events: ActivityEvent[] }) {
   const refreshTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastProcessedEventId = useRef<string | null>(null)
   const wallet = vault?.wallet
+
+  useOnAuthClear(() => {
+    setVault(null)
+    setHistory([])
+    setPrivacyData(null)
+    if (refreshTimer.current) {
+      clearTimeout(refreshTimer.current)
+      refreshTimer.current = null
+    }
+    lastProcessedEventId.current = null
+  })
 
   const fetchPrivacyScore = useCallback(async (signal?: AbortSignal) => {
     if (!wallet || !token) return

--- a/app/src/views/VaultView.tsx
+++ b/app/src/views/VaultView.tsx
@@ -3,6 +3,7 @@ import { apiFetch } from '../api/client'
 import { useAuthState } from '../hooks/useAuthState'
 import { useAppStore } from '../stores/app'
 import { useNetworkConfigStore } from '../lib/networkConfig'
+import { useOnAuthClear } from '../store/useOnAuthClear'
 import { Card } from '../components/ui/Card'
 import { Chip } from '../components/ui/Chip'
 import { HashCell } from '../components/ui/HashCell'
@@ -49,6 +50,13 @@ export default function VaultView() {
   const [positions, setPositions] = useState<Position[]>([])
   const [stealthTree, setStealthTree] = useState<StealthNode[]>([])
   const [loading, setLoading] = useState(true)
+
+  useOnAuthClear(() => {
+    setVault(null)
+    setPositions([])
+    setStealthTree([])
+    setLoading(true)
+  })
 
   useEffect(() => {
     if (!token) return

--- a/app/src/views/__tests__/DashboardView.test.tsx
+++ b/app/src/views/__tests__/DashboardView.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import DashboardView from '../DashboardView'
+import { onAuthClear } from '../../store/onAuthClear'
+
+vi.mock('../../api/client', () => ({
+  apiFetch: vi.fn(),
+}))
+
+vi.mock('../../hooks/useAuthState', async () => {
+  const { makeFakeAuthState } = await import('../../test-utils/makeFakeAuthState')
+  return {
+    useAuthState: () => makeFakeAuthState({ status: 'authed', token: 'tok', publicKey: 'W' }),
+  }
+})
+
+import { apiFetch } from '../../api/client'
+
+const fakePrivacyScore = {
+  data: {
+    score: 80,
+    grade: 'A',
+    factors: {
+      addressReuse: { score: 80, detail: 'detail-reuse' },
+      amountPatterns: { score: 80, detail: 'detail-amount' },
+      timingCorrelation: { score: 80, detail: 'detail-timing' },
+      counterpartyExposure: { score: 80, detail: 'detail-counterparty' },
+    },
+    recommendations: [],
+    transactionsAnalyzed: 1,
+  },
+}
+
+beforeAll(() => {
+  if (!('ResizeObserver' in globalThis)) {
+    ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  }
+})
+
+beforeEach(() => {
+  ;(apiFetch as ReturnType<typeof vi.fn>).mockReset()
+  onAuthClear._resetForTests()
+
+  // Path-based mock so the four fetches (vault, activity, privacy score,
+  // chains, chain aggregate, stealth index) can resolve in any order.
+  ;(apiFetch as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
+    if (path === '/api/vault') {
+      return Promise.resolve({ wallet: 'W', balances: { sol: 1, tokens: [], status: 'ok' } })
+    }
+    if (path === '/api/activity') {
+      return Promise.resolve({
+        activity: [
+          {
+            id: '1',
+            agent: 'a',
+            type: 'send.success',
+            level: 'info',
+            title: 't',
+            detail: null,
+            created_at: 't',
+          },
+        ],
+      })
+    }
+    if (path === '/v1/privacy/score') {
+      return Promise.resolve(fakePrivacyScore)
+    }
+    if (path === '/api/chains') {
+      return Promise.resolve({ chains: [] })
+    }
+    if (path === '/api/chains/aggregate') {
+      return Promise.resolve({ totalTvlSol: 0, chainCount: 0, liveChainCount: 0, asOf: 't' })
+    }
+    if (path === '/api/stealth/index') {
+      return Promise.resolve({ tree: [], rootWallet: 'W' })
+    }
+    return Promise.reject(new Error('unexpected path: ' + path))
+  })
+})
+
+describe('DashboardView', () => {
+  it('clears privacy data on auth-clear', async () => {
+    render(<DashboardView events={[]} />)
+
+    // Wait for privacy score data to render — MetricBar's "Anonymity set"
+    // label only appears once `data` is non-null.
+    await waitFor(() => {
+      expect(screen.getByText(/Anonymity set/i)).toBeInTheDocument()
+    })
+
+    act(() => onAuthClear.clearAll())
+
+    // After clear, privacy data falls back to null and MetricBar rows hide.
+    await waitFor(() => {
+      expect(screen.queryByText(/Anonymity set/i)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/app/src/views/__tests__/VaultView.test.tsx
+++ b/app/src/views/__tests__/VaultView.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { onAuthClear } from '../../store/onAuthClear'
 
 const setActiveView = vi.fn()
 let networkValue: 'devnet' | 'mainnet' = 'devnet'
@@ -102,6 +103,7 @@ beforeEach(() => {
   mockedFetch.mockReset()
   setActiveView.mockReset()
   networkValue = 'devnet'
+  onAuthClear._resetForTests()
 })
 
 function mockThreeFetches(positionsResponse: PositionsResponse = emptyPositions) {
@@ -171,5 +173,17 @@ describe('VaultView (split-panel)', () => {
     render(<VaultView />)
     const cta = await screen.findByRole('button', { name: /shield to vault/i })
     expect(cta).toBeDisabled()
+  })
+
+  it('clears vault, positions, and stealth tree on onAuthClear.clearAll', async () => {
+    mockThreeFetches(populatedPositions)
+    render(<VaultView />)
+    await waitFor(() => {
+      expect(screen.getByText('1 positions')).toBeInTheDocument()
+    })
+    act(() => onAuthClear.clearAll())
+    await waitFor(() => {
+      expect(screen.getByText('0 positions')).toBeInTheDocument()
+    })
   })
 })


### PR DESCRIPTION
## Summary

Closes #202 + #189. Adds module-singleton `onAuthClear` registry plus
`useOnAuthClear` thin hook. Wires `useAppStore.clearAuth()` to call
`clearAll()` after store reset. Migrates 5 components to register their
state-cleanup callbacks: `PrivacyGraph`, `VaultView`,
`StealthAddressBackup`, `DashboardView`, `useSSE`.

## Why

When a JWT expires (or the user clicks Disconnect), the auth store's
`clearAuth()` resets `token`, `messages`, and `activeView`,
but components had local state (`useState`) that retained data fetched
under the old token. The Skeptic QA archetype reproduced the bug by
walking React fibers and injecting a fake stealth tree into
`PrivacyGraph` — confirming stale data could leak across auth
boundaries.

The registry pattern centralizes the cleanup contract: any component
that fetches under a token must register a cleanup callback. The auth
store fires `clearAll()` after reset, so consumer callbacks see empty
store state when they read it.

## Architecture

- `app/src/store/onAuthClear.ts` — module-singleton registry
- `app/src/store/useOnAuthClear.ts` — thin hook wrapper (refs latest
  callback, unsubscribes on unmount)
- `app/src/stores/app.ts` — `clearAuth` calls `onAuthClear.clearAll()`
  after store `set`
- 5 component consumers register their cleanup callbacks

## Verification

- `pnpm exec tsc --noEmit` clean
- `pnpm test --run` green (64 files / 367+ tests, +15 from baseline)
- Spec compliance review: ✅ all 8 verification points passed
- Code quality review: ✅ APPROVED with minor follow-ups (filed as
  separate issues)

## Out of scope

The `useSSE` change in this PR addresses auth-clear cleanup. PR-D
(`feat/auth-error-handling`) adds network-error event clearing in the
same hook, rebases on this PR.

## Follow-ups (filed as separate issues)

- `useSSE` in-flight `connectSSE` race tightening
- Optional dev-only `console.warn` on swallowed callback throws

Spec: `docs/superpowers/specs/2026-05-10-qa-sweep-tier-0-1-design.md`
Plan: `docs/superpowers/plans/2026-05-10-qa-sweep-tier-0-1.md`