### PR TITLE
chore(agent): Wave 2b foundation — IP rate limiter + cache + /api/public/*

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -33,6 +33,7 @@ import { configRouter } from './routes/config.js'
 import { chainsRouter } from './routes/chains.js'
 import { stealthIndexRouter } from './routes/stealth-index.js'
 import { keysRouter } from './routes/keys.js'
+import { publicRouter } from './routes/public/index.js'
 import { buildCorsMiddleware } from './cors-config.js'
 import { loadNetworkConfig } from './config/network.js'
 import {
@@ -176,6 +177,10 @@ app.use('/api/config', configRouter)
 
 // Public chain registry + TVL aggregator (read by UI Shielded Volume + Chains views)
 app.use('/api/chains', chainsRouter)
+
+// Public, unauthenticated routes (rate-limited per IP) — used by Wave 2b
+// /demo, /activity-summary, /chat. Sub-routers registered inside the module.
+app.use('/api/public', publicRouter)
 
 // Activity SSE stream — JWT required (EventSource passes ?token=)
 app.get('/api/stream', verifyJwt, streamHandler)

--- a/packages/agent/src/lib/cache.ts
+++ b/packages/agent/src/lib/cache.ts
@@ -1,0 +1,15 @@
+import { createStore } from '../state/ephemeral.js'
+
+const responseCache = createStore<unknown>('responseCache', { maxSize: 1_000 })
+
+export async function getCached<T>(key: string): Promise<T | null> {
+  return (await responseCache.get(key)) as T | null
+}
+
+export async function setCached<T>(key: string, value: T, ttlSeconds: number): Promise<void> {
+  await responseCache.set(key, value, ttlSeconds)
+}
+
+export async function _resetForTests(): Promise<void> {
+  await responseCache._clear()
+}

--- a/packages/agent/src/lib/ip-rate-limit.ts
+++ b/packages/agent/src/lib/ip-rate-limit.ts
@@ -1,0 +1,73 @@
+import type { Request, RequestHandler, Response, NextFunction } from 'express'
+import { createStore } from '../state/ephemeral.js'
+
+interface BucketState { count: number; resetAt: number }
+
+const ipRateLimitStore = createStore<BucketState>('ipRateLimit', { maxSize: 10_000 })
+
+export interface RateLimitResult {
+  allowed: boolean
+  remaining: number
+  resetAt: number
+  cap: number
+}
+
+/**
+ * Per-(IP, key) sliding-window counter. Same IP can hit different keys
+ * (e.g., 'demo' and 'chat') with independent budgets.
+ */
+export async function checkAndIncrement(
+  ip: string,
+  key: string,
+  cap: number,
+  windowMs: number,
+): Promise<RateLimitResult> {
+  const now = Date.now()
+  const bucketKey = `${ip}:${key}`
+  const existing = await ipRateLimitStore.get(bucketKey)
+
+  if (!existing || existing.resetAt <= now) {
+    const resetAt = now + windowMs
+    await ipRateLimitStore.set(bucketKey, { count: 1, resetAt }, Math.ceil(windowMs / 1000))
+    return { allowed: true, remaining: cap - 1, resetAt, cap }
+  }
+
+  if (existing.count >= cap) {
+    return { allowed: false, remaining: 0, resetAt: existing.resetAt, cap }
+  }
+
+  const next: BucketState = { count: existing.count + 1, resetAt: existing.resetAt }
+  const ttlSeconds = Math.max(1, Math.ceil((existing.resetAt - now) / 1000))
+  await ipRateLimitStore.set(bucketKey, next, ttlSeconds)
+  return { allowed: true, remaining: cap - next.count, resetAt: existing.resetAt, cap }
+}
+
+/**
+ * Express middleware. Sets X-RateLimit-* headers; returns 429 + envelope on exceeded.
+ * Reads `req.ip` (Express trust-proxy is configured upstream at index.ts:146-148).
+ */
+export function ipRateLimitMiddleware(key: string, cap: number, windowMs: number): RequestHandler {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const ip = req.ip ?? 'unknown'
+    const result = await checkAndIncrement(ip, key, cap, windowMs)
+    res.setHeader('X-RateLimit-Limit', String(cap))
+    res.setHeader('X-RateLimit-Remaining', String(result.remaining))
+    res.setHeader('X-RateLimit-Reset', String(Math.floor(result.resetAt / 1000)))
+
+    if (!result.allowed) {
+      res.status(429).json({
+        error: {
+          code: 'RATE_LIMITED',
+          message: `Rate limit ${cap}/${Math.round(windowMs / 1000)}s exceeded`,
+          resetAt: result.resetAt,
+        },
+      })
+      return
+    }
+    next()
+  }
+}
+
+export async function _resetForTests(): Promise<void> {
+  await ipRateLimitStore._clear()
+}

