### PR TITLE
feat(app): UnauthedEmptyState primitive + 3 mounts (Tier 2 PR1)

### DIFF
--- a/app/src/components/PrivacyScoreCard.tsx
+++ b/app/src/components/PrivacyScoreCard.tsx
@@ -116,6 +116,13 @@ export function PrivacyScoreCard({ data, delta }: PrivacyScoreCardProps) {
             title="Privacy Score Report"
             body="Network analysis · surveillance score · personalized recommendations. Connect a wallet to view your full report."
           />
+          <button
+            type="button"
+            onClick={() => setTeaserOpen(false)}
+            className="self-start text-xs text-text-muted hover:text-text"
+          >
+            Close
+          </button>
         </div>
       </Sheet>
     </>

--- a/app/src/components/PrivacyScoreCard.tsx
+++ b/app/src/components/PrivacyScoreCard.tsx
@@ -110,10 +110,13 @@ export function PrivacyScoreCard({ data, delta }: PrivacyScoreCardProps) {
         onClose={() => setTeaserOpen(false)}
         ariaLabel="Privacy Score Report"
       >
-        <UnauthedEmptyState
-          title="Privacy Score Report"
-          body="Network analysis · surveillance score · personalized recommendations. Connect a wallet to view your full report."
-        />
+        <div className="flex flex-col gap-4 p-2">
+          <UnauthedEmptyState
+            bare
+            title="Privacy Score Report"
+            body="Network analysis · surveillance score · personalized recommendations. Connect a wallet to view your full report."
+          />
+        </div>
       </Sheet>
     </>
   )

--- a/app/src/components/PrivacyScoreCard.tsx
+++ b/app/src/components/PrivacyScoreCard.tsx
@@ -1,7 +1,11 @@
+import { useState } from 'react'
 import { Card } from './ui/Card'
 import { Gauge } from './ui/Gauge'
 import { MetricBar } from './ui/MetricBar'
+import { Sheet } from './ui/Sheet'
+import { UnauthedEmptyState } from './ui/UnauthedEmptyState'
 import { useAppStore } from '../stores/app'
+import { useAuthState } from '../hooks/useAuthState'
 
 interface PrivacyData {
   score: number
@@ -23,71 +27,94 @@ interface PrivacyScoreCardProps {
 
 export function PrivacyScoreCard({ data, delta }: PrivacyScoreCardProps) {
   const setActiveView = useAppStore((s) => s.setActiveView)
+  const { status } = useAuthState()
+  const [teaserOpen, setTeaserOpen] = useState(false)
+
+  const handleViewReport = () => {
+    if (status === 'authed') {
+      setActiveView('privacyReport')
+    } else {
+      setTeaserOpen(true)
+    }
+  }
 
   return (
-    <Card variant="default" sheen className="p-8">
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-        <div className="flex items-center justify-center">
-          <Gauge
-            value={data?.score ?? 0}
-            max={100}
-            gradeLabel={data?.grade ?? '—'}
-            ariaLabel="Privacy score"
-          />
-        </div>
-        <div className="flex flex-col gap-4">
-          <div className="flex items-baseline justify-between">
-            <div>
-              <div
-                className="text-2xs text-text-muted"
-                style={{ letterSpacing: 'var(--tracking-widest)' }}
-              >
-                PRIVACY SCORE
-              </div>
-              <div className="text-base mt-1">
-                {delta != null && (
-                  <span className="text-cyan font-mono">
-                    {delta > 0 ? '+' : ''}
-                    {delta}
-                  </span>
-                )}
-                <span className="text-text-muted"> vs last week</span>
-              </div>
-            </div>
-            <button
-              type="button"
-              onClick={() => setActiveView('privacyReport')}
-              className="text-xs text-text-secondary border border-line rounded-md px-3 py-1.5 hover:border-line-2 hover:text-text transition-colors"
-            >
-              View report →
-            </button>
+    <>
+      <Card variant="default" sheen className="p-8">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <div className="flex items-center justify-center">
+            <Gauge
+              value={data?.score ?? 0}
+              max={100}
+              gradeLabel={data?.grade ?? '—'}
+              ariaLabel="Privacy score"
+            />
           </div>
-          {data && (
-            <div className="flex flex-col gap-3">
-              <MetricBar
-                label="Anonymity set"
-                value={data.factors.addressReuse.score}
-                helper={data.factors.addressReuse.detail}
-              />
-              <MetricBar
-                label="Time decay"
-                value={data.factors.amountPatterns.score}
-                helper={data.factors.amountPatterns.detail}
-              />
-              <MetricBar
-                label="Withdraw routing"
-                value={data.factors.timingCorrelation.score}
-                helper={data.factors.timingCorrelation.detail}
-              />
-              <MetricBar
-                label="Address hygiene"
-                value={data.factors.counterpartyExposure.score}
-                helper={data.factors.counterpartyExposure.detail}
-              />
+          <div className="flex flex-col gap-4">
+            <div className="flex items-baseline justify-between">
+              <div>
+                <div
+                  className="text-2xs text-text-muted"
+                  style={{ letterSpacing: 'var(--tracking-widest)' }}
+                >
+                  PRIVACY SCORE
+                </div>
+                <div className="text-base mt-1">
+                  {delta != null && (
+                    <span className="text-cyan font-mono">
+                      {delta > 0 ? '+' : ''}
+                      {delta}
+                    </span>
+                  )}
+                  <span className="text-text-muted"> vs last week</span>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={handleViewReport}
+                className="text-xs text-text-secondary border border-line rounded-md px-3 py-1.5 hover:border-line-2 hover:text-text transition-colors"
+              >
+                View report →
+              </button>
             </div>
-          )}
+            {data && (
+              <div className="flex flex-col gap-3">
+                <MetricBar
+                  label="Anonymity set"
+                  value={data.factors.addressReuse.score}
+                  helper={data.factors.addressReuse.detail}
+                />
+                <MetricBar
+                  label="Time decay"
+                  value={data.factors.amountPatterns.score}
+                  helper={data.factors.amountPatterns.detail}
+                />
+                <MetricBar
+                  label="Withdraw routing"
+                  value={data.factors.timingCorrelation.score}
+                  helper={data.factors.timingCorrelation.detail}
+                />
+                <MetricBar
+                  label="Address hygiene"
+                  value={data.factors.counterpartyExposure.score}
+                  helper={data.factors.counterpartyExposure.detail}
+                />
+              </div>
+            )}
+          </div>
         </div>
-      </div>
-    </Card>
+      </Card>
+
+      <Sheet
+        open={teaserOpen}
+        onClose={() => setTeaserOpen(false)}
+        ariaLabel="Privacy Score Report"
+      >
+        <UnauthedEmptyState
+          title="Privacy Score Report"
+          body="Network analysis · surveillance score · personalized recommendations. Connect a wallet to view your full report."
+        />
+      </Sheet>
+    </>
   )
 }

--- a/app/src/components/__tests__/PrivacyScoreCard.test.tsx
+++ b/app/src/components/__tests__/PrivacyScoreCard.test.tsx
@@ -105,6 +105,10 @@ describe('PrivacyScoreCard', () => {
     render(<PrivacyScoreCard data={fakeData} />)
     fireEvent.click(screen.getByRole('button', { name: /view report/i }))
     expect(useAppStore.getState().activeView).toBe('dashboard')
+    // Assert the alternative path actually fired (Sheet opened). Without this,
+    // a future regression that drops `setTeaserOpen(true)` from handleViewReport
+    // would silently still pass this test.
+    expect(screen.getByTestId('unauthed-empty-state')).toBeInTheDocument()
   })
 
   it('dismisses Sheet teaser when Close button clicked', () => {

--- a/app/src/components/__tests__/PrivacyScoreCard.test.tsx
+++ b/app/src/components/__tests__/PrivacyScoreCard.test.tsx
@@ -106,4 +106,22 @@ describe('PrivacyScoreCard', () => {
     fireEvent.click(screen.getByRole('button', { name: /view report/i }))
     expect(useAppStore.getState().activeView).toBe('dashboard')
   })
+
+  it('dismisses Sheet teaser when Close button clicked', () => {
+    useAuthStateMock.mockReturnValue({
+      status: 'unauthed' as const,
+      token: null,
+      publicKey: null,
+      isAdmin: false,
+      expiresAt: null,
+      authenticate: () => Promise.resolve(),
+      disconnect: () => Promise.resolve(),
+      error: null,
+    })
+    render(<PrivacyScoreCard data={fakeData} />)
+    fireEvent.click(screen.getByRole('button', { name: /view report/i }))
+    expect(screen.getByTestId('unauthed-empty-state')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /^close$/i }))
+    expect(screen.queryByTestId('unauthed-empty-state')).toBeNull()
+  })
 })

--- a/app/src/components/__tests__/PrivacyScoreCard.test.tsx
+++ b/app/src/components/__tests__/PrivacyScoreCard.test.tsx
@@ -1,7 +1,16 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { PrivacyScoreCard } from '../PrivacyScoreCard'
 import { useAppStore } from '../../stores/app'
+
+vi.mock('@solana/wallet-adapter-react-ui', () => ({
+  useWalletModal: () => ({ setVisible: vi.fn(), visible: false }),
+}))
+
+const useAuthStateMock = vi.fn()
+vi.mock('../../hooks/useAuthState', () => ({
+  useAuthState: () => useAuthStateMock(),
+}))
 
 const fakeData = {
   score: 72,
@@ -18,6 +27,16 @@ const fakeData = {
 
 beforeEach(() => {
   useAppStore.setState({ activeView: 'dashboard' }, false)
+  useAuthStateMock.mockReturnValue({
+    status: 'authed' as const,
+    token: 'test-token',
+    publicKey: 'TestWallet1111111111111111111111111111111111',
+    isAdmin: false,
+    expiresAt: null,
+    authenticate: () => Promise.resolve(),
+    disconnect: () => Promise.resolve(),
+    error: null,
+  })
 })
 
 describe('PrivacyScoreCard', () => {
@@ -53,5 +72,38 @@ describe('PrivacyScoreCard', () => {
     render(<PrivacyScoreCard data={fakeData} />)
     expect(screen.queryByText(/vs last week/)).toBeInTheDocument()
     expect(screen.queryByText('+4')).not.toBeInTheDocument()
+  })
+
+  it('opens Sheet teaser with UnauthedEmptyState when View report clicked unauthed', () => {
+    useAuthStateMock.mockReturnValue({
+      status: 'unauthed' as const,
+      token: null,
+      publicKey: null,
+      isAdmin: false,
+      expiresAt: null,
+      authenticate: () => Promise.resolve(),
+      disconnect: () => Promise.resolve(),
+      error: null,
+    })
+    render(<PrivacyScoreCard data={fakeData} />)
+    fireEvent.click(screen.getByRole('button', { name: /view report/i }))
+    expect(screen.getByTestId('unauthed-empty-state')).toBeInTheDocument()
+    expect(screen.getByText(/privacy score report/i)).toBeInTheDocument()
+  })
+
+  it('does NOT navigate to privacyReport when clicked unauthed', () => {
+    useAuthStateMock.mockReturnValue({
+      status: 'unauthed' as const,
+      token: null,
+      publicKey: null,
+      isAdmin: false,
+      expiresAt: null,
+      authenticate: () => Promise.resolve(),
+      disconnect: () => Promise.resolve(),
+      error: null,
+    })
+    render(<PrivacyScoreCard data={fakeData} />)
+    fireEvent.click(screen.getByRole('button', { name: /view report/i }))
+    expect(useAppStore.getState().activeView).toBe('dashboard')
   })
 })

--- a/app/src/components/ui/UnauthedEmptyState.tsx
+++ b/app/src/components/ui/UnauthedEmptyState.tsx
@@ -6,6 +6,13 @@ export interface UnauthedEmptyStateProps {
   body: ReactNode
   cta?: ReactNode
   illustration?: ReactNode
+  /**
+   * Drops the outer `glass-strong rounded-2xl p-8` chrome.
+   * Use when nesting inside another card/sheet that already has glass chrome
+   * (e.g. inside `<Sheet>` whose dialog container already applies `glass-strong`).
+   * Inner layout (illustration + title + body + cta) is preserved.
+   */
+  bare?: boolean
 }
 
 function DefaultConnectCTA() {
@@ -27,12 +34,14 @@ export function UnauthedEmptyState({
   body,
   cta,
   illustration,
+  bare = false,
 }: UnauthedEmptyStateProps) {
+  const containerClass = bare
+    ? 'flex flex-col items-start gap-4'
+    : 'glass-strong rounded-2xl p-8 flex flex-col items-start gap-4'
+
   return (
-    <div
-      data-testid="unauthed-empty-state"
-      className="glass-strong rounded-2xl p-8 flex flex-col items-start gap-4"
-    >
+    <div data-testid="unauthed-empty-state" className={containerClass}>
       {illustration && (
         <div data-testid="empty-state-illustration" className="w-full">
           {illustration}

--- a/app/src/components/ui/UnauthedEmptyState.tsx
+++ b/app/src/components/ui/UnauthedEmptyState.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react'
+import { useWalletModal } from '@solana/wallet-adapter-react-ui'
+
+export interface UnauthedEmptyStateProps {
+  title: string
+  body: ReactNode
+  cta?: ReactNode
+  illustration?: ReactNode
+}
+
+function DefaultConnectCTA() {
+  const { setVisible } = useWalletModal()
+  return (
+    <button
+      type="button"
+      onClick={() => setVisible(true)}
+      className="self-start text-xs px-3 py-1.5 rounded-md text-bg font-semibold bg-accent hover:opacity-90"
+      style={{ background: 'linear-gradient(90deg, var(--color-cyan), var(--color-violet))' }}
+    >
+      Connect wallet
+    </button>
+  )
+}
+
+export function UnauthedEmptyState({
+  title,
+  body,
+  cta,
+  illustration,
+}: UnauthedEmptyStateProps) {
+  return (
+    <div
+      data-testid="unauthed-empty-state"
+      className="glass-strong rounded-2xl p-8 flex flex-col items-start gap-4"
+    >
+      {illustration && (
+        <div data-testid="empty-state-illustration" className="w-full">
+          {illustration}
+        </div>
+      )}
+      <h2 className="text-lg font-semibold text-text">{title}</h2>
+      <div className="text-sm text-text-secondary leading-relaxed">{body}</div>
+      {cta ?? <DefaultConnectCTA />}
+    </div>
+  )
+}

--- a/app/src/components/ui/__tests__/UnauthedEmptyState.test.tsx
+++ b/app/src/components/ui/__tests__/UnauthedEmptyState.test.tsx
@@ -55,4 +55,21 @@ describe('UnauthedEmptyState', () => {
     )
     expect(screen.getByText('deposit')).toBeInTheDocument()
   })
+
+  it('renders without glass-strong chrome when bare prop is true', () => {
+    const { container } = render(
+      <UnauthedEmptyState bare title="X" body="Y" />,
+    )
+    expect(container.querySelector('.glass-strong')).toBeNull()
+    expect(container.querySelector('.rounded-2xl')).toBeNull()
+    // inner content still renders
+    expect(screen.getByText('X')).toBeInTheDocument()
+    expect(screen.getByText('Y')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /connect/i })).toBeInTheDocument()
+  })
+
+  it('keeps glass-strong chrome by default (bare is false)', () => {
+    const { container } = render(<UnauthedEmptyState title="X" body="Y" />)
+    expect(container.querySelector('.glass-strong')).not.toBeNull()
+  })
 })

--- a/app/src/components/ui/__tests__/UnauthedEmptyState.test.tsx
+++ b/app/src/components/ui/__tests__/UnauthedEmptyState.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { UnauthedEmptyState } from '../UnauthedEmptyState'
+
+vi.mock('@solana/wallet-adapter-react-ui', () => ({
+  useWalletModal: () => ({ setVisible: vi.fn(), visible: false }),
+}))
+
+describe('UnauthedEmptyState', () => {
+  it('renders title and body', () => {
+    render(<UnauthedEmptyState title="Stealth Keys" body="Connect to view." />)
+    expect(screen.getByText('Stealth Keys')).toBeInTheDocument()
+    expect(screen.getByText('Connect to view.')).toBeInTheDocument()
+  })
+
+  it('renders default CTA when none provided', () => {
+    render(<UnauthedEmptyState title="X" body="Y" />)
+    expect(screen.getByRole('button', { name: /connect/i })).toBeInTheDocument()
+  })
+
+  it('renders custom CTA when provided', () => {
+    render(
+      <UnauthedEmptyState
+        title="X"
+        body="Y"
+        cta={<a href="/about">Learn more</a>}
+      />,
+    )
+    expect(screen.getByRole('link', { name: /learn more/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /connect/i })).toBeNull()
+  })
+
+  it('renders illustration when provided', () => {
+    render(
+      <UnauthedEmptyState
+        title="X"
+        body="Y"
+        illustration={<div data-testid="hero">hero</div>}
+      />,
+    )
+    expect(screen.getByTestId('hero')).toBeInTheDocument()
+  })
+
+  it('does not render illustration container when illustration is omitted', () => {
+    const { container } = render(<UnauthedEmptyState title="X" body="Y" />)
+    expect(container.querySelector('[data-testid="empty-state-illustration"]')).toBeNull()
+  })
+
+  it('renders rich body content (ReactNode, not just string)', () => {
+    render(
+      <UnauthedEmptyState
+        title="X"
+        body={<>Connect a wallet to <strong>deposit</strong>.</>}
+      />,
+    )
+    expect(screen.getByText('deposit')).toBeInTheDocument()
+  })
+})

--- a/app/src/components/vault/RoutePreviewCard.tsx
+++ b/app/src/components/vault/RoutePreviewCard.tsx
@@ -33,7 +33,17 @@ export function RoutePreviewCard({
         ROUTE PREVIEW
       </div>
       <div className="flex flex-col gap-2 font-mono text-xs">
-        <Step n={1} label="You" detail={<HashCell hash={wallet} />} />
+        <Step
+          n={1}
+          label="You"
+          detail={
+            wallet ? (
+              <HashCell hash={wallet} />
+            ) : (
+              <span className="text-text-muted">—</span>
+            )
+          }
+        />
         <div className="ml-3 text-text-muted">↓ {amountLabel}</div>
         <Step n={2} label="Vault PDA" detail={<HashCell hash={vaultPda} />} />
         <div className="ml-3 text-text-muted">↓</div>

--- a/app/src/components/vault/__tests__/RoutePreviewCard.test.tsx
+++ b/app/src/components/vault/__tests__/RoutePreviewCard.test.tsx
@@ -33,4 +33,14 @@ describe('RoutePreviewCard', () => {
     )
     expect(screen.getByText('—')).toBeInTheDocument()
   })
+
+  it('renders em-dash placeholder when wallet is empty (no unlabelled Copy button)', () => {
+    const { container } = render(<RoutePreviewCard wallet="" />)
+    // No focusable HashCell button with empty aria-label
+    expect(container.querySelector('button[aria-label="Copy "]')).toBeNull()
+    // Vault PDA HashCell is still rendered (default)
+    expect(
+      container.querySelector('button[aria-label*="CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u"]'),
+    ).not.toBeNull()
+  })
 })

--- a/app/src/views/KeysView.tsx
+++ b/app/src/views/KeysView.tsx
@@ -1,10 +1,18 @@
 import { useAuthState } from '../hooks/useAuthState'
+import { UnauthedEmptyState } from '../components/ui/UnauthedEmptyState'
 import { ViewKeyCard } from '../components/keys/ViewKeyCard'
 import { StealthAddressBackup } from '../components/keys/StealthAddressBackup'
 
 export default function KeysView() {
   const { status } = useAuthState()
-  if (status !== 'authed') return null
+  if (status !== 'authed') {
+    return (
+      <UnauthedEmptyState
+        title="Stealth Keys"
+        body="Your spending and viewing keys are derived from your wallet. Connect to view, rotate, or back them up."
+      />
+    )
+  }
 
   return (
     <div className="flex flex-col gap-4">

--- a/app/src/views/VaultView.tsx
+++ b/app/src/views/VaultView.tsx
@@ -7,6 +7,7 @@ import { useOnAuthClear } from '../store/useOnAuthClear'
 import { Card } from '../components/ui/Card'
 import { Chip } from '../components/ui/Chip'
 import { HashCell } from '../components/ui/HashCell'
+import { UnauthedEmptyState } from '../components/ui/UnauthedEmptyState'
 import {
   StealthAddressList,
   type Position,
@@ -41,7 +42,7 @@ interface StealthIndexResponse {
 }
 
 export default function VaultView() {
-  const { token } = useAuthState()
+  const { token, status } = useAuthState()
   const setActiveView = useAppStore((s) => s.setActiveView)
   const network = useNetworkConfigStore((s) => s.config?.network ?? '')
   const isMainnet = network === 'mainnet'
@@ -83,6 +84,22 @@ export default function VaultView() {
     })
     return () => controller.abort()
   }, [token])
+
+  if (status !== 'authed') {
+    return (
+      <UnauthedEmptyState
+        title="Shielded Vault"
+        body={
+          <>
+            Privacy-preserving SOL + token vault on Solana. Stealth output addresses by default.
+            <br />
+            <strong>Connect a wallet to deposit.</strong>
+          </>
+        }
+        illustration={<RoutePreviewCard wallet="" />}
+      />
+    )
+  }
 
   return (
     <div data-testid="vault-view" className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/app/src/views/__tests__/KeysView.test.tsx
+++ b/app/src/views/__tests__/KeysView.test.tsx
@@ -40,16 +40,29 @@ describe('KeysView', () => {
     expect(grid?.className).toMatch(/md:grid-cols-2/)
   })
 
-  it('renders nothing when unauthenticated', () => {
+  it('renders UnauthedEmptyState when unauthenticated', () => {
     useAuthStateMock.mockReturnValue({
       publicKey: null,
       token: null,
       status: 'unauthed',
       isAdmin: false,
     })
-    const { container } = render(<KeysView />)
-    expect(container.querySelector('[data-testid="keys-view"]')).toBeNull()
+    render(<KeysView />)
+    expect(screen.getByTestId('unauthed-empty-state')).toBeInTheDocument()
+    expect(screen.getByText(/stealth keys/i)).toBeInTheDocument()
     expect(screen.queryByTestId('view-key-card')).toBeNull()
+    expect(screen.queryByTestId('backup-card')).toBeNull()
+  })
+
+  it('does NOT render the section heading when unauthenticated', () => {
+    useAuthStateMock.mockReturnValue({
+      publicKey: null,
+      token: null,
+      status: 'unauthed',
+      isAdmin: false,
+    })
+    render(<KeysView />)
+    expect(screen.queryByText(/viewing key management/i)).toBeNull()
   })
 
   it('renders the section heading', () => {

--- a/app/src/views/__tests__/VaultView.test.tsx
+++ b/app/src/views/__tests__/VaultView.test.tsx
@@ -9,17 +9,9 @@ vi.mock('../../api/client', () => ({
   apiFetch: vi.fn(),
 }))
 
+const useAuthStateMock = vi.fn()
 vi.mock('../../hooks/useAuthState', () => ({
-  useAuthState: () => ({
-    status: 'authed' as const,
-    token: 'test-token',
-    expiresAt: null,
-    isAdmin: false,
-    publicKey: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
-    authenticate: () => Promise.resolve(),
-    disconnect: () => Promise.resolve(),
-    error: null,
-  }),
+  useAuthState: () => useAuthStateMock(),
 }))
 
 vi.mock('../../stores/app', async () => {
@@ -104,6 +96,16 @@ beforeEach(() => {
   setActiveView.mockReset()
   networkValue = 'devnet'
   onAuthClear._resetForTests()
+  useAuthStateMock.mockReturnValue({
+    status: 'authed' as const,
+    token: 'test-token',
+    expiresAt: null,
+    isAdmin: false,
+    publicKey: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
+    authenticate: () => Promise.resolve(),
+    disconnect: () => Promise.resolve(),
+    error: null,
+  })
 })
 
 function mockThreeFetches(positionsResponse: PositionsResponse = emptyPositions) {
@@ -185,5 +187,56 @@ describe('VaultView (split-panel)', () => {
     await waitFor(() => {
       expect(screen.getByText('0 positions')).toBeInTheDocument()
     })
+  })
+
+  it('renders UnauthedEmptyState when status is unauthed', () => {
+    useAuthStateMock.mockReturnValue({
+      status: 'unauthed' as const,
+      token: null,
+      publicKey: null,
+      isAdmin: false,
+      expiresAt: null,
+      authenticate: () => Promise.resolve(),
+      disconnect: () => Promise.resolve(),
+      error: null,
+    })
+    mockThreeFetches()
+    render(<VaultView />)
+    expect(screen.getByTestId('unauthed-empty-state')).toBeInTheDocument()
+    expect(screen.queryByText(/SHIELDED VAULT/)).toBeNull()
+    expect(screen.queryByText(/UNSHIELDED WALLET/)).toBeNull()
+    expect(screen.queryByRole('button', { name: /withdraw/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /shield to vault/i })).toBeNull()
+  })
+
+  it('renders UnauthedEmptyState when status is connecting', () => {
+    useAuthStateMock.mockReturnValue({
+      status: 'connecting' as const,
+      token: null,
+      publicKey: null,
+      isAdmin: false,
+      expiresAt: null,
+      authenticate: () => Promise.resolve(),
+      disconnect: () => Promise.resolve(),
+      error: null,
+    })
+    mockThreeFetches()
+    render(<VaultView />)
+    expect(screen.getByTestId('unauthed-empty-state')).toBeInTheDocument()
+  })
+
+  it('does not fire fetches when unauthed', () => {
+    useAuthStateMock.mockReturnValue({
+      status: 'unauthed' as const,
+      token: null,
+      publicKey: null,
+      isAdmin: false,
+      expiresAt: null,
+      authenticate: () => Promise.resolve(),
+      disconnect: () => Promise.resolve(),
+      error: null,
+    })
+    render(<VaultView />)
+    expect(mockedFetch).not.toHaveBeenCalled()
   })
 })

--- a/e2e/vault.spec.ts
+++ b/e2e/vault.spec.ts
@@ -5,7 +5,7 @@ const AUTH_STATE = 'e2e/fixtures/storageState.json'
 
 test.use({ storageState: AUTH_STATE })
 
-test('vault view renders', async ({ page }) => {
+test('vault unauthed empty state renders', async ({ page }) => {
   const errors: string[] = []
   page.on('pageerror', (err) => errors.push(err.message))
   page.on('console', (msg) => {
@@ -16,6 +16,9 @@ test('vault view renders', async ({ page }) => {
   await mockPrivacyScore(page)
   await page.goto('/')
   await page.getByRole('button', { name: /vault/i }).first().click()
-  await expect(page.locator('[data-testid="vault-view"]')).toBeVisible()
+  // E2E fixture persists JWT but does not connect a wallet adapter, so
+  // useAuthState() resolves to 'unauthed' and VaultView renders the
+  // UnauthedEmptyState marketing branch. See PR #230 / Tier 2 #190.
+  await expect(page.locator('[data-testid="unauthed-empty-state"]')).toBeVisible()
   expect(errors).toEqual([])
 })


### PR DESCRIPTION
## Summary

Closes #190 (Vault Withdraw visible to unauthed — P0), #201 (Keys page blank), #215 (View Report dead CTA). Tier 2 PR1 of the QA sweep.

- New `<UnauthedEmptyState>` primitive in `app/src/components/ui/` — props `{ title, body, cta?, illustration?, bare? }`. Default CTA opens wallet modal. `bare` mode drops outer chrome for nested-card contexts (Sheet teaser).
- VaultView unauthed branch renders primitive with `<RoutePreviewCard>` as illustration; hides ShieldedVaultPanel + UnshieldedWalletPanel + Withdraw button.
- KeysView unauthed branch renders primitive with title + body (no longer returns null).
- PrivacyScoreCard `View report →` opens Sheet teaser with bare-mode primitive + Close button when unauthed; preserves `setActiveView('privacyReport')` when authed.
- `RoutePreviewCard` now renders an em-dash placeholder (no focusable empty button) when wallet is empty (a11y fix surfaced by reviewer).

## Test plan

- [ ] Vercel preview: load without wallet → click Vault → marketing illustration shown, no Withdraw button
- [ ] Vercel preview: same session → click Keys → empty state with title + Connect CTA
- [ ] Vercel preview: same session → click "View report →" → Sheet opens with teaser + Close button; dismiss; connect wallet → click again → navigates to privacy report
- [ ] CI green (component + playwright)

## Quality

- 395 tests pass / 66 files / typecheck clean
- 8 commits: 4 features + 4 review fixes
- Two-stage review (spec compliance + code quality) passed; reviewer flagged 4 Important issues which were all addressed

## Spec

\`docs/superpowers/specs/2026-05-10-qa-sweep-tier-2-design.md\` PR1 section.