### PR TITLE
feat(app): URL router with react-router-dom@^7 (Tier 2 PR2)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -20,6 +20,7 @@
     "@tailwindcss/vite": "^4.2.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-router-dom": "^7.15.0",
     "reactflow": "^11.11.4",
     "tailwindcss": "^4.2.2",
     "zustand": "^5.0.12"

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo } from 'react'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react'
 import { WalletModalProvider } from '@solana/wallet-adapter-react-ui'
 import '@solana/wallet-adapter-react-ui/styles.css'
@@ -19,6 +20,9 @@ import PrivacyReportView from './views/PrivacyReportView'
 import ChainsView from './views/ChainsView'
 import KeysView from './views/KeysView'
 import SettingsView from './views/SettingsView'
+import ChatView from './views/ChatView'
+import NotFoundView from './views/NotFoundView'
+import AboutPlaceholderView from './views/AboutPlaceholderView'
 import { useAppStore } from './stores/app'
 import { useAuth } from './hooks/useAuth'
 import { useSSE } from './hooks/useSSE'
@@ -27,45 +31,11 @@ import { ToastProvider } from './providers/ToastProvider'
 import { AuthSyncProvider } from './providers/AuthSyncProvider'
 
 function AppShell() {
-  const activeView = useAppStore((s) => s.activeView)
   const chatSheetOpen = useAppStore((s) => s.chatSheetOpen)
   const setChatSheetOpen = useAppStore((s) => s.setChatSheetOpen)
-  const { token, isAdmin } = useAuth()
+  const { token } = useAuth()
   const { events } = useSSE()
   const beta = useNetworkConfigStore((s) => s.config?.beta ?? false)
-
-  const renderView = () => {
-    switch (activeView) {
-      case 'dashboard':
-        return <DashboardView events={events} />
-      case 'vault':
-        return <VaultView />
-      case 'deposit':
-        return <DepositView />
-      case 'withdraw':
-        return <WithdrawView />
-      case 'herald':
-        return isAdmin ? <HeraldView token={token} /> : <DashboardView events={events} />
-      case 'squad':
-        return isAdmin ? <SquadView token={token} /> : <DashboardView events={events} />
-      case 'privacyReport':
-        return <PrivacyReportView />
-      case 'chains':
-        return <ChainsView />
-      case 'keys':
-        return <KeysView />
-      case 'settings':
-        return isAdmin ? <SettingsView /> : <DashboardView events={events} />
-      case 'chat':
-        return (
-          <div className="lg:hidden h-full">
-            <ChatSidebar fullScreen />
-          </div>
-        )
-      default:
-        return <DashboardView events={events} />
-    }
-  }
 
   return (
     <div className="flex flex-col h-dvh bg-bg">
@@ -75,7 +45,21 @@ function AppShell() {
 
       <div className="flex-1 flex overflow-hidden">
         <main className="flex-1 overflow-y-auto px-4 py-5 lg:px-6">
-          {renderView()}
+          <Routes>
+            <Route path="/" element={<DashboardView events={events} />} />
+            <Route path="/vault" element={<VaultView />} />
+            <Route path="/vault/deposit" element={<DepositView />} />
+            <Route path="/vault/withdraw" element={<WithdrawView />} />
+            <Route path="/chains" element={<ChainsView />} />
+            <Route path="/keys" element={<KeysView />} />
+            <Route path="/chat" element={<ChatView />} />
+            <Route path="/herald" element={<HeraldView token={token} />} />
+            <Route path="/sentinel" element={<SquadView token={token} />} />
+            <Route path="/settings" element={<SettingsView />} />
+            <Route path="/privacy-report" element={<PrivacyReportView />} />
+            <Route path="/about" element={<AboutPlaceholderView />} />
+            <Route path="*" element={<NotFoundView />} />
+          </Routes>
         </main>
       </div>
 
@@ -127,16 +111,18 @@ export default function App() {
   }
 
   return (
-    <ConnectionProvider endpoint={config.publicRpcUrl}>
-      <WalletProvider wallets={wallets} autoConnect>
-        <WalletModalProvider>
-          <ToastProvider>
-            <AuthSyncProvider>
-              <AppShell />
-            </AuthSyncProvider>
-          </ToastProvider>
-        </WalletModalProvider>
-      </WalletProvider>
-    </ConnectionProvider>
+    <BrowserRouter>
+      <ConnectionProvider endpoint={config.publicRpcUrl}>
+        <WalletProvider wallets={wallets} autoConnect>
+          <WalletModalProvider>
+            <ToastProvider>
+              <AuthSyncProvider>
+                <AppShell />
+              </AuthSyncProvider>
+            </ToastProvider>
+          </WalletModalProvider>
+        </WalletProvider>
+      </ConnectionProvider>
+    </BrowserRouter>
   )
 }

--- a/app/src/components/BetaBanner.tsx
+++ b/app/src/components/BetaBanner.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useAppStore } from '../stores/app'
+import { useActiveView } from '../hooks/useActiveView'
 import { useNetworkConfigStore } from '../lib/networkConfig'
 
 const STORAGE_KEY = 'sipher.beta-banner.dismissed'
@@ -10,7 +10,7 @@ export function BetaBanner({ beta }: { beta: boolean }) {
   const [dismissed, setDismissed] = useState<boolean>(
     () => sessionStorage.getItem(STORAGE_KEY) === 'true',
   )
-  const activeView = useAppStore((s) => s.activeView)
+  const activeView = useActiveView()
   const network = useNetworkConfigStore((s) => s.config?.network ?? '')
 
   // Vault flows are devnet-only — surface a non-dismissible banner whenever

--- a/app/src/components/BetaBanner.tsx
+++ b/app/src/components/BetaBanner.tsx
@@ -16,7 +16,8 @@ export function BetaBanner({ beta }: { beta: boolean }) {
   // Vault flows are devnet-only — surface a non-dismissible banner whenever
   // the user is on a vault-related view but the active network is mainnet.
   // This trumps the generic beta banner so the constraint is unmissable.
-  const showVaultDevnetBanner = VAULT_VIEWS.has(activeView) && network === 'mainnet'
+  const showVaultDevnetBanner =
+    activeView !== null && VAULT_VIEWS.has(activeView) && network === 'mainnet'
 
   if (showVaultDevnetBanner) {
     return (

--- a/app/src/components/BottomNav.tsx
+++ b/app/src/components/BottomNav.tsx
@@ -10,7 +10,9 @@ import {
   Key,
   Gear,
 } from '@phosphor-icons/react'
-import { useAppStore, type View } from '../stores/app'
+import { Link, useNavigate } from 'react-router-dom'
+import { type View } from '../stores/app'
+import { useActiveView } from '../hooks/useActiveView'
 import { useAuthState } from '../hooks/useAuthState'
 import { useToast } from '../providers/ToastProvider'
 
@@ -26,9 +28,24 @@ const TABS: TabDef[] = [
   { id: 'chat', label: 'Chat', icon: ChatCircle },
 ]
 
+const VIEW_TO_PATH: Record<View, string> = {
+  dashboard: '/',
+  vault: '/vault',
+  chains: '/chains',
+  keys: '/keys',
+  chat: '/chat',
+  deposit: '/vault/deposit',
+  withdraw: '/vault/withdraw',
+  herald: '/herald',
+  squad: '/sentinel',
+  settings: '/settings',
+  privacyReport: '/privacy-report',
+  about: '/about',
+}
+
 export default function BottomNav() {
-  const activeView = useAppStore((s) => s.activeView)
-  const setActiveView = useAppStore((s) => s.setActiveView)
+  const activeView = useActiveView()
+  const navigate = useNavigate()
   const { isAdmin, disconnect } = useAuthState()
   const { show: showToast } = useToast()
   const [moreOpen, setMoreOpen] = useState(false)
@@ -48,16 +65,16 @@ export default function BottomNav() {
             activeView === tab.id ||
             (tab.id === 'vault' && (activeView === 'deposit' || activeView === 'withdraw'))
           return (
-            <button
+            <Link
               key={tab.id}
-              onClick={() => setActiveView(tab.id)}
+              to={VIEW_TO_PATH[tab.id]}
               className={`flex-1 flex flex-col items-center justify-center py-2.5 gap-1 transition-colors ${
                 active ? 'text-text' : 'text-text-muted'
               }`}
             >
               <Icon size={20} weight={active ? 'fill' : 'regular'} />
               <span className="text-2xs font-medium tracking-wide">{tab.label}</span>
-            </button>
+            </Link>
           )
         })}
         <button
@@ -84,7 +101,7 @@ export default function BottomNav() {
             <div className="flex flex-col gap-1">
               <button
                 onClick={() => {
-                  setActiveView('keys')
+                  navigate(VIEW_TO_PATH.keys)
                   setMoreOpen(false)
                 }}
                 className="flex items-center gap-3 px-3 py-3 rounded-lg text-text-secondary hover:bg-glass-2 transition-colors"
@@ -97,7 +114,7 @@ export default function BottomNav() {
                   <div className="border-t border-line my-1" />
                   <button
                     onClick={() => {
-                      setActiveView('herald')
+                      navigate(VIEW_TO_PATH.herald)
                       setMoreOpen(false)
                     }}
                     className="flex items-center gap-3 px-3 py-3 rounded-lg text-text-secondary hover:bg-glass-2 transition-colors"
@@ -107,7 +124,7 @@ export default function BottomNav() {
                   </button>
                   <button
                     onClick={() => {
-                      setActiveView('squad')
+                      navigate(VIEW_TO_PATH.squad)
                       setMoreOpen(false)
                     }}
                     className="flex items-center gap-3 px-3 py-3 rounded-lg text-text-secondary hover:bg-glass-2 transition-colors"
@@ -117,7 +134,7 @@ export default function BottomNav() {
                   </button>
                   <button
                     onClick={() => {
-                      setActiveView('settings')
+                      navigate(VIEW_TO_PATH.settings)
                       setMoreOpen(false)
                     }}
                     className="flex items-center gap-3 px-3 py-3 rounded-lg text-text-secondary hover:bg-glass-2 transition-colors"

--- a/app/src/components/BottomNav.tsx
+++ b/app/src/components/BottomNav.tsx
@@ -68,6 +68,7 @@ export default function BottomNav() {
             <Link
               key={tab.id}
               to={VIEW_TO_PATH[tab.id]}
+              aria-current={active ? 'page' : undefined}
               className={`flex-1 flex flex-col items-center justify-center py-2.5 gap-1 transition-colors ${
                 active ? 'text-text' : 'text-text-muted'
               }`}

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -96,6 +96,7 @@ export default function Header() {
               <Link
                 key={tab.id}
                 to={VIEW_TO_PATH[tab.id]}
+                aria-current={active ? 'page' : undefined}
                 className={[
                   'flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors',
                   tab.tabletOnly ? 'lg:hidden' : '',

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -5,7 +5,9 @@ import {
   GlobeHemisphereWest,
   Key,
 } from '@phosphor-icons/react'
+import { Link, useNavigate } from 'react-router-dom'
 import { useAppStore, type View } from '../stores/app'
+import { useActiveView } from '../hooks/useActiveView'
 import { useAuthState } from '../hooks/useAuthState'
 import { useToast } from '../providers/ToastProvider'
 import AgentDot from './AgentDot'
@@ -28,11 +30,26 @@ const TABS: Tab[] = [
   { id: 'chat', label: 'Chat', icon: ChatCircle, tabletOnly: true },
 ]
 
+const VIEW_TO_PATH: Record<View, string> = {
+  dashboard: '/',
+  vault: '/vault',
+  chains: '/chains',
+  keys: '/keys',
+  chat: '/chat',
+  deposit: '/vault/deposit',
+  withdraw: '/vault/withdraw',
+  herald: '/herald',
+  squad: '/sentinel',
+  settings: '/settings',
+  privacyReport: '/privacy-report',
+  about: '/about',
+}
+
 export default function Header() {
   const { status, publicKey, authenticate, disconnect, isAdmin } = useAuthState()
   const { show: showToast } = useToast()
-  const activeView = useAppStore((s) => s.activeView)
-  const setActiveView = useAppStore((s) => s.setActiveView)
+  const activeView = useActiveView()
+  const navigate = useNavigate()
   const setChatSheetOpen = useAppStore((s) => s.setChatSheetOpen)
   const network = useNetworkConfigStore((s) => s.config?.network ?? 'mainnet')
 
@@ -55,7 +72,7 @@ export default function Header() {
   }
 
   const handleAdminNavigate = (view: AdminView) => {
-    setActiveView(view)
+    navigate(VIEW_TO_PATH[view])
   }
 
   return (
@@ -76,9 +93,9 @@ export default function Header() {
               activeView === tab.id ||
               (tab.id === 'vault' && (activeView === 'deposit' || activeView === 'withdraw'))
             return (
-              <button
+              <Link
                 key={tab.id}
-                onClick={() => setActiveView(tab.id)}
+                to={VIEW_TO_PATH[tab.id]}
                 className={[
                   'flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-colors',
                   tab.tabletOnly ? 'lg:hidden' : '',
@@ -87,7 +104,7 @@ export default function Header() {
               >
                 <Icon size={14} weight={active ? 'fill' : 'regular'} />
                 {tab.label}
-              </button>
+              </Link>
             )
           })}
         </nav>

--- a/app/src/components/PrivacyScoreCard.tsx
+++ b/app/src/components/PrivacyScoreCard.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Card } from './ui/Card'
 import { Gauge } from './ui/Gauge'
 import { MetricBar } from './ui/MetricBar'
 import { Sheet } from './ui/Sheet'
 import { UnauthedEmptyState } from './ui/UnauthedEmptyState'
-import { useAppStore } from '../stores/app'
 import { useAuthState } from '../hooks/useAuthState'
 
 interface PrivacyData {
@@ -26,13 +26,13 @@ interface PrivacyScoreCardProps {
 }
 
 export function PrivacyScoreCard({ data, delta }: PrivacyScoreCardProps) {
-  const setActiveView = useAppStore((s) => s.setActiveView)
+  const navigate = useNavigate()
   const { status } = useAuthState()
   const [teaserOpen, setTeaserOpen] = useState(false)
 
   const handleViewReport = () => {
     if (status === 'authed') {
-      setActiveView('privacyReport')
+      navigate('/privacy-report')
     } else {
       setTeaserOpen(true)
     }

--- a/app/src/components/__tests__/BetaBanner.test.tsx
+++ b/app/src/components/__tests__/BetaBanner.test.tsx
@@ -1,17 +1,13 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import type { View } from '../../stores/app'
 
-let activeViewValue: string = 'dashboard'
+let activeViewValue: View = 'dashboard'
 let networkValue: string = 'devnet'
 
-vi.mock('../../stores/app', async () => {
-  const actual = await vi.importActual<typeof import('../../stores/app')>('../../stores/app')
-  return {
-    ...actual,
-    useAppStore: <T,>(selector: (s: { activeView: string }) => T) =>
-      selector({ activeView: activeViewValue }),
-  }
-})
+vi.mock('../../hooks/useActiveView', () => ({
+  useActiveView: () => activeViewValue,
+}))
 
 vi.mock('../../lib/networkConfig', () => ({
   useNetworkConfigStore: <T,>(selector: (s: { config: { network: string } | null }) => T) =>

--- a/app/src/components/__tests__/BetaBanner.test.tsx
+++ b/app/src/components/__tests__/BetaBanner.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, beforeEach, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import type { View } from '../../stores/app'
 
-let activeViewValue: View = 'dashboard'
+let activeViewValue: View | null = 'dashboard'
 let networkValue: string = 'devnet'
 
 vi.mock('../../hooks/useActiveView', () => ({
@@ -89,6 +89,13 @@ describe('BetaBanner', () => {
   it('does not show vault-devnet warning on devnet vault view', () => {
     activeViewValue = 'vault'
     networkValue = 'devnet'
+    render(<BetaBanner beta={false} />)
+    expect(screen.queryByText(/Sipher Vault is on devnet only/i)).not.toBeInTheDocument()
+  })
+
+  it('does not show vault-devnet warning on unmatched paths (activeView=null)', () => {
+    activeViewValue = null
+    networkValue = 'mainnet'
     render(<BetaBanner beta={false} />)
     expect(screen.queryByText(/Sipher Vault is on devnet only/i)).not.toBeInTheDocument()
   })

--- a/app/src/components/__tests__/BottomNav.test.tsx
+++ b/app/src/components/__tests__/BottomNav.test.tsx
@@ -134,4 +134,11 @@ describe('BottomNav', () => {
     const link = screen.getByRole('link', { name: /Vault/ })
     expect(link).toHaveAttribute('aria-current', 'page')
   })
+
+  it('does not highlight any tab on an unmatched path (404)', () => {
+    renderBottomNav('/vault/abc')
+    expect(screen.getByRole('link', { name: /Home/ })).not.toHaveAttribute('aria-current')
+    expect(screen.getByRole('link', { name: /Vault/ })).not.toHaveAttribute('aria-current')
+    expect(screen.getByRole('link', { name: /Chat/ })).not.toHaveAttribute('aria-current')
+  })
 })

--- a/app/src/components/__tests__/BottomNav.test.tsx
+++ b/app/src/components/__tests__/BottomNav.test.tsx
@@ -116,4 +116,22 @@ describe('BottomNav', () => {
     await Promise.resolve()
     expect(mockDisconnect).toHaveBeenCalledTimes(1)
   })
+
+  it('marks active link with aria-current="page"', () => {
+    renderBottomNav('/vault')
+    const link = screen.getByRole('link', { name: /Vault/ })
+    expect(link).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('does not mark inactive links with aria-current', () => {
+    renderBottomNav('/')
+    const link = screen.getByRole('link', { name: /Vault/ })
+    expect(link).not.toHaveAttribute('aria-current')
+  })
+
+  it('marks Vault link as active when on /vault/withdraw (sub-route)', () => {
+    renderBottomNav('/vault/withdraw')
+    const link = screen.getByRole('link', { name: /Vault/ })
+    expect(link).toHaveAttribute('aria-current', 'page')
+  })
 })

--- a/app/src/components/__tests__/BottomNav.test.tsx
+++ b/app/src/components/__tests__/BottomNav.test.tsx
@@ -1,8 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import BottomNav from '../BottomNav'
 import type { AuthState } from '../../hooks/useAuthState'
-import { useAppStore } from '../../stores/app'
+
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
 
 const mockDisconnect = vi.fn()
 const mockToastShow = vi.fn(() => 'toast-id')
@@ -26,32 +32,44 @@ vi.mock('../../providers/ToastProvider', () => ({
   useToast: () => ({ show: mockToastShow, dismiss: vi.fn() }),
 }))
 
+function renderBottomNav(initialPath = '/') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <BottomNav />
+    </MemoryRouter>,
+  )
+}
+
 beforeEach(() => {
+  navigateMock.mockReset()
   mockDisconnect.mockReset()
   mockDisconnect.mockResolvedValue(undefined)
   mockToastShow.mockReset()
-  useAppStore.setState({ activeView: 'dashboard' }, false)
   currentAuth = { ...currentAuth, isAdmin: false }
 })
 
 describe('BottomNav', () => {
   it('renders three primary tabs (Home, Vault, Chat) plus More', () => {
-    render(<BottomNav />)
-    expect(screen.getByRole('button', { name: /Home/ })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Vault/ })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Chat/ })).toBeInTheDocument()
+    renderBottomNav()
+    expect(screen.getByRole('link', { name: /Home/ })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Vault/ })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Chat/ })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /More/ })).toBeInTheDocument()
   })
 
-  it('clicking Vault sets activeView via the store', () => {
-    render(<BottomNav />)
-    fireEvent.click(screen.getByRole('button', { name: /Vault/ }))
-    expect(useAppStore.getState().activeView).toBe('vault')
+  it('Vault link points to /vault', () => {
+    renderBottomNav()
+    expect(screen.getByRole('link', { name: /Vault/ })).toHaveAttribute('href', '/vault')
+  })
+
+  it('Home link points to /', () => {
+    renderBottomNav()
+    expect(screen.getByRole('link', { name: /Home/ })).toHaveAttribute('href', '/')
   })
 
   it('More opens drawer; admin sees Herald + Squad entries when isAdmin=true', () => {
     currentAuth = { ...currentAuth, isAdmin: true }
-    render(<BottomNav />)
+    renderBottomNav()
     fireEvent.click(screen.getByRole('button', { name: /More/ }))
     expect(screen.getByRole('button', { name: /Herald/ })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Squad/ })).toBeInTheDocument()
@@ -60,15 +78,38 @@ describe('BottomNav', () => {
 
   it('non-admins do NOT see Herald/Squad in the More drawer', () => {
     currentAuth = { ...currentAuth, isAdmin: false }
-    render(<BottomNav />)
+    renderBottomNav()
     fireEvent.click(screen.getByRole('button', { name: /More/ }))
     expect(screen.queryByRole('button', { name: /Herald/ })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: /Squad/ })).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Disconnect Wallet/ })).toBeInTheDocument()
   })
 
+  it('clicking Keys in More drawer navigates to /keys', () => {
+    renderBottomNav()
+    fireEvent.click(screen.getByRole('button', { name: /More/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Keys/ }))
+    expect(navigateMock).toHaveBeenCalledWith('/keys')
+  })
+
+  it('clicking Herald in More drawer navigates to /herald', () => {
+    currentAuth = { ...currentAuth, isAdmin: true }
+    renderBottomNav()
+    fireEvent.click(screen.getByRole('button', { name: /More/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Herald/ }))
+    expect(navigateMock).toHaveBeenCalledWith('/herald')
+  })
+
+  it('clicking Squad in More drawer navigates to /sentinel', () => {
+    currentAuth = { ...currentAuth, isAdmin: true }
+    renderBottomNav()
+    fireEvent.click(screen.getByRole('button', { name: /More/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Squad/ }))
+    expect(navigateMock).toHaveBeenCalledWith('/sentinel')
+  })
+
   it('Disconnect Wallet calls disconnect + shows toast', async () => {
-    render(<BottomNav />)
+    renderBottomNav()
     fireEvent.click(screen.getByRole('button', { name: /More/ }))
     fireEvent.click(screen.getByRole('button', { name: /Disconnect Wallet/ }))
     await Promise.resolve()

--- a/app/src/components/__tests__/ChatSidebar.test.tsx
+++ b/app/src/components/__tests__/ChatSidebar.test.tsx
@@ -49,7 +49,6 @@ function resetStore() {
     messages: [],
     chatLoading: false,
     chatOpen: false,
-    activeView: 'dashboard',
   })
 }
 

--- a/app/src/components/__tests__/Header.test.tsx
+++ b/app/src/components/__tests__/Header.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import Header from '../Header'
 import type { AuthState, AuthStatus } from '../../hooks/useAuthState'
 import { useAppStore } from '../../stores/app'
@@ -44,6 +45,14 @@ function setAuth(partial: Partial<AuthState> & { status: AuthStatus }) {
   }
 }
 
+function renderHeader(initialPath = '/') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Header />
+    </MemoryRouter>,
+  )
+}
+
 beforeEach(() => {
   mockAuthenticate.mockReset()
   mockAuthenticate.mockResolvedValue(undefined)
@@ -54,47 +63,47 @@ beforeEach(() => {
   Object.assign(navigator, {
     clipboard: { writeText: mockClipboardWrite.mockResolvedValue(undefined) },
   })
-  useAppStore.setState({ activeView: 'dashboard', chatSheetOpen: false }, false)
+  useAppStore.setState({ chatSheetOpen: false }, false)
   setAuth({ status: 'unauthed', publicKey: null, isAdmin: false })
 })
 
 describe('Header — auth pill', () => {
   it('renders Connect button when unauthed', () => {
     setAuth({ status: 'unauthed', publicKey: null })
-    render(<Header />)
+    renderHeader()
     const btn = screen.getByRole('button', { name: 'Connect' })
     expect(btn).toBeInTheDocument()
   })
 
   it('Connect click calls authenticate', () => {
     setAuth({ status: 'unauthed', publicKey: null })
-    render(<Header />)
+    renderHeader()
     fireEvent.click(screen.getByRole('button', { name: 'Connect' }))
     expect(mockAuthenticate).toHaveBeenCalledTimes(1)
   })
 
   it('renders Re-sign in button when expired', () => {
     setAuth({ status: 'expired', publicKey: FULL })
-    render(<Header />)
+    renderHeader()
     expect(screen.getByRole('button', { name: /Re-sign in/i })).toBeInTheDocument()
   })
 
   it('Re-sign click calls authenticate', () => {
     setAuth({ status: 'expired', publicKey: FULL })
-    render(<Header />)
+    renderHeader()
     fireEvent.click(screen.getByRole('button', { name: /Re-sign in/i }))
     expect(mockAuthenticate).toHaveBeenCalledTimes(1)
   })
 
   it('renders UserMenu when authed with publicKey', () => {
     setAuth({ status: 'authed', publicKey: FULL, token: 'tok' })
-    render(<Header />)
+    renderHeader()
     expect(screen.getByRole('button', { name: /HciZ\.\.\.25En/ })).toBeInTheDocument()
   })
 
   it('UserMenu Disconnect calls disconnect + shows toast', async () => {
     setAuth({ status: 'authed', publicKey: FULL, token: 'tok' })
-    render(<Header />)
+    renderHeader()
     fireEvent.click(screen.getByRole('button', { name: /HciZ\.\.\.25En/ }))
     fireEvent.click(screen.getByText('Disconnect'))
     await Promise.resolve()
@@ -104,7 +113,7 @@ describe('Header — auth pill', () => {
 
   it('UserMenu Copy writes address to clipboard', async () => {
     setAuth({ status: 'authed', publicKey: FULL, token: 'tok' })
-    render(<Header />)
+    renderHeader()
     fireEvent.click(screen.getByRole('button', { name: /HciZ\.\.\.25En/ }))
     fireEvent.click(screen.getByText('Copy address'))
     await Promise.resolve()
@@ -114,24 +123,24 @@ describe('Header — auth pill', () => {
 
 describe('Header — wordmark + Ask SIPHER trigger', () => {
   it('renders the SIPHER wordmark', () => {
-    render(<Header />)
+    renderHeader()
     expect(screen.getByText('SIPHER')).toBeInTheDocument()
   })
 
   it('exposes Ask SIPHER trigger button', () => {
-    render(<Header />)
+    renderHeader()
     expect(screen.getByRole('button', { name: /ask sipher/i })).toBeInTheDocument()
   })
 
   it('Ask SIPHER click opens chat sheet via store', () => {
-    render(<Header />)
+    renderHeader()
     expect(useAppStore.getState().chatSheetOpen).toBe(false)
     fireEvent.click(screen.getByRole('button', { name: /ask sipher/i }))
     expect(useAppStore.getState().chatSheetOpen).toBe(true)
   })
 
   it('renders the active network identifier', () => {
-    render(<Header />)
+    renderHeader()
     expect(screen.getByText('devnet')).toBeInTheDocument()
   })
 })
@@ -139,27 +148,32 @@ describe('Header — wordmark + Ask SIPHER trigger', () => {
 describe('Header — tabs', () => {
   it('renders standard nav tabs for non-admin user', () => {
     setAuth({ status: 'authed', publicKey: FULL, token: 'tok', isAdmin: false })
-    render(<Header />)
-    expect(screen.getByRole('button', { name: /Dashboard/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Vault/i })).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /^Herald$/ })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /^Squad$/ })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /^Settings$/ })).not.toBeInTheDocument()
+    renderHeader()
+    expect(screen.getByRole('link', { name: /Dashboard/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Vault/i })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /^Herald$/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /^Squad$/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /^Settings$/ })).not.toBeInTheDocument()
   })
 
   it('does NOT render herald/squad/settings tabs in nav for admin user', () => {
     setAuth({ status: 'authed', publicKey: FULL, token: 'tok', isAdmin: true })
-    render(<Header />)
+    renderHeader()
     // Admin views live in UserMenu dropdown, not in the main nav
-    expect(screen.queryByRole('button', { name: /^Herald$/ })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /^Squad$/ })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /^Settings$/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /^Herald$/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /^Squad$/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /^Settings$/ })).not.toBeInTheDocument()
   })
 
-  it('clicking a tab calls setActiveView', () => {
+  it('Vault tab is a link to /vault', () => {
     setAuth({ status: 'authed', publicKey: FULL, token: 'tok' })
-    render(<Header />)
-    fireEvent.click(screen.getByRole('button', { name: /Vault/i }))
-    expect(useAppStore.getState().activeView).toBe('vault')
+    renderHeader()
+    expect(screen.getByRole('link', { name: /Vault/i })).toHaveAttribute('href', '/vault')
+  })
+
+  it('Dashboard tab is a link to /', () => {
+    setAuth({ status: 'authed', publicKey: FULL, token: 'tok' })
+    renderHeader()
+    expect(screen.getByRole('link', { name: /Dashboard/i })).toHaveAttribute('href', '/')
   })
 })

--- a/app/src/components/__tests__/Header.test.tsx
+++ b/app/src/components/__tests__/Header.test.tsx
@@ -197,4 +197,13 @@ describe('Header — tabs', () => {
     const link = screen.getByRole('link', { name: /Vault/i })
     expect(link).toHaveAttribute('aria-current', 'page')
   })
+
+  it('does not highlight any tab on an unmatched path (404)', () => {
+    setAuth({ status: 'authed', publicKey: FULL, token: 'tok' })
+    renderHeader('/vault/abc')
+    expect(screen.getByRole('link', { name: /Dashboard/i })).not.toHaveAttribute('aria-current')
+    expect(screen.getByRole('link', { name: /Vault/i })).not.toHaveAttribute('aria-current')
+    expect(screen.getByRole('link', { name: /Chains/i })).not.toHaveAttribute('aria-current')
+    expect(screen.getByRole('link', { name: /Keys/i })).not.toHaveAttribute('aria-current')
+  })
 })

--- a/app/src/components/__tests__/Header.test.tsx
+++ b/app/src/components/__tests__/Header.test.tsx
@@ -176,4 +176,25 @@ describe('Header — tabs', () => {
     renderHeader()
     expect(screen.getByRole('link', { name: /Dashboard/i })).toHaveAttribute('href', '/')
   })
+
+  it('marks active link with aria-current="page"', () => {
+    setAuth({ status: 'authed', publicKey: FULL, token: 'tok' })
+    renderHeader('/vault')
+    const link = screen.getByRole('link', { name: /Vault/i })
+    expect(link).toHaveAttribute('aria-current', 'page')
+  })
+
+  it('does not mark inactive links with aria-current', () => {
+    setAuth({ status: 'authed', publicKey: FULL, token: 'tok' })
+    renderHeader('/')
+    const link = screen.getByRole('link', { name: /Vault/i })
+    expect(link).not.toHaveAttribute('aria-current')
+  })
+
+  it('marks Vault link as active when on /vault/deposit (sub-route)', () => {
+    setAuth({ status: 'authed', publicKey: FULL, token: 'tok' })
+    renderHeader('/vault/deposit')
+    const link = screen.getByRole('link', { name: /Vault/i })
+    expect(link).toHaveAttribute('aria-current', 'page')
+  })
 })

--- a/app/src/components/__tests__/PrivacyScoreCard.test.tsx
+++ b/app/src/components/__tests__/PrivacyScoreCard.test.tsx
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import { PrivacyScoreCard } from '../PrivacyScoreCard'
-import { useAppStore } from '../../stores/app'
+
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
 
 vi.mock('@solana/wallet-adapter-react-ui', () => ({
   useWalletModal: () => ({ setVisible: vi.fn(), visible: false }),
@@ -25,8 +31,16 @@ const fakeData = {
   transactionsAnalyzed: 1284,
 }
 
+function renderCard(props: { data: typeof fakeData | null; delta?: number }) {
+  return render(
+    <MemoryRouter>
+      <PrivacyScoreCard data={props.data} delta={props.delta} />
+    </MemoryRouter>,
+  )
+}
+
 beforeEach(() => {
-  useAppStore.setState({ activeView: 'dashboard' }, false)
+  navigateMock.mockReset()
   useAuthStateMock.mockReturnValue({
     status: 'authed' as const,
     token: 'test-token',
@@ -41,14 +55,14 @@ beforeEach(() => {
 
 describe('PrivacyScoreCard', () => {
   it('renders score 72, grade GOOD, and the +4 delta', () => {
-    render(<PrivacyScoreCard data={fakeData} delta={4} />)
+    renderCard({ data: fakeData, delta: 4 })
     expect(screen.getByText('72')).toBeInTheDocument()
     expect(screen.getByText('GOOD')).toBeInTheDocument()
     expect(screen.getByText('+4')).toBeInTheDocument()
   })
 
   it('renders all 4 factor MetricBars with their detail copy', () => {
-    render(<PrivacyScoreCard data={fakeData} />)
+    renderCard({ data: fakeData })
     expect(screen.getByText('Anonymity set')).toBeInTheDocument()
     expect(screen.getByText('1,284 active depositors')).toBeInTheDocument()
     expect(screen.getByText('Time decay')).toBeInTheDocument()
@@ -57,19 +71,19 @@ describe('PrivacyScoreCard', () => {
   })
 
   it('renders gauge at 0 with em-dash grade when data is null', () => {
-    render(<PrivacyScoreCard data={null} />)
+    renderCard({ data: null })
     expect(screen.getByText('0')).toBeInTheDocument()
     expect(screen.getByText('—')).toBeInTheDocument()
   })
 
-  it('View report button navigates to privacyReport view via store', () => {
-    render(<PrivacyScoreCard data={fakeData} />)
+  it('View report button navigates to /privacy-report when authed', () => {
+    renderCard({ data: fakeData })
     fireEvent.click(screen.getByRole('button', { name: /view report/i }))
-    expect(useAppStore.getState().activeView).toBe('privacyReport')
+    expect(navigateMock).toHaveBeenCalledWith('/privacy-report')
   })
 
   it('omits delta block when delta is undefined', () => {
-    render(<PrivacyScoreCard data={fakeData} />)
+    renderCard({ data: fakeData })
     expect(screen.queryByText(/vs last week/)).toBeInTheDocument()
     expect(screen.queryByText('+4')).not.toBeInTheDocument()
   })
@@ -85,13 +99,13 @@ describe('PrivacyScoreCard', () => {
       disconnect: () => Promise.resolve(),
       error: null,
     })
-    render(<PrivacyScoreCard data={fakeData} />)
+    renderCard({ data: fakeData })
     fireEvent.click(screen.getByRole('button', { name: /view report/i }))
     expect(screen.getByTestId('unauthed-empty-state')).toBeInTheDocument()
     expect(screen.getByText(/privacy score report/i)).toBeInTheDocument()
   })
 
-  it('does NOT navigate to privacyReport when clicked unauthed', () => {
+  it('does NOT navigate to /privacy-report when clicked unauthed', () => {
     useAuthStateMock.mockReturnValue({
       status: 'unauthed' as const,
       token: null,
@@ -102,9 +116,9 @@ describe('PrivacyScoreCard', () => {
       disconnect: () => Promise.resolve(),
       error: null,
     })
-    render(<PrivacyScoreCard data={fakeData} />)
+    renderCard({ data: fakeData })
     fireEvent.click(screen.getByRole('button', { name: /view report/i }))
-    expect(useAppStore.getState().activeView).toBe('dashboard')
+    expect(navigateMock).not.toHaveBeenCalled()
     // Assert the alternative path actually fired (Sheet opened). Without this,
     // a future regression that drops `setTeaserOpen(true)` from handleViewReport
     // would silently still pass this test.
@@ -122,7 +136,7 @@ describe('PrivacyScoreCard', () => {
       disconnect: () => Promise.resolve(),
       error: null,
     })
-    render(<PrivacyScoreCard data={fakeData} />)
+    renderCard({ data: fakeData })
     fireEvent.click(screen.getByRole('button', { name: /view report/i }))
     expect(screen.getByTestId('unauthed-empty-state')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /^close$/i }))

--- a/app/src/hooks/__tests__/useActiveView.test.tsx
+++ b/app/src/hooks/__tests__/useActiveView.test.tsx
@@ -1,0 +1,55 @@
+import { renderHook } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { useActiveView } from '../useActiveView'
+
+function wrapper(initialEntries: string[]) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <MemoryRouter initialEntries={initialEntries}>{children}</MemoryRouter>
+  )
+}
+
+describe('useActiveView', () => {
+  it('maps / to dashboard', () => {
+    const { result } = renderHook(() => useActiveView(), { wrapper: wrapper(['/']) })
+    expect(result.current).toBe('dashboard')
+  })
+
+  it('maps /vault to vault', () => {
+    const { result } = renderHook(() => useActiveView(), { wrapper: wrapper(['/vault']) })
+    expect(result.current).toBe('vault')
+  })
+
+  it('maps /vault/deposit to deposit', () => {
+    const { result } = renderHook(() => useActiveView(), { wrapper: wrapper(['/vault/deposit']) })
+    expect(result.current).toBe('deposit')
+  })
+
+  it('maps /vault/withdraw to withdraw', () => {
+    const { result } = renderHook(() => useActiveView(), { wrapper: wrapper(['/vault/withdraw']) })
+    expect(result.current).toBe('withdraw')
+  })
+
+  it('maps /chains, /keys, /chat to their views', () => {
+    expect(renderHook(() => useActiveView(), { wrapper: wrapper(['/chains']) }).result.current).toBe('chains')
+    expect(renderHook(() => useActiveView(), { wrapper: wrapper(['/keys']) }).result.current).toBe('keys')
+    expect(renderHook(() => useActiveView(), { wrapper: wrapper(['/chat']) }).result.current).toBe('chat')
+  })
+
+  it('maps /sentinel to squad (View enum name)', () => {
+    const { result } = renderHook(() => useActiveView(), { wrapper: wrapper(['/sentinel']) })
+    expect(result.current).toBe('squad')
+  })
+
+  it('maps /herald, /settings, /privacy-report, /about', () => {
+    expect(renderHook(() => useActiveView(), { wrapper: wrapper(['/herald']) }).result.current).toBe('herald')
+    expect(renderHook(() => useActiveView(), { wrapper: wrapper(['/settings']) }).result.current).toBe('settings')
+    expect(renderHook(() => useActiveView(), { wrapper: wrapper(['/privacy-report']) }).result.current).toBe('privacyReport')
+    expect(renderHook(() => useActiveView(), { wrapper: wrapper(['/about']) }).result.current).toBe('about')
+  })
+
+  it('falls back to dashboard for unknown paths', () => {
+    expect(renderHook(() => useActiveView(), { wrapper: wrapper(['/unknown']) }).result.current).toBe('dashboard')
+    expect(renderHook(() => useActiveView(), { wrapper: wrapper(['/vault/abc']) }).result.current).toBe('dashboard')
+  })
+})

--- a/app/src/hooks/__tests__/useActiveView.test.tsx
+++ b/app/src/hooks/__tests__/useActiveView.test.tsx
@@ -48,8 +48,8 @@ describe('useActiveView', () => {
     expect(renderHook(() => useActiveView(), { wrapper: wrapper(['/about']) }).result.current).toBe('about')
   })
 
-  it('falls back to dashboard for unknown paths', () => {
-    expect(renderHook(() => useActiveView(), { wrapper: wrapper(['/unknown']) }).result.current).toBe('dashboard')
-    expect(renderHook(() => useActiveView(), { wrapper: wrapper(['/vault/abc']) }).result.current).toBe('dashboard')
+  it('returns null for unknown paths', () => {
+    expect(renderHook(() => useActiveView(), { wrapper: wrapper(['/unknown']) }).result.current).toBe(null)
+    expect(renderHook(() => useActiveView(), { wrapper: wrapper(['/vault/abc']) }).result.current).toBe(null)
   })
 })

--- a/app/src/hooks/useActiveView.ts
+++ b/app/src/hooks/useActiveView.ts
@@ -1,0 +1,22 @@
+import { useLocation } from 'react-router-dom'
+import type { View } from '../stores/app'
+
+const PATH_TO_VIEW: Record<string, View> = {
+  '/': 'dashboard',
+  '/vault': 'vault',
+  '/vault/deposit': 'deposit',
+  '/vault/withdraw': 'withdraw',
+  '/chains': 'chains',
+  '/keys': 'keys',
+  '/chat': 'chat',
+  '/herald': 'herald',
+  '/sentinel': 'squad',
+  '/settings': 'settings',
+  '/privacy-report': 'privacyReport',
+  '/about': 'about',
+}
+
+export function useActiveView(): View {
+  const { pathname } = useLocation()
+  return PATH_TO_VIEW[pathname] ?? 'dashboard'
+}

--- a/app/src/hooks/useActiveView.ts
+++ b/app/src/hooks/useActiveView.ts
@@ -16,7 +16,7 @@ const PATH_TO_VIEW: Record<string, View> = {
   '/about': 'about',
 }
 
-export function useActiveView(): View {
+export function useActiveView(): View | null {
   const { pathname } = useLocation()
-  return PATH_TO_VIEW[pathname] ?? 'dashboard'
+  return PATH_TO_VIEW[pathname] ?? null
 }

--- a/app/src/stores/app.ts
+++ b/app/src/stores/app.ts
@@ -26,9 +26,6 @@ export interface ChatMessage {
 }
 
 interface AppState {
-  activeView: View
-  setActiveView: (view: View) => void
-
   token: string | null
   isAdmin: boolean
   expiresAt: number | null
@@ -58,15 +55,12 @@ interface AppState {
 export const useAppStore = create<AppState>()(
   persist(
     (set, get) => ({
-      activeView: 'dashboard',
-      setActiveView: (activeView) => set({ activeView }),
-
       token: null,
       isAdmin: false,
       expiresAt: null,
       setAuth: (token, isAdmin, expiresAt = null) => set({ token, isAdmin, expiresAt }),
       clearAuth: () => {
-        set({ token: null, isAdmin: false, expiresAt: null, messages: [], activeView: 'dashboard' })
+        set({ token: null, isAdmin: false, expiresAt: null, messages: [] })
         onAuthClear.clearAll()
       },
 

--- a/app/src/stores/app.ts
+++ b/app/src/stores/app.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { onAuthClear } from '../store/onAuthClear'
 
-export type View = 'dashboard' | 'vault' | 'herald' | 'squad' | 'chat' | 'privacyReport' | 'chains' | 'deposit' | 'withdraw' | 'keys' | 'settings'
+export type View = 'dashboard' | 'vault' | 'herald' | 'squad' | 'chat' | 'privacyReport' | 'chains' | 'deposit' | 'withdraw' | 'keys' | 'settings' | 'about'
 export type ToolStatus = 'running' | 'success' | 'error'
 
 export interface ToolCall {

--- a/app/src/views/AboutPlaceholderView.tsx
+++ b/app/src/views/AboutPlaceholderView.tsx
@@ -1,0 +1,8 @@
+export default function AboutPlaceholderView() {
+  return (
+    <div data-testid="about-placeholder" className="flex flex-col items-start gap-4 p-8">
+      <h1 className="text-2xl font-semibold">About SIPHER</h1>
+      <p className="text-text-secondary">Coming soon.</p>
+    </div>
+  )
+}

--- a/app/src/views/ChatView.tsx
+++ b/app/src/views/ChatView.tsx
@@ -1,0 +1,9 @@
+import ChatSidebar from '../components/ChatSidebar'
+
+export default function ChatView() {
+  return (
+    <div data-testid="chat-view" className="lg:hidden h-full">
+      <ChatSidebar fullScreen />
+    </div>
+  )
+}

--- a/app/src/views/DepositView.tsx
+++ b/app/src/views/DepositView.tsx
@@ -9,6 +9,7 @@ import { DepositForm } from '../components/vault/DepositForm'
 import { RoutePreviewCard } from '../components/vault/RoutePreviewCard'
 import { PrivacyPreviewPanel } from '../components/vault/PrivacyPreviewPanel'
 import { Card } from '../components/ui/Card'
+import { UnauthedEmptyState } from '../components/ui/UnauthedEmptyState'
 
 interface TokenBalance {
   mint: string
@@ -55,7 +56,7 @@ interface DepositTxResponse {
 const DEPOSIT_SUCCESS_REDIRECT_MS = 2000
 
 export default function DepositView() {
-  const { token } = useAuthState()
+  const { token, status: authStatus } = useAuthState()
   const navigate = useNavigate()
   const network = useNetworkConfigStore((s) => s.config?.network ?? '')
   const isMainnet = network === 'mainnet'
@@ -123,6 +124,15 @@ export default function DepositView() {
     },
     [signAndBroadcast, token, navigate],
   )
+
+  if (authStatus !== 'authed') {
+    return (
+      <UnauthedEmptyState
+        title="Shielded Deposit"
+        body={<>Connect a wallet to deposit into the shielded vault.</>}
+      />
+    )
+  }
 
   if (isMainnet) {
     return (

--- a/app/src/views/DepositView.tsx
+++ b/app/src/views/DepositView.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { ArrowLeft } from '@phosphor-icons/react'
 import { apiFetch } from '../api/client'
 import { useAuthState } from '../hooks/useAuthState'
-import { useAppStore } from '../stores/app'
 import { useTransactionSigner } from '../hooks/useTransactionSigner'
 import { useNetworkConfigStore } from '../lib/networkConfig'
 import { DepositForm } from '../components/vault/DepositForm'
@@ -56,7 +56,7 @@ const DEPOSIT_SUCCESS_REDIRECT_MS = 2000
 
 export default function DepositView() {
   const { token } = useAuthState()
-  const setActiveView = useAppStore((s) => s.setActiveView)
+  const navigate = useNavigate()
   const network = useNetworkConfigStore((s) => s.config?.network ?? '')
   const isMainnet = network === 'mainnet'
 
@@ -114,20 +114,20 @@ export default function DepositView() {
         }
         setSignature(result.signature)
         redirectTimerRef.current = setTimeout(
-          () => setActiveView('vault'),
+          () => navigate('/vault'),
           DEPOSIT_SUCCESS_REDIRECT_MS,
         )
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Unknown error')
       }
     },
-    [signAndBroadcast, token, setActiveView],
+    [signAndBroadcast, token, navigate],
   )
 
   if (isMainnet) {
     return (
       <div className="flex flex-col gap-4 max-w-3xl mx-auto">
-        <BackChip onClick={() => setActiveView('vault')} />
+        <BackChip onClick={() => navigate('/vault')} />
         <Card variant="default" className="p-6">
           <p className="text-sm text-text">
             Sipher Vault is on devnet only — switch network to deposit.
@@ -141,7 +141,7 @@ export default function DepositView() {
 
   return (
     <div className="flex flex-col gap-4 max-w-3xl mx-auto">
-      <BackChip onClick={() => setActiveView('vault')} />
+      <BackChip onClick={() => navigate('/vault')} />
       <h1 className="text-2xl font-semibold">Shield to vault</h1>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/app/src/views/HeraldView.tsx
+++ b/app/src/views/HeraldView.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Calendar, X as XIcon } from '@phosphor-icons/react'
 import { apiFetch } from '../api/client'
 import { timeAgo } from '../lib/format'
 import { useAuthState } from '../hooks/useAuthState'
-import { useAppStore } from '../stores/app'
 
 type Tab = 'activity' | 'queue' | 'dms'
 
@@ -398,7 +398,7 @@ function DmsTab({ dms }: { dms: DmEntry[] }) {
 
 export default function HeraldView({ token }: { token: string | null }) {
   const { isAdmin } = useAuthState()
-  const setActiveView = useAppStore((s) => s.setActiveView)
+  const navigate = useNavigate()
 
   const [tab, setTab] = useState<Tab>('activity')
   const [data, setData] = useState<HeraldData | null>(null)
@@ -406,9 +406,9 @@ export default function HeraldView({ token }: { token: string | null }) {
 
   useEffect(() => {
     if (!isAdmin) {
-      setActiveView('dashboard')
+      navigate('/')
     }
-  }, [isAdmin, setActiveView])
+  }, [isAdmin, navigate])
 
   const load = useCallback(() => {
     if (!token) return

--- a/app/src/views/NotFoundView.tsx
+++ b/app/src/views/NotFoundView.tsx
@@ -3,18 +3,21 @@ import { UnauthedEmptyState } from '../components/ui/UnauthedEmptyState'
 
 export default function NotFoundView() {
   return (
-    <UnauthedEmptyState
-      title="Not found"
-      body="We couldn't find that page."
-      cta={
-        <Link
-          to="/"
-          className="self-start text-xs px-3 py-1.5 rounded-md text-bg font-semibold"
-          style={{ background: 'linear-gradient(90deg, var(--color-cyan), var(--color-violet))' }}
-        >
-          Back to Dashboard
-        </Link>
-      }
-    />
+    <>
+      <h1 className="sr-only">Not Found</h1>
+      <UnauthedEmptyState
+        title="Not found"
+        body="We couldn't find that page."
+        cta={
+          <Link
+            to="/"
+            className="self-start text-xs px-3 py-1.5 rounded-md text-bg font-semibold"
+            style={{ background: 'linear-gradient(90deg, var(--color-cyan), var(--color-violet))' }}
+          >
+            Back to Dashboard
+          </Link>
+        }
+      />
+    </>
   )
 }

--- a/app/src/views/NotFoundView.tsx
+++ b/app/src/views/NotFoundView.tsx
@@ -1,0 +1,20 @@
+import { Link } from 'react-router-dom'
+import { UnauthedEmptyState } from '../components/ui/UnauthedEmptyState'
+
+export default function NotFoundView() {
+  return (
+    <UnauthedEmptyState
+      title="Not found"
+      body="We couldn't find that page."
+      cta={
+        <Link
+          to="/"
+          className="self-start text-xs px-3 py-1.5 rounded-md text-bg font-semibold"
+          style={{ background: 'linear-gradient(90deg, var(--color-cyan), var(--color-violet))' }}
+        >
+          Back to Dashboard
+        </Link>
+      }
+    />
+  )
+}

--- a/app/src/views/PrivacyReportView.tsx
+++ b/app/src/views/PrivacyReportView.tsx
@@ -6,6 +6,7 @@ import { useAuthState } from '../hooks/useAuthState'
 import { Card } from '../components/ui/Card'
 import { Gauge } from '../components/ui/Gauge'
 import { MetricBar } from '../components/ui/MetricBar'
+import { UnauthedEmptyState } from '../components/ui/UnauthedEmptyState'
 
 interface PrivacyData {
   score: number
@@ -21,7 +22,7 @@ function humanizeFactorKey(key: string): string {
 
 export default function PrivacyReportView() {
   const navigate = useNavigate()
-  const { token } = useAuthState()
+  const { token, status } = useAuthState()
   const [data, setData] = useState<PrivacyData | null>(null)
   const [error, setError] = useState<string | null>(null)
 
@@ -41,6 +42,20 @@ export default function PrivacyReportView() {
       })
     return () => controller.abort()
   }, [token])
+
+  if (status !== 'authed') {
+    return (
+      <UnauthedEmptyState
+        title="Privacy Score Report"
+        body={
+          <>
+            Connect a wallet to view network analysis, surveillance score, and personalized
+            recommendations.
+          </>
+        }
+      />
+    )
+  }
 
   return (
     <div className="max-w-3xl mx-auto p-6 space-y-6">

--- a/app/src/views/PrivacyReportView.tsx
+++ b/app/src/views/PrivacyReportView.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { ArrowLeft } from '@phosphor-icons/react'
 import { apiFetch } from '../api/client'
 import { useAuthState } from '../hooks/useAuthState'
-import { useAppStore } from '../stores/app'
 import { Card } from '../components/ui/Card'
 import { Gauge } from '../components/ui/Gauge'
 import { MetricBar } from '../components/ui/MetricBar'
@@ -20,7 +20,7 @@ function humanizeFactorKey(key: string): string {
 }
 
 export default function PrivacyReportView() {
-  const setActiveView = useAppStore((s) => s.setActiveView)
+  const navigate = useNavigate()
   const { token } = useAuthState()
   const [data, setData] = useState<PrivacyData | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -46,7 +46,7 @@ export default function PrivacyReportView() {
     <div className="max-w-3xl mx-auto p-6 space-y-6">
       <button
         type="button"
-        onClick={() => setActiveView('dashboard')}
+        onClick={() => navigate('/')}
         className="flex items-center gap-2 text-sm text-text-muted hover:text-text transition-colors"
       >
         <ArrowLeft size={16} />

--- a/app/src/views/SettingsView.tsx
+++ b/app/src/views/SettingsView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { apiFetch } from '../api/client'
 import { useAuthState } from '../hooks/useAuthState'
-import { useAppStore } from '../stores/app'
 import { useNetworkConfigStore } from '../lib/networkConfig'
 import { Card } from '../components/ui/Card'
 import { Chip, type ChipTone } from '../components/ui/Chip'
@@ -38,7 +38,7 @@ function networkTone(network: string): ChipTone {
 
 export default function SettingsView() {
   const { token, isAdmin } = useAuthState()
-  const setActiveView = useAppStore((s) => s.setActiveView)
+  const navigate = useNavigate()
   const network = useNetworkConfigStore((s) => s.config?.network)
   const [config, setConfig] = useState<SentinelConfigPayload | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -46,7 +46,7 @@ export default function SettingsView() {
 
   useEffect(() => {
     if (!isAdmin) {
-      setActiveView('dashboard')
+      navigate('/')
       return
     }
     if (!token) return
@@ -64,7 +64,7 @@ export default function SettingsView() {
         }
       })
     return () => controller.abort()
-  }, [isAdmin, token, setActiveView])
+  }, [isAdmin, token, navigate])
 
   if (!isAdmin) return null
 

--- a/app/src/views/SquadView.tsx
+++ b/app/src/views/SquadView.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { apiFetch } from '../api/client'
 import { AGENTS, type AgentName } from '../lib/agents'
 import { WarningOctagon, ArrowRight, Power } from '@phosphor-icons/react'
 import AgentDot from '../components/AgentDot'
 import { Chip } from '../components/ui/Chip'
 import { useAuthState } from '../hooks/useAuthState'
-import { useAppStore } from '../stores/app'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -225,15 +225,15 @@ function KillSwitch({ token, active, onToggle }: { token: string | null; active:
 
 export default function SquadView({ token }: { token: string | null }) {
   const { isAdmin } = useAuthState()
-  const setActiveView = useAppStore((s) => s.setActiveView)
+  const navigate = useNavigate()
   const [data, setData] = useState<SquadData | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!isAdmin) {
-      setActiveView('dashboard')
+      navigate('/')
     }
-  }, [isAdmin, setActiveView])
+  }, [isAdmin, navigate])
 
   const load = useCallback(() => {
     if (!token) return

--- a/app/src/views/VaultView.tsx
+++ b/app/src/views/VaultView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { apiFetch } from '../api/client'
 import { useAuthState } from '../hooks/useAuthState'
-import { useAppStore } from '../stores/app'
 import { useNetworkConfigStore } from '../lib/networkConfig'
 import { useOnAuthClear } from '../store/useOnAuthClear'
 import { Card } from '../components/ui/Card'
@@ -43,7 +43,7 @@ interface StealthIndexResponse {
 
 export default function VaultView() {
   const { token, status } = useAuthState()
-  const setActiveView = useAppStore((s) => s.setActiveView)
+  const navigate = useNavigate()
   const network = useNetworkConfigStore((s) => s.config?.network ?? '')
   const isMainnet = network === 'mainnet'
 
@@ -107,13 +107,13 @@ export default function VaultView() {
         positions={positions}
         stealthTree={stealthTree}
         loading={loading}
-        onWithdraw={() => setActiveView('withdraw')}
+        onWithdraw={() => navigate('/vault/withdraw')}
         disabled={isMainnet}
       />
       <UnshieldedWalletPanel
         wallet={vault?.wallet ?? ''}
         sol={vault?.balances.sol ?? 0}
-        onDeposit={() => setActiveView('deposit')}
+        onDeposit={() => navigate('/vault/deposit')}
         disabled={isMainnet}
       />
     </div>

--- a/app/src/views/WithdrawView.tsx
+++ b/app/src/views/WithdrawView.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { ArrowLeft } from '@phosphor-icons/react'
 import { apiFetch } from '../api/client'
 import { useAuthState } from '../hooks/useAuthState'
-import { useAppStore } from '../stores/app'
 import { useTransactionSigner } from '../hooks/useTransactionSigner'
 import { useNetworkConfigStore } from '../lib/networkConfig'
 import { Card } from '../components/ui/Card'
@@ -25,7 +25,7 @@ interface RefundTxResponse {
 
 export default function WithdrawView() {
   const { token } = useAuthState()
-  const setActiveView = useAppStore((s) => s.setActiveView)
+  const navigate = useNavigate()
   const network = useNetworkConfigStore((s) => s.config?.network ?? '')
   const isMainnet = network === 'mainnet'
 
@@ -108,7 +108,7 @@ export default function WithdrawView() {
   if (isMainnet) {
     return (
       <div className="flex flex-col gap-4 max-w-3xl mx-auto">
-        <BackChip onClick={() => setActiveView('vault')} />
+        <BackChip onClick={() => navigate('/vault')} />
         <Card variant="default" className="p-6">
           <p className="text-sm text-text">
             Sipher Vault is on devnet only — switch network to withdraw.
@@ -120,7 +120,7 @@ export default function WithdrawView() {
 
   return (
     <div className="flex flex-col gap-4 max-w-3xl mx-auto">
-      <BackChip onClick={() => setActiveView('vault')} />
+      <BackChip onClick={() => navigate('/vault')} />
       <h1 className="text-2xl font-semibold">Refund from vault</h1>
       <p className="text-xs text-text-muted">
         Each refund returns the deposited balance to your wallet. The on-chain 24h cooldown is

--- a/app/src/views/WithdrawView.tsx
+++ b/app/src/views/WithdrawView.tsx
@@ -6,6 +6,7 @@ import { useAuthState } from '../hooks/useAuthState'
 import { useTransactionSigner } from '../hooks/useTransactionSigner'
 import { useNetworkConfigStore } from '../lib/networkConfig'
 import { Card } from '../components/ui/Card'
+import { UnauthedEmptyState } from '../components/ui/UnauthedEmptyState'
 import { RefundList } from '../components/vault/RefundList'
 import type { Position } from '../components/vault/StealthAddressList'
 import type { SignStatus } from '../hooks/useTransactionSigner'
@@ -24,7 +25,7 @@ interface RefundTxResponse {
 }
 
 export default function WithdrawView() {
-  const { token } = useAuthState()
+  const { token, status } = useAuthState()
   const navigate = useNavigate()
   const network = useNetworkConfigStore((s) => s.config?.network ?? '')
   const isMainnet = network === 'mainnet'
@@ -104,6 +105,15 @@ export default function WithdrawView() {
     },
     [signAndBroadcast, token, refresh],
   )
+
+  if (status !== 'authed') {
+    return (
+      <UnauthedEmptyState
+        title="Shielded Withdraw"
+        body={<>Connect a wallet to refund deposits and withdraw shielded balances.</>}
+      />
+    )
+  }
 
   if (isMainnet) {
     return (

--- a/app/src/views/__tests__/ChatView.test.tsx
+++ b/app/src/views/__tests__/ChatView.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import ChatView from '../ChatView'
+
+vi.mock('../../components/ChatSidebar', () => ({
+  default: ({ fullScreen }: { fullScreen?: boolean }) => (
+    <div data-testid="chat-sidebar-mock">{fullScreen ? 'full' : 'sheet'}</div>
+  ),
+}))
+
+describe('ChatView', () => {
+  it('renders ChatSidebar in fullScreen mode', () => {
+    render(<ChatView />)
+    expect(screen.getByTestId('chat-sidebar-mock')).toHaveTextContent('full')
+  })
+})

--- a/app/src/views/__tests__/DashboardView.test.tsx
+++ b/app/src/views/__tests__/DashboardView.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
 import { render, screen, waitFor, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import DashboardView from '../DashboardView'
 import { onAuthClear } from '../../store/onAuthClear'
 
@@ -84,7 +85,11 @@ beforeEach(() => {
 
 describe('DashboardView', () => {
   it('clears privacy data on auth-clear', async () => {
-    render(<DashboardView events={[]} />)
+    render(
+      <MemoryRouter>
+        <DashboardView events={[]} />
+      </MemoryRouter>,
+    )
 
     // Wait for privacy score data to render — MetricBar's "Anonymity set"
     // label only appears once `data` is non-null.

--- a/app/src/views/__tests__/DepositView.test.tsx
+++ b/app/src/views/__tests__/DepositView.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import type { AuthState } from '../../hooks/useAuthState'
 
 const navigateMock = vi.fn()
 vi.mock('react-router-dom', async () => {
@@ -14,17 +15,19 @@ vi.mock('../../api/client', () => ({
   apiFetch: vi.fn(),
 }))
 
+let currentAuth: AuthState = {
+  status: 'authed',
+  token: 'test-token',
+  expiresAt: null,
+  isAdmin: false,
+  publicKey: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
+  authenticate: () => Promise.resolve(),
+  disconnect: () => Promise.resolve(),
+  error: null,
+}
+
 vi.mock('../../hooks/useAuthState', () => ({
-  useAuthState: () => ({
-    status: 'authed' as const,
-    token: 'test-token',
-    expiresAt: null,
-    isAdmin: false,
-    publicKey: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
-    authenticate: () => Promise.resolve(),
-    disconnect: () => Promise.resolve(),
-    error: null,
-  }),
+  useAuthState: () => currentAuth,
 }))
 
 vi.mock('../../hooks/useTransactionSigner', () => ({
@@ -56,6 +59,16 @@ beforeEach(() => {
   ;(apiFetch as ReturnType<typeof vi.fn>).mockReset()
   navigateMock.mockReset()
   networkValue = 'devnet'
+  currentAuth = {
+    status: 'authed',
+    token: 'test-token',
+    expiresAt: null,
+    isAdmin: false,
+    publicKey: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
+    authenticate: () => Promise.resolve(),
+    disconnect: () => Promise.resolve(),
+    error: null,
+  }
 })
 
 describe('DepositView', () => {
@@ -93,6 +106,20 @@ describe('DepositView', () => {
     renderDeposit()
     expect(screen.getByText(/devnet only/i)).toBeInTheDocument()
     // Form should not be rendered on mainnet (no AssetSelector, no AmountForm)
+    expect(screen.queryByPlaceholderText('0.0')).not.toBeInTheDocument()
+  })
+
+  it('renders UnauthedEmptyState when status is unauthed', () => {
+    currentAuth = {
+      ...currentAuth,
+      status: 'unauthed',
+      token: null,
+      publicKey: null,
+    }
+    renderDeposit()
+    expect(screen.getByTestId('unauthed-empty-state')).toBeInTheDocument()
+    expect(screen.getByText(/shielded deposit/i)).toBeInTheDocument()
+    // Deposit form must be absent when unauthed
     expect(screen.queryByPlaceholderText('0.0')).not.toBeInTheDocument()
   })
 })

--- a/app/src/views/__tests__/DepositView.test.tsx
+++ b/app/src/views/__tests__/DepositView.test.tsx
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 
-const setActiveView = vi.fn()
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
 let networkValue: 'devnet' | 'mainnet' = 'devnet'
 
 vi.mock('../../api/client', () => ({
@@ -21,18 +27,6 @@ vi.mock('../../hooks/useAuthState', () => ({
   }),
 }))
 
-vi.mock('../../stores/app', async () => {
-  const actual = await vi.importActual<typeof import('../../stores/app')>('../../stores/app')
-  return {
-    ...actual,
-    useAppStore: Object.assign(
-      (selector: (s: { setActiveView: typeof setActiveView }) => unknown) =>
-        selector({ setActiveView }),
-      { getState: () => ({ setActiveView }) }
-    ),
-  }
-})
-
 vi.mock('../../hooks/useTransactionSigner', () => ({
   useTransactionSigner: () => ({
     signAndBroadcast: vi.fn().mockResolvedValue({ signature: 'CONFIRMED_SIG' }),
@@ -50,9 +44,17 @@ vi.mock('../../lib/networkConfig', () => ({
 import DepositView from '../DepositView'
 import { apiFetch } from '../../api/client'
 
+function renderDeposit() {
+  return render(
+    <MemoryRouter>
+      <DepositView />
+    </MemoryRouter>,
+  )
+}
+
 beforeEach(() => {
   ;(apiFetch as ReturnType<typeof vi.fn>).mockReset()
-  setActiveView.mockReset()
+  navigateMock.mockReset()
   networkValue = 'devnet'
 })
 
@@ -65,14 +67,14 @@ describe('DepositView', () => {
       })
       .mockResolvedValueOnce({ positions: [], available: true, network: 'devnet' })
 
-    render(<DepositView />)
+    renderDeposit()
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'SOL' })).toBeInTheDocument()
       expect(screen.getByPlaceholderText('0.0')).toBeInTheDocument()
     })
   })
 
-  it('renders Back to Vault chip that calls setActiveView("vault")', async () => {
+  it('renders Back to Vault chip that navigates to /vault', async () => {
     ;(apiFetch as ReturnType<typeof vi.fn>)
       .mockResolvedValueOnce({
         wallet: 'C1phr...85N',
@@ -80,15 +82,15 @@ describe('DepositView', () => {
       })
       .mockResolvedValueOnce({ positions: [], available: true, network: 'devnet' })
 
-    render(<DepositView />)
+    renderDeposit()
     const back = await screen.findByRole('button', { name: /back to vault/i })
     fireEvent.click(back)
-    expect(setActiveView).toHaveBeenCalledWith('vault')
+    expect(navigateMock).toHaveBeenCalledWith('/vault')
   })
 
   it('renders disabled state and banner copy when network is mainnet', async () => {
     networkValue = 'mainnet'
-    render(<DepositView />)
+    renderDeposit()
     expect(screen.getByText(/devnet only/i)).toBeInTheDocument()
     // Form should not be rendered on mainnet (no AssetSelector, no AmountForm)
     expect(screen.queryByPlaceholderText('0.0')).not.toBeInTheDocument()

--- a/app/src/views/__tests__/HeraldView-edit.test.tsx
+++ b/app/src/views/__tests__/HeraldView-edit.test.tsx
@@ -1,8 +1,17 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
 import { useAppStore } from '../../stores/app'
 import HeraldView from '../HeraldView'
+
+function renderHerald(token = 'test-token') {
+  return render(
+    <MemoryRouter>
+      <HeraldView token={token} />
+    </MemoryRouter>,
+  )
+}
 
 vi.mock('../../hooks/useAuthState', () => ({
   useAuthState: vi.fn(() => ({
@@ -36,7 +45,7 @@ describe('HeraldView Edit flow', () => {
   })
 
   it('toggles into edit mode and shows textarea on Edit click', async () => {
-    render(<HeraldView token="test-token" />)
+    renderHerald()
     await userEvent.click(screen.getByRole('button', { name: /^queue$/i }))
     await screen.findByText('old tweet')
     await userEvent.click(screen.getByRole('button', { name: /edit/i }))
@@ -45,7 +54,7 @@ describe('HeraldView Edit flow', () => {
   })
 
   it('saves the edit via PATCH and exits edit mode', async () => {
-    render(<HeraldView token="test-token" />)
+    renderHerald()
     await userEvent.click(screen.getByRole('button', { name: /^queue$/i }))
     await screen.findByText('old tweet')
     await userEvent.click(screen.getByRole('button', { name: /edit/i }))

--- a/app/src/views/__tests__/HeraldView.test.tsx
+++ b/app/src/views/__tests__/HeraldView.test.tsx
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import HeraldView from '../HeraldView'
 
-const setActiveViewMock = vi.fn()
-
-vi.mock('../../stores/app', () => ({
-  useAppStore: (selector: (s: unknown) => unknown) => selector({ setActiveView: setActiveViewMock }),
-}))
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
 
 vi.mock('../../hooks/useAuthState', () => ({
   useAuthState: vi.fn(),
@@ -23,9 +24,17 @@ vi.mock('../../api/client', () => ({
 
 import { useAuthState } from '../../hooks/useAuthState'
 
+function renderHerald(token = 't') {
+  return render(
+    <MemoryRouter>
+      <HeraldView token={token} />
+    </MemoryRouter>,
+  )
+}
+
 describe('HeraldView admin gating', () => {
   beforeEach(() => {
-    setActiveViewMock.mockClear()
+    navigateMock.mockClear()
   })
 
   it('redirects to dashboard when !isAdmin and renders null', () => {
@@ -35,8 +44,8 @@ describe('HeraldView admin gating', () => {
       publicKey: 'pk',
       isAdmin: false,
     } as ReturnType<typeof useAuthState>)
-    const { container } = render(<HeraldView token="t" />)
-    expect(setActiveViewMock).toHaveBeenCalledWith('dashboard')
+    const { container } = renderHerald()
+    expect(navigateMock).toHaveBeenCalledWith('/')
     expect(container.firstChild).toBeNull()
   })
 
@@ -47,11 +56,11 @@ describe('HeraldView admin gating', () => {
       publicKey: 'pk',
       isAdmin: true,
     } as ReturnType<typeof useAuthState>)
-    const { container } = render(<HeraldView token="t" />)
+    const { container } = renderHerald()
     await waitFor(() => {
       expect(container.firstChild).not.toBeNull()
     })
-    expect(setActiveViewMock).not.toHaveBeenCalled()
+    expect(navigateMock).not.toHaveBeenCalled()
   })
 })
 
@@ -73,7 +82,7 @@ describe('HeraldView budget bar colors', () => {
       dms: [],
       recentPosts: [],
     })
-    const { container } = render(<HeraldView token="t" />)
+    const { container } = renderHerald()
     await waitFor(() => {
       expect(container.querySelector('[class*="bg-success-soft"]')).toBeTruthy()
     })
@@ -87,7 +96,7 @@ describe('HeraldView budget bar colors', () => {
       dms: [],
       recentPosts: [],
     })
-    const { container } = render(<HeraldView token="t" />)
+    const { container } = renderHerald()
     await waitFor(() => {
       expect(container.querySelector('[class*="bg-warning-soft"]')).toBeTruthy()
     })
@@ -101,7 +110,7 @@ describe('HeraldView budget bar colors', () => {
       dms: [],
       recentPosts: [],
     })
-    const { container } = render(<HeraldView token="t" />)
+    const { container } = renderHerald()
     await waitFor(() => {
       expect(container.querySelector('[class*="bg-danger-soft"]')).toBeTruthy()
     })

--- a/app/src/views/__tests__/NotFoundView.test.tsx
+++ b/app/src/views/__tests__/NotFoundView.test.tsx
@@ -10,7 +10,8 @@ describe('NotFoundView', () => {
         <NotFoundView />
       </MemoryRouter>,
     )
-    expect(screen.getByText(/not found/i)).toBeInTheDocument()
+    // UnauthedEmptyState renders the title in an h2 (matching the design system)
+    expect(screen.getByRole('heading', { level: 2, name: /not found/i })).toBeInTheDocument()
   })
 
   it('renders Back to Dashboard link to /', () => {
@@ -21,5 +22,16 @@ describe('NotFoundView', () => {
     )
     const link = screen.getByRole('link', { name: /back to dashboard/i })
     expect(link).toHaveAttribute('href', '/')
+  })
+
+  it('renders an h1 for the route page heading', () => {
+    render(
+      <MemoryRouter>
+        <NotFoundView />
+      </MemoryRouter>,
+    )
+    expect(
+      screen.getByRole('heading', { level: 1, name: /not found/i }),
+    ).toBeInTheDocument()
   })
 })

--- a/app/src/views/__tests__/NotFoundView.test.tsx
+++ b/app/src/views/__tests__/NotFoundView.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import NotFoundView from '../NotFoundView'
+
+describe('NotFoundView', () => {
+  it('renders not-found title', () => {
+    render(
+      <MemoryRouter>
+        <NotFoundView />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText(/not found/i)).toBeInTheDocument()
+  })
+
+  it('renders Back to Dashboard link to /', () => {
+    render(
+      <MemoryRouter>
+        <NotFoundView />
+      </MemoryRouter>,
+    )
+    const link = screen.getByRole('link', { name: /back to dashboard/i })
+    expect(link).toHaveAttribute('href', '/')
+  })
+})

--- a/app/src/views/__tests__/PrivacyReportView.test.tsx
+++ b/app/src/views/__tests__/PrivacyReportView.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import PrivacyReportView from '../PrivacyReportView'
+import type { AuthState } from '../../hooks/useAuthState'
 
 const navigateMock = vi.fn()
 vi.mock('react-router-dom', async () => {
@@ -13,8 +14,19 @@ vi.mock('../../api/client', () => ({
   apiFetch: vi.fn(),
 }))
 
+let currentAuth: AuthState = {
+  status: 'authed',
+  token: 'abc',
+  expiresAt: null,
+  isAdmin: false,
+  publicKey: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
+  authenticate: () => Promise.resolve(),
+  disconnect: () => Promise.resolve(),
+  error: null,
+}
+
 vi.mock('../../hooks/useAuthState', () => ({
-  useAuthState: () => ({ token: 'abc', isAdmin: false }),
+  useAuthState: () => currentAuth,
 }))
 
 import { apiFetch } from '../../api/client'
@@ -43,6 +55,16 @@ function renderReport() {
 beforeEach(() => {
   ;(apiFetch as ReturnType<typeof vi.fn>).mockReset()
   navigateMock.mockReset()
+  currentAuth = {
+    status: 'authed',
+    token: 'abc',
+    expiresAt: null,
+    isAdmin: false,
+    publicKey: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
+    authenticate: () => Promise.resolve(),
+    disconnect: () => Promise.resolve(),
+    error: null,
+  }
 })
 
 describe('PrivacyReportView', () => {
@@ -86,5 +108,19 @@ describe('PrivacyReportView', () => {
     ;(apiFetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('boom'))
     renderReport()
     await waitFor(() => expect(screen.getByText('boom')).toBeInTheDocument())
+  })
+
+  it('renders UnauthedEmptyState when status is unauthed', () => {
+    currentAuth = {
+      ...currentAuth,
+      status: 'unauthed',
+      token: null,
+      publicKey: null,
+    }
+    renderReport()
+    expect(screen.getByTestId('unauthed-empty-state')).toBeInTheDocument()
+    expect(screen.getByText(/privacy score report/i)).toBeInTheDocument()
+    // Score gauge / loading copy must be absent when unauthed
+    expect(screen.queryByText(/Loading privacy report/)).not.toBeInTheDocument()
   })
 })

--- a/app/src/views/__tests__/PrivacyReportView.test.tsx
+++ b/app/src/views/__tests__/PrivacyReportView.test.tsx
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import PrivacyReportView from '../PrivacyReportView'
-import { useAppStore } from '../../stores/app'
+
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
 
 vi.mock('../../api/client', () => ({
   apiFetch: vi.fn(),
@@ -26,15 +32,23 @@ const fakePayload = {
   },
 }
 
+function renderReport() {
+  return render(
+    <MemoryRouter>
+      <PrivacyReportView />
+    </MemoryRouter>,
+  )
+}
+
 beforeEach(() => {
   ;(apiFetch as ReturnType<typeof vi.fn>).mockReset()
-  useAppStore.setState({ activeView: 'privacyReport' }, false)
+  navigateMock.mockReset()
 })
 
 describe('PrivacyReportView', () => {
   it('renders the score gauge once data loads', async () => {
     ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(fakePayload)
-    render(<PrivacyReportView />)
+    renderReport()
     await waitFor(() => expect(screen.getByText('72')).toBeInTheDocument())
     expect(screen.getByText('GOOD')).toBeInTheDocument()
     expect(screen.getByText(/1,284 transactions analyzed/)).toBeInTheDocument()
@@ -42,7 +56,7 @@ describe('PrivacyReportView', () => {
 
   it('renders factor breakdown with humanized labels', async () => {
     ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(fakePayload)
-    render(<PrivacyReportView />)
+    renderReport()
     await waitFor(() => expect(screen.getByText('Address Reuse')).toBeInTheDocument())
     expect(screen.getByText('Amount Patterns')).toBeInTheDocument()
     expect(screen.getByText('reuse detail')).toBeInTheDocument()
@@ -50,27 +64,27 @@ describe('PrivacyReportView', () => {
 
   it('lists recommendations when present', async () => {
     ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(fakePayload)
-    render(<PrivacyReportView />)
+    renderReport()
     await waitFor(() => expect(screen.getByText(/Use a fresh address/)).toBeInTheDocument())
     expect(screen.getByText(/Wait 24h between deposits/)).toBeInTheDocument()
   })
 
-  it('Back button returns to Dashboard via store', () => {
+  it('Back button returns to Dashboard via navigate("/")', () => {
     ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(fakePayload)
-    render(<PrivacyReportView />)
+    renderReport()
     fireEvent.click(screen.getByRole('button', { name: /back to dashboard/i }))
-    expect(useAppStore.getState().activeView).toBe('dashboard')
+    expect(navigateMock).toHaveBeenCalledWith('/')
   })
 
   it('shows loading copy before data arrives', () => {
     ;(apiFetch as ReturnType<typeof vi.fn>).mockReturnValueOnce(new Promise(() => {}))
-    render(<PrivacyReportView />)
+    renderReport()
     expect(screen.getByText(/Loading privacy report/)).toBeInTheDocument()
   })
 
   it('shows error copy when fetch fails', async () => {
     ;(apiFetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('boom'))
-    render(<PrivacyReportView />)
+    renderReport()
     await waitFor(() => expect(screen.getByText('boom')).toBeInTheDocument())
   })
 })

--- a/app/src/views/__tests__/SettingsView.test.tsx
+++ b/app/src/views/__tests__/SettingsView.test.tsx
@@ -1,13 +1,14 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
 import { useNetworkConfigStore } from '../../lib/networkConfig'
 import { makeFakeAuthState } from '../../test-utils/makeFakeAuthState'
 
-const setActiveViewMock = vi.fn()
-vi.mock('../../stores/app', () => ({
-  useAppStore: (selector: (s: unknown) => unknown) =>
-    selector({ setActiveView: setActiveViewMock, activeView: 'settings' }),
-}))
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
 
 const useAuthStateMock = vi.fn()
 vi.mock('../../hooks/useAuthState', () => ({
@@ -39,10 +40,18 @@ const sentinelConfigFixture = {
   fundMovingTools: ['send', 'deposit', 'swap', 'sweep', 'consolidate', 'splitSend', 'scheduleSend', 'drip', 'recurring', 'refund'],
 }
 
+function renderSettings(SettingsView: React.ComponentType) {
+  return render(
+    <MemoryRouter>
+      <SettingsView />
+    </MemoryRouter>,
+  )
+}
+
 describe('SettingsView', () => {
   beforeEach(() => {
     apiFetchMock.mockReset()
-    setActiveViewMock.mockReset()
+    navigateMock.mockReset()
     useAuthStateMock.mockReset()
     useNetworkConfigStore.setState({
       config: {
@@ -63,9 +72,9 @@ describe('SettingsView', () => {
       makeFakeAuthState({ publicKey: 'X', token: 't', status: 'authed', isAdmin: false }),
     )
     const { default: SettingsView } = await import('../SettingsView')
-    render(<SettingsView />)
+    renderSettings(SettingsView)
     await waitFor(() => {
-      expect(setActiveViewMock).toHaveBeenCalledWith('dashboard')
+      expect(navigateMock).toHaveBeenCalledWith('/')
     })
   })
 
@@ -75,7 +84,7 @@ describe('SettingsView', () => {
     )
     apiFetchMock.mockResolvedValue(sentinelConfigFixture)
     const { default: SettingsView } = await import('../SettingsView')
-    render(<SettingsView />)
+    renderSettings(SettingsView)
     await waitFor(() => {
       expect(screen.getByText(/devnet/i)).toBeInTheDocument()
     })
@@ -87,7 +96,7 @@ describe('SettingsView', () => {
     )
     apiFetchMock.mockResolvedValue(sentinelConfigFixture)
     const { default: SettingsView } = await import('../SettingsView')
-    render(<SettingsView />)
+    renderSettings(SettingsView)
     await waitFor(() => {
       const chip = screen.getByText(/^advisory$/i)
       expect(chip).toBeInTheDocument()
@@ -101,7 +110,7 @@ describe('SettingsView', () => {
     )
     apiFetchMock.mockResolvedValue(sentinelConfigFixture)
     const { default: SettingsView } = await import('../SettingsView')
-    render(<SettingsView />)
+    renderSettings(SettingsView)
     await waitFor(() => {
       sentinelConfigFixture.fundMovingTools.forEach((tool) => {
         expect(screen.getByText(tool, { selector: 'span' })).toBeInTheDocument()
@@ -115,7 +124,7 @@ describe('SettingsView', () => {
     )
     apiFetchMock.mockResolvedValue({ ...sentinelConfigFixture, dailyCostUsd: 1.23 })
     const { default: SettingsView } = await import('../SettingsView')
-    render(<SettingsView />)
+    renderSettings(SettingsView)
     await waitFor(() => {
       expect(screen.getByText(/\$1\.23/)).toBeInTheDocument()
       expect(screen.getByText(/\$10/)).toBeInTheDocument()

--- a/app/src/views/__tests__/SquadView.test.tsx
+++ b/app/src/views/__tests__/SquadView.test.tsx
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import SquadView from '../SquadView'
 
-const setActiveViewMock = vi.fn()
-
-vi.mock('../../stores/app', () => ({
-  useAppStore: (selector: (s: unknown) => unknown) => selector({ setActiveView: setActiveViewMock }),
-}))
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
 
 vi.mock('../../hooks/useAuthState', () => ({
   useAuthState: vi.fn(),
@@ -19,9 +20,17 @@ vi.mock('../../api/client', () => ({
 import { useAuthState } from '../../hooks/useAuthState'
 import { apiFetch } from '../../api/client'
 
+function renderSquad(token = 't') {
+  return render(
+    <MemoryRouter>
+      <SquadView token={token} />
+    </MemoryRouter>,
+  )
+}
+
 describe('SquadView admin gating', () => {
   beforeEach(() => {
-    setActiveViewMock.mockClear()
+    navigateMock.mockClear()
     vi.mocked(apiFetch).mockReset()
   })
 
@@ -32,8 +41,8 @@ describe('SquadView admin gating', () => {
       publicKey: 'pk',
       isAdmin: false,
     } as ReturnType<typeof useAuthState>)
-    const { container } = render(<SquadView token="t" />)
-    expect(setActiveViewMock).toHaveBeenCalledWith('dashboard')
+    const { container } = renderSquad()
+    expect(navigateMock).toHaveBeenCalledWith('/')
     expect(container.firstChild).toBeNull()
   })
 
@@ -50,11 +59,11 @@ describe('SquadView admin gating', () => {
       coordination: [],
       killSwitch: false,
     })
-    const { container } = render(<SquadView token="t" />)
+    const { container } = renderSquad()
     await waitFor(() => {
       expect(container.firstChild).not.toBeNull()
     })
-    expect(setActiveViewMock).not.toHaveBeenCalled()
+    expect(navigateMock).not.toHaveBeenCalled()
   })
 })
 
@@ -75,7 +84,7 @@ describe('SquadView sentinel identity', () => {
   })
 
   it('renders SENTINEL eyebrow chip', async () => {
-    const { container } = render(<SquadView token="t" />)
+    const { container } = renderSquad()
     await waitFor(() => {
       expect(screen.getByText('SENTINEL')).toBeInTheDocument()
     })
@@ -101,7 +110,7 @@ describe('SquadView KillSwitch tones', () => {
       coordination: [],
       killSwitch: true,
     })
-    render(<SquadView token="t" />)
+    renderSquad()
     await waitFor(() => {
       const btn = screen.getByRole('button', { name: /resume operations/i })
       expect(btn.className).toMatch(/border-success/)
@@ -116,7 +125,7 @@ describe('SquadView KillSwitch tones', () => {
       coordination: [],
       killSwitch: false,
     })
-    render(<SquadView token="t" />)
+    renderSquad()
     await waitFor(() => {
       const btn = screen.getByRole('button', { name: /pause all vault ops/i })
       expect(btn.className).toMatch(/border-danger/)

--- a/app/src/views/__tests__/VaultView.test.tsx
+++ b/app/src/views/__tests__/VaultView.test.tsx
@@ -1,8 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import { onAuthClear } from '../../store/onAuthClear'
 
-const setActiveView = vi.fn()
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
 let networkValue: 'devnet' | 'mainnet' = 'devnet'
 
 vi.mock('../../api/client', () => ({
@@ -13,18 +19,6 @@ const useAuthStateMock = vi.fn()
 vi.mock('../../hooks/useAuthState', () => ({
   useAuthState: () => useAuthStateMock(),
 }))
-
-vi.mock('../../stores/app', async () => {
-  const actual = await vi.importActual<typeof import('../../stores/app')>('../../stores/app')
-  return {
-    ...actual,
-    useAppStore: Object.assign(
-      (selector: (s: { setActiveView: typeof setActiveView }) => unknown) =>
-        selector({ setActiveView }),
-      { getState: () => ({ setActiveView }) },
-    ),
-  }
-})
 
 vi.mock('../../lib/networkConfig', () => ({
   useNetworkConfigStore: <T,>(selector: (s: { config: { network: string } }) => T) =>
@@ -91,9 +85,17 @@ const populatedPositions: PositionsResponse = {
   network: 'devnet',
 }
 
+function renderVault() {
+  return render(
+    <MemoryRouter>
+      <VaultView />
+    </MemoryRouter>,
+  )
+}
+
 beforeEach(() => {
   mockedFetch.mockReset()
-  setActiveView.mockReset()
+  navigateMock.mockReset()
   networkValue = 'devnet'
   onAuthClear._resetForTests()
   useAuthStateMock.mockReturnValue({
@@ -120,7 +122,7 @@ function mockThreeFetches(positionsResponse: PositionsResponse = emptyPositions)
 describe('VaultView (split-panel)', () => {
   it('fires three parallel fetches on mount', async () => {
     mockThreeFetches()
-    render(<VaultView />)
+    renderVault()
     await waitFor(() => {
       expect(mockedFetch).toHaveBeenCalledWith('/api/vault', expect.anything())
       expect(mockedFetch).toHaveBeenCalledWith('/api/vault/positions', expect.anything())
@@ -130,41 +132,41 @@ describe('VaultView (split-panel)', () => {
 
   it('renders ShieldedVault and UnshieldedWallet panels', async () => {
     mockThreeFetches()
-    render(<VaultView />)
+    renderVault()
     await waitFor(() => {
       expect(screen.getByText(/SHIELDED VAULT/)).toBeInTheDocument()
       expect(screen.getByText(/UNSHIELDED WALLET/)).toBeInTheDocument()
     })
   })
 
-  it('Shield to vault CTA routes to deposit view', async () => {
+  it('Shield to vault CTA navigates to /vault/deposit', async () => {
     mockThreeFetches()
-    render(<VaultView />)
+    renderVault()
     const cta = await screen.findByRole('button', { name: /shield to vault/i })
     fireEvent.click(cta)
-    expect(setActiveView).toHaveBeenCalledWith('deposit')
+    expect(navigateMock).toHaveBeenCalledWith('/vault/deposit')
   })
 
-  it('Withdraw CTA routes to withdraw view', async () => {
+  it('Withdraw CTA navigates to /vault/withdraw', async () => {
     mockThreeFetches()
-    render(<VaultView />)
+    renderVault()
     const withdrawBtn = await screen.findByRole('button', { name: /withdraw/i })
     fireEvent.click(withdrawBtn)
-    expect(setActiveView).toHaveBeenCalledWith('withdraw')
+    expect(navigateMock).toHaveBeenCalledWith('/vault/withdraw')
   })
 
-  it('Withdraw CTA still routes when positions exist', async () => {
+  it('Withdraw CTA still navigates when positions exist', async () => {
     mockThreeFetches(populatedPositions)
-    render(<VaultView />)
+    renderVault()
     const withdrawBtn = await screen.findByRole('button', { name: /withdraw/i })
     fireEvent.click(withdrawBtn)
-    expect(setActiveView).toHaveBeenCalledWith('withdraw')
+    expect(navigateMock).toHaveBeenCalledWith('/vault/withdraw')
   })
 
   it('Withdraw CTA disabled on mainnet', async () => {
     networkValue = 'mainnet'
     mockThreeFetches()
-    render(<VaultView />)
+    renderVault()
     const withdrawBtn = await screen.findByRole('button', { name: /withdraw/i })
     expect(withdrawBtn).toBeDisabled()
   })
@@ -172,14 +174,14 @@ describe('VaultView (split-panel)', () => {
   it('Shield to vault CTA disabled on mainnet', async () => {
     networkValue = 'mainnet'
     mockThreeFetches()
-    render(<VaultView />)
+    renderVault()
     const cta = await screen.findByRole('button', { name: /shield to vault/i })
     expect(cta).toBeDisabled()
   })
 
   it('clears vault, positions, and stealth tree on onAuthClear.clearAll', async () => {
     mockThreeFetches(populatedPositions)
-    render(<VaultView />)
+    renderVault()
     await waitFor(() => {
       expect(screen.getByText('1 positions')).toBeInTheDocument()
     })
@@ -201,7 +203,7 @@ describe('VaultView (split-panel)', () => {
       error: null,
     })
     mockThreeFetches()
-    render(<VaultView />)
+    renderVault()
     expect(screen.getByTestId('unauthed-empty-state')).toBeInTheDocument()
     expect(screen.queryByText(/SHIELDED VAULT/)).toBeNull()
     expect(screen.queryByText(/UNSHIELDED WALLET/)).toBeNull()
@@ -221,7 +223,7 @@ describe('VaultView (split-panel)', () => {
       error: null,
     })
     mockThreeFetches()
-    render(<VaultView />)
+    renderVault()
     expect(screen.getByTestId('unauthed-empty-state')).toBeInTheDocument()
   })
 
@@ -236,7 +238,7 @@ describe('VaultView (split-panel)', () => {
       disconnect: () => Promise.resolve(),
       error: null,
     })
-    render(<VaultView />)
+    renderVault()
     expect(mockedFetch).not.toHaveBeenCalled()
   })
 })

--- a/app/src/views/__tests__/WithdrawView.test.tsx
+++ b/app/src/views/__tests__/WithdrawView.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+import type { AuthState } from '../../hooks/useAuthState'
 
 const navigateMock = vi.fn()
 vi.mock('react-router-dom', async () => {
@@ -15,17 +16,19 @@ vi.mock('../../api/client', () => ({
   apiFetch: vi.fn(),
 }))
 
+let currentAuth: AuthState = {
+  status: 'authed',
+  token: 'test-token',
+  expiresAt: null,
+  isAdmin: false,
+  publicKey: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
+  authenticate: () => Promise.resolve(),
+  disconnect: () => Promise.resolve(),
+  error: null,
+}
+
 vi.mock('../../hooks/useAuthState', () => ({
-  useAuthState: () => ({
-    status: 'authed' as const,
-    token: 'test-token',
-    expiresAt: null,
-    isAdmin: false,
-    publicKey: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
-    authenticate: () => Promise.resolve(),
-    disconnect: () => Promise.resolve(),
-    error: null,
-  }),
+  useAuthState: () => currentAuth,
 }))
 
 vi.mock('../../hooks/useTransactionSigner', () => ({
@@ -78,6 +81,16 @@ beforeEach(() => {
   navigateMock.mockReset()
   signAndBroadcast.mockReset()
   networkValue = 'devnet'
+  currentAuth = {
+    status: 'authed',
+    token: 'test-token',
+    expiresAt: null,
+    isAdmin: false,
+    publicKey: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
+    authenticate: () => Promise.resolve(),
+    disconnect: () => Promise.resolve(),
+    error: null,
+  }
 })
 
 describe('WithdrawView', () => {
@@ -128,6 +141,20 @@ describe('WithdrawView', () => {
     renderWithdraw()
     expect(screen.getByText(/devnet only/i)).toBeInTheDocument()
     // RefundList should not render on mainnet
+    expect(screen.queryByText('SOL')).not.toBeInTheDocument()
+  })
+
+  it('renders UnauthedEmptyState when status is unauthed', () => {
+    currentAuth = {
+      ...currentAuth,
+      status: 'unauthed',
+      token: null,
+      publicKey: null,
+    }
+    renderWithdraw()
+    expect(screen.getByTestId('unauthed-empty-state')).toBeInTheDocument()
+    expect(screen.getByText(/shielded withdraw/i)).toBeInTheDocument()
+    // RefundList must be absent when unauthed
     expect(screen.queryByText('SOL')).not.toBeInTheDocument()
   })
 })

--- a/app/src/views/__tests__/WithdrawView.test.tsx
+++ b/app/src/views/__tests__/WithdrawView.test.tsx
@@ -1,7 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 
-const setActiveView = vi.fn()
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
 const signAndBroadcast = vi.fn()
 let networkValue: 'devnet' | 'mainnet' = 'devnet'
 
@@ -21,18 +27,6 @@ vi.mock('../../hooks/useAuthState', () => ({
     error: null,
   }),
 }))
-
-vi.mock('../../stores/app', async () => {
-  const actual = await vi.importActual<typeof import('../../stores/app')>('../../stores/app')
-  return {
-    ...actual,
-    useAppStore: Object.assign(
-      (selector: (s: { setActiveView: typeof setActiveView }) => unknown) =>
-        selector({ setActiveView }),
-      { getState: () => ({ setActiveView }) },
-    ),
-  }
-})
 
 vi.mock('../../hooks/useTransactionSigner', () => ({
   useTransactionSigner: () => ({
@@ -71,9 +65,17 @@ const fakePosition = {
   depositRecordAddress: 'DEPOSITRECORDPDA',
 }
 
+function renderWithdraw() {
+  return render(
+    <MemoryRouter>
+      <WithdrawView />
+    </MemoryRouter>,
+  )
+}
+
 beforeEach(() => {
   mockedFetch.mockReset()
-  setActiveView.mockReset()
+  navigateMock.mockReset()
   signAndBroadcast.mockReset()
   networkValue = 'devnet'
 })
@@ -85,18 +87,18 @@ describe('WithdrawView', () => {
       available: true,
       network: 'devnet',
     })
-    render(<WithdrawView />)
+    renderWithdraw()
     await waitFor(() => {
       expect(screen.getByText('SOL')).toBeInTheDocument()
     })
   })
 
-  it('renders Back chip that calls setActiveView("vault")', async () => {
+  it('renders Back chip that navigates to /vault', async () => {
     mockedFetch.mockResolvedValueOnce({ positions: [], available: true, network: 'devnet' })
-    render(<WithdrawView />)
+    renderWithdraw()
     const back = await screen.findByRole('button', { name: /back to vault/i })
     fireEvent.click(back)
-    expect(setActiveView).toHaveBeenCalledWith('vault')
+    expect(navigateMock).toHaveBeenCalledWith('/vault')
   })
 
   it('clicking Refund calls /api/vault/refund-tx and signAndBroadcast', async () => {
@@ -109,7 +111,7 @@ describe('WithdrawView', () => {
     })
     signAndBroadcast.mockResolvedValueOnce({ signature: 'CONFIRMED_SIG' })
 
-    render(<WithdrawView />)
+    renderWithdraw()
     const refundBtn = await screen.findByRole('button', { name: /^refund$/i })
     fireEvent.click(refundBtn)
     await waitFor(() => {
@@ -123,7 +125,7 @@ describe('WithdrawView', () => {
 
   it('shows mainnet-disabled copy when network is mainnet', async () => {
     networkValue = 'mainnet'
-    render(<WithdrawView />)
+    renderWithdraw()
     expect(screen.getByText(/devnet only/i)).toBeInTheDocument()
     // RefundList should not render on mainnet
     expect(screen.queryByText('SOL')).not.toBeInTheDocument()

--- a/e2e/herald.spec.ts
+++ b/e2e/herald.spec.ts
@@ -34,6 +34,9 @@ test('herald view renders with admin budget visible', async ({ page }) => {
   await page.goto('/')
   await page.getByRole('button', { name: /more/i }).click()
   await page.getByRole('button', { name: /^herald$/i }).click()
+  // BottomNav More-drawer admin items still trigger navigate() (not <Link>)
+  // because they need to dismiss the drawer first. After click, URL is /herald.
+  await expect(page).toHaveURL(/\/herald$/)
   await expect(page.locator('[data-testid="herald-view"]')).toBeVisible()
   expect(errors).toEqual([])
 })

--- a/e2e/squad.spec.ts
+++ b/e2e/squad.spec.ts
@@ -23,6 +23,9 @@ test('squad view renders', async ({ page }) => {
   await page.goto('/')
   await page.getByRole('button', { name: /more/i }).click()
   await page.getByRole('button', { name: /^squad$/i }).click()
+  // BottomNav More-drawer admin items still trigger navigate() (not <Link>).
+  // The Squad route URL is /sentinel even though the View enum keeps 'squad'.
+  await expect(page).toHaveURL(/\/sentinel$/)
   await expect(page.locator('[data-testid="squad-view"]')).toBeVisible()
   expect(errors).toEqual([])
 })

--- a/e2e/vault.spec.ts
+++ b/e2e/vault.spec.ts
@@ -15,7 +15,10 @@ test('vault unauthed empty state renders', async ({ page }) => {
   await mockSolanaRpc(page)
   await mockPrivacyScore(page)
   await page.goto('/')
-  await page.getByRole('button', { name: /vault/i }).first().click()
+  await page.getByRole('link', { name: /vault/i }).first().click()
+  // After react-router migration, Vault tabs are <Link> elements (role=link)
+  // not <button>. URL changes to /vault on click.
+  await expect(page).toHaveURL(/\/vault$/)
   // E2E fixture persists JWT but does not connect a wallet adapter, so
   // useAuthState() resolves to 'unauthed' and VaultView renders the
   // UnauthedEmptyState marketing branch. See PR #230 / Tier 2 #190.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      react-router-dom:
+        specifier: ^7.15.0
+        version: 7.15.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       reactflow:
         specifier: ^11.11.4
         version: 11.11.4(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -4400,6 +4403,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
 
@@ -6498,6 +6505,23 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom@7.15.0:
+    resolution: {integrity: sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.15.0:
+    resolution: {integrity: sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -6688,6 +6712,9 @@ packages:
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -13703,6 +13730,8 @@ snapshots:
 
   cookie@0.7.2: {}
 
+  cookie@1.1.1: {}
+
   cookiejar@2.1.4: {}
 
   core-util-is@1.0.3: {}
@@ -16203,6 +16232,20 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
+  react-router-dom@7.15.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-router: 7.15.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+
+  react-router@7.15.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.4
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+
   react@19.2.4: {}
 
   reactflow@11.11.4(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -16470,6 +16513,8 @@ snapshots:
       - supports-color
 
   set-blocking@2.0.0: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
     dependencies:

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
   "outputDirectory": "app/dist",
   "framework": null,
   "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+    { "source": "/((?!api/).*)", "destination": "/index.html" }
   ],
   "headers": [
     {


### PR DESCRIPTION
Closes #194 (URL router missing). Tier 2 PR2 of the QA sweep.

## Summary

- Adds \`react-router-dom@^7\` and \`<BrowserRouter>\` to App shell
- 13 routes total: 11 view components + \`/about\` placeholder + \`*\` 404
- \`/vault/deposit\` + \`/vault/withdraw\` as nested vault routes
- New \`<NotFoundView>\` (uses PR1's \`<UnauthedEmptyState>\`) with visually-hidden \`<h1>\` for landmark detection
- \`<AboutPlaceholderView>\` lands here; PR3 fills with full marketing content
- \`<ChatView>\` extracted from inline App.tsx switch
- \`useAppStore.activeView\` field deleted; \`useActiveView()\` derives from \`useLocation().pathname\`, returns \`null\` for unmatched paths (correct active-tab semantics on 404)
- Header + BottomNav nav use \`<Link>\` / \`useNavigate()\` with \`aria-current=\"page\"\` for active state
- Admin views (Herald/Squad/Settings) redirect non-admins via \`useNavigate('/')\` in \`useEffect\`; protected views (Deposit/Withdraw/PrivacyReport/Keys) render \`<UnauthedEmptyState>\` when disconnected
- vercel.json SPA fallback rewrite refined to exclude \`/api/\`
- E2E specs updated for URL-based navigation

## Test plan

- [ ] Direct visit to \`/vault\`, \`/chains\`, \`/keys\`, \`/privacy-report\`, \`/about\` mounts respective views
- [ ] Browser back/forward + bookmarks work
- [ ] Invalid path \`/foo\` renders NotFoundView; no nav tab highlighted
- [ ] Non-admin direct visit to \`/herald\` redirects to \`/\` (no flash)
- [ ] Disconnect from \`/vault/deposit\` shows UnauthedEmptyState (no broken form)
- [ ] PR1's UnauthedEmptyState mounts on \`/vault\`, \`/keys\` (regression check)
- [ ] PR1's PrivacyScoreCard Sheet teaser still opens for unauthed (regression check)
- [ ] CI green (component + playwright)

## Quality

- 424 tests / 69 files / typecheck clean
- 19 commits: 15 features + 4 review fixes
- Two-stage review (spec compliance + code quality) passed; reviewer flagged 4 Important issues which were all addressed

## Spec

\`docs/superpowers/specs/2026-05-10-qa-sweep-tier-2-design.md\` PR2 section.