--- a/packages/agent/src/lib/queries/public.ts
+++ b/packages/agent/src/lib/queries/public.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared types for public, unauthenticated /api/public/* responses.
+ * Feature subagents extend this file with their feature-specific helpers.
+ */
+
+export interface DemoVault {
+  wallet: string
+  balances: { sol: number; tokens: unknown[]; status: string }
+}
+
+export interface DemoActivityRow {
+  id: string
+  agent: string
+  type: string
+  level: string
+  title: string
+  detail?: string | null
+  created_at: string
+}
+
+export interface DemoPrivacyScore {
+  score: number
+  grade: string
+  factors: {
+    addressReuse: { score: number; detail: string }
+    amountPatterns: { score: number; detail: string }
+    timingCorrelation: { score: number; detail: string }
+    counterpartyExposure: { score: number; detail: string }
+  }
+  recommendations: string[]
+  transactionsAnalyzed: number
+}
+
+export type AmountBand = '<1' | '1-10' | '10-100' | '100-1000' | '>1000'
+
+export interface AnonActivityRow {
+  type: string
+  chain: string
+  amountBand: AmountBand
+  relativeTime: string
+}
+
+export interface ActivitySummaryResponse {
+  counter: number
+  recent: AnonActivityRow[]
+}

--- a/packages/agent/src/routes/public/index.ts
+++ b/packages/agent/src/routes/public/index.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express'
+
+/**
+ * Public, unauthenticated routes mounted at /api/public.
+ * Feature subagents (Wave 2b F1/F2/F3) extend this router by appending:
+ *   import { demoRouter } from './demo.js'
+ *   publicRouter.use('/demo', demoRouter)
+ *
+ * All sub-routers MUST apply ipRateLimitMiddleware with their own key/cap.
+ */
+export const publicRouter = Router()

--- a/packages/agent/tests/lib/cache.test.ts
+++ b/packages/agent/tests/lib/cache.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import { getCached, setCached, _resetForTests } from '../../src/lib/cache.js'
+
+describe('cache helpers', () => {
+  beforeEach(async () => {
+    await _resetForTests()
+  })
+
+  it('returns null for an unset key', async () => {
+    const v = await getCached<{ x: number }>('missing')
+    expect(v).toBeNull()
+  })
+
+  it('returns the value within TTL', async () => {
+    await setCached('hit', { x: 42 }, 60)
+    const v = await getCached<{ x: number }>('hit')
+    expect(v).toEqual({ x: 42 })
+  })
+
+  it('returns null after TTL expires', async () => {
+    vi.useFakeTimers()
+    await setCached('expiring', { x: 1 }, 1)
+    vi.advanceTimersByTime(1_500)
+    const v = await getCached<{ x: number }>('expiring')
+    expect(v).toBeNull()
+    vi.useRealTimers()
+  })
+
+  it('overwrites the value on second set', async () => {
+    await setCached('overwrite', { x: 1 }, 60)
+    await setCached('overwrite', { x: 2 }, 60)
+    const v = await getCached<{ x: number }>('overwrite')
+    expect(v).toEqual({ x: 2 })
+  })
+
+  it('clears state via _resetForTests', async () => {
+    await setCached('a', 1, 60)
+    await _resetForTests()
+    expect(await getCached('a')).toBeNull()
+  })
+})

