### PR TITLE
fix(app): auth/session UX hardening (P1+P2)

### DIFF
--- a/app/src/providers/AuthSyncProvider.tsx
+++ b/app/src/providers/AuthSyncProvider.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useEffect, useMemo, useRef, useState, ReactN
 import { useWallet } from '@solana/wallet-adapter-react'
 import { useWalletModal } from '@solana/wallet-adapter-react-ui'
 import { useAppStore } from '../stores/app'
+import { useOnAuthClear } from '../store/useOnAuthClear'
 import { decodeJwtPayload, isJwtExpired } from '../lib/jwt'
 import { requestNonce, verifySignature } from '../api/auth'
 import { refreshToken } from '../api/refresh'
@@ -27,6 +28,15 @@ export interface AuthState {
  * successful re-auth or once the timer fires.
  */
 const SESSION_EXPIRED_DEDUP_MS = 30_000
+
+/**
+ * Default `localStorageKey` for `@solana/wallet-adapter-react`'s
+ * `WalletProvider`. Mirroring the constant here keeps the cleanup in
+ * `onAuthClear` aligned with what the adapter persists. If `App.tsx`
+ * ever passes a custom `localStorageKey` to `WalletProvider`, update
+ * this constant in lockstep. See #213.
+ */
+const WALLET_ADAPTER_STORAGE_KEY = 'walletName'
 
 const AuthSyncContext = createContext<AuthState | null>(null)
 
@@ -285,6 +295,23 @@ export function AuthSyncProvider({ children }: { children: ReactNode }) {
       sessionExpiredToastTimerRef.current = null
     }
   }, [status])
