### PR TITLE
feat(app): network-error handling + ChatSidebar 401 interceptor — closes #191, #192

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -7,6 +7,7 @@ import Header from './components/Header'
 import BottomNav from './components/BottomNav'
 import ChatSidebar from './components/ChatSidebar'
 import { BetaBanner } from './components/BetaBanner'
+import { NetworkBanner } from './components/NetworkBanner'
 import { Sheet } from './components/ui/Sheet'
 import DashboardView from './views/DashboardView'
 import VaultView from './views/VaultView'
@@ -69,6 +70,7 @@ function AppShell() {
   return (
     <div className="flex flex-col h-dvh bg-bg">
       <BetaBanner beta={beta} />
+      <NetworkBanner />
       <Header />
 
       <div className="flex-1 flex overflow-hidden">

--- a/app/src/api/__tests__/client.test.ts
+++ b/app/src/api/__tests__/client.test.ts
@@ -181,6 +181,26 @@ describe('apiFetch network-error branch', () => {
     expect(handler).toHaveBeenCalledOnce()
     window.removeEventListener('sipher:network-recovered', handler)
   })
+
+  it('preserves AbortError name through the network-error catch wrapper', async () => {
+    globalThis.fetch = vi.fn().mockImplementation(async () => {
+      const e = new DOMException('aborted', 'AbortError')
+      throw e
+    })
+    const handler = vi.fn()
+    window.addEventListener('sipher:network-error', handler)
+    try {
+      await apiFetch('/whatever')
+      throw new Error('apiFetch should have thrown')
+    } catch (err) {
+      // AbortError must propagate as-is — 8+ callers in the app rely on
+      // `err.name === 'AbortError'` to distinguish user-cancelled requests
+      // from genuine failures. The new TypeError wrapper must NOT catch it.
+      expect((err as Error).name).toBe('AbortError')
+    }
+    expect(handler).not.toHaveBeenCalled()
+    window.removeEventListener('sipher:network-error', handler)
+  })
 })
 
 describe('triggerAuthInterceptor', () => {

--- a/app/src/api/__tests__/client.test.ts
+++ b/app/src/api/__tests__/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { apiFetch, registerAuthInterceptor } from '../client'
+import { apiFetch, registerAuthInterceptor, triggerAuthInterceptor } from '../client'
 
 describe('apiFetch', () => {
   const originalFetch = global.fetch
@@ -139,5 +139,68 @@ describe('apiFetch', () => {
     })
     const result = await apiFetch('/test')
     expect(result).toBeUndefined()
+  })
+})
+
+describe('apiFetch network-error branch', () => {
+  let originalFetch: typeof globalThis.fetch
+  beforeEach(() => {
+    originalFetch = globalThis.fetch
+  })
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('emits a network-error CustomEvent on TypeError: Failed to fetch', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+    const handler = vi.fn()
+    window.addEventListener('sipher:network-error', handler)
+    await expect(apiFetch('/whatever')).rejects.toThrow(/network/i)
+    expect(handler).toHaveBeenCalledOnce()
+    window.removeEventListener('sipher:network-error', handler)
+  })
+
+  it('does not emit network-error on a non-network failure (e.g. 500)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: 'server boom' }), { status: 500 }),
+    )
+    const handler = vi.fn()
+    window.addEventListener('sipher:network-error', handler)
+    await expect(apiFetch('/whatever')).rejects.toThrow(/boom/)
+    expect(handler).not.toHaveBeenCalled()
+    window.removeEventListener('sipher:network-error', handler)
+  })
+
+  it('emits network-recovered on successful fetch', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    )
+    const handler = vi.fn()
+    window.addEventListener('sipher:network-recovered', handler)
+    await apiFetch('/whatever')
+    expect(handler).toHaveBeenCalledOnce()
+    window.removeEventListener('sipher:network-recovered', handler)
+  })
+})
+
+describe('triggerAuthInterceptor', () => {
+  it('invokes the registered auth interceptor exactly once', () => {
+    const handler = vi.fn()
+    registerAuthInterceptor(handler)
+    triggerAuthInterceptor()
+    expect(handler).toHaveBeenCalledOnce()
+    registerAuthInterceptor(null)
+  })
+
+  it('is a no-op when no interceptor is registered', () => {
+    registerAuthInterceptor(null)
+    expect(() => triggerAuthInterceptor()).not.toThrow()
+  })
+
+  it('swallows interceptor exceptions like the 401 path does', () => {
+    const handler = vi.fn(() => { throw new Error('boom') })
+    registerAuthInterceptor(handler)
+    expect(() => triggerAuthInterceptor()).not.toThrow()
+    registerAuthInterceptor(null)
   })
 })