--- a/packages/agent/tests/lib/ip-rate-limit.test.ts
+++ b/packages/agent/tests/lib/ip-rate-limit.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import {
+  checkAndIncrement,
+  ipRateLimitMiddleware,
+  _resetForTests,
+} from '../../src/lib/ip-rate-limit.js'
+
+describe('checkAndIncrement', () => {
+  beforeEach(async () => {
+    await _resetForTests()
+  })
+
+  it('allows the first request and decrements remaining', async () => {
+    const result = await checkAndIncrement('1.2.3.4', 'demo', 5, 60_000)
+    expect(result.allowed).toBe(true)
+    expect(result.remaining).toBe(4)
+    expect(result.cap).toBe(5)
+    expect(result.resetAt).toBeGreaterThan(Date.now())
+  })
+
+  it('counts within the same window', async () => {
+    await checkAndIncrement('1.2.3.4', 'demo', 5, 60_000)
+    const r2 = await checkAndIncrement('1.2.3.4', 'demo', 5, 60_000)
+    expect(r2.remaining).toBe(3)
+  })
+
+  it('returns allowed=false when cap exceeded', async () => {
+    for (let i = 0; i < 5; i++) await checkAndIncrement('1.2.3.4', 'demo', 5, 60_000)
+    const denied = await checkAndIncrement('1.2.3.4', 'demo', 5, 60_000)
+    expect(denied.allowed).toBe(false)
+    expect(denied.remaining).toBe(0)
+  })
+
+  it('isolates buckets per IP', async () => {
+    await checkAndIncrement('1.1.1.1', 'demo', 5, 60_000)
+    const r = await checkAndIncrement('2.2.2.2', 'demo', 5, 60_000)
+    expect(r.remaining).toBe(4)
+  })
+
+  it('isolates buckets per key for same IP', async () => {
+    await checkAndIncrement('1.2.3.4', 'demo', 5, 60_000)
+    const r = await checkAndIncrement('1.2.3.4', 'chat', 5, 60_000)
+    expect(r.remaining).toBe(4)
+  })
+
+  it('resets the bucket after window expires', async () => {
+    vi.useFakeTimers()
+    await checkAndIncrement('1.2.3.4', 'demo', 1, 1_000)
+    const denied = await checkAndIncrement('1.2.3.4', 'demo', 1, 1_000)
+    expect(denied.allowed).toBe(false)
+    vi.advanceTimersByTime(1_001)
+    const fresh = await checkAndIncrement('1.2.3.4', 'demo', 1, 1_000)
+    expect(fresh.allowed).toBe(true)
+    expect(fresh.remaining).toBe(0)
+    vi.useRealTimers()
+  })
+})
+
+describe('ipRateLimitMiddleware', () => {
+  beforeEach(async () => {
+    await _resetForTests()
+  })
+
+  function makeApp(key: string, cap: number, windowMs: number) {
+    const app = express()
+    app.set('trust proxy', 1)
+    app.get('/test', ipRateLimitMiddleware(key, cap, windowMs), (_req, res) => {
+      res.json({ ok: true })
+    })
+    return app
+  }
+
+  it('sets X-RateLimit-* headers on success', async () => {
+    const app = makeApp('demo', 5, 60_000)
+    const res = await request(app).get('/test')
+    expect(res.status).toBe(200)
+    expect(res.headers['x-ratelimit-limit']).toBe('5')
+    expect(res.headers['x-ratelimit-remaining']).toBe('4')
+    expect(Number(res.headers['x-ratelimit-reset'])).toBeGreaterThan(Math.floor(Date.now() / 1000))
+  })
+
+  it('returns 429 + RATE_LIMITED envelope on exceeded', async () => {
+    const app = makeApp('demo', 1, 60_000)
+    await request(app).get('/test')
+    const res = await request(app).get('/test')
+    expect(res.status).toBe(429)
+    expect(res.body).toEqual({
+      error: {
+        code: 'RATE_LIMITED',
+        message: expect.stringMatching(/rate limit/i),
+        resetAt: expect.any(Number),
+      },
+    })
+  })
+
+  it('honors X-Forwarded-For when trust proxy is set', async () => {
+    const app = makeApp('demo', 1, 60_000)
+    await request(app).get('/test').set('X-Forwarded-For', '5.5.5.5')
+    const res = await request(app).get('/test').set('X-Forwarded-For', '6.6.6.6')
+    expect(res.status).toBe(200)
+    expect(res.headers['x-ratelimit-remaining']).toBe('0')
+  })
+})

