### PR TITLE
fix(app): harden admin views (token guard + AbortController)

### DIFF
--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -103,21 +103,34 @@ export default function DashboardView({ events }: { events: ActivityEvent[] }) {
 
   useEffect(() => {
     if (!token) return
-    apiFetch<VaultData>('/api/vault', { token }).then(setVault).catch(() => {})
-    apiFetch<{ activity: ActivityRecord[] }>('/api/activity', { token })
+    const controller = new AbortController()
+    apiFetch<VaultData>('/api/vault', { token, signal: controller.signal })
       .then((data) => {
-        setHistory(
-          (data.activity ?? []).map((a: ActivityRecord): ActivityRow => ({
-            id: a.id,
-            agent: a.agent,
-            type: a.type,
-            level: a.level,
-            data: parseDetail(a.detail),
-            timestamp: a.created_at,
-          })),
-        )
+        if (!controller.signal.aborted) setVault(data)
       })
-      .catch(() => {})
+      .catch((err: Error) => {
+        if (err.name === 'AbortError') return
+        // network errors fall through to null vault state
+      })
+    apiFetch<{ activity: ActivityRecord[] }>('/api/activity', { token, signal: controller.signal })
+      .then((data) => {
+        if (!controller.signal.aborted) {
+          setHistory(
+            (data.activity ?? []).map((a: ActivityRecord): ActivityRow => ({
+              id: a.id,
+              agent: a.agent,
+              type: a.type,
+              level: a.level,
+              data: parseDetail(a.detail),
+              timestamp: a.created_at,
+            })),
+          )
+        }
+      })
+      .catch((err: Error) => {
+        if (err.name === 'AbortError') return
+      })
+    return () => controller.abort()
   }, [token])
 
   const allRows: ActivityRow[] = [

--- a/app/src/views/HeraldView.tsx
+++ b/app/src/views/HeraldView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Calendar, X as XIcon } from '@phosphor-icons/react'
 import { apiFetch } from '../api/client'
@@ -410,34 +410,48 @@ export default function HeraldView({ token }: { token: string | null }) {
     }
   }, [isAdmin, navigate])
 