+
+  // Clear the wallet-adapter's persisted `walletName` whenever the auth
+  // store transitions to cleared. Without this, a user who picks a wallet,
+  // fails (or skips) sign-in, then reloads gets silently auto-reconnected
+  // to a wallet they never authenticated with. Fires ONLY via the
+  // `onAuthClear` registry — i.e. on explicit `clearAuth()` calls — never
+  // on initial mount, so returning users with a valid JWT still benefit
+  // from the adapter's `autoConnect`. See #213.
+  useOnAuthClear(() => {
+    try {
+      localStorage.removeItem(WALLET_ADAPTER_STORAGE_KEY)
+    } catch {
+      // localStorage may be unavailable (Safari private mode, quota errors).
+      // Best-effort cleanup — the next mount will simply retain the stale
+      // walletName, which is no worse than the pre-fix behavior.
+    }
+  })
 
   const value: AuthState = {
     status,

--- a/app/src/providers/AuthSyncProvider.tsx
+++ b/app/src/providers/AuthSyncProvider.tsx
@@ -21,6 +21,13 @@ export interface AuthState {
   error: string | null
 }
 
+/**
+ * Dedup window for the "Session expired" toast (#203). Concurrent 401s
+ * within this window emit only the first toast; the flag clears on a
+ * successful re-auth or once the timer fires.
+ */
+const SESSION_EXPIRED_DEDUP_MS = 30_000
+
 const AuthSyncContext = createContext<AuthState | null>(null)
 
 export function useAuthSyncContext(): AuthState {
@@ -49,6 +56,16 @@ export function AuthSyncProvider({ children }: { children: ReactNode }) {
   // autoConnect resolves) would clear auth on every page load.
   const wasConnectedRef = useRef(false)
   const authenticateRef = useRef<() => Promise<void>>(() => Promise.resolve())
+  // Single-shot guard for the "Session expired" toast: when several in-flight
+  // requests all fail with 401 concurrently the registered interceptor fires
+  // once per failure, and without dedup the user gets a stack of identical
+  // toasts. The flag flips true on first emission and resets on either a
+  // successful re-auth (status transitions back to 'authed') or after a
+  // SESSION_EXPIRED_DEDUP_MS window. See #203.
+  const sessionExpiredToastShownRef = useRef(false)
+  const sessionExpiredToastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  )
 
   // Track wallet identity across renders; clear auth when the wallet changes.
   useEffect(() => {
@@ -219,10 +236,21 @@ export function AuthSyncProvider({ children }: { children: ReactNode }) {
 
   // Wire the global 401 interceptor: any apiFetch that returns 401 clears
   // the token and surfaces a "Session expired — Sign in" toast with a CTA
-  // that re-runs authenticate().
+  // that re-runs authenticate(). The toast is deduplicated via a
+  // single-shot ref so a burst of concurrent 401s does not stack toasts;
+  // the flag clears on next successful auth or after the dedup window.
   useEffect(() => {
     registerAuthInterceptor(() => {
       clearAuth()
+      if (sessionExpiredToastShownRef.current) return
+      sessionExpiredToastShownRef.current = true
+      if (sessionExpiredToastTimerRef.current) {
+        clearTimeout(sessionExpiredToastTimerRef.current)
+      }
+      sessionExpiredToastTimerRef.current = setTimeout(() => {
+        sessionExpiredToastShownRef.current = false
+        sessionExpiredToastTimerRef.current = null
+      }, SESSION_EXPIRED_DEDUP_MS)
       showToast({
         message: 'Session expired — please sign in again.',
         kind: 'warn',
@@ -238,8 +266,25 @@ export function AuthSyncProvider({ children }: { children: ReactNode }) {
         },
       })
     })
-    return () => registerAuthInterceptor(null)
+    return () => {
+      registerAuthInterceptor(null)
+      if (sessionExpiredToastTimerRef.current) {
+        clearTimeout(sessionExpiredToastTimerRef.current)
+        sessionExpiredToastTimerRef.current = null
+      }
+    }
   }, [clearAuth, showToast])
+
+  // Reset the dedup guard whenever auth flips back to 'authed' — a fresh
+  // successful sign-in means the next expiry should surface a new toast.
+  useEffect(() => {
+    if (status !== 'authed') return
+    sessionExpiredToastShownRef.current = false
+    if (sessionExpiredToastTimerRef.current) {
+      clearTimeout(sessionExpiredToastTimerRef.current)
+      sessionExpiredToastTimerRef.current = null
+    }
+  }, [status])
 
   const value: AuthState = {
     status,

--- a/app/src/providers/__tests__/AuthSyncProvider.test.tsx
+++ b/app/src/providers/__tests__/AuthSyncProvider.test.tsx
@@ -984,3 +984,63 @@ describe('AuthSyncProvider — 401 interceptor toast dedup (#203)', () => {
     global.fetch = originalFetch
   })
 })
+
+describe('AuthSyncProvider — walletName localStorage cleanup (#213)', () => {
+  beforeEach(() => {
+    useAppStore.setState({ token: null, isAdmin: false, expiresAt: null }, false)
+    mockedUseWallet.mockReset()
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('clears walletName from localStorage when clearAuth fires', () => {
+    mockedUseWallet.mockReturnValue({
+      connected: false,
+      publicKey: null,
+      wallet: null,
+      signMessage: undefined,
+      disconnect: vi.fn(),
+    })
+    // The wallet-adapter persists the chosen wallet name as a JSON string.
+    localStorage.setItem('walletName', JSON.stringify('Phantom'))
+
+    render(
+      <AuthSyncProvider>
+        <div />
+      </AuthSyncProvider>,
+    )
+
+    expect(localStorage.getItem('walletName')).toBe(JSON.stringify('Phantom'))
+
+    act(() => {
+      useAppStore.getState().clearAuth()
+    })
+
+    expect(localStorage.getItem('walletName')).toBeNull()
+  })
+
+  it('does NOT clear walletName on initial mount (autoConnect happy path)', () => {
+    mockedUseWallet.mockReturnValue({
+      connected: false,
+      publicKey: null,
+      wallet: null,
+      signMessage: undefined,
+      disconnect: vi.fn(),
+    })
+    localStorage.setItem('walletName', JSON.stringify('Phantom'))
+
+    render(
+      <AuthSyncProvider>
+        <div />
+      </AuthSyncProvider>,
+    )
+
+    // Cleanup only fires on clearAuth — returning users with a valid JWT
+    // (or any user whose autoConnect is still resolving) keep the persisted
+    // walletName so the adapter can reconnect.
+    expect(localStorage.getItem('walletName')).toBe(JSON.stringify('Phantom'))
+  })
+})

--- a/app/src/providers/__tests__/AuthSyncProvider.test.tsx
+++ b/app/src/providers/__tests__/AuthSyncProvider.test.tsx
@@ -3,8 +3,9 @@ import { render, screen, act } from '@testing-library/react'
 import { AuthSyncProvider } from '../AuthSyncProvider'
 import { useAuthState, type AuthState } from '../../hooks/useAuthState'
 import { useAppStore } from '../../stores/app'
+import type { ToastInput } from '../../components/Toast'
 
-const mockToastShow = vi.fn(() => 'toast-id')
+const mockToastShow = vi.fn((_: ToastInput): string => 'toast-id')
 const mockToastDismiss = vi.fn()
 vi.mock('../ToastProvider', () => ({
   useToast: () => ({ show: mockToastShow, dismiss: mockToastDismiss }),
@@ -833,5 +834,153 @@ describe('AuthSyncProvider — authenticate', () => {
       await pending!
     })
     expect(captured.current!.status).toBe('authed')
+  })
+})
+
+describe('AuthSyncProvider — 401 interceptor toast dedup (#203)', () => {
+  beforeEach(() => {
+    useAppStore.setState({ token: null, isAdmin: false, expiresAt: null }, false)
+    mockedUseWallet.mockReset()
+    mockToastShow.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('emits only one "Session expired" toast when multiple 401s fire concurrently', async () => {
+    mockedUseWallet.mockReturnValue({
+      connected: false,
+      publicKey: null,
+      wallet: null,
+      signMessage: undefined,
+      disconnect: vi.fn(),
+    })
+
+    render(
+      <AuthSyncProvider>
+        <div />
+      </AuthSyncProvider>,
+    )
+
+    const { triggerAuthInterceptor } = await import('../../api/client')
+
+    act(() => {
+      triggerAuthInterceptor()
+      triggerAuthInterceptor()
+      triggerAuthInterceptor()
+    })
+
+    const toastCalls = mockToastShow.mock.calls.filter(([input]) =>
+      /session expired/i.test(input.message),
+    )
+    expect(toastCalls).toHaveLength(1)
+  })
+
+  it('re-emits toast after 30s dedup window expires', async () => {
+    vi.useFakeTimers()
+    mockedUseWallet.mockReturnValue({
+      connected: false,
+      publicKey: null,
+      wallet: null,
+      signMessage: undefined,
+      disconnect: vi.fn(),
+    })
+
+    render(
+      <AuthSyncProvider>
+        <div />
+      </AuthSyncProvider>,
+    )
+
+    const { triggerAuthInterceptor } = await import('../../api/client')
+    const matches = () =>
+      mockToastShow.mock.calls.filter(([input]) =>
+        /session expired/i.test(input.message),
+      )
+
+    act(() => {
+      triggerAuthInterceptor()
+    })
+    expect(matches()).toHaveLength(1)
+
+    // Inside the window: subsequent 401s do NOT emit additional toasts.
+    act(() => {
+      triggerAuthInterceptor()
+    })
+    expect(matches()).toHaveLength(1)
+
+    // Past the 30s window: next 401 emits a fresh toast.
+    act(() => {
+      vi.advanceTimersByTime(31_000)
+    })
+
+    act(() => {
+      triggerAuthInterceptor()
+    })
+    expect(matches()).toHaveLength(2)
+  })
+
+  it('clears the dedup flag after successful auth so a later 401 re-emits the toast', async () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 86400
+    const issuedToken = makeJwtForTest({ wallet: 'W', exp: futureExp })
+    const mockSignMessage = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]))
+    mockedUseWallet.mockReturnValue({
+      connected: true,
+      publicKey: { toBase58: () => 'W' },
+      wallet: null,
+      signMessage: mockSignMessage,
+      disconnect: vi.fn(),
+    })
+
+    const originalFetch = global.fetch
+    global.fetch = vi.fn() as unknown as typeof fetch
+    ;(global.fetch as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ nonce: 'n', message: 'm' }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ token: issuedToken, isAdmin: false, expiresIn: '24h' }),
+      })
+
+    const captured: { current: AuthState | null } = { current: null }
+    function Capture() {
+      captured.current = useAuthState()
+      return null
+    }
+
+    render(
+      <AuthSyncProvider>
+        <Capture />
+      </AuthSyncProvider>,
+    )
+
+    const { triggerAuthInterceptor } = await import('../../api/client')
+    const matches = () =>
+      mockToastShow.mock.calls.filter(([input]) =>
+        /session expired/i.test(input.message),
+      )
+
+    act(() => {
+      triggerAuthInterceptor()
+    })
+    expect(matches()).toHaveLength(1)
+
+    // A second 401 inside the dedup window is suppressed.
+    act(() => {
+      triggerAuthInterceptor()
+    })
+    expect(matches()).toHaveLength(1)
+
+    // Successful re-auth resets the flag.
+    await act(async () => {
+      await captured.current!.authenticate()
+    })
+
+    act(() => {
+      triggerAuthInterceptor()
+    })
+    expect(matches()).toHaveLength(2)
+
+    global.fetch = originalFetch
   })
 })