--- a/packages/agent/tests/public-router-mount.test.ts
+++ b/packages/agent/tests/public-router-mount.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, beforeAll } from 'vitest'
+import request from 'supertest'
+
+// Probes /api/public/_smoke (a probe route added below) to confirm
+// publicRouter mounts cleanly at the expected prefix and 404s on
+// unmounted children.
+
+describe('publicRouter mount point', () => {
+  let app: import('express').Express
+
+  beforeAll(async () => {
+    const { publicRouter } = await import('../src/routes/public/index.js')
+    publicRouter.get('/_smoke', (_req, res) => {
+      res.json({ ok: true, mount: '/api/public' })
+    })
+    const express = (await import('express')).default
+    app = express()
+    app.set('trust proxy', 1)
+    app.use('/api/public', publicRouter)
+  })
+
+  it('responds at /api/public/_smoke without auth', async () => {
+    const res = await request(app).get('/api/public/_smoke')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ ok: true, mount: '/api/public' })
+  })
+
+  it('returns 404 for unmounted /api/public/missing', async () => {
+    const res = await request(app).get('/api/public/missing')
+    expect(res.status).toBe(404)
+  })
+})


### PR DESCRIPTION
## Summary

Foundation PR for Wave 2b (#216 demo mode, #217 activity teaser, #218 unauthed chat). No user-facing changes — sets up shared infrastructure that the 3 follow-up cluster PRs consume.

## What ships

- **`packages/agent/src/lib/ip-rate-limit.ts`** — `createStore`-backed per-(IP, key) sliding-window rate limiter. Forward-compat with the documented Redis swap path (same backend as `verifyAttempts` in routes/auth.ts).
  - `checkAndIncrement(ip, key, cap, windowMs)` returns `{ allowed, remaining, resetAt, cap }`
  - `ipRateLimitMiddleware(key, cap, windowMs)` Express middleware — sets X-RateLimit-* headers, returns 429 + `{ error: { code: 'RATE_LIMITED', resetAt } }` envelope on exceeded
- **`packages/agent/src/lib/cache.ts`** — tiny TTL-based response cache (createStore-backed) for upcoming GET `/api/public/*` cached responses.
- **`packages/agent/src/routes/public/index.ts`** — empty Express `publicRouter`, mounted at `/api/public` in `agent/src/index.ts`. Feature subagents append their sub-routers.
- **`packages/agent/src/lib/queries/public.ts`** — shared types for upcoming public response shapes.

## Tests

+16 agent tests (baseline 1399 → 1415, files 116 → 119):
- 9 ip-rate-limit cases (counter behavior, isolation per IP/key, window expiry, X-Forwarded-For honored, 429 envelope, X-RateLimit-* headers)
- 5 cache cases (set/get within TTL, expiry, overwrite, _resetForTests)
- 2 public-router mount cases

## Notes

- Trust proxy is already configured (`packages/agent/src/index.ts:146-148` reads `TRUST_PROXY` env, default 1) — middleware honors `X-Forwarded-For` out of the box.
- CORS configured upstream (`CORS_ORIGINS` env) — `/api/public/*` inherits, no special wiring needed.
- No user-facing routes ship in this PR — `publicRouter` stays empty until F1/F2/F3 land.

## References

- Spec: `docs/superpowers/specs/2026-05-11-qa-sweep-tier-4-wave-2b-design.md`
- Plan: `docs/superpowers/plans/2026-05-11-qa-sweep-tier-4-wave-2b.md`