--- a/app/src/api/client.ts
+++ b/app/src/api/client.ts
@@ -14,6 +14,32 @@ export function registerAuthInterceptor(handler: UnauthHandler | null) {
   authInterceptor = handler
 }
 
+/**
+ * Manually fire the registered auth interceptor. Used by code paths that
+ * bypass `apiFetch` — most notably ChatSidebar's streaming fetch, which
+ * cannot route through the interceptor branch in `apiFetch` because it
+ * needs the response body as a stream.
+ */
+export function triggerAuthInterceptor(): void {
+  if (!authInterceptor) return
+  try {
+    authInterceptor()
+  } catch {
+    // Mirror the 401 branch: an interceptor crash is best-effort UX and
+    // should not propagate. The caller already knows the request failed.
+  }
+}
+
+function emitNetworkError(): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new CustomEvent('sipher:network-error'))
+}
+
+function emitNetworkRecovered(): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new CustomEvent('sipher:network-recovered'))
+}
+
 export async function apiFetch<T>(
   path: string,
   options?: RequestInit & { token?: string }
@@ -23,19 +49,28 @@ export async function apiFetch<T>(
     'Content-Type': 'application/json',
     ...(token ? { Authorization: `Bearer ${token}` } : {}),
   }
-  const res = await fetch(`${BASE}${path}`, {
-    ...fetchOpts,
-    headers: { ...headers, ...(fetchOpts.headers as Record<string, string>) },
-  })
-  if (res.status === 401) {
-    if (authInterceptor) {
-      try {
-        authInterceptor()
-      } catch {
-        // Never let an interceptor crash propagate up — auth-loss UX is
-        // best-effort. The original request still throws below.
-      }
+  let res: Response
+  try {
+    res = await fetch(`${BASE}${path}`, {
+      ...fetchOpts,
+      headers: { ...headers, ...(fetchOpts.headers as Record<string, string>) },
+    })
+  } catch (err) {
+    // Network-layer failure (offline, DNS, CORS preflight refusal): browsers
+    // throw `TypeError: Failed to fetch`. Surface to the global event bus so
+    // <NetworkBanner> can react; rethrow so callers still see the error.
+    if (err instanceof TypeError) {
+      emitNetworkError()
+      throw new Error('Network connection lost')
     }
+    throw err
+  }
+
+  // If we recovered from a prior network error, let the banner know.
+  emitNetworkRecovered()
+
+  if (res.status === 401) {
+    triggerAuthInterceptor()
     const body = await res.json().catch(() => ({}))
     const err = (body as { error?: { message?: string } | string }).error
     if (typeof err === 'string') throw new Error(err)

--- a/app/src/components/ChatSidebar.tsx
+++ b/app/src/components/ChatSidebar.tsx
@@ -5,6 +5,7 @@ import { useAuthState } from '../hooks/useAuthState'
 import { useToast } from '../providers/ToastProvider'
 import { sanitizeArgs } from '../lib/sanitize-args'
 import { isAuthError } from '../lib/auth-errors'
+import { triggerAuthInterceptor } from '../api/client'
 import ToolTimeline from './ToolTimeline'
 import SentinelConfirm from './SentinelConfirm'
 
@@ -64,6 +65,14 @@ export default function ChatSidebar({ fullScreen }: Props) {
       })
 
       if (!res.ok) {
+        if (res.status === 401) {
+          triggerAuthInterceptor()
+          // Surface a neutral message — the global session-expired toast already
+          // tells the user what happened and offers a sign-in CTA. Returning
+          // here without throwing avoids painting the raw 401 body into the
+          // assistant bubble.
+          return
+        }
         const err = await res.json().catch(() => ({}))
         throw new Error((err as { error?: string }).error ?? `Error ${res.status}`)
       }

--- a/app/src/components/ChatSidebar.tsx
+++ b/app/src/components/ChatSidebar.tsx
@@ -66,11 +66,11 @@ export default function ChatSidebar({ fullScreen }: Props) {
 
       if (!res.ok) {
         if (res.status === 401) {
+          // Drop the empty assistant placeholder so the user doesn't see a
+          // ghost bubble next to the session-expired toast. The toast (wired
+          // globally in AuthSyncProvider) carries the re-auth UX.
+          dismissMessage(assistantMsg.id)
           triggerAuthInterceptor()
-          // Surface a neutral message — the global session-expired toast already
-          // tells the user what happened and offers a sign-in CTA. Returning
-          // here without throwing avoids painting the raw 401 body into the
-          // assistant bubble.
           return
         }
         const err = await res.json().catch(() => ({}))

--- a/app/src/components/NetworkBanner.tsx
+++ b/app/src/components/NetworkBanner.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+
+export function NetworkBanner() {
+  const [offline, setOffline] = useState(false)
+
+  useEffect(() => {
+    const handleError = () => setOffline(true)
+    const handleRecover = () => setOffline(false)
+    window.addEventListener('sipher:network-error', handleError)
+    window.addEventListener('sipher:network-recovered', handleRecover)
+    return () => {
+      window.removeEventListener('sipher:network-error', handleError)
+      window.removeEventListener('sipher:network-recovered', handleRecover)
+    }
+  }, [])
+
+  if (!offline) return null
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="bg-warning/15 border-b border-warning/30 text-warning px-4 py-2 text-xs flex items-center gap-2 shrink-0"
+    >
+      <span aria-hidden="true">●</span>
+      <span>Network connection lost — checking…</span>
+    </div>
+  )
+}

--- a/app/src/components/__tests__/ChatSidebar.test.tsx
+++ b/app/src/components/__tests__/ChatSidebar.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { useAppStore } from '../../stores/app'
 import ChatSidebar from '../ChatSidebar'
+import { triggerAuthInterceptor } from '../../api/client'
 
 const mockToastShow = vi.fn(() => 'toast-id')
 const mockToastDismiss = vi.fn()
@@ -9,6 +10,16 @@ const mockToastDismiss = vi.fn()
 vi.mock('../../providers/ToastProvider', () => ({
   useToast: () => ({ show: mockToastShow, dismiss: mockToastDismiss }),
 }))
+
+vi.mock('../../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../../api/client')>(
+    '../../api/client',
+  )
+  return {
+    ...actual,
+    triggerAuthInterceptor: vi.fn(),
+  }
+})
 
 vi.mock('../../hooks/useAuthState', async () => {
   const { useAppStore: store } = await vi.importActual<
@@ -47,6 +58,7 @@ describe('ChatSidebar', () => {
     resetStore()
     mockToastShow.mockClear()
     mockToastDismiss.mockClear()
+    vi.mocked(triggerAuthInterceptor).mockClear()
   })
 
   afterEach(() => {
@@ -171,5 +183,28 @@ describe('ChatSidebar', () => {
     })
     expect(mockToastShow).not.toHaveBeenCalled()
     expect(screen.queryByText(/invalid or expired token/)).not.toBeInTheDocument()
+  })
+
+  it('calls triggerAuthInterceptor when streaming fetch returns 401', async () => {
+    useAppStore.setState({ token: 'test-jwt', isAdmin: true })
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: 'unauthorized' }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        })
+      )
+    )
+
+    render(<ChatSidebar />)
+    const input = screen.getByPlaceholderText('Message SIPHER...') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(triggerAuthInterceptor).toHaveBeenCalledOnce()
+    })
   })
 })