### PR DESCRIPTION
## Summary

Closes 2 auth-lifecycle QA findings:

- **#203 (P1)** "Session expired" toast no longer stacks when multiple in-flight 401s fire concurrently. Single-shot \`sessionExpiredToastShownRef\` in AuthSyncProvider gates emission; flag resets on (a) status transitioning to \`'authed'\` (successful re-auth) or (b) 30s timeout. Both reset paths tested.
- **#213 (P2)** \`walletName\` localStorage carryover cleared on \`clearAuth\` via the \`onAuthClear\` registry (Tier 0+1). User who cancels wallet popup or has JWT expire no longer gets stuck with persisted walletName triggering ghost auto-reconnect on next mount.

## Cleanup mechanism for #213: Option B — Direct \`localStorage.removeItem('walletName')\` via \`useOnAuthClear\`

Chose Option B over Option A (\`useWallet().disconnect()\`) because:

1. The wallet-adapter's internal \`setWalletName(null)\` only fires on the adapter's \`'disconnect'\` event, which is gated on \`isUnloadingRef.current\` AND requires a currently-connected adapter. In the scenarios we care about (stale walletName with no active adapter, JWT expired before autoConnect resolves, user cancels wallet popup but adapter never fully connected), calling \`disconnect()\` is either a no-op or non-deterministic.
2. D-B3 is explicit: cleanup must hook into \`onAuthClear\` registry. The registry is designed for synchronous, deterministic side-effects — not adapter lifecycle orchestration.
3. Direct cleanup pairs cleanly with D-B3's happy-path requirement: only fires when \`clearAuth()\` is invoked, so a returning user with valid JWT never triggers it and \`walletName\` persists for the adapter's \`autoConnect\`.

Module-scope \`WALLET_ADAPTER_STORAGE_KEY = 'walletName'\` mirrors \`@solana/wallet-adapter-react@0.15.39\`'s default \`localStorageKey\`. Comment instructs updating in lockstep if \`App.tsx\` ever passes a custom key.

## Spec + Plan

- Spec: \`docs/superpowers/specs/2026-05-11-qa-sweep-tier-4-design.md\` (Cluster B — Auth/session UX)
- Plan: \`docs/superpowers/plans/2026-05-11-qa-sweep-tier-4-wave-1.md\`

## Test plan

- [x] New: concurrent 401s emit exactly 1 "Session expired" toast
- [x] New: post-30s-window expiry, next 401 emits a fresh toast (fake-timer paired with useRealTimers cleanup)
- [x] New: dedup flag resets when status transitions to 'authed' so subsequent 401s re-emit
- [x] New: \`walletName\` cleared on \`clearAuth\` invocation
- [x] New: returning user with valid JWT keeps walletName (cleanup does NOT fire on initial mount)
- [x] App test count: 460 → 465 (+5)
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] All 31 AuthSyncProvider tests pass

Closes #203
Closes #213