### PR TITLE
feat(app): Wave 2a Cluster C — a11y and SEO

### DIFF
--- a/app/src/components/ChatSidebar.tsx
+++ b/app/src/components/ChatSidebar.tsx
@@ -216,6 +216,8 @@ export default function ChatSidebar({ fullScreen }: Props) {
                 sendMessage()
               }
             }}
+            aria-label="Ask SIPHER"
+            maxLength={4000}
             placeholder={token ? 'Message SIPHER...' : 'Connect wallet first'}
             className="flex-1 bg-elevated border border-border rounded-lg px-3 py-2 text-[13px] text-text placeholder-text-muted focus:outline-none focus:border-accent/40 transition-colors"
             disabled={!token || chatLoading}

--- a/app/src/components/PrivacyGraph.tsx
+++ b/app/src/components/PrivacyGraph.tsx
@@ -17,20 +17,33 @@ interface StealthNode {
 export function PrivacyGraph() {
   const { token } = useAuthState()
   const [tree, setTree] = useState<StealthNode[]>([])
+  const [loading, setLoading] = useState<boolean>(Boolean(token))
 
-  useOnAuthClear(() => setTree([]))
+  useOnAuthClear(() => {
+    setTree([])
+    setLoading(false)
+  })
 
   useEffect(() => {
-    if (!token) return
+    if (!token) {
+      setLoading(false)
+      return
+    }
     const controller = new AbortController()
+    setLoading(true)
     apiFetch<{ tree: StealthNode[]; rootWallet: string }>('/api/stealth/index', {
       token,
       signal: controller.signal,
     })
-      .then((j) => setTree(j.tree))
+      .then((j) => {
+        if (controller.signal.aborted) return
+        setTree(j.tree)
+        setLoading(false)
+      })
       .catch((err) => {
         if (err instanceof Error && err.name === 'AbortError') return
         setTree([])
+        setLoading(false)
       })
     return () => controller.abort()
   }, [token])
@@ -60,8 +73,22 @@ export function PrivacyGraph() {
           {tree.length} {tree.length === 1 ? 'address' : 'addresses'}
         </span>
       </div>
-      {tree.length === 0 ? (
-        <div className="h-[400px] flex flex-col items-center justify-center text-center px-6">
+      {loading ? (
+        <div
+          data-testid="privacy-graph-skeleton"
+          aria-busy="true"
+          aria-label="Loading privacy graph"
+          className="h-[400px] animate-pulse flex flex-col items-center justify-center text-center px-6 gap-3"
+        >
+          <div className="h-3 bg-text/10 rounded w-1/3" />
+          <div className="h-3 bg-text/10 rounded w-2/3" />
+          <div className="h-3 bg-text/10 rounded w-1/2" />
+        </div>
+      ) : tree.length === 0 ? (
+        <div
+          data-testid="privacy-graph-empty"
+          className="h-[400px] flex flex-col items-center justify-center text-center px-6"
+        >
           <p className="text-sm text-text-secondary">
             Each node is a one-time stealth address.
           </p>

--- a/app/src/components/PrivacyGraph.tsx
+++ b/app/src/components/PrivacyGraph.tsx
@@ -41,6 +41,7 @@ export function PrivacyGraph() {
         setLoading(false)
       })
       .catch((err) => {
+        if (controller.signal.aborted) return
         if (err instanceof Error && err.name === 'AbortError') return
         setTree([])
         setLoading(false)

--- a/app/src/components/Toast.tsx
+++ b/app/src/components/Toast.tsx
@@ -14,13 +14,25 @@ const kindStyles: Record<NonNullable<ToastInput['kind']>, string> = {
   success: 'bg-emerald-950/90 border-emerald-700 text-emerald-100',
 }
 
+const ariaSemantics: Record<
+  NonNullable<ToastInput['kind']>,
+  { role: 'status' | 'alert'; ariaLive: 'polite' | 'assertive' }
+> = {
+  info: { role: 'status', ariaLive: 'polite' },
+  success: { role: 'status', ariaLive: 'polite' },
+  warn: { role: 'alert', ariaLive: 'assertive' },
+  error: { role: 'alert', ariaLive: 'assertive' },
+}
+
 export function Toast({ toast, onDismiss }: { toast: ToastInput; onDismiss: () => void }) {
-  const styles = kindStyles[toast.kind ?? 'info']
+  const kind = toast.kind ?? 'info'
+  const styles = kindStyles[kind]
+  const { role, ariaLive } = ariaSemantics[kind]
   return (
     <div
       className={`border rounded px-3 py-2 text-sm shadow-lg ${styles}`}
-      role="status"
-      aria-live="polite"
+      role={role}
+      aria-live={ariaLive}
     >
       <div className="flex items-start gap-2">
         <span className="flex-1">{toast.message}</span>

--- a/app/src/components/__tests__/ChatSidebar.test.tsx
+++ b/app/src/components/__tests__/ChatSidebar.test.tsx
@@ -206,4 +206,14 @@ describe('ChatSidebar', () => {
       expect(triggerAuthInterceptor).toHaveBeenCalledOnce()
     })
   })
+
+  describe('input accessibility', () => {
+    it('input has aria-label="Ask SIPHER" and maxLength=4000', () => {
+      useAppStore.setState({ token: 'test-jwt', isAdmin: true })
+      render(<ChatSidebar />)
+      const input = screen.getByLabelText('Ask SIPHER') as HTMLInputElement
+      expect(input).toBeInTheDocument()
+      expect(input.maxLength).toBe(4000)
+    })
+  })
 })

--- a/app/src/components/__tests__/PrivacyGraph.test.tsx
+++ b/app/src/components/__tests__/PrivacyGraph.test.tsx
@@ -66,6 +66,68 @@ describe('PrivacyGraph', () => {
     await waitFor(() => expect(screen.getByText(/0 addresses/)).toBeInTheDocument())
   })
 
+  it('catch handler returns early when controller.signal.aborted is true (verified via aborted-signal probe)', async () => {
+    // Probe the abort signal state at the moment the catch handler runs.
+    // We achieve this by tapping into apiFetch: store the signal it receives,
+    // then resolve via a deferred rejection AFTER unmounting. The guard the
+    // production code adds — `if (controller.signal.aborted) return` — is
+    // covered behaviourally: when the catch handler's guard reads the signal,
+    // signal.aborted MUST be true because unmount fires the AbortController's
+    // abort() synchronously via useEffect cleanup. We assert this directly
+    // by probing the signal post-unmount and post-rejection.
+    let rejectFetch: (err: Error) => void = () => {}
+    let receivedSignal: AbortSignal | undefined
+    const fetchPromise = new Promise((_resolve, reject) => {
+      rejectFetch = reject
+    })
+    ;(apiFetch as ReturnType<typeof vi.fn>).mockImplementationOnce((_url, opts) => {
+      receivedSignal = opts?.signal
+      return fetchPromise
+    })
+
+    const { unmount } = render(<PrivacyGraph />)
+
+    // Skeleton renders while the promise is pending.
+    expect(screen.getByTestId('privacy-graph-skeleton')).toBeInTheDocument()
+    expect(receivedSignal).toBeDefined()
+    expect(receivedSignal!.aborted).toBe(false)
+
+    // Unmount fires controller.abort() via useEffect cleanup.
+    unmount()
+    expect(receivedSignal!.aborted).toBe(true)
+
+    // Probe the guard predicate: count how many times signal.aborted is
+    // read AFTER the rejection fires. If the catch guard reads it (which it
+    // must to short-circuit), we'll observe the read here.
+    let abortedReadCount = 0
+    const originalSignal = receivedSignal!
+    Object.defineProperty(receivedSignal, 'aborted', {
+      configurable: true,
+      get() {
+        abortedReadCount++
+        return true
+      },
+    })
+
+    // Reject with a generic (non-Abort) error AFTER unmount.
+    await act(async () => {
+      rejectFetch(new Error('network failure after unmount'))
+      // Drain microtask queue so .catch handler runs.
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // The catch handler's first line reads controller.signal.aborted.
+    // If the guard is in place, abortedReadCount must be >= 1.
+    expect(abortedReadCount).toBeGreaterThanOrEqual(1)
+
+    // Restore the signal's prototype getter (cleanup).
+    Object.defineProperty(originalSignal, 'aborted', {
+      configurable: true,
+      value: true,
+    })
+  })
+
   it('wraps Stealth Address Tree label in JargonTerm tooltip', async () => {
     ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       tree: [],

--- a/app/src/components/__tests__/PrivacyGraph.test.tsx
+++ b/app/src/components/__tests__/PrivacyGraph.test.tsx
@@ -105,4 +105,26 @@ describe('PrivacyGraph', () => {
       expect(screen.getByText(/0 addresses/)).toBeInTheDocument()
     })
   })
+
+  describe('loading state', () => {
+    it('renders skeleton while loading and hides empty state', async () => {
+      // Mock a fetch that never resolves so the loading state persists
+      ;(apiFetch as ReturnType<typeof vi.fn>).mockImplementationOnce(() => new Promise(() => {}))
+      render(<PrivacyGraph />)
+      expect(screen.getByTestId('privacy-graph-skeleton')).toBeInTheDocument()
+      expect(screen.queryByTestId('privacy-graph-empty')).not.toBeInTheDocument()
+    })
+
+    it('renders empty state when loaded with no nodes', async () => {
+      ;(apiFetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        tree: [],
+        rootWallet: '',
+      })
+      render(<PrivacyGraph />)
+      await waitFor(() => {
+        expect(screen.getByTestId('privacy-graph-empty')).toBeInTheDocument()
+      })
+      expect(screen.queryByTestId('privacy-graph-skeleton')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/app/src/components/__tests__/Toast.test.tsx
+++ b/app/src/components/__tests__/Toast.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { Toast } from '../Toast'
+
+describe('Toast aria semantics', () => {
+  it('info kind uses role=status + aria-live=polite', () => {
+    const { container } = render(
+      <Toast toast={{ message: 'hello', kind: 'info' }} onDismiss={() => {}} />,
+    )
+    const root = container.firstChild as HTMLElement
+    expect(root.getAttribute('role')).toBe('status')
+    expect(root.getAttribute('aria-live')).toBe('polite')
+  })
+
+  it('success kind uses role=status + aria-live=polite', () => {
+    const { container } = render(
+      <Toast toast={{ message: 'done', kind: 'success' }} onDismiss={() => {}} />,
+    )
+    const root = container.firstChild as HTMLElement
+    expect(root.getAttribute('role')).toBe('status')
+    expect(root.getAttribute('aria-live')).toBe('polite')
+  })
+
+  it('warn kind uses role=alert + aria-live=assertive', () => {
+    const { container } = render(
+      <Toast toast={{ message: 'check this', kind: 'warn' }} onDismiss={() => {}} />,
+    )
+    const root = container.firstChild as HTMLElement
+    expect(root.getAttribute('role')).toBe('alert')
+    expect(root.getAttribute('aria-live')).toBe('assertive')
+  })
+
+  it('error kind uses role=alert + aria-live=assertive', () => {
+    const { container } = render(
+      <Toast toast={{ message: 'oops', kind: 'error' }} onDismiss={() => {}} />,
+    )
+    const root = container.firstChild as HTMLElement
+    expect(root.getAttribute('role')).toBe('alert')
+    expect(root.getAttribute('aria-live')).toBe('assertive')
+  })
+
+  it('defaults to info semantics when kind is omitted', () => {
+    const { container } = render(
+      <Toast toast={{ message: 'no kind' }} onDismiss={() => {}} />,
+    )
+    const root = container.firstChild as HTMLElement
+    expect(root.getAttribute('role')).toBe('status')
+    expect(root.getAttribute('aria-live')).toBe('polite')
+  })
+})

--- a/app/src/providers/__tests__/ToastProvider.test.tsx
+++ b/app/src/providers/__tests__/ToastProvider.test.tsx
@@ -105,7 +105,9 @@ describe('ToastProvider', () => {
       </ToastProvider>,
     )
     fireEvent.click(screen.getByText('Trigger'))
-    const toast = screen.getByText('Warn me').closest('[role="status"]')
+    // warn upgrades to role="alert" + aria-live="assertive" per Toast aria
+    // semantics; info/success keep role="status" + aria-live="polite".
+    const toast = screen.getByText('Warn me').closest('[role="alert"]')
     expect(toast).toHaveClass('bg-amber-950/90')
   })
 

--- a/app/src/views/AboutView.tsx
+++ b/app/src/views/AboutView.tsx
@@ -3,6 +3,12 @@ import { Link } from 'react-router-dom'
 export default function AboutView() {
   return (
     <div data-testid="about-view" className="flex flex-col gap-12 max-w-4xl mx-auto py-8">
+      <title>SIPHER — About</title>
+      <meta name="description" content="About SIPHER — privacy primitives, multi-chain support, and dual-identity architecture." />
+      <meta property="og:title" content="SIPHER — About" />
+      <meta property="og:description" content="About SIPHER — privacy primitives, multi-chain support, and dual-identity architecture." />
+      <meta property="og:type" content="website" />
+      <meta property="og:image" content="/icons/sipher.svg" />
       <section className="flex flex-col gap-4">
         <h1 className="text-3xl md:text-5xl font-semibold leading-tight">
           Privacy-by-default for Solana

--- a/app/src/views/AboutView.tsx
+++ b/app/src/views/AboutView.tsx
@@ -7,8 +7,6 @@ export default function AboutView() {
       <meta name="description" content="About SIPHER — privacy primitives, multi-chain support, and dual-identity architecture." />
       <meta property="og:title" content="SIPHER — About" />
       <meta property="og:description" content="About SIPHER — privacy primitives, multi-chain support, and dual-identity architecture." />
-      <meta property="og:type" content="website" />
-      <meta property="og:image" content="/icons/sipher.svg" />
       <section className="flex flex-col gap-4">
         <h1 className="text-3xl md:text-5xl font-semibold leading-tight">
           Privacy-by-default for Solana

--- a/app/src/views/ChainsView.tsx
+++ b/app/src/views/ChainsView.tsx
@@ -36,6 +36,12 @@ export default function ChainsView() {
 
   return (
     <div className="max-w-6xl mx-auto p-6 space-y-6">
+      <title>SIPHER — Chains</title>
+      <meta name="description" content="Multi-chain support spanning 9+ blockchains including Solana, Ethereum, and L2s." />
+      <meta property="og:title" content="SIPHER — Chains" />
+      <meta property="og:description" content="Multi-chain support spanning 9+ blockchains including Solana, Ethereum, and L2s." />
+      <meta property="og:type" content="website" />
+      <meta property="og:image" content="/icons/sipher.svg" />
       <div>
         <h1 className="text-3xl text-text font-semibold">Chains</h1>
         <p className="text-base text-text-muted mt-1">

--- a/app/src/views/ChainsView.tsx
+++ b/app/src/views/ChainsView.tsx
@@ -40,8 +40,6 @@ export default function ChainsView() {
       <meta name="description" content="Multi-chain support spanning 9+ blockchains including Solana, Ethereum, and L2s." />
       <meta property="og:title" content="SIPHER — Chains" />
       <meta property="og:description" content="Multi-chain support spanning 9+ blockchains including Solana, Ethereum, and L2s." />
-      <meta property="og:type" content="website" />
-      <meta property="og:image" content="/icons/sipher.svg" />
       <div>
         <h1 className="text-3xl text-text font-semibold">Chains</h1>
         <p className="text-base text-text-muted mt-1">

--- a/app/src/views/ChatView.tsx
+++ b/app/src/views/ChatView.tsx
@@ -7,8 +7,6 @@ export default function ChatView() {
       <meta name="description" content="Ask SIPHER about your privacy posture." />
       <meta property="og:title" content="SIPHER — Chat" />
       <meta property="og:description" content="Ask SIPHER about your privacy posture." />
-      <meta property="og:type" content="website" />
-      <meta property="og:image" content="/icons/sipher.svg" />
       <ChatSidebar fullScreen />
     </div>
   )

--- a/app/src/views/ChatView.tsx
+++ b/app/src/views/ChatView.tsx
@@ -3,6 +3,12 @@ import ChatSidebar from '../components/ChatSidebar'
 export default function ChatView() {
   return (
     <div data-testid="chat-view" className="lg:hidden h-full">
+      <title>SIPHER — Chat</title>
+      <meta name="description" content="Ask SIPHER about your privacy posture." />
+      <meta property="og:title" content="SIPHER — Chat" />
+      <meta property="og:description" content="Ask SIPHER about your privacy posture." />
+      <meta property="og:type" content="website" />
+      <meta property="og:image" content="/icons/sipher.svg" />
       <ChatSidebar fullScreen />
     </div>
   )

--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -151,8 +151,6 @@ export default function DashboardView({ events }: { events: ActivityEvent[] }) {
       <meta name="description" content="Multi-chain privacy command center for shielded transfers across 9+ chains." />
       <meta property="og:title" content="SIPHER — Multi-chain privacy command center" />
       <meta property="og:description" content="Multi-chain privacy command center for shielded transfers across 9+ chains." />
-      <meta property="og:type" content="website" />
-      <meta property="og:image" content="/icons/sipher.svg" />
       <div data-testid="dashboard-view" className="space-y-6 p-6">
         <PrivacyGraph />
 

--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -146,21 +146,29 @@ export default function DashboardView({ events }: { events: ActivityEvent[] }) {
   ].slice(0, 30)
 
   return (
-    <div data-testid="dashboard-view" className="space-y-6 p-6">
-      <PrivacyGraph />
+    <>
+      <title>SIPHER — Multi-chain privacy command center</title>
+      <meta name="description" content="Multi-chain privacy command center for shielded transfers across 9+ chains." />
+      <meta property="og:title" content="SIPHER — Multi-chain privacy command center" />
+      <meta property="og:description" content="Multi-chain privacy command center for shielded transfers across 9+ chains." />
+      <meta property="og:type" content="website" />
+      <meta property="og:image" content="/icons/sipher.svg" />
+      <div data-testid="dashboard-view" className="space-y-6 p-6">
+        <PrivacyGraph />
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <div className="lg:col-span-2">
-          <PrivacyScoreCard data={privacyData} />
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="lg:col-span-2">
+            <PrivacyScoreCard data={privacyData} />
+          </div>
+          <div>
+            <ShieldedVolumeCard />
+          </div>
         </div>
-        <div>
-          <ShieldedVolumeCard />
-        </div>
+
+        <MultiChainVaultGrid />
+
+        <ActivityStreamTable rows={allRows} />
       </div>
-
-      <MultiChainVaultGrid />
-
-      <ActivityStreamTable rows={allRows} />
-    </div>
+    </>
   )
 }

--- a/app/src/views/DepositView.tsx
+++ b/app/src/views/DepositView.tsx
@@ -131,8 +131,6 @@ export default function DepositView() {
       <meta name="description" content="Deposit to shielded vault." />
       <meta property="og:title" content="SIPHER — Deposit" />
       <meta property="og:description" content="Deposit to shielded vault." />
-      <meta property="og:type" content="website" />
-      <meta property="og:image" content="/icons/sipher.svg" />
     </>
   )
 

--- a/app/src/views/DepositView.tsx
+++ b/app/src/views/DepositView.tsx
@@ -125,18 +125,33 @@ export default function DepositView() {
     [signAndBroadcast, token, navigate],
   )
 
+  const seoTags = (
+    <>
+      <title>SIPHER — Deposit</title>
+      <meta name="description" content="Deposit to shielded vault." />
+      <meta property="og:title" content="SIPHER — Deposit" />
+      <meta property="og:description" content="Deposit to shielded vault." />
+      <meta property="og:type" content="website" />
+      <meta property="og:image" content="/icons/sipher.svg" />
+    </>
+  )
+
   if (authStatus !== 'authed') {
     return (
-      <UnauthedEmptyState
-        title="Shielded Deposit"
-        body={<>Connect a wallet to deposit into the shielded vault.</>}
-      />
+      <>
+        {seoTags}
+        <UnauthedEmptyState
+          title="Shielded Deposit"
+          body={<>Connect a wallet to deposit into the shielded vault.</>}
+        />
+      </>
     )
   }
 
   if (isMainnet) {
     return (
       <div className="flex flex-col gap-4 max-w-3xl mx-auto">
+        {seoTags}
         <BackChip onClick={() => navigate('/vault')} />
         <Card variant="default" className="p-6">
           <p className="text-sm text-text">
@@ -151,6 +166,7 @@ export default function DepositView() {
 
   return (
     <div className="flex flex-col gap-4 max-w-3xl mx-auto">
+      {seoTags}
       <BackChip onClick={() => navigate('/vault')} />
       <h1 className="text-2xl font-semibold">Shield to vault</h1>
 

--- a/app/src/views/HeraldView.tsx
+++ b/app/src/views/HeraldView.tsx
@@ -410,8 +410,6 @@ export default function HeraldView({ token }: { token: string | null }) {
       <meta name="description" content="Monitor HERALD agent activity and X interactions." />
       <meta property="og:title" content="SIPHER — Herald" />
       <meta property="og:description" content="Monitor HERALD agent activity and X interactions." />
-      <meta property="og:type" content="website" />
-      <meta property="og:image" content="/icons/sipher.svg" />
     </>
   )
 

--- a/app/src/views/HeraldView.tsx
+++ b/app/src/views/HeraldView.tsx
@@ -404,6 +404,17 @@ export default function HeraldView({ token }: { token: string | null }) {
   const [data, setData] = useState<HeraldData | null>(null)
   const [error, setError] = useState<string | null>(null)
 
+  const seoTags = (
+    <>
+      <title>SIPHER — Herald</title>
+      <meta name="description" content="Monitor HERALD agent activity and X interactions." />
+      <meta property="og:title" content="SIPHER — Herald" />
+      <meta property="og:description" content="Monitor HERALD agent activity and X interactions." />
+      <meta property="og:type" content="website" />
+      <meta property="og:image" content="/icons/sipher.svg" />
+    </>
+  )
+
   useEffect(() => {
     if (!isAdmin) {
       navigate('/')
@@ -460,6 +471,7 @@ export default function HeraldView({ token }: { token: string | null }) {
   if (!token) {
     return (
       <div className="text-text-muted text-sm text-center py-20">
+        {seoTags}
         Connect your wallet to view HERALD activity.
       </div>
     )
@@ -469,6 +481,7 @@ export default function HeraldView({ token }: { token: string | null }) {
 
   return (
     <div data-testid="herald-view" className="flex flex-col h-full">
+      {seoTags}
       <BudgetBar budget={budget} />
       <SubTabs active={tab} onChange={setTab} />
 

--- a/app/src/views/KeysView.tsx
+++ b/app/src/views/KeysView.tsx
@@ -6,9 +6,20 @@ import { StealthAddressBackup } from '../components/keys/StealthAddressBackup'
 
 export default function KeysView() {
   const { status } = useAuthState()
+  const seoTags = (
+    <>
+      <title>SIPHER — Keys</title>
+      <meta name="description" content="Manage viewing keys and stealth addresses for shielded transfers." />
+      <meta property="og:title" content="SIPHER — Keys" />
+      <meta property="og:description" content="Manage viewing keys and stealth addresses for shielded transfers." />
+      <meta property="og:type" content="website" />
+      <meta property="og:image" content="/icons/sipher.svg" />
+    </>
+  )
   if (status !== 'authed') {
     return (
       <div className="flex flex-col gap-4">
+        {seoTags}
         <Banner kind="info">
           Stealth keys are a connected-wallet feature. Connect your wallet to view, rotate, or back them up.
         </Banner>
@@ -22,6 +33,7 @@ export default function KeysView() {
 
   return (
     <div className="flex flex-col gap-4">
+      {seoTags}
       <h1 className="text-sm text-text-muted" style={{ letterSpacing: 'var(--tracking-widest)' }}>
         VIEWING KEY MANAGEMENT
       </h1>

--- a/app/src/views/KeysView.tsx
+++ b/app/src/views/KeysView.tsx
@@ -12,8 +12,6 @@ export default function KeysView() {
       <meta name="description" content="Manage viewing keys and stealth addresses for shielded transfers." />
       <meta property="og:title" content="SIPHER — Keys" />
       <meta property="og:description" content="Manage viewing keys and stealth addresses for shielded transfers." />
-      <meta property="og:type" content="website" />
-      <meta property="og:image" content="/icons/sipher.svg" />
     </>
   )
   if (status !== 'authed') {

--- a/app/src/views/NotFoundView.tsx
+++ b/app/src/views/NotFoundView.tsx
@@ -8,8 +8,6 @@ export default function NotFoundView() {
       <meta name="description" content="Page not found." />
       <meta property="og:title" content="SIPHER — Not found" />
       <meta property="og:description" content="Page not found." />
-      <meta property="og:type" content="website" />
-      <meta property="og:image" content="/icons/sipher.svg" />
       <h1 className="sr-only">Not Found</h1>
       <UnauthedEmptyState
         title="Not found"

--- a/app/src/views/NotFoundView.tsx
+++ b/app/src/views/NotFoundView.tsx
@@ -4,6 +4,12 @@ import { UnauthedEmptyState } from '../components/ui/UnauthedEmptyState'
 export default function NotFoundView() {
   return (
     <>
+      <title>SIPHER — Not found</title>
+      <meta name="description" content="Page not found." />
+      <meta property="og:title" content="SIPHER — Not found" />
+      <meta property="og:description" content="Page not found." />
+      <meta property="og:type" content="website" />
+      <meta property="og:image" content="/icons/sipher.svg" />
       <h1 className="sr-only">Not Found</h1>
       <UnauthedEmptyState
         title="Not found"

--- a/app/src/views/PrivacyReportView.tsx
+++ b/app/src/views/PrivacyReportView.tsx
@@ -49,8 +49,6 @@ export default function PrivacyReportView() {
       <meta name="description" content="On-chain privacy score and surveillance exposure analysis." />
       <meta property="og:title" content="SIPHER — Privacy Report" />
       <meta property="og:description" content="On-chain privacy score and surveillance exposure analysis." />
-      <meta property="og:type" content="website" />
-      <meta property="og:image" content="/icons/sipher.svg" />
     </>
   )
 

--- a/app/src/views/PrivacyReportView.tsx
+++ b/app/src/views/PrivacyReportView.tsx
@@ -43,22 +43,37 @@ export default function PrivacyReportView() {
     return () => controller.abort()
   }, [token])
 
+  const seoTags = (
+    <>
+      <title>SIPHER — Privacy Report</title>
+      <meta name="description" content="On-chain privacy score and surveillance exposure analysis." />
+      <meta property="og:title" content="SIPHER — Privacy Report" />
+      <meta property="og:description" content="On-chain privacy score and surveillance exposure analysis." />
+      <meta property="og:type" content="website" />
+      <meta property="og:image" content="/icons/sipher.svg" />
+    </>
+  )
+
   if (status !== 'authed') {
     return (
-      <UnauthedEmptyState
-        title="Privacy Score Report"
-        body={
-          <>
-            Connect a wallet to view network analysis, surveillance score, and personalized
-            recommendations.
-          </>
-        }
-      />
+      <>
+        {seoTags}
+        <UnauthedEmptyState
+          title="Privacy Score Report"
+          body={
+            <>
+              Connect a wallet to view network analysis, surveillance score, and personalized
+              recommendations.
+            </>
+          }
+        />
+      </>
     )
   }
 
   return (
     <div className="max-w-3xl mx-auto p-6 space-y-6">
+      {seoTags}
       <button
         type="button"
         onClick={() => navigate('/')}

--- a/app/src/views/SettingsView.tsx
+++ b/app/src/views/SettingsView.tsx
@@ -79,8 +79,6 @@ export default function SettingsView() {
       <meta name="description" content="Configure network, privacy, and admin settings." />
       <meta property="og:title" content="SIPHER — Settings" />
       <meta property="og:description" content="Configure network, privacy, and admin settings." />
-      <meta property="og:type" content="website" />
-      <meta property="og:image" content="/icons/sipher.svg" />
       <h1 className="text-sm text-text-muted" style={{ letterSpacing: 'var(--tracking-widest)' }}>
         SETTINGS — READ-ONLY INSPECTOR
       </h1>

--- a/app/src/views/SettingsView.tsx
+++ b/app/src/views/SettingsView.tsx
@@ -75,6 +75,12 @@ export default function SettingsView() {
 
   return (
     <div className="flex flex-col gap-4">
+      <title>SIPHER — Settings</title>
+      <meta name="description" content="Configure network, privacy, and admin settings." />
+      <meta property="og:title" content="SIPHER — Settings" />
+      <meta property="og:description" content="Configure network, privacy, and admin settings." />
+      <meta property="og:type" content="website" />
+      <meta property="og:image" content="/icons/sipher.svg" />
       <h1 className="text-sm text-text-muted" style={{ letterSpacing: 'var(--tracking-widest)' }}>
         SETTINGS — READ-ONLY INSPECTOR
       </h1>

--- a/app/src/views/SquadView.tsx
+++ b/app/src/views/SquadView.tsx
@@ -263,8 +263,6 @@ export default function SquadView({ token }: { token: string | null }) {
       <meta name="description" content="SENTINEL guardian squad oversight and threat assessment." />
       <meta property="og:title" content="SIPHER — Guardian Squad" />
       <meta property="og:description" content="SENTINEL guardian squad oversight and threat assessment." />
-      <meta property="og:type" content="website" />
-      <meta property="og:image" content="/icons/sipher.svg" />
     </>
   )
 

--- a/app/src/views/SquadView.tsx
+++ b/app/src/views/SquadView.tsx
@@ -257,12 +257,29 @@ export default function SquadView({ token }: { token: string | null }) {
 
   if (!isAdmin) return null
 
+  const seoTags = (
+    <>
+      <title>SIPHER — Guardian Squad</title>
+      <meta name="description" content="SENTINEL guardian squad oversight and threat assessment." />
+      <meta property="og:title" content="SIPHER — Guardian Squad" />
+      <meta property="og:description" content="SENTINEL guardian squad oversight and threat assessment." />
+      <meta property="og:type" content="website" />
+      <meta property="og:image" content="/icons/sipher.svg" />
+    </>
+  )
+
   if (!data && !error) {
-    return <div className="text-text-muted text-sm text-center py-20">Loading squad data...</div>
+    return (
+      <div className="text-text-muted text-sm text-center py-20">
+        {seoTags}
+        Loading squad data...
+      </div>
+    )
   }
 
   return (
     <div data-testid="squad-view" className="flex flex-col gap-6">
+      {seoTags}
       <div className="flex items-center gap-2">
         <Chip tone="sentinel">SENTINEL</Chip>
         <span className="text-2xs text-text-muted tracking-widest uppercase">Operations</span>

--- a/app/src/views/VaultView.tsx
+++ b/app/src/views/VaultView.tsx
@@ -86,9 +86,21 @@ export default function VaultView() {
     return () => controller.abort()
   }, [token])
 
+  const seoTags = (
+    <>
+      <title>SIPHER — Vault</title>
+      <meta name="description" content="Shielded vault for private deposits and withdrawals on Solana." />
+      <meta property="og:title" content="SIPHER — Vault" />
+      <meta property="og:description" content="Shielded vault for private deposits and withdrawals on Solana." />
+      <meta property="og:type" content="website" />
+      <meta property="og:image" content="/icons/sipher.svg" />
+    </>
+  )
+
   if (status !== 'authed') {
     return (
       <div className="flex flex-col gap-4">
+        {seoTags}
         <Banner kind="info">
           Vault is a connected-wallet feature. Connect your wallet to deposit, manage stealth keys, and view your shielded balance.
         </Banner>
@@ -109,6 +121,7 @@ export default function VaultView() {
 
   return (
     <div data-testid="vault-view" className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {seoTags}
       <ShieldedVaultPanel
         positions={positions}
         stealthTree={stealthTree}

--- a/app/src/views/VaultView.tsx
+++ b/app/src/views/VaultView.tsx
@@ -92,8 +92,6 @@ export default function VaultView() {
       <meta name="description" content="Shielded vault for private deposits and withdrawals on Solana." />
       <meta property="og:title" content="SIPHER — Vault" />
       <meta property="og:description" content="Shielded vault for private deposits and withdrawals on Solana." />
-      <meta property="og:type" content="website" />
-      <meta property="og:image" content="/icons/sipher.svg" />
     </>
   )
 

--- a/app/src/views/WithdrawView.tsx
+++ b/app/src/views/WithdrawView.tsx
@@ -106,18 +106,33 @@ export default function WithdrawView() {
     [signAndBroadcast, token, refresh],
   )
 
+  const seoTags = (
+    <>
+      <title>SIPHER — Withdraw</title>
+      <meta name="description" content="Withdraw from shielded vault to stealth address." />
+      <meta property="og:title" content="SIPHER — Withdraw" />
+      <meta property="og:description" content="Withdraw from shielded vault to stealth address." />
+      <meta property="og:type" content="website" />
+      <meta property="og:image" content="/icons/sipher.svg" />
+    </>
+  )
+
   if (status !== 'authed') {
     return (
-      <UnauthedEmptyState
-        title="Shielded Withdraw"
-        body={<>Connect a wallet to refund deposits and withdraw shielded balances.</>}
-      />
+      <>
+        {seoTags}
+        <UnauthedEmptyState
+          title="Shielded Withdraw"
+          body={<>Connect a wallet to refund deposits and withdraw shielded balances.</>}
+        />
+      </>
     )
   }
 
   if (isMainnet) {
     return (
       <div className="flex flex-col gap-4 max-w-3xl mx-auto">
+        {seoTags}
         <BackChip onClick={() => navigate('/vault')} />
         <Card variant="default" className="p-6">
           <p className="text-sm text-text">
@@ -130,6 +145,7 @@ export default function WithdrawView() {
 
   return (
     <div className="flex flex-col gap-4 max-w-3xl mx-auto">
+      {seoTags}
       <BackChip onClick={() => navigate('/vault')} />
       <h1 className="text-2xl font-semibold">Refund from vault</h1>
       <p className="text-xs text-text-muted">

--- a/app/src/views/WithdrawView.tsx
+++ b/app/src/views/WithdrawView.tsx
@@ -112,8 +112,6 @@ export default function WithdrawView() {
       <meta name="description" content="Withdraw from shielded vault to stealth address." />
       <meta property="og:title" content="SIPHER — Withdraw" />
       <meta property="og:description" content="Withdraw from shielded vault to stealth address." />
-      <meta property="og:type" content="website" />
-      <meta property="og:image" content="/icons/sipher.svg" />
     </>
   )
 

--- a/app/src/views/__tests__/DashboardView.test.tsx
+++ b/app/src/views/__tests__/DashboardView.test.tsx
@@ -131,4 +131,23 @@ describe('DashboardView', () => {
     unmount()
     expect(capturedSignals.every((s) => s.aborted === true)).toBe(true)
   })
+
+  describe('SEO metadata', () => {
+    it('renders document.title and og:title meta tags', async () => {
+      render(
+        <MemoryRouter>
+          <DashboardView events={[]} />
+        </MemoryRouter>,
+      )
+      await waitFor(() => {
+        expect(document.title).toBe('SIPHER — Multi-chain privacy command center')
+      })
+      const ogTitle = document.querySelector('meta[property="og:title"]')
+      expect(ogTitle?.getAttribute('content')).toBe('SIPHER — Multi-chain privacy command center')
+      const ogDescription = document.querySelector('meta[property="og:description"]')
+      expect(ogDescription?.getAttribute('content')).toBe(
+        'Multi-chain privacy command center for shielded transfers across 9+ chains.',
+      )
+    })
+  })
 })

--- a/app/src/views/__tests__/NotFoundView.test.tsx
+++ b/app/src/views/__tests__/NotFoundView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import NotFoundView from '../NotFoundView'
@@ -33,5 +33,18 @@ describe('NotFoundView', () => {
     expect(
       screen.getByRole('heading', { level: 1, name: /not found/i }),
     ).toBeInTheDocument()
+  })
+
+  describe('SEO metadata', () => {
+    it('renders SIPHER — Not found title', async () => {
+      render(
+        <MemoryRouter>
+          <NotFoundView />
+        </MemoryRouter>,
+      )
+      await waitFor(() => {
+        expect(document.title).toBe('SIPHER — Not found')
+      })
+    })
   })
 })

--- a/app/src/views/__tests__/VaultView.test.tsx
+++ b/app/src/views/__tests__/VaultView.test.tsx
@@ -258,4 +258,16 @@ describe('VaultView (split-panel)', () => {
     renderVault()
     expect(mockedFetch).not.toHaveBeenCalled()
   })
+
+  describe('SEO metadata', () => {
+    it('renders SIPHER — Vault title and og description', async () => {
+      mockThreeFetches()
+      renderVault()
+      await waitFor(() => {
+        expect(document.title).toBe('SIPHER — Vault')
+      })
+      expect(document.querySelector('meta[property="og:description"]')?.getAttribute('content'))
+        .toBe('Shielded vault for private deposits and withdrawals on Solana.')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Wave 2a Cluster C — Accessibility and SEO improvements. Adds per-route SEO meta tags via React 19 native metadata, a loading skeleton to Privacy Graph, proper role + aria-live semantics to Toast, and an aria-label + maxLength to ChatSidebar input.

## Issues closed

Closes #206
Closes #210
Closes #211
Closes #214

## Changes

- **#206 Per-route SEO + Open Graph meta tags** — Inline `<title>` + `<meta name="description">` + `<meta property="og:title">` + `<meta property="og:description">` in 13 views (Dashboard, Vault, Chains, Keys, About, Herald, Squad, Settings, PrivacyReport, Deposit, Withdraw, Chat, NotFound). React 19 auto-hoists to `<head>`. Per-view `seoTags` const pattern for views with auth-gated early returns (7 views); inline for views without branches (6 views). Title pattern: `SIPHER — <View>` (Index = `SIPHER — Multi-chain privacy command center`).
- **#210 Privacy Graph loading state skeleton** — `<PrivacyGraph>` gains internal `loading` state (initialized to `Boolean(token)`). Skeleton renders during loading with `data-testid="privacy-graph-skeleton"`, `aria-busy="true"`, `aria-label="Loading privacy graph"`. Empty state (`data-testid="privacy-graph-empty"`) renders when `loaded && nodes.length === 0`. `onAuthClear` clears loading alongside tree.
- **#211 Toast role + aria-live semantics** — `kind: 'info' | 'success'` → `role="status"` + `aria-live="polite"`. `kind: 'warn' | 'error'` → `role="alert"` + `aria-live="assertive"`. ToastProvider warn-styles test updated accordingly. Audited other `role="status"` callers (Banner, BetaBanner, TxStatusBadge, CooldownChip) — none are toasts, unaffected.
- **#214 ChatSidebar input accessibility** — `<input>` gains `aria-label="Ask SIPHER"` (screen reader accessible name) and `maxLength={4000}` (defensive client cap).

## Code-review fixes (2 follow-up commits)

- **`858347f` — og:image path dropped (Path A)** — Original code-quality review flagged the `/icons/sipher.svg` og:image path as broken (no asset exists in repo; SPA fallback serves index.html → social-card crawlers get HTML when they expect an image). Chose Path A: drop `og:image` + `og:type` from all 13 views. Social cards still work via title+description. Asset can be reintroduced in a single follow-up commit when the brand mark stabilizes. No test changes required (existing SEO tests only asserted og:title/og:description).
- **`bbfdf24` — PrivacyGraph catch abort guard** — Original code-quality review flagged inconsistency between `.then` (correctly guarded on `controller.signal.aborted`) and `.catch` (only filtered `AbortError.name`). Added `if (controller.signal.aborted) return` at top of catch handler. New TDD test probes the `signal.aborted` getter via `Object.defineProperty` to verify guard fires (red→green proven by removing the guard line: test fails with expected count not reached).

## Tests

- App tests: **488 passed** (was 476; +12 net: 3 SEO + 2 PrivacyGraph + 5 Toast + 1 ChatSidebar + 1 PrivacyGraph catch guard)
- TSC: clean (\`pnpm exec tsc --noEmit\` exit 0)
- 75 test files (was 74; +1 new \`Toast.test.tsx\`)

## Spec + reviews

- **Spec:** [docs/superpowers/specs/2026-05-11-qa-sweep-tier-4-design.md](https://github.com/sip-protocol/sipher/blob/main/docs/superpowers/specs/2026-05-11-qa-sweep-tier-4-design.md) → Wave 2 appendix → Cluster C
- **Plan:** [docs/superpowers/plans/2026-05-11-qa-sweep-tier-4-wave-2a.md](https://github.com/sip-protocol/sipher/blob/main/docs/superpowers/plans/2026-05-11-qa-sweep-tier-4-wave-2a.md) → Cluster C section
- **Spec-compliance review:** ✅ APPROVED (D-C1 through D-C4 met)
- **Code-quality review:** 🔴 INITIALLY BLOCKED (1 Critical og:image, 1 Important PrivacyGraph catch) → 🟢 RESOLVED via fix-loop (2 new commits above)
- **10 Minor follow-ups** to file as \`tech-debt,priority:low\` (SEO duplication, missing og:url/og:site_name, missing image dimensions, index.html static title, test fragility in document.head cleanup, etc.)