### PR TITLE
feat(app): Wave 2a Cluster E1 — marketing polish

### DIFF
--- a/app/src/components/BetaBanner.tsx
+++ b/app/src/components/BetaBanner.tsx
@@ -2,14 +2,27 @@ import { useState } from 'react'
 import { useActiveView } from '../hooks/useActiveView'
 import { useNetworkConfigStore } from '../lib/networkConfig'
 
-const STORAGE_KEY = 'sipher.beta-banner.dismissed'
+// Persist the dismissal as an absolute epoch-ms cutoff in localStorage so
+// the banner stays hidden for 24 hours across tab close + reopen, but
+// re-appears afterwards. Old sessionStorage key
+// `sipher.beta-banner.dismissed` is intentionally NOT read here — the
+// migration is one-way and stale entries should not silently suppress
+// a banner the user hasn't dismissed under the new scheme.
+const STORAGE_KEY = 'sipher.devnet-banner.dismissed-until'
+const COOLDOWN_MS = 24 * 60 * 60 * 1000
 
 const VAULT_VIEWS = new Set(['vault', 'deposit', 'withdraw'])
 
+function isCurrentlyDismissed(): boolean {
+  const raw = localStorage.getItem(STORAGE_KEY)
+  if (raw === null) return false
+  const until = Number(raw)
+  if (!Number.isFinite(until)) return false
+  return until > Date.now()
+}
+
 export function BetaBanner({ beta }: { beta: boolean }) {
-  const [dismissed, setDismissed] = useState<boolean>(
-    () => sessionStorage.getItem(STORAGE_KEY) === 'true',
-  )
+  const [dismissed, setDismissed] = useState<boolean>(isCurrentlyDismissed)
   const activeView = useActiveView()
   const network = useNetworkConfigStore((s) => s.config?.network ?? '')
 
@@ -37,7 +50,8 @@ export function BetaBanner({ beta }: { beta: boolean }) {
   if (dismissed) return null
 
   function handleDismiss() {
-    sessionStorage.setItem(STORAGE_KEY, 'true')
+    const until = Date.now() + COOLDOWN_MS
+    localStorage.setItem(STORAGE_KEY, String(until))
     setDismissed(true)
   }
 

--- a/app/src/components/ConnectionQualityIndicator.tsx
+++ b/app/src/components/ConnectionQualityIndicator.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Backend connection-quality indicator.
+ *
+ * Pings the lightweight `/api/health` endpoint every 30s while the document
+ * is visible to keep tab-suspended browsers from wasting cycles. Resulting
+ * latency drives a tri-state color: green <500ms, yellow 500-2000ms, red
+ * >2000ms or fetch failure.
+ */
+
+const PING_INTERVAL_MS = 30_000
+const ENDPOINT = '/api/health'
+
+type Quality = 'green' | 'yellow' | 'red'
+
+function latencyToQuality(latencyMs: number): Quality {
+  if (latencyMs < 500) return 'green'
+  if (latencyMs < 2000) return 'yellow'
+  return 'red'
+}
+
+const colorClasses: Record<Quality, string> = {
+  green: 'bg-emerald-500',
+  yellow: 'bg-amber-500',
+  red: 'bg-red-500',
+}
+
+export function ConnectionQualityIndicator() {
+  const [quality, setQuality] = useState<Quality>('green')
+  const [latencyMs, setLatencyMs] = useState<number | null>(null)
+  const [errored, setErrored] = useState<boolean>(false)
+
+  useEffect(() => {
+    let intervalId: ReturnType<typeof setInterval> | null = null
+    let cancelled = false
+
+    const ping = async () => {
+      const start = performance.now()
+      try {
+        await fetch(ENDPOINT, { method: 'GET' })
+        if (cancelled) return
+        const latency = performance.now() - start
+        setLatencyMs(latency)
+        setQuality(latencyToQuality(latency))
+        setErrored(false)
+      } catch {
+        if (cancelled) return
+        setQuality('red')
+        setErrored(true)
+        setLatencyMs(null)
+      }
+    }
+
+    const startInterval = () => {
+      if (intervalId !== null) return
+      intervalId = setInterval(ping, PING_INTERVAL_MS)
+      ping()
+    }
+
+    const stopInterval = () => {
+      if (intervalId === null) return
+      clearInterval(intervalId)
+      intervalId = null
+    }
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') startInterval()
+      else stopInterval()
+    }
+
+    if (document.visibilityState === 'visible') startInterval()
+    document.addEventListener('visibilitychange', handleVisibility)
+
+    return () => {
+      cancelled = true
+      stopInterval()
+      document.removeEventListener('visibilitychange', handleVisibility)
+    }
+  }, [])
+
+  const ariaLabel = errored
+    ? 'Unreachable'
+    : `Backend reachable (${latencyMs !== null ? `${Math.round(latencyMs)}ms` : 'pending'})`
+
+  return (
+    <span
+      role="img"
+      aria-label={ariaLabel}
+      title={ariaLabel}
+      className={`inline-block w-2 h-2 rounded-full ${colorClasses[quality]}`}
+    />
+  )
+}

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -14,6 +14,7 @@ import AgentDot from './AgentDot'
 import { UserMenu, type AdminView } from './UserMenu'
 import { useNetworkConfigStore } from '../lib/networkConfig'
 import { TickerBar } from './ui/TickerBar'
+import { ConnectionQualityIndicator } from './ConnectionQualityIndicator'
 
 interface Tab {
   id: View
@@ -128,6 +129,7 @@ export default function Header() {
         </button>
 
         <div className="flex items-center gap-1.5">
+          <ConnectionQualityIndicator />
           <AgentDot agent="sipher" size={5} />
           <AgentDot agent="herald" size={5} />
           <AgentDot agent="sentinel" size={5} />

--- a/app/src/components/__tests__/BetaBanner.test.tsx
+++ b/app/src/components/__tests__/BetaBanner.test.tsx
@@ -1,6 +1,9 @@
-import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import type { View } from '../../stores/app'
+
+const DISMISS_KEY = 'sipher.devnet-banner.dismissed-until'
+const COOLDOWN_MS = 24 * 60 * 60 * 1000
 
 let activeViewValue: View | null = 'dashboard'
 let networkValue: string = 'devnet'
@@ -18,9 +21,14 @@ import { BetaBanner } from '../BetaBanner'
 
 describe('BetaBanner', () => {
   beforeEach(() => {
+    localStorage.clear()
     sessionStorage.clear()
     activeViewValue = 'dashboard'
     networkValue = 'devnet'
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('renders when beta=true', () => {
@@ -37,16 +45,10 @@ describe('BetaBanner', () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it('is dismissible via button, hides for the rest of the session', () => {
+  it('is dismissible via button, hides immediately', () => {
     render(<BetaBanner beta={true} />)
     expect(screen.getByText(/DEVNET BETA/i)).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
-    expect(screen.queryByText(/DEVNET BETA/i)).not.toBeInTheDocument()
-  })
-
-  it('respects sessionStorage dismissal across re-renders', () => {
-    sessionStorage.setItem('sipher.beta-banner.dismissed', 'true')
-    render(<BetaBanner beta={true} />)
     expect(screen.queryByText(/DEVNET BETA/i)).not.toBeInTheDocument()
   })
 
@@ -98,5 +100,61 @@ describe('BetaBanner', () => {
     networkValue = 'mainnet'
     render(<BetaBanner beta={false} />)
     expect(screen.queryByText(/Sipher Vault is on devnet only/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('BetaBanner — 24h localStorage cooldown', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    activeViewValue = 'dashboard'
+    networkValue = 'devnet'
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not render when dismissed-until timestamp is in the future', () => {
+    localStorage.setItem(DISMISS_KEY, String(Date.now() + 60_000))
+    render(<BetaBanner beta={true} />)
+    expect(screen.queryByText(/DEVNET BETA/i)).not.toBeInTheDocument()
+  })
+
+  it('renders when dismissed-until timestamp is in the past', () => {
+    localStorage.setItem(DISMISS_KEY, String(Date.now() - 60_000))
+    render(<BetaBanner beta={true} />)
+    expect(screen.getByText(/DEVNET BETA/i)).toBeInTheDocument()
+  })
+
+  it('sets dismissed-until to ~24h from now on dismiss click', () => {
+    const fixedNow = 1_700_000_000_000
+    vi.useFakeTimers()
+    vi.setSystemTime(fixedNow)
+
+    render(<BetaBanner beta={true} />)
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+
+    const stored = Number(localStorage.getItem(DISMISS_KEY))
+    expect(stored).toBe(fixedNow + COOLDOWN_MS)
+  })
+
+  it('does not write to the old sessionStorage key after dismiss', () => {
+    render(<BetaBanner beta={true} />)
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+    expect(sessionStorage.getItem('sipher.beta-banner.dismissed')).toBeNull()
+  })
+
+  it('ignores stale sessionStorage entries from the old dismissal scheme', () => {
+    sessionStorage.setItem('sipher.beta-banner.dismissed', 'true')
+    render(<BetaBanner beta={true} />)
+    // Migration: legacy sessionStorage key must not gate the banner anymore.
+    expect(screen.getByText(/DEVNET BETA/i)).toBeInTheDocument()
+  })
+
+  it('treats malformed timestamp values as not-dismissed', () => {
+    localStorage.setItem(DISMISS_KEY, 'not-a-number')
+    render(<BetaBanner beta={true} />)
+    expect(screen.getByText(/DEVNET BETA/i)).toBeInTheDocument()
   })
 })

--- a/app/src/components/__tests__/ConnectionQualityIndicator.test.tsx
+++ b/app/src/components/__tests__/ConnectionQualityIndicator.test.tsx
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { ConnectionQualityIndicator } from '../ConnectionQualityIndicator'
+
+const originalVisibility = Object.getOwnPropertyDescriptor(Document.prototype, 'visibilityState')
+
+function setVisibility(value: 'visible' | 'hidden') {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => value,
+  })
+}
+
+function restoreVisibility() {
+  if (originalVisibility) {
+    Object.defineProperty(Document.prototype, 'visibilityState', originalVisibility)
+  }
+}
+
+describe('ConnectionQualityIndicator', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    setVisibility('visible')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    restoreVisibility()
+  })
+
+  it('pings the health endpoint on mount when document is visible', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}'))
+    await act(async () => {
+      render(<ConnectionQualityIndicator />)
+      await Promise.resolve()
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [calledPath] = fetchSpy.mock.calls[0]
+    expect(typeof calledPath === 'string' ? calledPath : '').toMatch(/\/api\/health/)
+  })
+
+  it('renders green dot when latency < 500ms', async () => {
+    let perfCalls = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => {
+      perfCalls += 1
+      return perfCalls === 1 ? 0 : 100
+    })
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}'))
+
+    await act(async () => {
+      render(<ConnectionQualityIndicator />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const indicator = screen.getByRole('img')
+    expect(indicator.className).toMatch(/bg-emerald-500/)
+    expect(indicator.getAttribute('aria-label')).toMatch(/Backend reachable/)
+    expect(indicator.getAttribute('aria-label')).toMatch(/100ms/)
+  })
+
+  it('renders yellow dot when latency is between 500ms and 2000ms', async () => {
+    let perfCalls = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => {
+      perfCalls += 1
+      return perfCalls === 1 ? 0 : 1200
+    })
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}'))
+
+    await act(async () => {
+      render(<ConnectionQualityIndicator />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const indicator = screen.getByRole('img')
+    expect(indicator.className).toMatch(/bg-amber-500/)
+  })
+
+  it('renders red dot when latency exceeds 2000ms', async () => {
+    let perfCalls = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => {
+      perfCalls += 1
+      return perfCalls === 1 ? 0 : 2500
+    })
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}'))
+
+    await act(async () => {
+      render(<ConnectionQualityIndicator />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const indicator = screen.getByRole('img')
+    expect(indicator.className).toMatch(/bg-red-500/)
+  })
+
+  it('renders red dot and Unreachable label on fetch failure', async () => {
+    vi.spyOn(global, 'fetch').mockRejectedValue(new TypeError('Failed to fetch'))
+
+    await act(async () => {
+      render(<ConnectionQualityIndicator />)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const indicator = screen.getByRole('img')
+    expect(indicator.className).toMatch(/bg-red-500/)
+    expect(indicator.getAttribute('aria-label')).toMatch(/Unreachable/)
+  })
+
+  it('does not ping when document is hidden on mount', async () => {
+    setVisibility('hidden')
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}'))
+
+    await act(async () => {
+      render(<ConnectionQualityIndicator />)
+      vi.advanceTimersByTime(60_000)
+      await Promise.resolve()
+    })
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('re-pings every 30 seconds while visible', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}'))
+
+    await act(async () => {
+      render(<ConnectionQualityIndicator />)
+      await Promise.resolve()
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000)
+      await Promise.resolve()
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000)
+      await Promise.resolve()
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(3)
+  })
+
+  it('cleans up interval and visibility listener on unmount', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}'))
+    const removeListenerSpy = vi.spyOn(document, 'removeEventListener')
+
+    const { unmount } = render(<ConnectionQualityIndicator />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+    unmount()
+    expect(removeListenerSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+
+    await act(async () => {
+      vi.advanceTimersByTime(60_000)
+      await Promise.resolve()
+    })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/src/components/__tests__/Header.test.tsx
+++ b/app/src/components/__tests__/Header.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Header from '../Header'
@@ -70,6 +70,16 @@ beforeEach(() => {
   useAppStore.setState({ chatSheetOpen: false }, false)
   setAuth({ status: 'unauthed', publicKey: null, isAdmin: false })
   mockNetworkConfig = { config: { network: 'devnet' } }
+
+  // Stub fetch so the ConnectionQualityIndicator mounted in the header
+  // does not fire real network requests during these tests. Each test
+  // gets a fresh stub; the indicator's async state updates are swallowed
+  // by vi.restoreAllMocks() between specs.
+  vi.spyOn(global, 'fetch').mockResolvedValue(new Response('{}'))
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
 })
 
 describe('Header — auth pill', () => {

--- a/app/src/views/AboutView.tsx
+++ b/app/src/views/AboutView.tsx
@@ -12,6 +12,9 @@ export default function AboutView() {
           Privacy-by-default for Solana
         </h1>
         <p className="text-base text-text-secondary leading-relaxed">
+          Multi-chain privacy command center for shielded transfers across 9+ chains.
+        </p>
+        <p className="text-sm text-text-secondary leading-relaxed">
           SIPHER is a wallet and an autonomous agent for shielded payments, swaps, and stealth-address management. Stealth output by default. Real Pedersen commitments. Multi-chain.
         </p>
         <div className="flex gap-3">
@@ -33,6 +36,13 @@ export default function AboutView() {
         </div>
       </section>
 
+      <section className="flex flex-col gap-4">
+        <h2 className="text-xl font-semibold">Privacy primitives</h2>
+        <p className="text-sm text-text-secondary leading-relaxed">
+          SIPHER combines three cryptographic primitives to deliver transaction privacy: <strong>stealth addresses</strong> (one-time recipient addresses that prevent linkability across payments), <strong>Pedersen commitments</strong> (homomorphic hiding of transfer amounts), and <strong>viewing keys</strong> (selective disclosure so auditors and compliance partners can verify activity without breaking the privacy guarantees for the rest of the network).
+        </p>
+      </section>
+
       <section className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div className="glass-strong rounded-2xl p-6 flex flex-col gap-3">
           <div className="text-2xs text-cyan" style={{ letterSpacing: 'var(--tracking-widest)' }}>
@@ -40,7 +50,7 @@ export default function AboutView() {
           </div>
           <h2 className="text-lg font-semibold">Stealth-first wallet</h2>
           <p className="text-sm text-text-secondary leading-relaxed">
-            Every received payment lands at a one-time stealth address. Viewing keys give selective disclosure for compliance. 12 chains supported via cross-chain shielded transfers.
+            Every received payment lands at a one-time stealth address. Viewing keys give selective disclosure for compliance. 9+ chains supported via cross-chain shielded transfers — Solana (native + L2s), Ethereum and its testnets (Sepolia, Arbitrum, Base, Optimism), and NEAR via Intents.
           </p>
         </div>
         <div className="glass-strong rounded-2xl p-6 flex flex-col gap-3">
@@ -49,7 +59,7 @@ export default function AboutView() {
           </div>
           <h2 className="text-lg font-semibold">Autonomous co-pilot</h2>
           <p className="text-sm text-text-secondary leading-relaxed">
-            HERALD responds to mentions on X. SENTINEL audits high-risk actions before they fire. Ask SIPHER chat handles privacy operations conversationally — deposits, swaps, sweeps, threat checks.
+            Each SIPHER user has two identities — a wallet they sign with, and an agent that acts on their behalf. <strong>HERALD</strong> responds to mentions on X. <strong>SENTINEL</strong> audits high-risk actions before they fire. <strong>Ask SIPHER</strong> chat handles privacy operations conversationally — deposits, swaps, sweeps, threat checks.
           </p>
         </div>
       </section>
@@ -58,6 +68,21 @@ export default function AboutView() {
         <h2 className="text-xl font-semibold">Architecture</h2>
         <p className="text-sm text-text-secondary leading-relaxed">
           Anchor program on Solana mainnet. Pedersen commitments hide amounts. Stealth addresses hide recipients. Viewing keys preserve compliance. Read the <a href="https://docs.sip-protocol.org" target="_blank" rel="noopener noreferrer" className="text-cyan underline">technical docs</a> for the full breakdown.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h2 className="text-xl font-semibold">Roadmap</h2>
+        <p className="text-sm text-text-secondary leading-relaxed">
+          See the public roadmap for current and upcoming milestones — same-chain Ethereum privacy in flight (M18), proof composition research and a denominated note mixer planned for late 2026.{' '}
+          <a
+            href="https://github.com/sip-protocol/sipher/blob/main/ROADMAP.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-cyan underline"
+          >
+            View ROADMAP.md →
+          </a>
         </p>
       </section>
 

--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -46,7 +46,7 @@ function parseDetail(detail: unknown): Record<string, unknown> {
 }
 
 export default function DashboardView({ events }: { events: ActivityEvent[] }) {
-  const { token } = useAuthState()
+  const { token, status } = useAuthState()
   const [vault, setVault] = useState<VaultData | null>(null)
   const [history, setHistory] = useState<ActivityRow[]>([])
   const [privacyData, setPrivacyData] = useState<PrivacyData | null>(null)
@@ -152,6 +152,14 @@ export default function DashboardView({ events }: { events: ActivityEvent[] }) {
       <meta property="og:title" content="SIPHER — Multi-chain privacy command center" />
       <meta property="og:description" content="Multi-chain privacy command center for shielded transfers across 9+ chains." />
       <div data-testid="dashboard-view" className="space-y-6 p-6">
+        {status !== 'authed' && (
+          <p
+            data-testid="dashboard-unauthed-tagline"
+            className="text-sm text-text-muted text-center max-w-2xl mx-auto"
+          >
+            Multi-chain privacy command center for shielded transfers across 9+ chains.
+          </p>
+        )}
         <PrivacyGraph />
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/app/src/views/__tests__/AboutView.test.tsx
+++ b/app/src/views/__tests__/AboutView.test.tsx
@@ -36,3 +36,37 @@ describe('AboutView', () => {
     expect(link).toHaveAttribute('target', '_blank')
   })
 })
+
+describe('AboutView body content', () => {
+  it('contains the positioning tagline with 9+ chains', () => {
+    renderAbout()
+    expect(
+      screen.getByText(
+        /Multi-chain privacy command center for shielded transfers across 9\+ chains\./,
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('mentions stealth addresses and Pedersen commitments as privacy primitives', () => {
+    renderAbout()
+    const body = screen.getByTestId('about-view').textContent ?? ''
+    expect(/stealth addresses?/i.test(body)).toBe(true)
+    expect(/Pedersen commitments?/i.test(body)).toBe(true)
+    expect(/viewing keys?/i.test(body)).toBe(true)
+  })
+
+  it('mentions HERALD and SENTINEL agent components', () => {
+    renderAbout()
+    const body = screen.getByTestId('about-view').textContent ?? ''
+    expect(/HERALD/.test(body)).toBe(true)
+    expect(/SENTINEL/.test(body)).toBe(true)
+  })
+
+  it('renders a ROADMAP link', () => {
+    renderAbout()
+    const link = screen.getByRole('link', { name: /roadmap/i })
+    expect(link).toHaveAttribute('href', expect.stringContaining('ROADMAP'))
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'))
+  })
+})

--- a/app/src/views/__tests__/DashboardView.test.tsx
+++ b/app/src/views/__tests__/DashboardView.test.tsx
@@ -3,15 +3,22 @@ import { render, screen, waitFor, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import DashboardView from '../DashboardView'
 import { onAuthClear } from '../../store/onAuthClear'
+import type { AuthState } from '../../hooks/useAuthState'
 
 vi.mock('../../api/client', () => ({
   apiFetch: vi.fn(),
 }))
 
+let currentAuthOverrides: Partial<AuthState> = {
+  status: 'authed',
+  token: 'tok',
+  publicKey: 'W',
+}
+
 vi.mock('../../hooks/useAuthState', async () => {
   const { makeFakeAuthState } = await import('../../test-utils/makeFakeAuthState')
   return {
-    useAuthState: () => makeFakeAuthState({ status: 'authed', token: 'tok', publicKey: 'W' }),
+    useAuthState: () => makeFakeAuthState(currentAuthOverrides),
   }
 })
 
@@ -45,6 +52,7 @@ beforeAll(() => {
 beforeEach(() => {
   ;(apiFetch as ReturnType<typeof vi.fn>).mockReset()
   onAuthClear._resetForTests()
+  currentAuthOverrides = { status: 'authed', token: 'tok', publicKey: 'W' }
 
   // Path-based mock so the four fetches (vault, activity, privacy score,
   // chains, chain aggregate, stealth index) can resolve in any order.
@@ -149,5 +157,47 @@ describe('DashboardView', () => {
         'Multi-chain privacy command center for shielded transfers across 9+ chains.',
       )
     })
+  })
+})
+
+describe('DashboardView — unauthed tagline', () => {
+  it('renders the SIPHER tagline when status is unauthed', () => {
+    currentAuthOverrides = { status: 'unauthed', token: null, publicKey: null }
+    render(
+      <MemoryRouter>
+        <DashboardView events={[]} />
+      </MemoryRouter>,
+    )
+    expect(
+      screen.getByText(
+        /Multi-chain privacy command center for shielded transfers across 9\+ chains\./,
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it('does not render the tagline when status is authed', () => {
+    currentAuthOverrides = { status: 'authed', token: 'tok', publicKey: 'W' }
+    render(
+      <MemoryRouter>
+        <DashboardView events={[]} />
+      </MemoryRouter>,
+    )
+    expect(
+      screen.queryByText(/Multi-chain privacy command center/),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders the tagline when status is expired (treated as not-authed)', () => {
+    // Spec D-E1-5: tagline gates on status !== 'authed'. Any non-authed
+    // state (unauthed / connecting / expired / error) surfaces the tagline.
+    currentAuthOverrides = { status: 'expired', token: null, publicKey: 'W' }
+    render(
+      <MemoryRouter>
+        <DashboardView events={[]} />
+      </MemoryRouter>,
+    )
+    expect(
+      screen.getByText(/Multi-chain privacy command center/),
+    ).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

Wave 2a Cluster E1 — Marketing-surface polish. Adds a connection-quality indicator to the Header (pings `/api/health` every 30s when visible; green/yellow/red latency thresholds), migrates the DEVNET banner dismissal from sessionStorage to localStorage with a 24h cooldown, and ships the About SIPHER tagline + body copy.

## Issues closed

Closes #219
Closes #220
Closes #221

## Changes

- **#219 Connection-quality indicator in Header** — New `<ConnectionQualityIndicator />` component mounted in the Header's right-side icon group. Pings `/api/health` (lightweight backend liveness endpoint at `packages/agent/src/index.ts:295`) every 30s, gated on `document.visibilityState === 'visible'`. Latency thresholds: <500ms green, 500ms-2s yellow, >2s OR fetch-failure red. Hover tooltip surfaces `Backend reachable (XXXms)` or `Unreachable`.
- **#220 DEVNET banner localStorage migration** — `BetaBanner.tsx` migrates from `sessionStorage` (key `sipher.beta-banner.dismissed`, boolean) to `localStorage` (key `sipher.devnet-banner.dismissed-until`, value = epoch ms timestamp). 24-hour cooldown — banner reappears after 24h. Old sessionStorage key fully removed.
- **#221 About SIPHER tagline + body copy** — Tagline `Multi-chain privacy command center for shielded transfers across 9+ chains.` mounted on the unauthed Dashboard (gated on `status !== 'authed'`). AboutView body populated with ~300 words covering privacy primitives (stealth addresses, Pedersen commitments, viewing keys), 9+ chain support, dual-identity architecture (wallet + agent: HERALD, SENTINEL, Ask SIPHER), and a ROADMAP link to https://github.com/sip-protocol/sipher/blob/main/ROADMAP.md.

## Tests

- App tests: **496 passed** (was 476; +20 net: +8 ConnectionQualityIndicator + 5 BetaBanner + 7 About/Dashboard)
- TSC: clean (\`pnpm exec tsc --noEmit\` exit 0)

## Spec + reviews

- **Spec:** [docs/superpowers/specs/2026-05-11-qa-sweep-tier-4-design.md](https://github.com/sip-protocol/sipher/blob/main/docs/superpowers/specs/2026-05-11-qa-sweep-tier-4-design.md) → Wave 2 appendix → Cluster E1
- **Plan:** [docs/superpowers/plans/2026-05-11-qa-sweep-tier-4-wave-2a.md](https://github.com/sip-protocol/sipher/blob/main/docs/superpowers/plans/2026-05-11-qa-sweep-tier-4-wave-2a.md) → Cluster E1 section
- **Spec-compliance review:** ✅ APPROVED (D-E1-1 through D-E1-5 met; `/api/health` chosen over `/api/config`/`/healthz` after backend investigation)
- **Code-quality review:** ✅ APPROVED (no Critical/Important; 6 Minor follow-ups to file as \`tech-debt,priority:low\`)

## Notes

- **`/api/health` endpoint choice (D-E1-1):** Backend exposes a dedicated lightweight health endpoint returning `{ status, agent, version, tools, uptime, activeSessions }` — chosen over `/api/config` (heavier, includes CRITICAL-marked whitelist data) and `/healthz` (does not exist). Defensible deviation from literal spec text.
- **Tagline gating (D-E1-5):** Uses `status !== 'authed'` per spec text. This means `expired` and `connecting` statuses also show the tagline; explicit test documents this behavior. May be narrowed to `status === 'unauthed'` in a follow-up if desired.

## Coordination

`Header.tsx` also modified in parallel by Cluster D (#208 network default fix). E1 touches the **right-side icon group** (adds `<ConnectionQualityIndicator />` next to UserMenu/AgentDot); D touches the **left-side data binding** (line 54 selector + network badge `<span>`). Distinct sections — git auto-merge expected; rebase only if hunk overlap detected.