### PR TITLE
fix(app): Wave 2a Cluster D — network and asset alignment

### DIFF
--- a/app/src/components/AmountForm.tsx
+++ b/app/src/components/AmountForm.tsx
@@ -5,9 +5,16 @@ interface Props {
   max: number
   onSubmit: (amount: number) => void
   onCancel: () => void
+  assetSymbol?: string
 }
 
-export default function AmountForm({ action, max, onSubmit, onCancel }: Props) {
+export default function AmountForm({
+  action,
+  max,
+  onSubmit,
+  onCancel,
+  assetSymbol = 'SOL',
+}: Props) {
   const [raw, setRaw] = useState('')
   const parsed = Number(raw)
   const valid = raw.length > 0 && Number.isFinite(parsed) && parsed > 0 && parsed <= max
@@ -26,9 +33,9 @@ export default function AmountForm({ action, max, onSubmit, onCancel }: Props) {
           className="flex-1 bg-elevated border border-border rounded-lg px-3 py-2 text-[14px] font-mono text-text focus:outline-none focus:border-accent/40"
           placeholder="0.0"
         />
-        <span className="text-[12px] font-mono text-text-muted">SOL</span>
+        <span className="text-[12px] font-mono text-text-muted">{assetSymbol}</span>
       </div>
-      <div className="text-[10px] font-mono text-text-muted">Max: {max} SOL</div>
+      <div className="text-[10px] font-mono text-text-muted">Max: {max} {assetSymbol}</div>
       <div className="flex gap-2">
         <button
           onClick={() => valid && onSubmit(parsed)}

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -51,7 +51,11 @@ export default function Header() {
   const activeView = useActiveView()
   const navigate = useNavigate()
   const setChatSheetOpen = useAppStore((s) => s.setChatSheetOpen)
-  const network = useNetworkConfigStore((s) => s.config?.network ?? 'mainnet')
+  // App.tsx gates the entire shell on `config` resolving (shows "Loading…"
+  // until then), so this selector is always defined at render time. The old
+  // `?? 'mainnet'` fallback was dead code that would silently mislabel devnet
+  // sessions if the gate ever changed. Render the network only when known.
+  const network = useNetworkConfigStore((s) => s.config?.network)
 
   const handleConnectOrSignIn = () => {
     authenticate().catch((err: unknown) => {
@@ -84,7 +88,9 @@ export default function Header() {
         >
           SIPHER
         </span>
-        <span className="text-2xs text-text-muted font-mono uppercase">{network}</span>
+        {network && (
+          <span className="text-2xs text-text-muted font-mono uppercase">{network}</span>
+        )}
         <TickerBar />
         <nav className="flex items-center ml-3">
           {TABS.map((tab) => {

--- a/app/src/components/__tests__/AmountForm.test.tsx
+++ b/app/src/components/__tests__/AmountForm.test.tsx
@@ -36,4 +36,41 @@ describe('AmountForm', () => {
     await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
     expect(onCancel).toHaveBeenCalled()
   })
+
+  describe('assetSymbol prop', () => {
+    it('renders SOL by default', () => {
+      render(<AmountForm action="Deposit" max={5} onSubmit={() => {}} onCancel={() => {}} />)
+      expect(screen.getByText('SOL')).toBeInTheDocument()
+      expect(screen.getByText(/Max:\s*5\s*SOL/)).toBeInTheDocument()
+    })
+
+    it('renders custom assetSymbol when passed (USDC)', () => {
+      render(
+        <AmountForm
+          action="Deposit"
+          max={5}
+          onSubmit={() => {}}
+          onCancel={() => {}}
+          assetSymbol="USDC"
+        />,
+      )
+      expect(screen.getByText('USDC')).toBeInTheDocument()
+      expect(screen.getByText(/Max:\s*5\s*USDC/)).toBeInTheDocument()
+      expect(screen.queryByText('SOL')).not.toBeInTheDocument()
+    })
+
+    it('renders custom assetSymbol when passed (USDT)', () => {
+      render(
+        <AmountForm
+          action="Deposit"
+          max={10}
+          onSubmit={() => {}}
+          onCancel={() => {}}
+          assetSymbol="USDT"
+        />,
+      )
+      expect(screen.getByText('USDT')).toBeInTheDocument()
+      expect(screen.queryByText('SOL')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/app/src/components/__tests__/Header.test.tsx
+++ b/app/src/components/__tests__/Header.test.tsx
@@ -29,9 +29,13 @@ vi.mock('../../providers/ToastProvider', () => ({
   useToast: () => ({ show: mockToastShow, dismiss: vi.fn() }),
 }))
 
+let mockNetworkConfig: { config: { network: string } | undefined } = {
+  config: { network: 'devnet' },
+}
+
 vi.mock('../../lib/networkConfig', () => ({
-  useNetworkConfigStore: <T,>(selector: (s: { config: { network: string } }) => T) =>
-    selector({ config: { network: 'devnet' } }),
+  useNetworkConfigStore: <T,>(selector: (s: { config: { network: string } | undefined }) => T) =>
+    selector(mockNetworkConfig),
 }))
 
 const FULL = 'HciZTd6rR7YsaS5ZNThx9KdgqSimxwMzJgs2j98U25En'
@@ -65,6 +69,7 @@ beforeEach(() => {
   })
   useAppStore.setState({ chatSheetOpen: false }, false)
   setAuth({ status: 'unauthed', publicKey: null, isAdmin: false })
+  mockNetworkConfig = { config: { network: 'devnet' } }
 })
 
 describe('Header — auth pill', () => {
@@ -205,5 +210,29 @@ describe('Header — tabs', () => {
     expect(screen.getByRole('link', { name: /Vault/i })).not.toHaveAttribute('aria-current')
     expect(screen.getByRole('link', { name: /Chains/i })).not.toHaveAttribute('aria-current')
     expect(screen.getByRole('link', { name: /Keys/i })).not.toHaveAttribute('aria-current')
+  })
+})
+
+describe('Header — network identifier', () => {
+  it('renders the active network when config is loaded (devnet)', () => {
+    mockNetworkConfig = { config: { network: 'devnet' } }
+    renderHeader()
+    expect(screen.getByText('devnet')).toBeInTheDocument()
+  })
+
+  it('renders the active network when config is mainnet', () => {
+    mockNetworkConfig = { config: { network: 'mainnet' } }
+    renderHeader()
+    expect(screen.getByText('mainnet')).toBeInTheDocument()
+  })
+
+  it('omits the network badge when config is undefined (App.tsx gates shell — defensive)', () => {
+    // App.tsx shows a "Loading…" splash until config resolves, so Header
+    // should never see undefined in production. Assert the defensive
+    // behaviour: no stale "mainnet" fallback leaks through.
+    mockNetworkConfig = { config: undefined }
+    renderHeader()
+    expect(screen.queryByText('mainnet')).not.toBeInTheDocument()
+    expect(screen.queryByText('devnet')).not.toBeInTheDocument()
   })
 })

--- a/app/src/components/ui/TickerBar.tsx
+++ b/app/src/components/ui/TickerBar.tsx
@@ -5,14 +5,14 @@ const POLL_MS = 5000
 
 interface Tick {
   solUsd: number | null
-  slot: number | null
 }
 
 export function TickerBar() {
-  const [tick, setTick] = useState<Tick>({ solUsd: null, slot: null })
+  const [tick, setTick] = useState<Tick>({ solUsd: null })
 
   useEffect(() => {
     let cancelled = false
+    let intervalId: ReturnType<typeof setInterval> | null = null
 
     async function poll() {
       try {
@@ -26,11 +26,35 @@ export function TickerBar() {
       }
     }
 
-    poll()
-    const id = setInterval(poll, POLL_MS)
+    function startPolling() {
+      if (intervalId !== null) return
+      void poll()
+      intervalId = setInterval(poll, POLL_MS)
+    }
+
+    function stopPolling() {
+      if (intervalId === null) return
+      clearInterval(intervalId)
+      intervalId = null
+    }
+
+    function handleVisibilityChange() {
+      if (document.visibilityState === 'visible') {
+        startPolling()
+      } else {
+        stopPolling()
+      }
+    }
+
+    if (document.visibilityState === 'visible') {
+      startPolling()
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
     return () => {
       cancelled = true
-      clearInterval(id)
+      stopPolling()
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
     }
   }, [])
 
@@ -38,10 +62,6 @@ export function TickerBar() {
     <div className="flex items-center gap-3 text-2xs font-mono text-text-secondary">
       <span>
         SOL <span className="text-text">{tick.solUsd != null ? tick.solUsd.toFixed(2) : '—'}</span>
-      </span>
-      <span className="text-text-muted">·</span>
-      <span>
-        SLOT <span className="text-text">{tick.slot != null ? tick.slot.toLocaleString() : '—'}</span>
       </span>
     </div>
   )

--- a/app/src/components/ui/__tests__/TickerBar.test.tsx
+++ b/app/src/components/ui/__tests__/TickerBar.test.tsx
@@ -1,17 +1,30 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import { TickerBar } from '../TickerBar'
 
 const SOL_MINT = 'So11111111111111111111111111111111111111112'
 
+function setVisibility(state: 'visible' | 'hidden') {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    value: state,
+  })
+  Object.defineProperty(document, 'hidden', {
+    configurable: true,
+    value: state === 'hidden',
+  })
+}
+
 describe('TickerBar', () => {
   beforeEach(() => {
+    setVisibility('visible')
     vi.useFakeTimers({ shouldAdvanceTime: true })
     vi.spyOn(global, 'fetch').mockImplementation(() => Promise.reject(new Error('default')))
   })
   afterEach(() => {
     vi.useRealTimers()
     vi.restoreAllMocks()
+    setVisibility('visible')
   })
 
   it('renders SOL price once data loads', async () => {
@@ -43,14 +56,79 @@ describe('TickerBar', () => {
     })
   })
 
-  it('renders SLOT placeholder until backend exposes it', async () => {
-    ;(global.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(() =>
-      Promise.resolve({
+  describe('slot field removal', () => {
+    it('does not render a SLOT label or slot value', () => {
+      ;(global.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ [SOL_MINT]: { usdPrice: 100 } }),
+        }) as unknown as Promise<Response>,
+      )
+      render(<TickerBar />)
+      expect(screen.queryByText(/slot/i)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('visibility-gating', () => {
+    it('does not poll when document is hidden on mount', () => {
+      setVisibility('hidden')
+      const fetchSpy = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchSpy.mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({ [SOL_MINT]: { usdPrice: 100 } }),
-      }) as unknown as Promise<Response>,
-    )
-    render(<TickerBar />)
-    expect(screen.getByText('SLOT')).toBeInTheDocument()
+      } as unknown as Response)
+
+      render(<TickerBar />)
+      // Advance >2× the poll cadence — still no fetch should fire.
+      act(() => {
+        vi.advanceTimersByTime(15_000)
+      })
+      expect(fetchSpy).not.toHaveBeenCalled()
+    })
+
+    it('resumes polling on hidden → visible transition', async () => {
+      setVisibility('hidden')
+      const fetchSpy = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ [SOL_MINT]: { usdPrice: 100 } }),
+      } as unknown as Response)
+
+      render(<TickerBar />)
+      expect(fetchSpy).not.toHaveBeenCalled()
+
+      // Flip to visible and dispatch the standard browser event.
+      act(() => {
+        setVisibility('visible')
+        document.dispatchEvent(new Event('visibilitychange'))
+      })
+      await waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalled()
+      })
+    })
+
+    it('pauses polling on visible → hidden transition', async () => {
+      const fetchSpy = global.fetch as unknown as ReturnType<typeof vi.fn>
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ [SOL_MINT]: { usdPrice: 100 } }),
+      } as unknown as Response)
+
+      render(<TickerBar />)
+      // Allow the immediate visible-mount fetch to register.
+      await waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalled()
+      })
+      const callsAfterMount = fetchSpy.mock.calls.length
+
+      act(() => {
+        setVisibility('hidden')
+        document.dispatchEvent(new Event('visibilitychange'))
+      })
+      act(() => {
+        vi.advanceTimersByTime(15_000)
+      })
+      expect(fetchSpy.mock.calls.length).toBe(callsAfterMount)
+    })
   })
 })

--- a/app/src/components/vault/DepositForm.tsx
+++ b/app/src/components/vault/DepositForm.tsx
@@ -45,6 +45,7 @@ export function DepositForm({
         max={max}
         onSubmit={handleSubmit}
         onCancel={() => {}}
+        assetSymbol={asset}
       />
       <TxStatusBadge status={status} signature={signature} />
     </div>

--- a/app/src/components/vault/__tests__/DepositForm.test.tsx
+++ b/app/src/components/vault/__tests__/DepositForm.test.tsx
@@ -50,4 +50,17 @@ describe('DepositForm', () => {
     render(<DepositForm {...baseProps} status="signing" />)
     expect(screen.getByText(/signing/i)).toBeInTheDocument()
   })
+
+  it('passes the selected asset as assetSymbol to AmountForm', () => {
+    render(<DepositForm {...baseProps} />)
+    // Default selected asset is SOL — AmountForm should render SOL label
+    expect(screen.getByText(/Max:\s*5\s*SOL/)).toBeInTheDocument()
+    // Switch to USDC — AmountForm should re-render with USDC label
+    fireEvent.click(screen.getByRole('button', { name: 'USDC' }))
+    expect(screen.getByText(/Max:\s*100\s*USDC/)).toBeInTheDocument()
+    expect(screen.queryByText(/Max:\s*100\s*SOL/)).not.toBeInTheDocument()
+    // Switch to USDT — AmountForm should re-render with USDT label
+    fireEvent.click(screen.getByRole('button', { name: 'USDT' }))
+    expect(screen.getByText(/Max:\s*100\s*USDT/)).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary

Wave 2a Cluster D — Network/asset alignment fixes for the QA sweep Tier 4 sprint. AmountForm gains `assetSymbol` prop (default 'SOL') propagated from DepositForm, Header's unreachable `?? 'mainnet'` fallback dropped, and TickerBar polling gated on document visibility with the dead `slot` field removed.

## Issues closed

Closes #207
Closes #208
Closes #209

## Changes

- **#207 AmountForm `assetSymbol` prop** — Adds optional `assetSymbol?: string` (default `'SOL'`) to `AmountForm`. DepositForm passes the selected asset's symbol; AmountForm renders `{assetSymbol}` for both the unit label and the "Max:" hint. WithdrawForm verified not to render AmountForm (uses RefundList for full-deposit refunds).
- **#208 Header default network (Path A — drop fallback)** — Replaces `useNetworkConfigStore((s) => s.config?.network ?? 'mainnet')` with `useNetworkConfigStore((s) => s.config?.network)` and gates the network badge JSX on truthy network. App.tsx:96-113 already returns early for both `error` (render error screen) and `!config` (render "Loading…" splash) states, so the old fallback was unreachable dead code. Choice documented with inline source comment.
- **#209 TickerBar visibility-gating + dead `slot` field** — Polling subscribes to `visibilitychange` with `startPolling`/`stopPolling` helpers; only polls when `document.visibilityState === 'visible'`. The `slot` field removed from the `Tick` interface AND the rendered JSX (the `·` separator + SLOT `<span>` block deleted).

## Tests

- App tests: **486 passed** (was 476; +10 net: 3 AmountForm + 1 DepositForm + 3 Header + 3 TickerBar)
- TSC: clean (\`pnpm exec tsc --noEmit\` exit 0)

## Spec + reviews

- **Spec:** [docs/superpowers/specs/2026-05-11-qa-sweep-tier-4-design.md](https://github.com/sip-protocol/sipher/blob/main/docs/superpowers/specs/2026-05-11-qa-sweep-tier-4-design.md) → Wave 2 appendix → Cluster D
- **Plan:** [docs/superpowers/plans/2026-05-11-qa-sweep-tier-4-wave-2a.md](https://github.com/sip-protocol/sipher/blob/main/docs/superpowers/plans/2026-05-11-qa-sweep-tier-4-wave-2a.md) → Cluster D section
- **Spec-compliance review:** ✅ APPROVED (all D-D1 through D-D4 met)
- **Code-quality review:** ✅ APPROVED (no Critical/Important; 4 Minor follow-ups to file as \`tech-debt,priority:low\`)

## Coordination

`Header.tsx` also modified in parallel by Cluster E1 (#219 connection-quality indicator). D touches the **left-side data binding** (line 54 selector + network badge `<span>`); E1 touches the **right-side icon group**. Distinct sections — git auto-merge expected; rebase only if hunk overlap detected.