### PR TITLE
feat(app): Footer + Tooltip + JargonTerm + Banner + AboutView (Tier 2 PR3)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -6,6 +6,7 @@ import '@solana/wallet-adapter-react-ui/styles.css'
 
 import Header from './components/Header'
 import BottomNav from './components/BottomNav'
+import { Footer } from './components/Footer'
 import ChatSidebar from './components/ChatSidebar'
 import { BetaBanner } from './components/BetaBanner'
 import { NetworkBanner } from './components/NetworkBanner'
@@ -64,6 +65,7 @@ function AppShell() {
       </div>
 
       <BottomNav />
+      <Footer />
 
       <Sheet
         open={chatSheetOpen}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -23,7 +23,7 @@ import KeysView from './views/KeysView'
 import SettingsView from './views/SettingsView'
 import ChatView from './views/ChatView'
 import NotFoundView from './views/NotFoundView'
-import AboutPlaceholderView from './views/AboutPlaceholderView'
+import AboutView from './views/AboutView'
 import { useAppStore } from './stores/app'
 import { useAuth } from './hooks/useAuth'
 import { useSSE } from './hooks/useSSE'
@@ -58,7 +58,7 @@ function AppShell() {
             <Route path="/sentinel" element={<SquadView token={token} />} />
             <Route path="/settings" element={<SettingsView />} />
             <Route path="/privacy-report" element={<PrivacyReportView />} />
-            <Route path="/about" element={<AboutPlaceholderView />} />
+            <Route path="/about" element={<AboutView />} />
             <Route path="*" element={<NotFoundView />} />
           </Routes>
         </main>

--- a/app/src/components/Footer.tsx
+++ b/app/src/components/Footer.tsx
@@ -1,0 +1,31 @@
+const LINKS = [
+  { href: 'https://docs.sip-protocol.org', label: 'Docs' },
+  { href: 'https://blog.sip-protocol.org', label: 'Blog' },
+  { href: 'https://github.com/sip-protocol/sipher', label: 'GitHub' },
+  { href: 'https://x.com/SIPProtocol', label: 'X' },
+  { href: 'https://sip-protocol.org', label: 'sip-protocol.org' },
+]
+
+export function Footer() {
+  return (
+    <footer
+      data-testid="app-footer"
+      className="border-t border-line px-4 py-4 lg:px-6 flex flex-wrap items-center gap-4 text-2xs text-text-muted"
+    >
+      <nav className="flex flex-wrap gap-3">
+        {LINKS.map((l) => (
+          <a
+            key={l.href}
+            href={l.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-text-secondary transition-colors"
+          >
+            {l.label}
+          </a>
+        ))}
+      </nav>
+      <span className="ml-auto">© 2026 SIP Labs</span>
+    </footer>
+  )
+}

--- a/app/src/components/PrivacyGraph.tsx
+++ b/app/src/components/PrivacyGraph.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Card } from './ui/Card'
+import { JargonTerm } from './ui/JargonTerm'
 import { NodeGraph, type GraphNode, type GraphEdge } from './ui/NodeGraph'
 import { apiFetch } from '../api/client'
 import { useAuthState } from '../hooks/useAuthState'
@@ -49,10 +50,11 @@ export function PrivacyGraph() {
     <Card variant="default" sheen className="p-6">
       <div className="flex items-center justify-between mb-4">
         <span
-          className="text-2xs text-text-muted"
+          className="text-2xs text-text-muted inline-flex items-center gap-1"
           style={{ letterSpacing: 'var(--tracking-widest)' }}
         >
-          PRIVACY GRAPH · STEALTH ADDRESS TREE
+          PRIVACY GRAPH ·{' '}
+          <JargonTerm term="Stealth Address Tree">STEALTH ADDRESS TREE</JargonTerm>
         </span>
         <span className="text-xs text-text-muted">
           {tree.length} {tree.length === 1 ? 'address' : 'addresses'}

--- a/app/src/components/PrivacyGraph.tsx
+++ b/app/src/components/PrivacyGraph.tsx
@@ -59,8 +59,13 @@ export function PrivacyGraph() {
         </span>
       </div>
       {tree.length === 0 ? (
-        <div className="h-[400px] flex items-center justify-center text-text-muted text-sm">
-          Connect a wallet to see your privacy graph.
+        <div className="h-[400px] flex flex-col items-center justify-center text-center px-6">
+          <p className="text-sm text-text-secondary">
+            Each node is a one-time stealth address.
+          </p>
+          <p className="text-xs text-text-muted mt-1">
+            Connect a wallet and send/receive shielded payments to populate.
+          </p>
         </div>
       ) : (
         <NodeGraph nodes={nodes} edges={edges} />

--- a/app/src/components/PrivacyScoreCard.tsx
+++ b/app/src/components/PrivacyScoreCard.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Card } from './ui/Card'
 import { Gauge } from './ui/Gauge'
+import { JargonTerm } from './ui/JargonTerm'
 import { MetricBar } from './ui/MetricBar'
 import { Sheet } from './ui/Sheet'
 import { UnauthedEmptyState } from './ui/UnauthedEmptyState'
@@ -57,7 +58,7 @@ export function PrivacyScoreCard({ data, delta }: PrivacyScoreCardProps) {
                   className="text-2xs text-text-muted"
                   style={{ letterSpacing: 'var(--tracking-widest)' }}
                 >
-                  PRIVACY SCORE
+                  <JargonTerm term="Privacy Score">PRIVACY SCORE</JargonTerm>
                 </div>
                 <div className="text-base mt-1">
                   {delta != null && (

--- a/app/src/components/__tests__/Footer.test.tsx
+++ b/app/src/components/__tests__/Footer.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { Footer } from '../Footer'
+
+describe('Footer', () => {
+  function renderFooter() {
+    return render(
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>,
+    )
+  }
+
+  it('renders docs link with target=_blank + rel=noopener', () => {
+    renderFooter()
+    const link = screen.getByRole('link', { name: /docs/i })
+    expect(link).toHaveAttribute('href', 'https://docs.sip-protocol.org')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('renders blog, github, x, sip-protocol links', () => {
+    renderFooter()
+    expect(screen.getByRole('link', { name: /blog/i })).toHaveAttribute('href', 'https://blog.sip-protocol.org')
+    expect(screen.getByRole('link', { name: /github/i })).toHaveAttribute('href', 'https://github.com/sip-protocol/sipher')
+    expect(screen.getByRole('link', { name: /^x$|twitter|x \(/i })).toHaveAttribute('href', expect.stringMatching(/x\.com/))
+    expect(screen.getByRole('link', { name: /sip-protocol\.org/i })).toHaveAttribute('href', 'https://sip-protocol.org')
+  })
+
+  it('renders copyright', () => {
+    renderFooter()
+    expect(screen.getByText(/© 2026 SIP Labs/i)).toBeInTheDocument()
+  })
+})

--- a/app/src/components/__tests__/PrivacyGraph.test.tsx
+++ b/app/src/components/__tests__/PrivacyGraph.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
-import { render, screen, waitFor, act } from '@testing-library/react'
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react'
 import { PrivacyGraph } from '../PrivacyGraph'
 import { onAuthClear } from '../../store/onAuthClear'
 
@@ -64,6 +64,21 @@ describe('PrivacyGraph', () => {
     ;(apiFetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('network'))
     render(<PrivacyGraph />)
     await waitFor(() => expect(screen.getByText(/0 addresses/)).toBeInTheDocument())
+  })
+
+  it('wraps Stealth Address Tree label in JargonTerm tooltip', async () => {
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      tree: [],
+      rootWallet: '',
+    })
+    render(<PrivacyGraph />)
+    await waitFor(() => {
+      expect(screen.getByText(/0 addresses/)).toBeInTheDocument()
+    })
+    const trigger = screen.getByText('STEALTH ADDRESS TREE').closest('button')
+    expect(trigger).not.toBeNull()
+    fireEvent.mouseEnter(trigger!)
+    expect(screen.getByRole('tooltip')).toHaveTextContent(/one-time recipient/i)
   })
 
   it('clears the tree when onAuthClear.clearAll fires', async () => {

--- a/app/src/components/__tests__/PrivacyGraph.test.tsx
+++ b/app/src/components/__tests__/PrivacyGraph.test.tsx
@@ -37,7 +37,8 @@ describe('PrivacyGraph', () => {
     render(<PrivacyGraph />)
     await waitFor(() => {
       expect(screen.getByText(/0 addresses/)).toBeInTheDocument()
-      expect(screen.getByText(/Connect a wallet to see your privacy graph/)).toBeInTheDocument()
+      expect(screen.getByText(/each node is a one-time stealth address/i)).toBeInTheDocument()
+      expect(screen.getByText(/connect a wallet and send\/receive shielded payments/i)).toBeInTheDocument()
     })
   })
 

--- a/app/src/components/__tests__/PrivacyScoreCard.test.tsx
+++ b/app/src/components/__tests__/PrivacyScoreCard.test.tsx
@@ -125,6 +125,14 @@ describe('PrivacyScoreCard', () => {
     expect(screen.getByTestId('unauthed-empty-state')).toBeInTheDocument()
   })
 
+  it('wraps Privacy Score label in JargonTerm tooltip', () => {
+    renderCard({ data: fakeData })
+    const trigger = screen.getByText('PRIVACY SCORE').closest('button')
+    expect(trigger).not.toBeNull()
+    fireEvent.mouseEnter(trigger!)
+    expect(screen.getByRole('tooltip')).toHaveTextContent(/composite metric/i)
+  })
+
   it('dismisses Sheet teaser when Close button clicked', () => {
     useAuthStateMock.mockReturnValue({
       status: 'unauthed' as const,

--- a/app/src/components/ui/Banner.tsx
+++ b/app/src/components/ui/Banner.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react'
+
+export interface BannerProps {
+  kind: 'info' | 'warning' | 'error'
+  children: ReactNode
+}
+
+const TONES: Record<BannerProps['kind'], string> = {
+  info: 'border-cyan/40 text-cyan bg-cyan/5',
+  warning: 'border-amber-500/40 text-amber-400 bg-amber-500/5',
+  error: 'border-danger/40 text-danger bg-danger-soft',
+}
+
+export function Banner({ kind, children }: BannerProps) {
+  const role = kind === 'info' ? 'status' : 'alert'
+  return (
+    <div
+      role={role}
+      data-testid="banner"
+      className={`border rounded-md px-3 py-2 text-xs ${TONES[kind]}`}
+    >
+      {children}
+    </div>
+  )
+}

--- a/app/src/components/ui/JargonTerm.tsx
+++ b/app/src/components/ui/JargonTerm.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from 'react'
+import { Info } from '@phosphor-icons/react'
+import { Tooltip } from './Tooltip'
+
+export const JARGON_DEFINITIONS = {
+  'Privacy Score':
+    'Composite metric of address reuse, amount patterns, timing correlation, and counterparty exposure. Higher = more private.',
+  'Stealth Address Tree':
+    'Each leaf is a one-time recipient address. Connecting your wallet derives the tree from your viewing key.',
+  'Vault PDA':
+    'Program-Derived Address — the on-chain account holding shielded vault state. Owned by the Sipher Vault program, not by any wallet.',
+  'fee 50 bps':
+    '0.5% fee on shielded transfers — funds protocol development. Paid in the transferred token.',
+  'Pedersen':
+    'Cryptographic commitment scheme used to hide amounts. Each commitment combines value × G + blinding × H, where G and H are base points on the secp256k1 curve.',
+  'DKSAP':
+    "Dual-Key Stealth Address Protocol — sender derives a one-time recipient address from the recipient's spending + viewing public keys. Only the recipient can spend.",
+} as const
+
+export type JargonKey = keyof typeof JARGON_DEFINITIONS
+
+export interface JargonTermProps {
+  term: JargonKey
+  children: ReactNode
+}
+
+export function JargonTerm({ term, children }: JargonTermProps) {
+  return (
+    <Tooltip content={JARGON_DEFINITIONS[term]}>
+      <button type="button" className="inline-flex items-center gap-1 cursor-help underline decoration-dotted">
+        {children}
+        <Info size={12} className="text-text-muted" />
+      </button>
+    </Tooltip>
+  )
+}

--- a/app/src/components/ui/Tooltip.tsx
+++ b/app/src/components/ui/Tooltip.tsx
@@ -23,6 +23,7 @@ export function Tooltip({ content, children, side = 'top' }: TooltipProps) {
     onMouseLeave: () => setOpen(false),
     onFocus: () => setOpen(true),
     onBlur: () => setOpen(false),
+    onClick: () => setOpen((o) => !o),
     onKeyDown: (e: KeyboardEvent) => {
       if (e.key === 'Escape') setOpen(false)
     },

--- a/app/src/components/ui/Tooltip.tsx
+++ b/app/src/components/ui/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, useId, useState, type ReactElement, type ReactNode } from 'react'
+import { cloneElement, useId, useState, type KeyboardEvent, type ReactElement, type ReactNode } from 'react'
 
 export interface TooltipProps {
   content: ReactNode
@@ -23,6 +23,9 @@ export function Tooltip({ content, children, side = 'top' }: TooltipProps) {
     onMouseLeave: () => setOpen(false),
     onFocus: () => setOpen(true),
     onBlur: () => setOpen(false),
+    onKeyDown: (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    },
   } as Record<string, unknown>)
 
   return (

--- a/app/src/components/ui/Tooltip.tsx
+++ b/app/src/components/ui/Tooltip.tsx
@@ -1,0 +1,42 @@
+import { cloneElement, useId, useState, type ReactElement, type ReactNode } from 'react'
+
+export interface TooltipProps {
+  content: ReactNode
+  children: ReactElement
+  side?: 'top' | 'right' | 'bottom' | 'left'
+}
+
+const SIDE_CLASSES: Record<NonNullable<TooltipProps['side']>, string> = {
+  top: 'bottom-full mb-2 left-1/2 -translate-x-1/2',
+  right: 'left-full ml-2 top-1/2 -translate-y-1/2',
+  bottom: 'top-full mt-2 left-1/2 -translate-x-1/2',
+  left: 'right-full mr-2 top-1/2 -translate-y-1/2',
+}
+
+export function Tooltip({ content, children, side = 'top' }: TooltipProps) {
+  const id = useId()
+  const [open, setOpen] = useState(false)
+
+  const trigger = cloneElement(children, {
+    'aria-describedby': open ? id : undefined,
+    onMouseEnter: () => setOpen(true),
+    onMouseLeave: () => setOpen(false),
+    onFocus: () => setOpen(true),
+    onBlur: () => setOpen(false),
+  } as Record<string, unknown>)
+
+  return (
+    <span className="relative inline-flex">
+      {trigger}
+      {open && (
+        <span
+          role="tooltip"
+          id={id}
+          className={`absolute z-tooltip whitespace-pre-line max-w-xs glass-strong rounded-md px-2 py-1.5 text-2xs text-text shadow-lg ${SIDE_CLASSES[side]}`}
+        >
+          {content}
+        </span>
+      )}
+    </span>
+  )
+}

--- a/app/src/components/ui/__tests__/Banner.test.tsx
+++ b/app/src/components/ui/__tests__/Banner.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { Banner } from '../Banner'
+
+describe('Banner', () => {
+  it('renders children', () => {
+    render(<Banner kind="info">Connect a wallet</Banner>)
+    expect(screen.getByText('Connect a wallet')).toBeInTheDocument()
+  })
+
+  it('uses role=status for info kind', () => {
+    render(<Banner kind="info">x</Banner>)
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+
+  it('uses role=alert for warning + error kinds', () => {
+    const { rerender } = render(<Banner kind="warning">x</Banner>)
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    rerender(<Banner kind="error">x</Banner>)
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  it('applies info variant tone classes', () => {
+    const { container } = render(<Banner kind="info">x</Banner>)
+    expect(container.firstChild).toHaveClass(/border-cyan/, /text-cyan/)
+  })
+})

--- a/app/src/components/ui/__tests__/JargonTerm.test.tsx
+++ b/app/src/components/ui/__tests__/JargonTerm.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { JargonTerm } from '../JargonTerm'
+
+describe('JargonTerm', () => {
+  it('renders the term as the visible label', () => {
+    render(<JargonTerm term="Privacy Score">{'Privacy Score'}</JargonTerm>)
+    expect(screen.getAllByText('Privacy Score').length).toBeGreaterThan(0)
+  })
+
+  it('shows definition on hover for Privacy Score', () => {
+    render(<JargonTerm term="Privacy Score">Privacy Score</JargonTerm>)
+    const trigger = screen.getByRole('button')
+    fireEvent.mouseEnter(trigger)
+    expect(screen.getByRole('tooltip')).toHaveTextContent(/composite metric/i)
+  })
+
+  it('shows definition for Stealth Address Tree', () => {
+    render(<JargonTerm term="Stealth Address Tree">tree</JargonTerm>)
+    fireEvent.mouseEnter(screen.getByRole('button'))
+    expect(screen.getByRole('tooltip')).toHaveTextContent(/one-time recipient/i)
+  })
+
+  it('shows definition for Vault PDA', () => {
+    render(<JargonTerm term="Vault PDA">PDA</JargonTerm>)
+    fireEvent.mouseEnter(screen.getByRole('button'))
+    expect(screen.getByRole('tooltip')).toHaveTextContent(/program-derived address/i)
+  })
+
+  it('shows definition for fee 50 bps', () => {
+    render(<JargonTerm term="fee 50 bps">50 bps</JargonTerm>)
+    fireEvent.mouseEnter(screen.getByRole('button'))
+    expect(screen.getByRole('tooltip')).toHaveTextContent(/0\.5%/)
+  })
+
+  it('shows definition for Pedersen', () => {
+    render(<JargonTerm term="Pedersen">Pedersen</JargonTerm>)
+    fireEvent.mouseEnter(screen.getByRole('button'))
+    expect(screen.getByRole('tooltip')).toHaveTextContent(/commitment scheme/i)
+  })
+
+  it('shows definition for DKSAP', () => {
+    render(<JargonTerm term="DKSAP">DKSAP</JargonTerm>)
+    fireEvent.mouseEnter(screen.getByRole('button'))
+    expect(screen.getByRole('tooltip')).toHaveTextContent(/dual-key/i)
+  })
+})

--- a/app/src/components/ui/__tests__/Tooltip.test.tsx
+++ b/app/src/components/ui/__tests__/Tooltip.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { Tooltip } from '../Tooltip'
+
+describe('Tooltip', () => {
+  it('renders trigger element', () => {
+    render(
+      <Tooltip content="Helpful info">
+        <button>Trigger</button>
+      </Tooltip>,
+    )
+    expect(screen.getByRole('button', { name: 'Trigger' })).toBeInTheDocument()
+  })
+
+  it('does not show tooltip content by default', () => {
+    render(
+      <Tooltip content="Helpful info">
+        <button>Trigger</button>
+      </Tooltip>,
+    )
+    expect(screen.queryByRole('tooltip')).toBeNull()
+  })
+
+  it('shows tooltip on mouseEnter', () => {
+    render(
+      <Tooltip content="Helpful info">
+        <button>Trigger</button>
+      </Tooltip>,
+    )
+    fireEvent.mouseEnter(screen.getByRole('button'))
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Helpful info')
+  })
+
+  it('hides tooltip on mouseLeave', () => {
+    render(
+      <Tooltip content="Helpful info">
+        <button>Trigger</button>
+      </Tooltip>,
+    )
+    fireEvent.mouseEnter(screen.getByRole('button'))
+    fireEvent.mouseLeave(screen.getByRole('button'))
+    expect(screen.queryByRole('tooltip')).toBeNull()
+  })
+
+  it('shows tooltip on focus', () => {
+    render(
+      <Tooltip content="Helpful info">
+        <button>Trigger</button>
+      </Tooltip>,
+    )
+    fireEvent.focus(screen.getByRole('button'))
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Helpful info')
+  })
+
+  it('hides tooltip on blur', () => {
+    render(
+      <Tooltip content="Helpful info">
+        <button>Trigger</button>
+      </Tooltip>,
+    )
+    fireEvent.focus(screen.getByRole('button'))
+    fireEvent.blur(screen.getByRole('button'))
+    expect(screen.queryByRole('tooltip')).toBeNull()
+  })
+
+  it('sets aria-describedby on trigger when shown', () => {
+    render(
+      <Tooltip content="Helpful info">
+        <button>Trigger</button>
+      </Tooltip>,
+    )
+    fireEvent.mouseEnter(screen.getByRole('button'))
+    const trigger = screen.getByRole('button')
+    const tooltip = screen.getByRole('tooltip')
+    expect(trigger).toHaveAttribute('aria-describedby', tooltip.id)
+  })
+})

--- a/app/src/components/ui/__tests__/Tooltip.test.tsx
+++ b/app/src/components/ui/__tests__/Tooltip.test.tsx
@@ -74,4 +74,16 @@ describe('Tooltip', () => {
     const tooltip = screen.getByRole('tooltip')
     expect(trigger).toHaveAttribute('aria-describedby', tooltip.id)
   })
+
+  it('hides tooltip on Escape key', () => {
+    render(
+      <Tooltip content="Helpful info">
+        <button>Trigger</button>
+      </Tooltip>,
+    )
+    fireEvent.focus(screen.getByRole('button'))
+    expect(screen.getByRole('tooltip')).toBeInTheDocument()
+    fireEvent.keyDown(screen.getByRole('button'), { key: 'Escape' })
+    expect(screen.queryByRole('tooltip')).toBeNull()
+  })
 })

--- a/app/src/components/ui/__tests__/Tooltip.test.tsx
+++ b/app/src/components/ui/__tests__/Tooltip.test.tsx
@@ -86,4 +86,18 @@ describe('Tooltip', () => {
     fireEvent.keyDown(screen.getByRole('button'), { key: 'Escape' })
     expect(screen.queryByRole('tooltip')).toBeNull()
   })
+
+  it('toggles tooltip on click (touch + keyboard activation)', () => {
+    render(
+      <Tooltip content="Helpful info">
+        <button>Trigger</button>
+      </Tooltip>,
+    )
+    // open
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Helpful info')
+    // close
+    fireEvent.click(screen.getByRole('button'))
+    expect(screen.queryByRole('tooltip')).toBeNull()
+  })
 })

--- a/app/src/components/vault/RoutePreviewCard.tsx
+++ b/app/src/components/vault/RoutePreviewCard.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react'
 import { Card } from '../ui/Card'
 import { HashCell } from '../ui/HashCell'
+import { JargonTerm } from '../ui/JargonTerm'
 
 interface RoutePreviewCardProps {
   wallet: string
@@ -45,7 +46,11 @@ export function RoutePreviewCard({
           }
         />
         <div className="ml-3 text-text-muted">↓ {amountLabel}</div>
-        <Step n={2} label="Vault PDA" detail={<HashCell hash={vaultPda} />} />
+        <Step
+          n={2}
+          label={<JargonTerm term="Vault PDA">Vault PDA</JargonTerm>}
+          detail={<HashCell hash={vaultPda} />}
+        />
         <div className="ml-3 text-text-muted">↓</div>
         <Step
           n={3}
@@ -57,7 +62,7 @@ export function RoutePreviewCard({
   )
 }
 
-function Step({ n, label, detail }: { n: number; label: string; detail: ReactNode }) {
+function Step({ n, label, detail }: { n: number; label: ReactNode; detail: ReactNode }) {
   return (
     <div className="flex items-center gap-2">
       <span className="w-5 h-5 inline-flex items-center justify-center rounded-full border border-cyan text-cyan text-2xs">

--- a/app/src/components/vault/__tests__/RoutePreviewCard.test.tsx
+++ b/app/src/components/vault/__tests__/RoutePreviewCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { RoutePreviewCard } from '../RoutePreviewCard'
 
 describe('RoutePreviewCard', () => {
@@ -32,6 +32,14 @@ describe('RoutePreviewCard', () => {
       />
     )
     expect(screen.getByText('—')).toBeInTheDocument()
+  })
+
+  it('wraps Vault PDA label in JargonTerm tooltip', () => {
+    render(<RoutePreviewCard wallet="C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N" />)
+    const trigger = screen.getByText(/Vault PDA/).closest('button')
+    expect(trigger).not.toBeNull()
+    fireEvent.mouseEnter(trigger!)
+    expect(screen.getByRole('tooltip')).toHaveTextContent(/program-derived address/i)
   })
 
   it('renders em-dash placeholder when wallet is empty (no unlabelled Copy button)', () => {

--- a/app/src/views/AboutPlaceholderView.tsx
+++ b/app/src/views/AboutPlaceholderView.tsx
@@ -1,8 +1,0 @@
-export default function AboutPlaceholderView() {
-  return (
-    <div data-testid="about-placeholder" className="flex flex-col items-start gap-4 p-8">
-      <h1 className="text-2xl font-semibold">About SIPHER</h1>
-      <p className="text-text-secondary">Coming soon.</p>
-    </div>
-  )
-}

--- a/app/src/views/AboutView.tsx
+++ b/app/src/views/AboutView.tsx
@@ -1,0 +1,80 @@
+import { Link } from 'react-router-dom'
+
+export default function AboutView() {
+  return (
+    <div data-testid="about-view" className="flex flex-col gap-12 max-w-4xl mx-auto py-8">
+      <section className="flex flex-col gap-4">
+        <h1 className="text-3xl md:text-5xl font-semibold leading-tight">
+          Privacy-by-default for Solana
+        </h1>
+        <p className="text-base text-text-secondary leading-relaxed">
+          SIPHER is a wallet and an autonomous agent for shielded payments, swaps, and stealth-address management. Stealth output by default. Real Pedersen commitments. Multi-chain.
+        </p>
+        <div className="flex gap-3">
+          <Link
+            to="/"
+            className="text-sm px-4 py-2 rounded-md text-bg font-semibold"
+            style={{ background: 'linear-gradient(90deg, var(--color-cyan), var(--color-violet))' }}
+          >
+            Open SIPHER
+          </Link>
+          <a
+            href="https://docs.sip-protocol.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm px-4 py-2 rounded-md border border-line text-text-secondary hover:text-text"
+          >
+            Read the docs
+          </a>
+        </div>
+      </section>
+
+      <section className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="glass-strong rounded-2xl p-6 flex flex-col gap-3">
+          <div className="text-2xs text-cyan" style={{ letterSpacing: 'var(--tracking-widest)' }}>
+            ◆ WALLET
+          </div>
+          <h2 className="text-lg font-semibold">Stealth-first wallet</h2>
+          <p className="text-sm text-text-secondary leading-relaxed">
+            Every received payment lands at a one-time stealth address. Viewing keys give selective disclosure for compliance. 12 chains supported via cross-chain shielded transfers.
+          </p>
+        </div>
+        <div className="glass-strong rounded-2xl p-6 flex flex-col gap-3">
+          <div className="text-2xs text-violet" style={{ letterSpacing: 'var(--tracking-widest)' }}>
+            ◇ AGENT
+          </div>
+          <h2 className="text-lg font-semibold">Autonomous co-pilot</h2>
+          <p className="text-sm text-text-secondary leading-relaxed">
+            HERALD responds to mentions on X. SENTINEL audits high-risk actions before they fire. Ask SIPHER chat handles privacy operations conversationally — deposits, swaps, sweeps, threat checks.
+          </p>
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-xl font-semibold">Architecture</h2>
+        <p className="text-sm text-text-secondary leading-relaxed">
+          Anchor program on Solana mainnet. Pedersen commitments hide amounts. Stealth addresses hide recipients. Viewing keys preserve compliance. Read the <a href="https://docs.sip-protocol.org" target="_blank" rel="noopener noreferrer" className="text-cyan underline">technical docs</a> for the full breakdown.
+        </p>
+      </section>
+
+      <section className="flex flex-wrap gap-3">
+        <a
+          href="https://github.com/sip-protocol/sipher"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm px-4 py-2 rounded-md border border-line text-text-secondary hover:text-text"
+        >
+          Star on GitHub
+        </a>
+        <a
+          href="https://x.com/SIPProtocol"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm px-4 py-2 rounded-md border border-line text-text-secondary hover:text-text"
+        >
+          Follow on X
+        </a>
+      </section>
+    </div>
+  )
+}

--- a/app/src/views/KeysView.tsx
+++ b/app/src/views/KeysView.tsx
@@ -1,4 +1,5 @@
 import { useAuthState } from '../hooks/useAuthState'
+import { Banner } from '../components/ui/Banner'
 import { UnauthedEmptyState } from '../components/ui/UnauthedEmptyState'
 import { ViewKeyCard } from '../components/keys/ViewKeyCard'
 import { StealthAddressBackup } from '../components/keys/StealthAddressBackup'
@@ -7,10 +8,15 @@ export default function KeysView() {
   const { status } = useAuthState()
   if (status !== 'authed') {
     return (
-      <UnauthedEmptyState
-        title="Stealth Keys"
-        body="Your spending and viewing keys are derived from your wallet. Connect to view, rotate, or back them up."
-      />
+      <div className="flex flex-col gap-4">
+        <Banner kind="info">
+          Stealth keys are a connected-wallet feature. Connect your wallet to view, rotate, or back them up.
+        </Banner>
+        <UnauthedEmptyState
+          title="Stealth Keys"
+          body="Your spending and viewing keys are derived from your wallet. Connect to view, rotate, or back them up."
+        />
+      </div>
     )
   }
 

--- a/app/src/views/VaultView.tsx
+++ b/app/src/views/VaultView.tsx
@@ -4,6 +4,7 @@ import { apiFetch } from '../api/client'
 import { useAuthState } from '../hooks/useAuthState'
 import { useNetworkConfigStore } from '../lib/networkConfig'
 import { useOnAuthClear } from '../store/useOnAuthClear'
+import { Banner } from '../components/ui/Banner'
 import { Card } from '../components/ui/Card'
 import { Chip } from '../components/ui/Chip'
 import { HashCell } from '../components/ui/HashCell'
@@ -87,17 +88,22 @@ export default function VaultView() {
 
   if (status !== 'authed') {
     return (
-      <UnauthedEmptyState
-        title="Shielded Vault"
-        body={
-          <>
-            Privacy-preserving SOL + token vault on Solana. Stealth output addresses by default.
-            <br />
-            <strong>Connect a wallet to deposit.</strong>
-          </>
-        }
-        illustration={<RoutePreviewCard wallet="" />}
-      />
+      <div className="flex flex-col gap-4">
+        <Banner kind="info">
+          Vault is a connected-wallet feature. Connect your wallet to deposit, manage stealth keys, and view your shielded balance.
+        </Banner>
+        <UnauthedEmptyState
+          title="Shielded Vault"
+          body={
+            <>
+              Privacy-preserving SOL + token vault on Solana. Stealth output addresses by default.
+              <br />
+              <strong>Connect a wallet to deposit.</strong>
+            </>
+          }
+          illustration={<RoutePreviewCard wallet="" />}
+        />
+      </div>
     )
   }
 

--- a/app/src/views/__tests__/AboutView.test.tsx
+++ b/app/src/views/__tests__/AboutView.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import AboutView from '../AboutView'
+
+function renderAbout() {
+  return render(
+    <MemoryRouter>
+      <AboutView />
+    </MemoryRouter>,
+  )
+}
+
+describe('AboutView', () => {
+  it('renders the hero h1', () => {
+    renderAbout()
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument()
+  })
+
+  it('mentions both wallet and agent identities', () => {
+    renderAbout()
+    expect(screen.getAllByText(/wallet/i).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/agent/i).length).toBeGreaterThan(0)
+  })
+
+  it('renders Open SIPHER link to /', () => {
+    renderAbout()
+    const link = screen.getByRole('link', { name: /open sipher/i })
+    expect(link).toHaveAttribute('href', '/')
+  })
+
+  it('renders docs link with target=_blank', () => {
+    renderAbout()
+    const link = screen.getByRole('link', { name: /read the docs/i })
+    expect(link).toHaveAttribute('href', expect.stringContaining('docs.sip-protocol.org'))
+    expect(link).toHaveAttribute('target', '_blank')
+  })
+})

--- a/app/src/views/__tests__/KeysView.test.tsx
+++ b/app/src/views/__tests__/KeysView.test.tsx
@@ -49,9 +49,21 @@ describe('KeysView', () => {
     })
     render(<KeysView />)
     expect(screen.getByTestId('unauthed-empty-state')).toBeInTheDocument()
-    expect(screen.getByText(/stealth keys/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/stealth keys/i).length).toBeGreaterThan(0)
     expect(screen.queryByTestId('view-key-card')).toBeNull()
     expect(screen.queryByTestId('backup-card')).toBeNull()
+  })
+
+  it('renders connect-wallet Banner above UnauthedEmptyState when unauthed', () => {
+    useAuthStateMock.mockReturnValue({
+      publicKey: null,
+      token: null,
+      status: 'unauthed',
+      isAdmin: false,
+    })
+    render(<KeysView />)
+    const banner = screen.getByRole('status')
+    expect(banner).toHaveTextContent(/connected-wallet feature|connect your wallet/i)
   })
 
   it('does NOT render the section heading when unauthenticated', () => {

--- a/app/src/views/__tests__/VaultView.test.tsx
+++ b/app/src/views/__tests__/VaultView.test.tsx
@@ -211,6 +211,23 @@ describe('VaultView (split-panel)', () => {
     expect(screen.queryByRole('button', { name: /shield to vault/i })).toBeNull()
   })
 
+  it('renders connect-wallet Banner above UnauthedEmptyState when unauthed', () => {
+    useAuthStateMock.mockReturnValue({
+      status: 'unauthed' as const,
+      token: null,
+      publicKey: null,
+      isAdmin: false,
+      expiresAt: null,
+      authenticate: () => Promise.resolve(),
+      disconnect: () => Promise.resolve(),
+      error: null,
+    })
+    mockThreeFetches()
+    renderVault()
+    const banner = screen.getByRole('status')
+    expect(banner).toHaveTextContent(/connected-wallet feature|connect your wallet/i)
+  })
+
   it('renders UnauthedEmptyState when status is connecting', () => {
     useAuthStateMock.mockReturnValue({
       status: 'connecting' as const,


### PR DESCRIPTION
Closes #200 (onboarding gap), #204 (auth-fallback breadcrumb). Tier 2 PR3 of the QA sweep.

## Summary

- New \`<Footer>\` mounted in App shell, always visible — docs / blog / GitHub / X / sip-protocol.org / © 2026 SIP Labs
- New \`<Tooltip>\` primitive — hover/focus/click triggered, ARIA \`aria-describedby\`, Escape dismissal, click toggle (touch + keyboard activation)
- New \`<JargonTerm>\` wrapper with 6 hardcoded definitions (Privacy Score, Stealth Address Tree, Vault PDA, fee 50 bps, Pedersen, DKSAP); 3 visible labels wired in production (PRIVACY SCORE in PrivacyScoreCard, STEALTH ADDRESS TREE in PrivacyGraph, Vault PDA in RoutePreviewCard) — remaining 3 definitions ready for future wiring
- New \`<Banner>\` primitive (info / warning / error tones); used as connect-wallet breadcrumb above unauthed VaultView + KeysView
- New \`<AboutView>\` marketing page replaces PR2's \`<AboutPlaceholderView>\`; routed at \`/about\` — hero + wallet identity + agent identity + architecture + footer CTAs
- Privacy Graph empty-state copy expanded to 2-line educational

## Copy review needed

@RECTOR — Vercel preview will include /about marketing copy + tooltip definitions. Particular items to verify:
1. **X handle** — hardcoded \`https://x.com/SIPProtocol\`; please confirm or correct.
2. **Copyright** — "© 2026 SIP Labs"; confirm legal entity name.
3. **/about hero copy** — "Privacy-by-default for Solana" + tagline.
4. **6 JargonTerm definitions** — accuracy + tone.

Iterations land as commits on this branch.

## Test plan

- [ ] Vercel preview \`/about\` renders hero + wallet identity + agent identity + CTAs
- [ ] Footer visible on /, /vault, /keys, /about, /privacy-report, /herald, NotFound
- [ ] Hover Privacy Score label → tooltip with composite-metric definition
- [ ] Hover Vault PDA label → tooltip with Program-Derived Address definition
- [ ] Tap JargonTerm on mobile → tooltip toggles (verify touch dismissal)
- [ ] Press Escape with tooltip focused → dismisses
- [ ] Unauthed visit to /vault → connect-wallet Banner above UnauthedEmptyState
- [ ] CI green (component + playwright)

## Quality

- 456 tests / 74 files / typecheck clean
- 10 commits: 8 features + 2 review fixes (Tooltip Escape + click)
- Two-stage review (spec compliance + code quality) passed; reviewer flagged 1 must-fix (Escape spec violation) + 1 should-fix (touch dismissal) — both addressed; remaining minors deferred to Tier 4

## Spec

\`docs/superpowers/specs/2026-05-10-qa-sweep-tier-2-design.md\` PR3 section.