### PR TITLE
fix(app): hardcoded data cleanup (P1) — D10 compliance

### DIFF
--- a/app/src/components/PrivacyScoreCard.tsx
+++ b/app/src/components/PrivacyScoreCard.tsx
@@ -60,15 +60,15 @@ export function PrivacyScoreCard({ data, delta }: PrivacyScoreCardProps) {
                 >
                   <JargonTerm term="Privacy Score">PRIVACY SCORE</JargonTerm>
                 </div>
-                <div className="text-base mt-1">
-                  {delta != null && (
+                {delta != null && (
+                  <div className="text-base mt-1">
                     <span className="text-cyan font-mono">
                       {delta > 0 ? '+' : ''}
                       {delta}
                     </span>
-                  )}
-                  <span className="text-text-muted"> vs last week</span>
-                </div>
+                    <span className="text-text-muted"> vs last week</span>
+                  </div>
+                )}
               </div>
               <button
                 type="button"

--- a/app/src/components/__tests__/PrivacyScoreCard.test.tsx
+++ b/app/src/components/__tests__/PrivacyScoreCard.test.tsx
@@ -82,10 +82,16 @@ describe('PrivacyScoreCard', () => {
     expect(navigateMock).toHaveBeenCalledWith('/privacy-report')
   })
 
-  it('omits delta block when delta is undefined', () => {
+  it('renders nothing for delta section when delta is undefined', () => {
     renderCard({ data: fakeData })
-    expect(screen.queryByText(/vs last week/)).toBeInTheDocument()
+    expect(screen.queryByText(/vs last week/)).toBeNull()
     expect(screen.queryByText('+4')).not.toBeInTheDocument()
+  })
+
+  it('renders both delta and " vs last week" when delta is provided', () => {
+    renderCard({ data: null, delta: 3 })
+    expect(screen.getByText('+3')).toBeInTheDocument()
+    expect(screen.getByText(/vs last week/)).toBeInTheDocument()
   })
 
   it('opens Sheet teaser with UnauthedEmptyState when View report clicked unauthed', () => {

--- a/app/src/components/vault/RoutePreviewCard.tsx
+++ b/app/src/components/vault/RoutePreviewCard.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react'
 import { Card } from '../ui/Card'
 import { HashCell } from '../ui/HashCell'
 import { JargonTerm } from '../ui/JargonTerm'
+import { useNetworkConfigStore } from '../../lib/networkConfig'
 
 interface RoutePreviewCardProps {
   wallet: string
@@ -11,15 +12,31 @@ interface RoutePreviewCardProps {
   vaultPda?: string
 }
 
-const DEFAULT_VAULT_PDA = 'CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u'
-
 export function RoutePreviewCard({
   wallet,
   amount,
   asset,
   stealthIndex,
-  vaultPda = DEFAULT_VAULT_PDA,
+  vaultPda,
 }: RoutePreviewCardProps) {
+  const network = useNetworkConfigStore((s) => s.config?.network)
+  const networkVaultPda = useNetworkConfigStore((s) => s.config?.vaultConfig)
+
+  if (network === 'mainnet') {
+    return (
+      <Card variant="default" className="p-4">
+        <div
+          className="text-2xs text-text-muted mb-3"
+          style={{ letterSpacing: 'var(--tracking-widest)' }}
+        >
+          ROUTE PREVIEW
+        </div>
+        <p className="text-xs text-text-muted">Vault on mainnet coming soon</p>
+      </Card>
+    )
+  }
+
+  const resolvedVaultPda = vaultPda ?? networkVaultPda ?? ''
   const hasAmount = typeof amount === 'number' && amount > 0 && asset
   const amountLabel = hasAmount ? `${amount} ${asset}` : '—'
   const stealthLabel =
@@ -49,7 +66,13 @@ export function RoutePreviewCard({
         <Step
           n={2}
           label={<JargonTerm term="Vault PDA">Vault PDA</JargonTerm>}
-          detail={<HashCell hash={vaultPda} />}
+          detail={
+            resolvedVaultPda ? (
+              <HashCell hash={resolvedVaultPda} />
+            ) : (
+              <span className="text-text-muted">—</span>
+            )
+          }
         />
         <div className="ml-3 text-text-muted">↓</div>
         <Step

--- a/app/src/components/vault/StealthAddressList.tsx
+++ b/app/src/components/vault/StealthAddressList.tsx
@@ -120,11 +120,6 @@ function StealthTreeSection({
               </div>
             </div>
           ))}
-          {stealthTree.length === 1 && (
-            <Chip tone="neutral" className="self-start mt-2">
-              M19 — Derived stealth tree expands when M19 ships
-            </Chip>
-          )}
         </div>
       )}
     </Card>

--- a/app/src/components/vault/__tests__/RoutePreviewCard.test.tsx
+++ b/app/src/components/vault/__tests__/RoutePreviewCard.test.tsx
@@ -1,6 +1,29 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+
+type NetworkConfig = {
+  network: 'devnet' | 'mainnet'
+  vaultConfig: string
+} | null
+
+let networkConfigValue: NetworkConfig = {
+  network: 'devnet',
+  vaultConfig: 'CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u',
+}
+
+vi.mock('../../../lib/networkConfig', () => ({
+  useNetworkConfigStore: <T,>(selector: (s: { config: NetworkConfig }) => T) =>
+    selector({ config: networkConfigValue }),
+}))
+
 import { RoutePreviewCard } from '../RoutePreviewCard'
+
+beforeEach(() => {
+  networkConfigValue = {
+    network: 'devnet',
+    vaultConfig: 'CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u',
+  }
+})
 
 describe('RoutePreviewCard', () => {
   it('renders 3 numbered steps', () => {
@@ -46,9 +69,34 @@ describe('RoutePreviewCard', () => {
     const { container } = render(<RoutePreviewCard wallet="" />)
     // No focusable HashCell button with empty aria-label
     expect(container.querySelector('button[aria-label="Copy "]')).toBeNull()
-    // Vault PDA HashCell is still rendered (default)
+    // Vault PDA HashCell is still rendered (derived from network config)
     expect(
       container.querySelector('button[aria-label*="CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u"]'),
     ).not.toBeNull()
+  })
+
+  it('renders "Vault on mainnet coming soon" when network is mainnet', () => {
+    networkConfigValue = { network: 'mainnet', vaultConfig: '' }
+    render(<RoutePreviewCard wallet="C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N" />)
+    expect(screen.getByText(/Vault on mainnet coming soon/i)).toBeInTheDocument()
+    expect(screen.queryByText(/Vault PDA/)).toBeNull()
+  })
+
+  it('uses vaultConfig from the network store when on devnet', () => {
+    networkConfigValue = {
+      network: 'devnet',
+      vaultConfig: 'D3vN3tVaultPDA111111111111111111111111111111',
+    }
+    const { container } = render(
+      <RoutePreviewCard wallet="C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N" />,
+    )
+    // The derived PDA from the store appears in the rendered HashCell
+    expect(
+      container.querySelector(
+        'button[aria-label*="D3vN3tVaultPDA111111111111111111111111111111"]',
+      ),
+    ).not.toBeNull()
+    // Mainnet copy must NOT render on devnet
+    expect(screen.queryByText(/Vault on mainnet/i)).toBeNull()
   })
 })

--- a/app/src/components/vault/__tests__/StealthAddressList.test.tsx
+++ b/app/src/components/vault/__tests__/StealthAddressList.test.tsx
@@ -42,9 +42,9 @@ describe('StealthAddressList', () => {
     expect(screen.getByText("m/0'")).toBeInTheDocument()
   })
 
-  it('renders M19 banner when stealthTree has only the root node', () => {
+  it('does not render M19 placeholder copy', () => {
     render(<StealthAddressList positions={[]} stealthTree={[fakeNode]} loading={false} />)
-    expect(screen.getByText(/M19/i)).toBeInTheDocument()
+    expect(screen.queryByText(/M19/i)).toBeNull()
   })
 
   it('renders empty-positions empty-state copy', () => {

--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -151,7 +151,7 @@ export default function DashboardView({ events }: { events: ActivityEvent[] }) {
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2">
-          <PrivacyScoreCard data={privacyData} delta={4} />
+          <PrivacyScoreCard data={privacyData} />
         </div>
         <div>
           <ShieldedVolumeCard />


### PR DESCRIPTION
## Summary

Closes 3 P1 QA findings related to hardcoded mock data and orphan placeholder copy that violate D10 (no mock data — every visible string/number must be real or removed) from the Phase 4b redesign spec.

- **#195** PrivacyScoreCard: dropped hardcoded `delta={4}` at DashboardView call site; wrapped both the delta `<span>` and the " vs last week" label in a single `{delta != null && ...}` block so neither renders orphaned when delta is absent. Strict-D10 invisible (no em-dash, no "N/A").
- **#196** RoutePreviewCard: derived vault PDA from `useNetworkConfigStore.config.vaultConfig` (backend-sourced via `/api/config`) instead of hardcoded constant. Mainnet renders "Vault on mainnet coming soon" empty state until vault deploys there.
- **#197** StealthAddressList: removed M19 placeholder Chip entirely. `Chip` import preserved (still used by Cooldown/Refundable/symbol badges).

## Spec + Plan

- Spec: `docs/superpowers/specs/2026-05-11-qa-sweep-tier-4-design.md` (Cluster A — Hardcoded data cleanup)
- Plan: `docs/superpowers/plans/2026-05-11-qa-sweep-tier-4-wave-1.md`

## Notable adaptation

For #196, used the existing `useNetworkConfigStore.config.vaultConfig` field instead of deriving the PDA client-side via SDK helper or `findProgramAddressSync`. The backend already populates this from `/api/config`, so it's the canonical single-source-of-truth across networks. Avoids client/SDK derivation drift if the program ID changes. The `vaultPda` prop is preserved as an optional override for callers that need to force a value.

## Test plan

- [x] New: PrivacyScoreCard renders no delta/label when delta undefined; renders both when defined
- [x] New: RoutePreviewCard renders mainnet fallback copy
- [x] New: RoutePreviewCard derives devnet PDA from network store
- [x] Inverted: StealthAddressList no longer renders M19 placeholder
- [x] App test count: 460 → 463 (+3)
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] DashboardView, VaultView, DepositView integration tests still pass

Closes #195
Closes #196
Closes #197