### PR TITLE
chore(app): tech-debt followups from Tier 0+1+3

### DIFF
--- a/app/src/api/__tests__/client.test.ts
+++ b/app/src/api/__tests__/client.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { apiFetch, registerAuthInterceptor, triggerAuthInterceptor } from '../client'
+import {
+  apiFetch,
+  registerAuthInterceptor,
+  triggerAuthInterceptor,
+  _resetClientForTests,
+} from '../client'
 
 describe('apiFetch', () => {
   const originalFetch = global.fetch
@@ -146,9 +151,11 @@ describe('apiFetch network-error branch', () => {
   let originalFetch: typeof globalThis.fetch
   beforeEach(() => {
     originalFetch = globalThis.fetch
+    _resetClientForTests()
   })
   afterEach(() => {
     globalThis.fetch = originalFetch
+    _resetClientForTests()
   })
 
   it('emits a network-error CustomEvent on TypeError: Failed to fetch', async () => {
@@ -171,15 +178,43 @@ describe('apiFetch network-error branch', () => {
     window.removeEventListener('sipher:network-error', handler)
   })
 
-  it('emits network-recovered on successful fetch', async () => {
+  it('does NOT emit network-recovered on first successful fetch (was never offline)', async () => {
+    // Lock: recovery is a transition event. Without a prior network-error
+    // there is nothing to recover from, so the banner must not flash.
     globalThis.fetch = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ ok: true }), { status: 200 }),
     )
     const handler = vi.fn()
     window.addEventListener('sipher:network-recovered', handler)
     await apiFetch('/whatever')
-    expect(handler).toHaveBeenCalledOnce()
+    expect(handler).not.toHaveBeenCalled()
     window.removeEventListener('sipher:network-recovered', handler)
+  })
+
+  it('emits network-recovered ONLY after a prior network error (offline→online transition)', async () => {
+    const recoveredHandler = vi.fn()
+    window.addEventListener('sipher:network-recovered', recoveredHandler)
+
+    // Step 1: simulate going offline via a real network TypeError.
+    globalThis.fetch = vi.fn().mockRejectedValueOnce(new TypeError('Failed to fetch'))
+    await expect(apiFetch('/foo')).rejects.toThrow()
+    expect(recoveredHandler).not.toHaveBeenCalled()
+
+    // Step 2: next successful fetch fires recovery exactly once.
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    )
+    await apiFetch('/foo')
+    expect(recoveredHandler).toHaveBeenCalledOnce()
+
+    // Step 3: subsequent successes do NOT refire (offline flag was reset).
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    )
+    await apiFetch('/foo')
+    expect(recoveredHandler).toHaveBeenCalledOnce()
+
+    window.removeEventListener('sipher:network-recovered', recoveredHandler)
   })
 
   it('preserves AbortError name through the network-error catch wrapper', async () => {

--- a/app/src/api/__tests__/client.test.ts
+++ b/app/src/api/__tests__/client.test.ts
@@ -201,6 +201,41 @@ describe('apiFetch network-error branch', () => {
     expect(handler).not.toHaveBeenCalled()
     window.removeEventListener('sipher:network-error', handler)
   })
+
+  it('does NOT emit network-error for non-network TypeErrors (e.g. JSON parse)', async () => {
+    // A TypeError thrown from a downstream codepath (e.g., `Cannot read
+    // properties of undefined`) is NOT a network failure and must not pollute
+    // the NetworkBanner. Lock: only the canonical browser network-error
+    // message strings trigger the network-error event.
+    globalThis.fetch = vi.fn().mockRejectedValue(
+      new TypeError('Cannot read properties of undefined (reading "foo")'),
+    )
+    const handler = vi.fn()
+    window.addEventListener('sipher:network-error', handler)
+    await expect(apiFetch('/whatever')).rejects.toThrow()
+    expect(handler).not.toHaveBeenCalled()
+    window.removeEventListener('sipher:network-error', handler)
+  })
+
+  it('emits network-error for Safari "Load failed" TypeError', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new TypeError('Load failed'))
+    const handler = vi.fn()
+    window.addEventListener('sipher:network-error', handler)
+    await expect(apiFetch('/whatever')).rejects.toThrow()
+    expect(handler).toHaveBeenCalledOnce()
+    window.removeEventListener('sipher:network-error', handler)
+  })
+
+  it('emits network-error for Firefox "NetworkError when attempting to fetch resource" TypeError', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(
+      new TypeError('NetworkError when attempting to fetch resource'),
+    )
+    const handler = vi.fn()
+    window.addEventListener('sipher:network-error', handler)
+    await expect(apiFetch('/whatever')).rejects.toThrow()
+    expect(handler).toHaveBeenCalledOnce()
+    window.removeEventListener('sipher:network-error', handler)
+  })
 })
 
 describe('triggerAuthInterceptor', () => {

--- a/app/src/api/client.ts
+++ b/app/src/api/client.ts
@@ -39,14 +39,31 @@ export function triggerAuthInterceptor(): void {
 // (NetworkError when attempting to fetch resource).
 const NETWORK_ERROR_PATTERN = /^(Failed to fetch|Load failed|NetworkError when attempting to fetch resource)$/i
 
+// Module-scope offline flag. Flipped to `true` when a real network-error
+// fires; gates the recovery emit so the banner only animates on actual
+// offline→online transitions instead of flashing on every successful fetch.
+let wasOffline = false
+
 function emitNetworkError(): void {
+  wasOffline = true
   if (typeof window === 'undefined') return
   window.dispatchEvent(new CustomEvent('sipher:network-error'))
 }
 
 function emitNetworkRecovered(): void {
+  if (!wasOffline) return
+  wasOffline = false
   if (typeof window === 'undefined') return
   window.dispatchEvent(new CustomEvent('sipher:network-recovered'))
+}
+
+/**
+ * Test-only helper. Resets module-scope state (currently just `wasOffline`).
+ * Tests that exercise the offline→online transition logic call this in
+ * `beforeEach`/`afterEach` so suites can't leak the flag between cases.
+ */
+export function _resetClientForTests(): void {
+  wasOffline = false
 }
 
 export async function apiFetch<T>(

--- a/app/src/api/client.ts
+++ b/app/src/api/client.ts
@@ -30,6 +30,15 @@ export function triggerAuthInterceptor(): void {
   }
 }
 
+// Canonical browser messages for actual network-layer fetch failures.
+// `fetch` throws a generic TypeError for many distinct codepaths (offline DNS,
+// CORS preflight refusal, a bug downstream of fetch itself); only the
+// browser-emitted "this request never reached the network" messages are
+// genuine network errors and should surface to <NetworkBanner>.
+// Sources: WHATWG fetch spec (Failed to fetch), Safari (Load failed), Firefox
+// (NetworkError when attempting to fetch resource).
+const NETWORK_ERROR_PATTERN = /^(Failed to fetch|Load failed|NetworkError when attempting to fetch resource)$/i
+
 function emitNetworkError(): void {
   if (typeof window === 'undefined') return
   window.dispatchEvent(new CustomEvent('sipher:network-error'))
@@ -57,9 +66,11 @@ export async function apiFetch<T>(
     })
   } catch (err) {
     // Network-layer failure (offline, DNS, CORS preflight refusal): browsers
-    // throw `TypeError: Failed to fetch`. Surface to the global event bus so
-    // <NetworkBanner> can react; rethrow so callers still see the error.
-    if (err instanceof TypeError) {
+    // throw `TypeError` with one of the canonical messages tracked above.
+    // Other TypeErrors (e.g., `Cannot read property X of undefined` from a
+    // bug downstream of fetch) must NOT trigger the network banner — they
+    // surface as ordinary failures to the caller.
+    if (err instanceof TypeError && NETWORK_ERROR_PATTERN.test(err.message)) {
       emitNetworkError()
       throw new Error('Network connection lost')
     }

--- a/app/src/hooks/__tests__/useSSE.test.ts
+++ b/app/src/hooks/__tests__/useSSE.test.ts
@@ -55,6 +55,37 @@ describe('useSSE', () => {
     await waitFor(() => expect(result.current.events).toHaveLength(0))
   })
 
+  it('skips state setters and closes resolved source when auth clears mid-connectSSE resolution', async () => {
+    // Race: connectSSE returns a Promise. If auth clears AFTER connectSSE
+    // is called but BEFORE the Promise resolves, the eventual .then
+    // callback must NOT push the resolved source into state — that would
+    // bypass the auth-clear cleanup the user just performed.
+    let resolveConnect: ((source: EventSource) => void) | null = null
+    const connectPromise = new Promise<EventSource>((resolve) => {
+      resolveConnect = resolve
+    })
+    const closeMock = vi.fn()
+    const mockSource = {
+      close: closeMock,
+      addEventListener: vi.fn(),
+      onerror: null,
+    } as unknown as EventSource
+    ;(connectSSE as ReturnType<typeof vi.fn>).mockReturnValueOnce(connectPromise)
+
+    const { result } = renderHook(() => useSSE())
+    // Auth clears BEFORE connectSSE resolves.
+    act(() => onAuthClear.clearAll())
+    // NOW resolve connectSSE — the resolved source must be closed and
+    // state setters must skip.
+    await act(async () => {
+      resolveConnect!(mockSource)
+      await connectPromise
+    })
+
+    expect(result.current.connected).toBe(false)
+    expect(closeMock).toHaveBeenCalled()
+  })
+
   it('keeps events on transient EventSource error and only flips connected to false', async () => {
     let onMessageCb: ((e: MessageEvent) => void) | null = null
     const onerrorRef: { current: (() => void) | null } = { current: null }

--- a/app/src/hooks/useSSE.ts
+++ b/app/src/hooks/useSSE.ts
@@ -17,8 +17,13 @@ export function useSSE() {
   const [events, setEvents] = useState<ActivityEvent[]>([])
   const [connected, setConnected] = useState(false)
   const sourceRef = useRef<EventSource | null>(null)
+  // Flips to `true` when onAuthClear fires while a connectSSE Promise is
+  // still pending. The .then handler checks this before any state setter
+  // so a stale resolution can't bypass auth-clear cleanup.
+  const authClearedRef = useRef(false)
 
   useOnAuthClear(() => {
+    authClearedRef.current = true
     setEvents([])
     setConnected(false)
     sourceRef.current?.close()
@@ -29,12 +34,16 @@ export function useSSE() {
     if (!token) { setConnected(false); return }
 
     let cancelled = false
+    // Fresh connect attempt — reset the auth-cleared flag so this attempt
+    // is allowed to land. If auth clears mid-resolution, the flag flips
+    // back to true and the .then handler will short-circuit.
+    authClearedRef.current = false
 
     connectSSE(token, (e) => {
       const data = JSON.parse(e.data) as ActivityEvent
       setEvents(prev => [data, ...prev].slice(0, 200))
     }).then((source) => {
-      if (cancelled) { source.close(); return }
+      if (cancelled || authClearedRef.current) { source.close(); return }
       sourceRef.current = source
       setConnected(true)
       // EventSource fires onerror on every transient blip (1s WiFi hiccup,

--- a/app/src/store/__tests__/onAuthClear.test.ts
+++ b/app/src/store/__tests__/onAuthClear.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { onAuthClear } from '../onAuthClear'
 
 describe('onAuthClear registry', () => {
   beforeEach(() => {
     onAuthClear._resetForTests()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
   })
 
   it('register returns an unsubscribe function', () => {
@@ -41,11 +45,43 @@ describe('onAuthClear registry', () => {
   })
 
   it('a callback that throws does not block subsequent callbacks', () => {
+    // Vitest's default env is DEV=true, which routes the swallowed-error
+    // warning to console.warn. Suppress it here so the test output stays
+    // clean — the warn behavior itself is covered by the DEV-mode test
+    // below.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const a = vi.fn(() => { throw new Error('boom') })
     const b = vi.fn()
     onAuthClear.register(a)
     onAuthClear.register(b)
     expect(() => onAuthClear.clearAll()).not.toThrow()
     expect(b).toHaveBeenCalledOnce()
+    warnSpy.mockRestore()
+  })
+
+  it('warns in DEV mode when a registered callback throws', () => {
+    vi.stubEnv('DEV', true)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const err = new Error('boom')
+    onAuthClear.register(() => { throw err })
+    onAuthClear.clearAll()
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('onAuthClear callback threw'),
+      err,
+    )
+    warnSpy.mockRestore()
+  })
+
+  it('does NOT warn in production mode when a callback throws', () => {
+    vi.stubEnv('DEV', false)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    onAuthClear.register(() => { throw new Error('boom') })
+    onAuthClear.clearAll()
+
+    expect(warnSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
   })
 })

--- a/app/src/store/onAuthClear.ts
+++ b/app/src/store/onAuthClear.ts
@@ -28,9 +28,14 @@ function createRegistry(): OnAuthClearRegistry {
       for (const cb of snapshot) {
         try {
           cb()
-        } catch {
+        } catch (err) {
           // A consumer's cleanup throwing should not block other consumers.
-          // Swallow; auth-clear is best-effort UI cleanup.
+          // Swallow; auth-clear is best-effort UI cleanup. Surface the
+          // swallowed error in DEV so the developer sees it locally — in
+          // production we stay quiet to avoid polluting the user console.
+          if (import.meta.env.DEV) {
+            console.warn('onAuthClear callback threw (swallowed)', err)
+          }
         }
       }
     },

--- a/app/src/views/SettingsView.tsx
+++ b/app/src/views/SettingsView.tsx
@@ -57,6 +57,13 @@ export default function SettingsView() {
         if (!controller.signal.aborted) setConfig(r)
       })
       .catch((e: unknown) => {
+        // AbortError convention aligns with HeraldView/SquadView — the err
+        // name is the authoritative signal (works whether the abort came
+        // from this effect's controller or an upstream AbortError). The
+        // signal.aborted check remains as belt-and-suspenders against
+        // unmount races where setError would run after the controller's
+        // effect-cleanup fired but before the catch micro-task drained.
+        if (e instanceof Error && e.name === 'AbortError') return
         if (!controller.signal.aborted) {
           setError(e instanceof Error ? e.message : 'Failed to load config')
         }

--- a/app/src/views/__tests__/HeraldView.test.tsx
+++ b/app/src/views/__tests__/HeraldView.test.tsx
@@ -110,7 +110,19 @@ describe('HeraldView budget bar colors', () => {
 })
 
 describe('HeraldView AbortController', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    const { apiFetch } = await import('../../api/client')
+    // mockClear wipes call history but leaks any mockImplementation set in
+    // a prior test in this describe; mockReset clears both. Re-seed the
+    // file-level happy-path default so the second test (empty-token guard)
+    // can still assert "not called" against a clean default.
+    vi.mocked(apiFetch).mockReset()
+    vi.mocked(apiFetch).mockResolvedValue({
+      queue: [],
+      budget: { spent: 0, limit: 100, gate: 'open', percentage: 0 },
+      dms: [],
+      recentPosts: [],
+    })
     vi.mocked(useAuthState).mockReturnValue(
       makeFakeAuthState({ status: 'authed', token: 't', publicKey: 'pk', isAdmin: true }),
     )
@@ -132,7 +144,6 @@ describe('HeraldView AbortController', () => {
 
   it('does not call apiFetch when token prop is empty even with isAdmin', async () => {
     const { apiFetch } = await import('../../api/client')
-    vi.mocked(apiFetch).mockClear()
     const { container } = renderHerald('')
     expect(container.textContent).toMatch(/Connect your wallet to view HERALD activity/i)
     expect(vi.mocked(apiFetch)).not.toHaveBeenCalled()

--- a/app/src/views/__tests__/SettingsView.test.tsx
+++ b/app/src/views/__tests__/SettingsView.test.tsx
@@ -130,4 +130,22 @@ describe('SettingsView', () => {
       expect(screen.getByText(/\$10/)).toBeInTheDocument()
     })
   })
+
+  it('ignores AbortError thrown directly (not via controller.abort())', async () => {
+    // Regression-locker for the convention switch from
+    // `if (!signal.aborted)` to `if (err.name === 'AbortError') return`.
+    // An AbortError surfaced from a downstream code path (rather than via
+    // the local controller) must not paint the error card.
+    useAuthStateMock.mockReturnValue(
+      makeFakeAuthState({ publicKey: 'X', token: 't', status: 'authed', isAdmin: true }),
+    )
+    const abortError = Object.assign(new Error('aborted'), { name: 'AbortError' })
+    apiFetchMock.mockRejectedValueOnce(abortError)
+    const { default: SettingsView } = await import('../SettingsView')
+    const { container } = renderSettings(SettingsView)
+    await waitFor(() => {
+      expect(container.firstChild).not.toBeNull()
+    })
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
 })

--- a/app/src/views/__tests__/SquadView.test.tsx
+++ b/app/src/views/__tests__/SquadView.test.tsx
@@ -125,6 +125,17 @@ describe('SquadView KillSwitch tones', () => {
 
 describe('SquadView AbortController', () => {
   beforeEach(() => {
+    // mockClear wipes call history but leaks any mockImplementation set in
+    // a prior test in this describe; mockReset clears both. Re-seed the
+    // happy-path default so future tests added to this block can still
+    // assert on a clean default fixture instead of a never-resolving stub.
+    vi.mocked(apiFetch).mockReset()
+    vi.mocked(apiFetch).mockResolvedValue({
+      agents: [],
+      stats: { toolCalls: 0, walletSessions: 0, xPosts: 0, xReplies: 0, blocksScanned: 0, alerts: 0 },
+      coordination: [],
+      killSwitch: false,
+    })
     vi.mocked(useAuthState).mockReturnValue(
       makeFakeAuthState({ status: 'authed', token: 't', publicKey: 'pk', isAdmin: true }),
     )


### PR DESCRIPTION
## Summary

Closes 6 polish followups filed during prior Tier sprints (frontier_46 + frontier_48). All small, mechanical fixes to test patterns and error-handling edges. Applied in dependency order (D-F1):

1. **#227** Narrow \`apiFetch\` TypeError catch to actual network errors via regex \`/^(Failed to fetch|Load failed|NetworkError when attempting to fetch resource)$/i\`. JSON parse errors or other TypeErrors no longer fire spurious \`sipher:network-error\` events.
2. **#228** \`emitNetworkRecovered\` fires only on offline→online transition via module-scope \`wasOffline\` flag. Initial successful fetches no longer fire ghost recovery events.
3. **#225** \`useSSE\` \`authClearedRef\` prevents stale state setters when auth clears mid-\`connectSSE\` resolution. Resolved-but-abandoned source is \`.close()\`'d cleanly.
4. **#226** Dev-only \`console.warn\` (\`import.meta.env.DEV\` gated) when an \`onAuthClear\` callback throws. Helps developers surface registry-consumer bugs without polluting prod logs.
5. **#234** Added \`mockReset\` + default re-seed to the admin-view AbortController test beforeEach blocks (HeraldView.test.tsx + SquadView.test.tsx). Locks against future test-pollution from \`mockResolvedValueOnce\` leakage.
6. **#235** SettingsView abort-error filter standardized to \`err.name === 'AbortError'\` early-return pattern, matching the Tier 3 convention from HeraldView/SquadView/DashboardView/ChainsView (belt-and-suspenders with existing \`!signal.aborted\` gate).

## Test infrastructure addition

Added \`_resetClientForTests()\` named export on \`app/src/api/client.ts\` so the test suite can reset the new \`wasOffline\` module-scope flag between cases (parallel to the existing \`_resetAuthStateForTests\` pattern). Test-only export, explicitly authorized by spec D-F3.

## Spec + Plan

- Spec: \`docs/superpowers/specs/2026-05-11-qa-sweep-tier-4-design.md\` (Cluster F — Tech-debt followups)
- Plan: \`docs/superpowers/plans/2026-05-11-qa-sweep-tier-4-wave-1.md\`

## Test plan

- [x] New: apiFetch non-network TypeError does NOT emit \`sipher:network-error\` (3 positive + 1 negative branch coverage)
- [x] New: \`sipher:network-recovered\` fires only after a prior network-error event (offline→online transition)
- [x] New: useSSE skips state setters AND closes abandoned source when auth clears mid-resolution
- [x] New: onAuthClear throw → \`console.warn\` in DEV, silent in prod (2 branch tests with \`vi.stubEnv\`)
- [x] Added: \`mockReset\` + default re-seed in HeraldView + SquadView admin AbortController beforeEach blocks
- [x] New: SettingsView ignores AbortError thrown directly (regression-locker)
- [x] App test count: 460 → 468 (+8)
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] All 51 tests across the 6 touched test files pass

Closes #225
Closes #226
Closes #227
Closes #228
Closes #234
Closes #235