-  const load = useCallback(() => {
+  const mountedRef = useRef(true)
+  useEffect(() => () => { mountedRef.current = false }, [])
+
+  const load = useCallback((signal?: AbortSignal) => {
     if (!token) return
     setError(null)
-    apiFetch<HeraldData>('/api/herald', { token })
-      .then(setData)
-      .catch((err: Error) => setError(err.message))
+    apiFetch<HeraldData>('/api/herald', { token, signal })
+      .then((data) => {
+        if (!signal?.aborted) setData(data)
+      })
+      .catch((err: Error) => {
+        if (err.name === 'AbortError') return
+        if (!signal?.aborted) setError(err.message)
+      })
   }, [token])
 
   useEffect(() => {
     if (!isAdmin) return
-    load()
+    const controller = new AbortController()
+    load(controller.signal)
+    return () => controller.abort()
   }, [isAdmin, load])
 
   const handleApprove = async (id: string, action: 'approve' | 'reject') => {
+    if (!token) return
     await apiFetch(`/api/herald/approve/${id}`, {
       method: 'POST',
       body: JSON.stringify({ action }),
-      token: token!,
+      token,
     })
+    if (!mountedRef.current) return
     load()
   }
 
   const handleEditSave = async (id: string, content: string) => {
+    if (!token) return
     await apiFetch(`/api/herald/queue/${id}`, {
       method: 'PATCH',
       body: JSON.stringify({ content }),
-      token: token!,
+      token,
     })
+    if (!mountedRef.current) return
     load()
   }
 

--- a/app/src/views/SettingsView.tsx
+++ b/app/src/views/SettingsView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { apiFetch } from '../api/client'
 import { useAuthState } from '../hooks/useAuthState'
@@ -42,7 +42,6 @@ export default function SettingsView() {
   const network = useNetworkConfigStore((s) => s.config?.network)
   const [config, setConfig] = useState<SentinelConfigPayload | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const aborterRef = useRef<AbortController | null>(null)
 
   useEffect(() => {
     if (!isAdmin) {
@@ -51,7 +50,6 @@ export default function SettingsView() {
     }
     if (!token) return
     const controller = new AbortController()
-    aborterRef.current = controller
     apiFetch<SentinelConfigPayload>('/api/sentinel/config', {
       token, signal: controller.signal,
     })

--- a/app/src/views/SquadView.tsx
+++ b/app/src/views/SquadView.tsx
@@ -235,17 +235,24 @@ export default function SquadView({ token }: { token: string | null }) {
     }
   }, [isAdmin, navigate])
 
-  const load = useCallback(() => {
+  const load = useCallback((signal?: AbortSignal) => {
     if (!token) return
     setError(null)
-    apiFetch<SquadRaw>('/api/squad', { token })
-      .then((raw) => setData(normalizeSquadData(raw)))
-      .catch((err: Error) => setError(err.message))
+    apiFetch<SquadRaw>('/api/squad', { token, signal })
+      .then((raw) => {
+        if (!signal?.aborted) setData(normalizeSquadData(raw))
+      })
+      .catch((err: Error) => {
+        if (err.name === 'AbortError') return
+        if (!signal?.aborted) setError(err.message)
+      })
   }, [token])
 
   useEffect(() => {
     if (!isAdmin) return
-    load()
+    const controller = new AbortController()
+    load(controller.signal)
+    return () => controller.abort()
   }, [isAdmin, load])
 
   if (!isAdmin) return null

--- a/app/src/views/__tests__/DashboardView.test.tsx
+++ b/app/src/views/__tests__/DashboardView.test.tsx
@@ -104,4 +104,31 @@ describe('DashboardView', () => {
       expect(screen.queryByText(/Anonymity set/i)).not.toBeInTheDocument()
     })
   })
+
+  it('aborts in-flight /api/vault and /api/activity on unmount', async () => {
+    const capturedSignals: AbortSignal[] = []
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockImplementation((path: string, opts?: { signal?: AbortSignal }) => {
+      if (path === '/api/vault' || path === '/api/activity') {
+        if (opts?.signal) capturedSignals.push(opts.signal)
+        return new Promise(() => {}) // never resolves so the signal stays in flight
+      }
+      // privacy-score and chains paths still resolve so the rest of the view mounts cleanly
+      if (path === '/v1/privacy/score') return Promise.resolve(fakePrivacyScore)
+      if (path === '/api/chains') return Promise.resolve({ chains: [] })
+      if (path === '/api/chains/aggregate') {
+        return Promise.resolve({ totalTvlSol: 0, chainCount: 0, liveChainCount: 0, asOf: 't' })
+      }
+      if (path === '/api/stealth/index') return Promise.resolve({ tree: [], rootWallet: 'W' })
+      return Promise.reject(new Error('unexpected path: ' + path))
+    })
+    const { unmount } = render(
+      <MemoryRouter>
+        <DashboardView events={[]} />
+      </MemoryRouter>,
+    )
+    await waitFor(() => expect(capturedSignals.length).toBe(2))
+    expect(capturedSignals.every((s) => s.aborted === false)).toBe(true)
+    unmount()
+    expect(capturedSignals.every((s) => s.aborted === true)).toBe(true)
+  })
 })

--- a/app/src/views/__tests__/HeraldView-edit.test.tsx
+++ b/app/src/views/__tests__/HeraldView-edit.test.tsx
@@ -13,14 +13,14 @@ function renderHerald(token = 'test-token') {
   )
 }
 
-vi.mock('../../hooks/useAuthState', () => ({
-  useAuthState: vi.fn(() => ({
-    status: 'authed',
-    token: 'test-token',
-    publicKey: 'pk',
-    isAdmin: true,
-  })),
-}))
+vi.mock('../../hooks/useAuthState', async () => {
+  const { makeFakeAuthState } = await import('../../test-utils/makeFakeAuthState')
+  return {
+    useAuthState: vi.fn(() =>
+      makeFakeAuthState({ status: 'authed', token: 'test-token', publicKey: 'pk', isAdmin: true }),
+    ),
+  }
+})
 
 describe('HeraldView Edit flow', () => {
   beforeEach(() => {

--- a/app/src/views/__tests__/HeraldView.test.tsx
+++ b/app/src/views/__tests__/HeraldView.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import HeraldView from '../HeraldView'
+import { makeFakeAuthState } from '../../test-utils/makeFakeAuthState'
 
 const navigateMock = vi.fn()
 vi.mock('react-router-dom', async () => {
@@ -114,5 +115,35 @@ describe('HeraldView budget bar colors', () => {
     await waitFor(() => {
       expect(container.querySelector('[class*="bg-danger-soft"]')).toBeTruthy()
     })
+  })
+})
+
+describe('HeraldView AbortController', () => {
+  beforeEach(() => {
+    vi.mocked(useAuthState).mockReturnValue(
+      makeFakeAuthState({ status: 'authed', token: 't', publicKey: 'pk', isAdmin: true }),
+    )
+  })
+
+  it('aborts in-flight /api/herald load on unmount', async () => {
+    const { apiFetch } = await import('../../api/client')
+    let capturedSignal: AbortSignal | undefined
+    vi.mocked(apiFetch).mockImplementation((_path, opts) => {
+      capturedSignal = (opts as { signal?: AbortSignal } | undefined)?.signal
+      return new Promise(() => {}) // never resolves
+    })
+    const { unmount } = renderHerald()
+    await waitFor(() => expect(capturedSignal).toBeDefined())
+    expect(capturedSignal?.aborted).toBe(false)
+    unmount()
+    expect(capturedSignal?.aborted).toBe(true)
+  })
+
+  it('does not call apiFetch when token prop is empty even with isAdmin', async () => {
+    const { apiFetch } = await import('../../api/client')
+    vi.mocked(apiFetch).mockClear()
+    const { container } = renderHerald('')
+    expect(container.textContent).toMatch(/Connect your wallet to view HERALD activity/i)
+    expect(vi.mocked(apiFetch)).not.toHaveBeenCalled()
   })
 })

--- a/app/src/views/__tests__/HeraldView.test.tsx
+++ b/app/src/views/__tests__/HeraldView.test.tsx
@@ -39,24 +39,18 @@ describe('HeraldView admin gating', () => {
   })
 
   it('redirects to dashboard when !isAdmin and renders null', () => {
-    vi.mocked(useAuthState).mockReturnValue({
-      status: 'authed',
-      token: 't',
-      publicKey: 'pk',
-      isAdmin: false,
-    } as ReturnType<typeof useAuthState>)
+    vi.mocked(useAuthState).mockReturnValue(
+      makeFakeAuthState({ status: 'authed', token: 't', publicKey: 'pk', isAdmin: false }),
+    )
     const { container } = renderHerald()
     expect(navigateMock).toHaveBeenCalledWith('/')
     expect(container.firstChild).toBeNull()
   })
 
   it('does NOT redirect when isAdmin', async () => {
-    vi.mocked(useAuthState).mockReturnValue({
-      status: 'authed',
-      token: 't',
-      publicKey: 'pk',
-      isAdmin: true,
-    } as ReturnType<typeof useAuthState>)
+    vi.mocked(useAuthState).mockReturnValue(
+      makeFakeAuthState({ status: 'authed', token: 't', publicKey: 'pk', isAdmin: true }),
+    )
     const { container } = renderHerald()
     await waitFor(() => {
       expect(container.firstChild).not.toBeNull()
@@ -67,12 +61,9 @@ describe('HeraldView admin gating', () => {
 
 describe('HeraldView budget bar colors', () => {
   beforeEach(() => {
-    vi.mocked(useAuthState).mockReturnValue({
-      status: 'authed',
-      token: 't',
-      publicKey: 'pk',
-      isAdmin: true,
-    } as ReturnType<typeof useAuthState>)
+    vi.mocked(useAuthState).mockReturnValue(
+      makeFakeAuthState({ status: 'authed', token: 't', publicKey: 'pk', isAdmin: true }),
+    )
   })
 
   it('uses success-soft when budget < 80%', async () => {

--- a/app/src/views/__tests__/SquadView.test.tsx
+++ b/app/src/views/__tests__/SquadView.test.tsx
@@ -19,6 +19,7 @@ vi.mock('../../api/client', () => ({
 
 import { useAuthState } from '../../hooks/useAuthState'
 import { apiFetch } from '../../api/client'
+import { makeFakeAuthState } from '../../test-utils/makeFakeAuthState'
 
 function renderSquad(token = 't') {
   return render(
@@ -35,24 +36,18 @@ describe('SquadView admin gating', () => {
   })
 
   it('redirects to dashboard when !isAdmin and renders null', () => {
-    vi.mocked(useAuthState).mockReturnValue({
-      status: 'authed',
-      token: 't',
-      publicKey: 'pk',
-      isAdmin: false,
-    } as ReturnType<typeof useAuthState>)
+    vi.mocked(useAuthState).mockReturnValue(
+      makeFakeAuthState({ status: 'authed', token: 't', publicKey: 'pk', isAdmin: false }),
+    )
     const { container } = renderSquad()
     expect(navigateMock).toHaveBeenCalledWith('/')
     expect(container.firstChild).toBeNull()
   })
 
   it('does NOT redirect when isAdmin', async () => {
-    vi.mocked(useAuthState).mockReturnValue({
-      status: 'authed',
-      token: 't',
-      publicKey: 'pk',
-      isAdmin: true,
-    } as ReturnType<typeof useAuthState>)
+    vi.mocked(useAuthState).mockReturnValue(
+      makeFakeAuthState({ status: 'authed', token: 't', publicKey: 'pk', isAdmin: true }),
+    )
     vi.mocked(apiFetch).mockResolvedValue({
       agents: [],
       stats: { toolCalls: 0, walletSessions: 0, xPosts: 0, xReplies: 0, blocksScanned: 0, alerts: 0 },
@@ -69,12 +64,9 @@ describe('SquadView admin gating', () => {
 
 describe('SquadView sentinel identity', () => {
   beforeEach(() => {
-    vi.mocked(useAuthState).mockReturnValue({
-      status: 'authed',
-      token: 't',
-      publicKey: 'pk',
-      isAdmin: true,
-    } as ReturnType<typeof useAuthState>)
+    vi.mocked(useAuthState).mockReturnValue(
+      makeFakeAuthState({ status: 'authed', token: 't', publicKey: 'pk', isAdmin: true }),
+    )
     vi.mocked(apiFetch).mockResolvedValue({
       agents: [],
       stats: { toolCalls: 0, walletSessions: 0, xPosts: 0, xReplies: 0, blocksScanned: 0, alerts: 0 },
@@ -95,12 +87,9 @@ describe('SquadView sentinel identity', () => {
 
 describe('SquadView KillSwitch tones', () => {
   beforeEach(() => {
-    vi.mocked(useAuthState).mockReturnValue({
-      status: 'authed',
-      token: 't',
-      publicKey: 'pk',
-      isAdmin: true,
-    } as ReturnType<typeof useAuthState>)
+    vi.mocked(useAuthState).mockReturnValue(
+      makeFakeAuthState({ status: 'authed', token: 't', publicKey: 'pk', isAdmin: true }),
+    )
   })
 
   it('uses success tones when killSwitch active', async () => {
@@ -136,12 +125,9 @@ describe('SquadView KillSwitch tones', () => {
 
 describe('SquadView AbortController', () => {
   beforeEach(() => {
-    vi.mocked(useAuthState).mockReturnValue({
-      status: 'authed',
-      token: 't',
-      publicKey: 'pk',
-      isAdmin: true,
-    } as ReturnType<typeof useAuthState>)
+    vi.mocked(useAuthState).mockReturnValue(
+      makeFakeAuthState({ status: 'authed', token: 't', publicKey: 'pk', isAdmin: true }),
+    )
   })
 
   it('aborts in-flight /api/squad load on unmount', async () => {

--- a/app/src/views/__tests__/SquadView.test.tsx
+++ b/app/src/views/__tests__/SquadView.test.tsx
@@ -133,3 +133,27 @@ describe('SquadView KillSwitch tones', () => {
     })
   })
 })
+
+describe('SquadView AbortController', () => {
+  beforeEach(() => {
+    vi.mocked(useAuthState).mockReturnValue({
+      status: 'authed',
+      token: 't',
+      publicKey: 'pk',
+      isAdmin: true,
+    } as ReturnType<typeof useAuthState>)
+  })
+
+  it('aborts in-flight /api/squad load on unmount', async () => {
+    let capturedSignal: AbortSignal | undefined
+    vi.mocked(apiFetch).mockImplementation((_path, opts) => {
+      capturedSignal = (opts as { signal?: AbortSignal } | undefined)?.signal
+      return new Promise(() => {}) // never resolves
+    })
+    const { unmount } = renderSquad()
+    await waitFor(() => expect(capturedSignal).toBeDefined())
+    expect(capturedSignal?.aborted).toBe(false)
+    unmount()
+    expect(capturedSignal?.aborted).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Hardens the three admin views (Herald, Squad, Settings) and Dashboard against two latent defect classes uncovered in the QA sweep.

### #198 — \`token!\` non-null assertion

\`HeraldView.handleApprove\` and \`handleEditSave\` used \`token: token!\` after the user clicked Approve/Save. If the JWT cleared between render and click (very possible given the 5min refresh window + tab inactivity), the assertion would crash with \`TypeError: Cannot read properties of null\` instead of doing the expected re-auth flow.

**Fix:** silent early-return guard at the top of each handler (\`if (!token) return\`). Next render naturally shows the existing \"Connect your wallet to view HERALD activity\" empty state. The global 401 interceptor still catches mid-action token expirations from the network round-trip.

### #199 — Missing AbortController on async fetches

\`HeraldView.load\`, the \`handleApprove\`/\`handleEditSave\` re-loads, \`SquadView.load\`, and the second useEffect in \`DashboardView\` for \`/api/vault\` + \`/api/activity\` all called \`apiFetch\` without \`signal:\`. If the user navigated away (or \`clearAuth\` fired) mid-fetch, \`setData\`/\`setHistory\` ran on an unmounted component (test noise + the ghost-state symptom from #189). Plus \`aborterRef\` in \`SettingsView.tsx:45,54\` was assigned but never read — dead state.

**Fix:**
- Refactored \`load\` in HeraldView and SquadView to accept an optional \`AbortSignal\`. The useEffect creates a controller, passes the signal, and aborts on cleanup.
- HeraldView's action handlers added a \`mountedRef\` so the post-action \`load()\` is skipped after unmount.
- DashboardView's second useEffect now uses an AbortController matching the existing privacy-score useEffect pattern.
- SettingsView's dead \`aborterRef\` and unused \`useRef\` import deleted.

### Bundled (D4) — opportunistic Tier 4 cleanup

Migrated inline \`{ ... } as ReturnType<typeof useAuthState>\` test fixtures in \`HeraldView.test.tsx\`, \`HeraldView-edit.test.tsx\`, \`SquadView.test.tsx\` to the type-safe \`makeFakeAuthState\` factory. Locks the AuthState contract in admin-view tests and cuts one Tier 4 polish item.

## Test plan

- [x] \`grep -rn \"token!\" app/src/\` — zero matches
- [x] \`grep -rn \"aborterRef\" app/src/\` — zero matches
- [x] HeraldView abort-on-unmount + defensive token-guard tests green
- [x] SquadView abort-on-unmount test green
- [x] DashboardView abort-on-unmount test green (vault + activity)
- [x] SettingsView 5 existing tests still pass after dead-ref cleanup
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] App tests: 456 → 460 (+4), 74 files, no regressions
- [x] Spec compliance review: ✅ (all D1-D6 verified)
- [x] Code-quality review: ✅ Approve (no Critical/Important; 2 Minor mock-hygiene gaps + 1 SettingsView pattern inconsistency filed as #234, #235)

Closes #198
Closes #199