--- a/app/src/components/__tests__/NetworkBanner.test.tsx
+++ b/app/src/components/__tests__/NetworkBanner.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import { NetworkBanner } from '../NetworkBanner'
+
+describe('NetworkBanner', () => {
+  it('does not render anything by default', () => {
+    render(<NetworkBanner />)
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('appears when sipher:network-error is dispatched', async () => {
+    render(<NetworkBanner />)
+    act(() => {
+      window.dispatchEvent(new CustomEvent('sipher:network-error'))
+    })
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+      expect(screen.getByText(/network connection lost/i)).toBeInTheDocument()
+    })
+  })
+
+  it('disappears when sipher:network-recovered is dispatched', async () => {
+    render(<NetworkBanner />)
+    act(() => {
+      window.dispatchEvent(new CustomEvent('sipher:network-error'))
+    })
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+    act(() => {
+      window.dispatchEvent(new CustomEvent('sipher:network-recovered'))
+    })
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/app/src/hooks/__tests__/useSSE.test.ts
+++ b/app/src/hooks/__tests__/useSSE.test.ts
@@ -55,7 +55,7 @@ describe('useSSE', () => {
     await waitFor(() => expect(result.current.events).toHaveLength(0))
   })
 
-  it('clears events when the EventSource emits an error', async () => {
+  it('keeps events on transient EventSource error and only flips connected to false', async () => {
     let onMessageCb: ((e: MessageEvent) => void) | null = null
     const onerrorRef: { current: (() => void) | null } = { current: null }
 
@@ -73,6 +73,7 @@ describe('useSSE', () => {
 
     const { result } = renderHook(() => useSSE())
     await waitFor(() => expect(onMessageCb).not.toBeNull())
+    await waitFor(() => expect(result.current.connected).toBe(true))
 
     act(() => {
       onMessageCb?.({
@@ -88,9 +89,14 @@ describe('useSSE', () => {
     })
     await waitFor(() => expect(result.current.events).toHaveLength(1))
 
+    // Transient EventSource blip: connected flips false but events are NOT
+    // wiped — users keep seeing their activity feed across short network
+    // hiccups. Auth-clear (the test above) is the only path that drains
+    // events.
     act(() => {
       onerrorRef.current?.()
     })
-    await waitFor(() => expect(result.current.events).toHaveLength(0))
+    await waitFor(() => expect(result.current.connected).toBe(false))
+    expect(result.current.events).toHaveLength(1)
   })
 })

--- a/app/src/hooks/__tests__/useSSE.test.ts
+++ b/app/src/hooks/__tests__/useSSE.test.ts
@@ -54,4 +54,43 @@ describe('useSSE', () => {
     act(() => onAuthClear.clearAll())
     await waitFor(() => expect(result.current.events).toHaveLength(0))
   })
+
+  it('clears events when the EventSource emits an error', async () => {
+    let onMessageCb: ((e: MessageEvent) => void) | null = null
+    const onerrorRef: { current: (() => void) | null } = { current: null }
+
+    ;(connectSSE as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_token, onMessage) => {
+        onMessageCb = onMessage
+        const source = {
+          close: vi.fn(),
+          get onerror() { return onerrorRef.current },
+          set onerror(v: (() => void) | null) { onerrorRef.current = v },
+        }
+        return source as unknown as EventSource
+      },
+    )
+
+    const { result } = renderHook(() => useSSE())
+    await waitFor(() => expect(onMessageCb).not.toBeNull())
+
+    act(() => {
+      onMessageCb?.({
+        data: JSON.stringify({
+          id: '1',
+          agent: 'a',
+          type: 't',
+          level: 'info',
+          data: {},
+          timestamp: 'x',
+        }),
+      } as MessageEvent)
+    })
+    await waitFor(() => expect(result.current.events).toHaveLength(1))
+
+    act(() => {
+      onerrorRef.current?.()
+    })
+    await waitFor(() => expect(result.current.events).toHaveLength(0))
+  })
 })

--- a/app/src/hooks/useSSE.ts
+++ b/app/src/hooks/useSSE.ts
@@ -37,7 +37,10 @@ export function useSSE() {
       if (cancelled) { source.close(); return }
       sourceRef.current = source
       setConnected(true)
-      source.onerror = () => setConnected(false)
+      source.onerror = () => {
+        setConnected(false)
+        setEvents([])
+      }
     }).catch(() => {
       setConnected(false)
     })

--- a/app/src/hooks/useSSE.ts
+++ b/app/src/hooks/useSSE.ts
@@ -37,10 +37,14 @@ export function useSSE() {
       if (cancelled) { source.close(); return }
       sourceRef.current = source
       setConnected(true)
-      source.onerror = () => {
-        setConnected(false)
-        setEvents([])
-      }
+      // EventSource fires onerror on every transient blip (1s WiFi hiccup,
+      // server hot-reload, browser-driven auto-reconnect). Wiping events on
+      // each one would clear the user's live activity feed mid-read. Keep
+      // events visible; users can see they're stale via the connected flag
+      // (and the upcoming <NetworkBanner> for offline state at the network
+      // layer). Auth-clear cleanup remains the single owner of "drain
+      // events" via useOnAuthClear above.
+      source.onerror = () => setConnected(false)
     }).catch(() => {
       setConnected(false)
     })


### PR DESCRIPTION
## Summary

Closes #191 + #192. Three changes wired through a new
`triggerAuthInterceptor` export and a CustomEvent bus on `window`:

1. `apiFetch` catches `TypeError: Failed to fetch` and dispatches
   `sipher:network-error`. Successful fetches dispatch
   `sipher:network-recovered`.
2. New `<NetworkBanner>` mounted in app shell subscribes to those
   events; renders a sticky banner while offline, auto-dismisses on
   recovery.
3. `useSSE` flips `connected=false` on `EventSource` error (transient
   blips no longer wipe the user's live activity feed — see fix
   commit below).
4. `ChatSidebar` calls `triggerAuthInterceptor()` when its streaming
   fetch returns 401, dismisses the empty assistant placeholder, and
   returns silently.

## Why

- Sipher had ZERO offline indicators. `window.fetch =
  () => Promise.reject(...)` would silently fail every action and
  leave users staring at a frozen UI. Privacy/finance products MUST
  surface network state.
- `ChatSidebar` bypassed the global 401 interceptor because its
  streaming fetch doesn't go through `apiFetch`. Users could chat
  with an expired JWT, get a raw 401 message in the assistant bubble,
  and never know they needed to sign in again.

## Code-review fixes applied (post-review, in-PR)

- `217a0ce` ChatSidebar 401: dismiss the empty assistant placeholder
  before returning so users don't see a phantom bubble next to the
  session-expired toast.
- `70c89e0` useSSE: keep events on transient EventSource error;
  `connected=false` is the only state change. Auth-clear remains the
  single owner of "drain events" via `useOnAuthClear`.
- `8e48347` Test: pin AbortError preservation through the new catch
  wrapper — 8+ callers rely on `err.name === 'AbortError'` to
  distinguish user-cancelled from genuine failures.

## Verification

- `pnpm exec tsc --noEmit` clean
- `pnpm test --run` green (65 files / 379 tests, +12 from baseline)
- Spec compliance review: ✅ all 10 verification points passed
- Code quality review: ❌ 2 blocking issues identified → both fixed
  in-PR before merge (3 fix commits added). Re-verified all 379
  tests green.

## Manual repros (Vercel preview)

1. **Network blackout**: in DevTools console run
   `window.fetch = () => Promise.reject(new TypeError('Failed to fetch'))`
   → `<NetworkBanner>` appears; restore fetch → banner dismisses on
   next successful request.
2. **Chat 401**: force JWT expiry, send chat message → triggers
   global session-expired toast + clean chat (no ghost bubble).
3. **SSE blip**: block `*.sip-protocol.org` SSE endpoint via DevTools
   Network tab → `connected=false` chip flips; events list stays
   visible (no wipe). Unblock → connection restores, new events
   prepend.

## Out of scope / follow-ups

- #225 useSSE in-flight `connectSSE` race tightening
- #226 dev-only `console.warn` on swallowed onAuthClear callback throws
- #227 narrow apiFetch TypeError catch to actual network errors
- #228 emitNetworkRecovered should only fire on offline→online transition

Spec: `docs/superpowers/specs/2026-05-10-qa-sweep-tier-0-1-design.md`
Plan: `docs/superpowers/plans/2026-05-10-qa-sweep-tier-0-1.md`