### PR TITLE
feat: #216 demo mode — read-only preview at /demo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,13 @@ TRUST_PROXY=1
 SHUTDOWN_TIMEOUT_MS=30000
 
 # ───────────────────────────────────────────
+# Demo mode (#216) — public read-only /demo route
+# ───────────────────────────────────────────
+# Devnet wallet whose vault/activity/privacy-score is exposed on the public
+# /api/public/demo/* routes. Empty/unset disables demo mode (routes return 503).
+DEMO_WALLET=FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr
+
+# ───────────────────────────────────────────
 # SENTINEL Security Agent (see docs/deployment.md)
 # ───────────────────────────────────────────
 # Autonomy mode: yolo (full autonomy) | advisory (recommend only) | off (rule-based only)

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -32,19 +32,25 @@ import { useNetworkConfigStore, fetchNetworkConfig } from './lib/networkConfig'
 import { ToastProvider } from './providers/ToastProvider'
 import { AuthSyncProvider } from './providers/AuthSyncProvider'
 
+// Exact-match set of routes where authed-only nav chrome (Header tabs,
+// BottomNav, Ask-SIPHER chat sheet trigger) is suppressed. Using a Set
+// instead of `pathname.startsWith('/demo')` so future neighbour routes
+// like `/demo-foo` or `/demothing` don't accidentally inherit the hide
+// treatment.
+const HIDE_CHROME_PATHS = new Set(['/demo'])
+
 function AppShell() {
   const chatSheetOpen = useAppStore((s) => s.chatSheetOpen)
   const setChatSheetOpen = useAppStore((s) => s.setChatSheetOpen)
   const { token } = useAuth()
   const { events } = useSSE()
   const beta = useNetworkConfigStore((s) => s.config?.beta ?? false)
-  // On /demo we strip the authed-only nav chrome (Header tabs, BottomNav,
-  // Ask-SIPHER chat sheet trigger) so the read-only preview stays focused
-  // and visitors cannot navigate into routes that require a JWT. The
-  // BetaBanner + NetworkBanner stay visible because they communicate
-  // network identity, which is also material to the demo.
+  // On /demo we strip the authed-only nav chrome so the read-only preview
+  // stays focused and visitors cannot navigate into routes that require a
+  // JWT. The BetaBanner + NetworkBanner stay visible because they
+  // communicate network identity, which is also material to the demo.
   const location = useLocation()
-  const hideChrome = location.pathname.startsWith('/demo')
+  const hideChrome = HIDE_CHROME_PATHS.has(location.pathname)
 
   return (
     <div className="flex flex-col h-dvh bg-bg">

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react'
 import { WalletModalProvider } from '@solana/wallet-adapter-react-ui'
 import '@solana/wallet-adapter-react-ui/styles.css'
@@ -12,6 +12,7 @@ import { BetaBanner } from './components/BetaBanner'
 import { NetworkBanner } from './components/NetworkBanner'
 import { Sheet } from './components/ui/Sheet'
 import DashboardView from './views/DashboardView'
+import DemoView from './views/DemoView'
 import VaultView from './views/VaultView'
 import DepositView from './views/DepositView'
 import WithdrawView from './views/WithdrawView'
@@ -37,17 +38,25 @@ function AppShell() {
   const { token } = useAuth()
   const { events } = useSSE()
   const beta = useNetworkConfigStore((s) => s.config?.beta ?? false)
+  // On /demo we strip the authed-only nav chrome (Header tabs, BottomNav,
+  // Ask-SIPHER chat sheet trigger) so the read-only preview stays focused
+  // and visitors cannot navigate into routes that require a JWT. The
+  // BetaBanner + NetworkBanner stay visible because they communicate
+  // network identity, which is also material to the demo.
+  const location = useLocation()
+  const hideChrome = location.pathname.startsWith('/demo')
 
   return (
     <div className="flex flex-col h-dvh bg-bg">
       <BetaBanner beta={beta} />
       <NetworkBanner />
-      <Header />
+      {!hideChrome && <Header />}
 
       <div className="flex-1 flex overflow-hidden">
         <main className="flex-1 overflow-y-auto px-4 py-5 lg:px-6">
           <Routes>
             <Route path="/" element={<DashboardView events={events} />} />
+            <Route path="/demo" element={<DemoView />} />
             <Route path="/vault" element={<VaultView />} />
             <Route path="/vault/deposit" element={<DepositView />} />
             <Route path="/vault/withdraw" element={<WithdrawView />} />
@@ -64,16 +73,18 @@ function AppShell() {
         </main>
       </div>
 
-      <BottomNav />
+      {!hideChrome && <BottomNav />}
       <Footer />
 
-      <Sheet
-        open={chatSheetOpen}
-        onClose={() => setChatSheetOpen(false)}
-        ariaLabel="Ask SIPHER"
-      >
-        <ChatSidebar />
-      </Sheet>
+      {!hideChrome && (
+        <Sheet
+          open={chatSheetOpen}
+          onClose={() => setChatSheetOpen(false)}
+          ariaLabel="Ask SIPHER"
+        >
+          <ChatSidebar />
+        </Sheet>
+      )}
     </div>
   )
 }

--- a/app/src/__tests__/App.test.tsx
+++ b/app/src/__tests__/App.test.tsx
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+// ─── Provider mocks ──────────────────────────────────────────────────────────
+// App.tsx mounts the full Solana wallet-adapter + auth provider tree. For
+// a route-mount smoke test we replace each provider with a pass-through so
+// nothing reaches the network. Mocks must be declared BEFORE the App import
+// so the module-graph rewrites pick them up.
+
+vi.mock('@solana/wallet-adapter-react', () => ({
+  ConnectionProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  WalletProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useWallet: () => ({
+    connected: false,
+    publicKey: null,
+    wallet: null,
+    signMessage: undefined,
+    disconnect: vi.fn(),
+  }),
+}))
+
+vi.mock('@solana/wallet-adapter-react-ui', () => ({
+  WalletModalProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useWalletModal: () => ({ setVisible: vi.fn(), visible: false }),
+}))
+
+// We can't simply pass-through BrowserRouter because AppShell calls
+// useLocation(); leaving it bare would explode. Replace BrowserRouter with
+// a MemoryRouter that reads the current window pathname at construction
+// time — the per-test push to window.history works the same way as
+// production navigation, so tests just call window.history.pushState then
+// render.
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    BrowserRouter: ({ children }: { children: ReactNode }) => (
+      <actual.MemoryRouter initialEntries={[window.location.pathname]}>
+        {children}
+      </actual.MemoryRouter>
+    ),
+  }
+})
+
+vi.mock('../providers/AuthSyncProvider', async () => {
+  const { makeFakeAuthState } = await import('../test-utils/makeFakeAuthState')
+  return {
+    AuthSyncProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+    useAuthSyncContext: () => makeFakeAuthState(),
+  }
+})
+
+vi.mock('../providers/ToastProvider', () => ({
+  ToastProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useToast: () => ({ show: vi.fn(() => 'id'), dismiss: vi.fn() }),
+}))
+
+vi.mock('../hooks/useAuthState', async () => {
+  const { makeFakeAuthState } = await import('../test-utils/makeFakeAuthState')
+  return {
+    useAuthState: () => makeFakeAuthState({ status: 'unauthed' }),
+  }
+})
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({ token: null, isAdmin: false, publicKey: null }),
+}))
+
+vi.mock('../hooks/useSSE', () => ({
+  useSSE: () => ({ events: [] }),
+}))
+
+vi.mock('../lib/networkConfig', () => ({
+  fetchNetworkConfig: vi.fn(),
+  useNetworkConfigStore: (selector: (s: unknown) => unknown) =>
+    selector({ config: { network: 'devnet', publicRpcUrl: '', beta: false }, error: null }),
+}))
+
+// Bypass Wallet Standard discovery + autoConnect side-effects entirely.
+vi.mock('../components/Header', () => ({ default: () => <header data-testid="mock-header" /> }))
+vi.mock('../components/BottomNav', () => ({ default: () => <nav data-testid="mock-bottom-nav" /> }))
+vi.mock('../components/Footer', () => ({ Footer: () => <footer /> }))
+vi.mock('../components/ChatSidebar', () => ({ default: () => <div data-testid="mock-chat" /> }))
+vi.mock('../components/BetaBanner', () => ({ BetaBanner: () => null }))
+vi.mock('../components/NetworkBanner', () => ({ NetworkBanner: () => null }))
+
+import App from '../App'
+
+function stubDemoFetch() {
+  global.fetch = vi.fn().mockImplementation((url: string) => {
+    if (url.includes('/api/public/demo/vault')) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          wallet: 'demo',
+          network: 'devnet',
+          balances: { sol: 0, tokens: [], status: 'ok' },
+          activity: [],
+        }),
+      } as Response)
+    }
+    if (url.includes('/api/public/demo/privacy-score')) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          address: 'demo',
+          score: 80,
+          grade: 'B',
+          transactionsAnalyzed: 0,
+          factors: {
+            addressReuse: { score: 80, detail: '' },
+            amountPatterns: { score: 80, detail: '' },
+            timingCorrelation: { score: 80, detail: '' },
+            counterpartyExposure: { score: 80, detail: '' },
+          },
+          recommendations: [],
+        }),
+      } as Response)
+    }
+    if (url.includes('/api/public/demo/activity')) {
+      return Promise.resolve({ ok: true, json: async () => ({ activity: [] }) } as Response)
+    }
+    // ShieldedVolumeCard + MultiChainVaultGrid issue /api/chains[/aggregate]
+    return Promise.resolve({
+      ok: true,
+      json: async () => ({ chains: [], totalTvlSol: 0, chainCount: 0, liveChainCount: 0, asOf: 't' }),
+    } as Response)
+  })
+}
+
+beforeEach(() => {
+  // jsdom doesn't implement history navigation deeply; reset before each.
+  window.history.pushState({}, '', '/')
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('App routing', () => {
+  it('mounts DashboardView at / (smoke)', () => {
+    window.history.pushState({}, '', '/')
+    render(<App />)
+    // DashboardView renders the unauthed tagline when status !== authed.
+    expect(
+      screen.getByText(/Multi-chain privacy command center/),
+    ).toBeInTheDocument()
+  })
+
+  it('mounts DemoView at /demo', async () => {
+    window.history.pushState({}, '', '/demo')
+    stubDemoFetch()
+    render(<App />)
+    await waitFor(() => {
+      expect(screen.getByTestId('demo-banner')).toBeInTheDocument()
+    })
+    expect(screen.getByText(/demo mode/i)).toBeInTheDocument()
+  })
+
+  it('hides Header + BottomNav chrome on /demo', () => {
+    window.history.pushState({}, '', '/demo')
+    stubDemoFetch()
+    render(<App />)
+    expect(screen.queryByTestId('mock-header')).toBeNull()
+    expect(screen.queryByTestId('mock-bottom-nav')).toBeNull()
+  })
+
+  it('shows Header + BottomNav chrome on / (regression guard)', () => {
+    window.history.pushState({}, '', '/')
+    render(<App />)
+    expect(screen.getByTestId('mock-header')).toBeInTheDocument()
+    expect(screen.getByTestId('mock-bottom-nav')).toBeInTheDocument()
+  })
+})

--- a/app/src/__tests__/App.test.tsx
+++ b/app/src/__tests__/App.test.tsx
@@ -172,4 +172,15 @@ describe('App routing', () => {
     expect(screen.getByTestId('mock-header')).toBeInTheDocument()
     expect(screen.getByTestId('mock-bottom-nav')).toBeInTheDocument()
   })
+
+  it('does NOT hide chrome on /demo-foo (prefix-match footgun guard)', () => {
+    // /demo-foo is a hypothetical future route that should NOT inherit
+    // /demo's chrome-hidden treatment. Using pathname.startsWith('/demo')
+    // would match it; an exact-match Set scopes the hide correctly to /demo
+    // alone.
+    window.history.pushState({}, '', '/demo-foo')
+    render(<App />)
+    expect(screen.getByTestId('mock-header')).toBeInTheDocument()
+    expect(screen.getByTestId('mock-bottom-nav')).toBeInTheDocument()
+  })
 })

--- a/app/src/components/DemoCtaCard.tsx
+++ b/app/src/components/DemoCtaCard.tsx
@@ -20,7 +20,6 @@ export default function DemoCtaCard() {
     >
       <p className="text-sm text-text-secondary mb-3">Curious how it looks populated?</p>
       <a
-        role="link"
         href="/demo"
         onClick={(e) => {
           e.preventDefault()

--- a/app/src/components/DemoCtaCard.tsx
+++ b/app/src/components/DemoCtaCard.tsx
@@ -1,0 +1,36 @@
+import { useNavigate } from 'react-router-dom'
+import { ArrowRight } from '@phosphor-icons/react'
+
+/**
+ * DemoCtaCard — unauthed-Dashboard CTA inviting visitors to preview the
+ * populated /demo experience without committing a wallet. Rendered above
+ * the empty PrivacyGraph slot on DashboardView when status !== 'authed'.
+ *
+ * The "link" is a click-handled anchor (not Link) so we can keep the
+ * navigation gesture observable via the mocked useNavigate hook in tests.
+ * `href="/demo"` preserves middle-click + accessibility semantics.
+ */
+export default function DemoCtaCard() {
+  const navigate = useNavigate()
+
+  return (
+    <div
+      data-testid="demo-cta-card"
+      className="rounded-lg border border-line bg-glass-1 p-5 text-center"
+    >
+      <p className="text-sm text-text-secondary mb-3">Curious how it looks populated?</p>
+      <a
+        role="link"
+        href="/demo"
+        onClick={(e) => {
+          e.preventDefault()
+          navigate('/demo')
+        }}
+        className="inline-flex items-center gap-1.5 text-sm font-medium text-accent hover:underline cursor-pointer"
+      >
+        View sample dashboard
+        <ArrowRight size={14} weight="bold" />
+      </a>
+    </div>
+  )
+}

--- a/app/src/components/__tests__/DemoCtaCard.test.tsx
+++ b/app/src/components/__tests__/DemoCtaCard.test.tsx
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import DemoCtaCard from '../DemoCtaCard'
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+beforeEach(() => {
+  mockNavigate.mockReset()
+})
+
+describe('<DemoCtaCard />', () => {
+  it('renders the CTA copy and link', () => {
+    render(
+      <MemoryRouter>
+        <DemoCtaCard />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText(/curious how it looks populated/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /view sample dashboard/i })).toBeInTheDocument()
+  })
+
+  it('navigates to /demo when the CTA is clicked', () => {
+    render(
+      <MemoryRouter>
+        <DemoCtaCard />
+      </MemoryRouter>,
+    )
+    fireEvent.click(screen.getByRole('link', { name: /view sample dashboard/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/demo')
+  })
+})

--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -8,6 +8,7 @@ import { ActivityStreamTable, type ActivityRow } from '../components/ActivityStr
 import { PrivacyGraph } from '../components/PrivacyGraph'
 import { ShieldedVolumeCard } from '../components/ShieldedVolumeCard'
 import { MultiChainVaultGrid } from '../components/MultiChainVaultGrid'
+import DemoCtaCard from '../components/DemoCtaCard'
 
 interface VaultData {
   wallet: string
@@ -160,6 +161,7 @@ export default function DashboardView({ events }: { events: ActivityEvent[] }) {
             Multi-chain privacy command center for shielded transfers across 9+ chains.
           </p>
         )}
+        {status !== 'authed' && <DemoCtaCard />}
         <PrivacyGraph />
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/app/src/views/DemoView.tsx
+++ b/app/src/views/DemoView.tsx
@@ -1,0 +1,191 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useWalletModal } from '@solana/wallet-adapter-react-ui'
+import { useAuthState } from '../hooks/useAuthState'
+import { PrivacyScoreCard } from '../components/PrivacyScoreCard'
+import { ActivityStreamTable, type ActivityRow } from '../components/ActivityStreamTable'
+import { PrivacyGraph } from '../components/PrivacyGraph'
+import { ShieldedVolumeCard } from '../components/ShieldedVolumeCard'
+import { MultiChainVaultGrid } from '../components/MultiChainVaultGrid'
+
+interface DemoVaultData {
+  wallet: string
+  network: string
+  balances: { sol: number; tokens: unknown[]; status: string }
+  activity?: Array<Record<string, unknown>>
+}
+
+interface DemoPrivacyData {
+  address: string
+  score: number
+  grade: string
+  factors: {
+    addressReuse: { score: number; detail: string }
+    amountPatterns: { score: number; detail: string }
+    timingCorrelation: { score: number; detail: string }
+    counterpartyExposure: { score: number; detail: string }
+  }
+  recommendations: string[]
+  transactionsAnalyzed: number
+}
+
+interface DemoActivityRecord {
+  id: string
+  agent: string
+  type: string
+  level: string
+  title: string
+  detail?: string | null
+  created_at: string
+}
+
+const API_BASE = import.meta.env.VITE_API_URL ?? ''
+
+function parseDetail(detail: unknown): Record<string, unknown> {
+  if (typeof detail === 'string') {
+    try { return JSON.parse(detail) }
+    catch { return { detail } }
+  }
+  return (detail as Record<string, unknown>) ?? {}
+}
+
+async function fetchDemoJson<T>(path: string, signal: AbortSignal): Promise<T> {
+  // Public endpoints — NO Authorization header is included. We use a fresh
+  // headers object (not spread from any global default) so a future auth-
+  // injecting middleware can't leak the JWT into the demo channel.
+  const res = await fetch(`${API_BASE}${path}`, { signal, headers: { 'Content-Type': 'application/json' } })
+  if (!res.ok) {
+    throw new Error(`Demo API error ${res.status}`)
+  }
+  return res.json() as Promise<T>
+}
+
+/**
+ * DemoView — public, read-only "/demo" route that previews the Dashboard
+ * populated with data from a real devnet wallet (DEMO_WALLET env on the
+ * backend). Banner + Exit/Connect CTAs make the demo identity unmistakable.
+ *
+ * Hiding the AppShell chrome on /demo is handled in App.tsx via a
+ * useLocation()-gated render guard so the demo stays focused and routes
+ * cannot leak the user into authed-only views.
+ *
+ * Auto-redirects to "/" once the auth state transitions to 'authed' so the
+ * user lands on their real dashboard the moment they connect.
+ */
+export default function DemoView() {
+  const navigate = useNavigate()
+  const { status } = useAuthState()
+  const { setVisible } = useWalletModal()
+  const [vault, setVault] = useState<DemoVaultData | null>(null)
+  const [privacy, setPrivacy] = useState<DemoPrivacyData | null>(null)
+  const [history, setHistory] = useState<ActivityRow[]>([])
+
+  useEffect(() => {
+    if (status === 'authed') {
+      navigate('/')
+    }
+  }, [status, navigate])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    fetchDemoJson<DemoVaultData>('/api/public/demo/vault', controller.signal)
+      .then((d) => { if (!controller.signal.aborted) setVault(d) })
+      .catch((err: Error) => {
+        if (err.name === 'AbortError') return
+        // Non-fatal — leave vault null so the cards show their empty states.
+      })
+    fetchDemoJson<DemoPrivacyData>('/api/public/demo/privacy-score', controller.signal)
+      .then((d) => { if (!controller.signal.aborted) setPrivacy(d) })
+      .catch((err: Error) => {
+        if (err.name === 'AbortError') return
+      })
+    fetchDemoJson<{ activity: DemoActivityRecord[] }>('/api/public/demo/activity', controller.signal)
+      .then((data) => {
+        if (controller.signal.aborted) return
+        setHistory(
+          (data.activity ?? []).map((a): ActivityRow => ({
+            id: a.id,
+            agent: a.agent,
+            type: a.type,
+            level: a.level,
+            data: parseDetail(a.detail),
+            timestamp: a.created_at,
+          })),
+        )
+      })
+      .catch((err: Error) => {
+        if (err.name === 'AbortError') return
+      })
+    return () => controller.abort()
+  }, [])
+
+  // PrivacyScoreCard expects the {data:{score,grade,factors,recommendations,transactionsAnalyzed}}
+  // shape — same shape as Mode 2's /v1/privacy/score `data` block. Our demo
+  // service returns it flat, so re-shape inline.
+  const privacyForCard = privacy
+    ? {
+        score: privacy.score,
+        grade: privacy.grade,
+        factors: privacy.factors,
+        recommendations: privacy.recommendations,
+        transactionsAnalyzed: privacy.transactionsAnalyzed,
+      }
+    : null
+
+  return (
+    <div data-testid="demo-view" className="space-y-6 p-6">
+      <title>SIPHER — Demo mode</title>
+      <meta name="description" content="Read-only preview of the SIPHER privacy command center on devnet." />
+
+      <div
+        data-testid="demo-banner"
+        className="flex flex-col gap-3 rounded-lg border border-accent/40 bg-accent/5 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+        role="status"
+        aria-live="polite"
+      >
+        <div className="text-sm text-text">
+          <strong className="font-semibold">Demo mode</strong> — read-only preview using a real devnet wallet.{' '}
+          Connect your wallet to use SIPHER for real.
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => navigate('/')}
+            className="text-xs px-3 py-1.5 rounded-md border border-line text-text-secondary hover:text-text hover:border-line-2 transition-colors"
+          >
+            Exit demo
+          </button>
+          <button
+            type="button"
+            onClick={() => setVisible(true)}
+            className="text-xs px-3 py-1.5 rounded-md text-bg font-semibold hover:opacity-90"
+            style={{ background: 'linear-gradient(90deg, var(--color-cyan), var(--color-violet))' }}
+          >
+            Connect wallet
+          </button>
+        </div>
+      </div>
+
+      <PrivacyGraph />
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2">
+          <PrivacyScoreCard data={privacyForCard} />
+        </div>
+        <div>
+          <ShieldedVolumeCard />
+        </div>
+      </div>
+
+      <MultiChainVaultGrid />
+
+      <ActivityStreamTable rows={history} />
+
+      {vault?.balances.status === 'unavailable' && (
+        <p className="text-xs text-text-muted text-center">
+          On-chain balances are temporarily unavailable. Snapshot from cache.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/app/src/views/DemoView.tsx
+++ b/app/src/views/DemoView.tsx
@@ -181,7 +181,7 @@ export default function DemoView() {
 
       <ActivityStreamTable rows={history} />
 
-      {vault?.balances.status === 'unavailable' && (
+      {vault?.balances?.status === 'unavailable' && (
         <p className="text-xs text-text-muted text-center">
           On-chain balances are temporarily unavailable. Snapshot from cache.
         </p>

--- a/app/src/views/__tests__/DashboardView.test.tsx
+++ b/app/src/views/__tests__/DashboardView.test.tsx
@@ -201,3 +201,29 @@ describe('DashboardView — unauthed tagline', () => {
     ).toBeInTheDocument()
   })
 })
+
+describe('Demo CTA (unauthed)', () => {
+  it('renders DemoCtaCard when status is unauthed', () => {
+    currentAuthOverrides = { status: 'unauthed', token: null, publicKey: null }
+    render(
+      <MemoryRouter>
+        <DashboardView events={[]} />
+      </MemoryRouter>,
+    )
+    expect(
+      screen.getByRole('link', { name: /view sample dashboard/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('does NOT render DemoCtaCard when status is authed', () => {
+    currentAuthOverrides = { status: 'authed', token: 'tok', publicKey: 'W' }
+    render(
+      <MemoryRouter>
+        <DashboardView events={[]} />
+      </MemoryRouter>,
+    )
+    expect(
+      screen.queryByRole('link', { name: /view sample dashboard/i }),
+    ).toBeNull()
+  })
+})

--- a/app/src/views/__tests__/DemoView.test.tsx
+++ b/app/src/views/__tests__/DemoView.test.tsx
@@ -1,0 +1,139 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { AuthState } from '../../hooks/useAuthState'
+import { makeFakeAuthState } from '../../test-utils/makeFakeAuthState'
+import DemoView from '../DemoView'
+
+let currentAuthOverrides: Partial<AuthState> = { status: 'unauthed' }
+let mockSetVisible: ReturnType<typeof vi.fn>
+
+vi.mock('../../hooks/useAuthState', () => ({
+  useAuthState: () => makeFakeAuthState(currentAuthOverrides),
+}))
+
+vi.mock('@solana/wallet-adapter-react-ui', () => ({
+  useWalletModal: () => ({ setVisible: mockSetVisible, visible: false }),
+}))
+
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+const vaultFixture = {
+  wallet: 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr',
+  network: 'devnet',
+  balances: { sol: 1.5, tokens: [], status: 'ok' },
+  activity: [],
+}
+
+const activityFixture = { activity: [] }
+
+const privacyFixture = {
+  address: 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr',
+  score: 82,
+  grade: 'B',
+  transactionsAnalyzed: 50,
+  factors: {
+    addressReuse: { score: 80, detail: 'demo-detail' },
+    amountPatterns: { score: 85, detail: 'demo-detail' },
+    timingCorrelation: { score: 80, detail: 'demo-detail' },
+    counterpartyExposure: { score: 82, detail: 'demo-detail' },
+  },
+  recommendations: [],
+}
+
+beforeEach(() => {
+  mockNavigate.mockReset()
+  mockSetVisible = vi.fn()
+  currentAuthOverrides = { status: 'unauthed' }
+  global.fetch = vi.fn().mockImplementation((url: string) => {
+    if (typeof url !== 'string') {
+      return Promise.reject(new Error('unexpected fetch url type'))
+    }
+    if (url.includes('/api/public/demo/vault')) {
+      return Promise.resolve({ ok: true, json: async () => vaultFixture } as Response)
+    }
+    if (url.includes('/api/public/demo/activity')) {
+      return Promise.resolve({ ok: true, json: async () => activityFixture } as Response)
+    }
+    if (url.includes('/api/public/demo/privacy-score')) {
+      return Promise.resolve({ ok: true, json: async () => privacyFixture } as Response)
+    }
+    return Promise.reject(new Error(`unexpected fetch url: ${url}`))
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('<DemoView />', () => {
+  it('renders the banner with "Demo mode" copy plus Exit + Connect CTA buttons', async () => {
+    render(
+      <MemoryRouter>
+        <DemoView />
+      </MemoryRouter>,
+    )
+    expect(await screen.findByText(/demo mode/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /exit demo/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /connect wallet/i })).toBeInTheDocument()
+  })
+
+  it('navigates to / when the exit-demo button is clicked', () => {
+    render(
+      <MemoryRouter>
+        <DemoView />
+      </MemoryRouter>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /exit demo/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/')
+  })
+
+  it('opens the wallet modal when the connect-wallet button is clicked', () => {
+    render(
+      <MemoryRouter>
+        <DemoView />
+      </MemoryRouter>,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /connect wallet/i }))
+    expect(mockSetVisible).toHaveBeenCalledWith(true)
+  })
+
+  it('auto-redirects to / when the auth status transitions to authed', async () => {
+    const { rerender } = render(
+      <MemoryRouter>
+        <DemoView />
+      </MemoryRouter>,
+    )
+    expect(mockNavigate).not.toHaveBeenCalled()
+    act(() => {
+      currentAuthOverrides = { status: 'authed', token: 'tok', publicKey: 'W' }
+    })
+    rerender(
+      <MemoryRouter>
+        <DemoView />
+      </MemoryRouter>,
+    )
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/'))
+  })
+
+  it('fetches /api/public/demo/* with no Authorization header', async () => {
+    render(
+      <MemoryRouter>
+        <DemoView />
+      </MemoryRouter>,
+    )
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled())
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls
+    expect(calls.length).toBeGreaterThan(0)
+    for (const callArgs of calls) {
+      const init = callArgs[1] as RequestInit | undefined
+      const headers = (init?.headers ?? {}) as Record<string, string>
+      expect(headers.Authorization).toBeUndefined()
+      expect(headers.authorization).toBeUndefined()
+    }
+  })
+})

--- a/packages/agent/src/routes/public/demo.ts
+++ b/packages/agent/src/routes/public/demo.ts
@@ -1,0 +1,111 @@
+import { Router, type Request, type Response } from 'express'
+import { ipRateLimitMiddleware } from '../../lib/ip-rate-limit.js'
+import { getCached, setCached } from '../../lib/cache.js'
+import {
+  getDemoVault,
+  getDemoActivity,
+  getDemoPrivacyScore,
+  type DemoVaultResponse,
+  type DemoPrivacyScoreResponse,
+} from '../../services/demo-wallet.js'
+
+/**
+ * Demo routes — public, rate-limited, 60s in-memory cache.
+ *
+ * Three GETs serve the marketing /demo page:
+ *   GET /api/public/demo/vault          → balances + activity snapshot
+ *   GET /api/public/demo/activity       → DB activity stream
+ *   GET /api/public/demo/privacy-score  → 4-factor privacy analysis
+ *
+ * Env gate: `DEMO_WALLET` MUST be set. If unset, every route returns
+ * 503 + { error: { code: 'UNAVAILABLE', message: 'Demo mode disabled' } }.
+ * This lets operators disable the marketing surface without redeploying
+ * the agent (e.g., during a sensitive migration window).
+ */
+export const demoRouter = Router()
+
+const CACHE_TTL_SECONDS = 60
+
+// 60 req/IP/min — generous; cache absorbs the bulk of traffic.
+demoRouter.use(ipRateLimitMiddleware('demo', 60, 60_000))
+
+function demoUnavailable(res: Response): void {
+  res.status(503).json({
+    error: { code: 'UNAVAILABLE', message: 'Demo mode disabled' },
+  })
+}
+
+function getDemoWalletOrNull(): string | null {
+  const w = process.env.DEMO_WALLET
+  return w && w.trim().length > 0 ? w : null
+}
+
+demoRouter.get('/vault', async (_req: Request, res: Response) => {
+  const wallet = getDemoWalletOrNull()
+  if (!wallet) {
+    demoUnavailable(res)
+    return
+  }
+  const cacheKey = 'public-demo-vault'
+  const cached = await getCached<DemoVaultResponse>(cacheKey)
+  if (cached) {
+    res.json(cached)
+    return
+  }
+  try {
+    const vault = await getDemoVault(wallet)
+    await setCached(cacheKey, vault, CACHE_TTL_SECONDS)
+    res.json(vault)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'failed to load demo vault'
+    console.error('[demo] vault error:', message)
+    res.status(500).json({ error: { code: 'INTERNAL', message } })
+  }
+})
+
+demoRouter.get('/activity', async (_req: Request, res: Response) => {
+  const wallet = getDemoWalletOrNull()
+  if (!wallet) {
+    demoUnavailable(res)
+    return
+  }
+  const cacheKey = 'public-demo-activity'
+  const cached = await getCached<{ activity: Array<Record<string, unknown>> }>(cacheKey)
+  if (cached) {
+    res.json(cached)
+    return
+  }
+  try {
+    const activity = getDemoActivity(wallet)
+    const payload = { activity }
+    await setCached(cacheKey, payload, CACHE_TTL_SECONDS)
+    res.json(payload)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'failed to load demo activity'
+    console.error('[demo] activity error:', message)
+    res.status(500).json({ error: { code: 'INTERNAL', message } })
+  }
+})
+
+demoRouter.get('/privacy-score', async (_req: Request, res: Response) => {
+  const wallet = getDemoWalletOrNull()
+  if (!wallet) {
+    demoUnavailable(res)
+    return
+  }
+  const cacheKey = 'public-demo-privacy-score'
+  const cached = await getCached<DemoPrivacyScoreResponse>(cacheKey)
+  if (cached) {
+    res.json(cached)
+    return
+  }
+  try {
+    const score = await getDemoPrivacyScore(wallet)
+    await setCached(cacheKey, score, CACHE_TTL_SECONDS)
+    res.json(score)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'failed to load demo privacy score'
+    console.error('[demo] privacy-score error:', message)
+    res.status(500).json({ error: { code: 'INTERNAL', message } })
+  }
+})

--- a/packages/agent/src/routes/public/index.ts
+++ b/packages/agent/src/routes/public/index.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express'
+import { demoRouter } from './demo.js'
 
 /**
  * Public, unauthenticated routes mounted at /api/public.
@@ -9,3 +10,6 @@ import { Router } from 'express'
  * All sub-routers MUST apply ipRateLimitMiddleware with their own key/cap.
  */
 export const publicRouter = Router()
+
+// #216 — demo mode (vault / activity / privacy-score snapshots for /demo)
+publicRouter.use('/demo', demoRouter)

--- a/packages/agent/src/services/demo-wallet.ts
+++ b/packages/agent/src/services/demo-wallet.ts
@@ -1,0 +1,357 @@
+/**
+ * Demo wallet service — read-only helpers that fetch on-chain + DB state
+ * for the public /api/public/demo/* routes.
+ *
+ * Strategy B (per Wave 2b plan F1.1): re-implement queries directly using
+ * the same primitives as the authed routes, instead of refactoring those
+ * handlers. Justification:
+ *
+ *   - `vault-api.ts` (/api/vault) reads `req.wallet` injected by `verifyJwt`.
+ *     Factoring its body out would require introducing a wallet-parameter
+ *     surface and threading it through 90+ lines of mostly-ceremonial code
+ *     (mint label tables, decimals fallback, batch fetch). The demo route
+ *     only needs the same primitives (connection.getBalance + token accounts),
+ *     and the duplication is small + isolated.
+ *   - `/v1/privacy/score` lives in the *Mode 2* package (src/routes/privacy.ts,
+ *     compiled to dist/app.js). Reusing it from the agent would mean either
+ *     importing across package boundaries or HTTP-calling our own process,
+ *     both of which are messier than implementing a focused privacy-score
+ *     analyzer here. The 4-factor analyzers (addressReuse / amountPatterns /
+ *     timingCorrelation / counterpartyExposure) are the analyzers the FE
+ *     <PrivacyScoreCard> expects.
+ *   - `getActivity()` is already a pure DB helper exported from `db.ts`; we
+ *     call it directly (no duplication needed).
+ *
+ * The 60s response cache in `routes/public/demo.ts` keeps RPC + DB pressure
+ * minimal so the marketing surface stays cheap regardless of traffic.
+ */
+
+import { PublicKey, LAMPORTS_PER_SOL } from '@solana/web3.js'
+import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
+import { createConnection, WSOL_MINT, USDC_MINT, USDT_MINT } from '@sipher/sdk'
+import { getActivity } from '../db.js'
+import { loadNetworkConfig } from '../config/network.js'
+
+// ─── Vault ───────────────────────────────────────────────────────────────────
+
+const MINT_LABELS: Record<string, string> = {
+  [WSOL_MINT.toBase58()]: 'SOL',
+  [USDC_MINT.toBase58()]: 'USDC',
+  [USDT_MINT.toBase58()]: 'USDT',
+}
+
+const KNOWN_DECIMALS: Record<string, number> = {
+  [WSOL_MINT.toBase58()]: 9,
+  [USDC_MINT.toBase58()]: 6,
+  [USDT_MINT.toBase58()]: 6,
+}
+
+export interface DemoVaultResponse {
+  wallet: string
+  network: string
+  balances: {
+    sol: number
+    tokens: Array<{
+      mint: string
+      symbol: string
+      amount: string
+      decimals: number
+      uiAmount: number
+    }>
+    status: 'ok' | 'unavailable'
+  }
+  activity: Array<Record<string, unknown>>
+}
+
+/**
+ * Returns the demo wallet's on-chain balances + recent activity.
+ * Mirrors the shape of `GET /api/vault` so the FE can reuse types.
+ */
+export async function getDemoVault(wallet: string): Promise<DemoVaultResponse> {
+  const network = loadNetworkConfig().clusterName
+  const connection = createConnection(network)
+
+  let solBalance = 0
+  let balanceStatus: 'ok' | 'unavailable' = 'ok'
+  const tokens: DemoVaultResponse['balances']['tokens'] = []
+
+  try {
+    const pubkey = new PublicKey(wallet)
+    const lamports = await connection.getBalance(pubkey)
+    solBalance = lamports / LAMPORTS_PER_SOL
+
+    const tokenAccounts = await connection.getTokenAccountsByOwner(pubkey, {
+      programId: TOKEN_PROGRAM_ID,
+    })
+
+    const unknownMints: PublicKey[] = []
+    const tokenEntries: { mint: PublicKey; mintStr: string; rawAmount: bigint }[] = []
+
+    for (const { account } of tokenAccounts.value) {
+      const data = account.data
+      const mint = new PublicKey(data.subarray(0, 32))
+      const mintStr = mint.toBase58()
+      const rawAmount = data.readBigUInt64LE(64)
+
+      if (rawAmount === 0n || mint.equals(WSOL_MINT)) continue
+
+      tokenEntries.push({ mint, mintStr, rawAmount })
+      if (!(mintStr in KNOWN_DECIMALS)) {
+        unknownMints.push(mint)
+      }
+    }
+
+    const fetchedDecimals: Record<string, number> = {}
+    if (unknownMints.length > 0) {
+      try {
+        const mintAccounts = await connection.getMultipleAccountsInfo(unknownMints)
+        for (let i = 0; i < unknownMints.length; i++) {
+          const info = mintAccounts[i]
+          if (info?.data && info.data.length >= 45) {
+            fetchedDecimals[unknownMints[i].toBase58()] = info.data[44]
+          }
+        }
+      } catch {
+        // Non-fatal — fall back to 9 for unknown mints
+      }
+    }
+
+    for (const { mintStr, rawAmount } of tokenEntries) {
+      const symbol = MINT_LABELS[mintStr] ?? mintStr.slice(0, 8) + '...'
+      const decimals = KNOWN_DECIMALS[mintStr] ?? fetchedDecimals[mintStr] ?? 9
+      const uiAmount = Number(rawAmount) / 10 ** decimals
+      tokens.push({ mint: mintStr, symbol, amount: rawAmount.toString(), decimals, uiAmount })
+    }
+  } catch (err) {
+    balanceStatus = 'unavailable'
+    console.warn('[demo-wallet] vault balance fetch failed:', err instanceof Error ? err.message : err)
+  }
+
+  const activity = getActivity(wallet, { limit: 20 })
+
+  return {
+    wallet,
+    network,
+    balances: { sol: solBalance, tokens, status: balanceStatus },
+    activity,
+  }
+}
+
+// ─── Activity ────────────────────────────────────────────────────────────────
+
+/**
+ * Pure DB read — returns the activity stream for the demo wallet.
+ * Matches the shape returned by GET /api/activity.
+ */
+export function getDemoActivity(wallet: string): Array<Record<string, unknown>> {
+  return getActivity(wallet, { limit: 50 })
+}
+
+// ─── Privacy score ───────────────────────────────────────────────────────────
+
+interface PrivacyFactor {
+  score: number
+  weight: number
+  detail: string
+}
+
+export interface DemoPrivacyScoreResponse {
+  address: string
+  score: number
+  grade: string
+  transactionsAnalyzed: number
+  factors: {
+    addressReuse: { score: number; detail: string }
+    amountPatterns: { score: number; detail: string }
+    timingCorrelation: { score: number; detail: string }
+    counterpartyExposure: { score: number; detail: string }
+  }
+  recommendations: string[]
+}
+
+function computeGrade(score: number): string {
+  if (score >= 90) return 'A'
+  if (score >= 80) return 'B'
+  if (score >= 70) return 'C'
+  if (score >= 50) return 'D'
+  return 'F'
+}
+
+const KNOWN_PROGRAMS = new Set([
+  '11111111111111111111111111111111', // System Program
+  'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA', // Token Program
+  'JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4', // Jupiter
+  '9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin', // Serum DEX
+  'whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc', // Orca Whirlpool
+  'RVKd61ztZW9GUwhRbbLoYVRE5Xf1B2tVscKqwZqXgEr', // Raydium
+  'So1endDq2YkqhipRh3WViPa8hFb7GVETnyRcDMEVXHi', // Solend
+  'mv3ekLzLbnVPNxjSKvqBpU3ZeZXPQdEC3bp5MDEBG68', // Marinade
+])
+
+function analyzeAddressReuse(
+  transactions: Array<{ to: Set<string>; from: string }>,
+  address: string,
+): PrivacyFactor {
+  const counterparties = new Set<string>()
+  let txCount = 0
+  for (const tx of transactions) {
+    txCount++
+    for (const addr of tx.to) {
+      if (addr !== address) counterparties.add(addr)
+    }
+  }
+  if (txCount === 0) {
+    return { score: 100, weight: 0.25, detail: 'No transaction history to analyze' }
+  }
+  const ratio = counterparties.size / txCount
+  const score = Math.min(100, Math.round(ratio * 100))
+  const detail = counterparties.size === 0
+    ? 'No counterparty addresses found'
+    : `${counterparties.size} unique counterparties across ${txCount} transactions`
+  return { score, weight: 0.25, detail }
+}
+
+function analyzeAmountPatterns(amounts: bigint[]): PrivacyFactor {
+  if (amounts.length === 0) {
+    return { score: 100, weight: 0.25, detail: 'No transfer amounts to analyze' }
+  }
+  const SOL_DECIMALS = 1_000_000_000n
+  let roundCount = 0
+  for (const amt of amounts) {
+    if (amt === 0n) continue
+    if (amt % (SOL_DECIMALS / 10n) === 0n) roundCount++
+  }
+  const roundRatio = roundCount / amounts.length
+  const score = Math.round((1 - roundRatio) * 100)
+  const detail = roundCount === 0
+    ? 'No round amount patterns detected'
+    : `${roundCount} of ${amounts.length} transfers use round amounts`
+  return { score, weight: 0.25, detail }
+}
+
+function analyzeTimingCorrelation(timestamps: number[]): PrivacyFactor {
+  if (timestamps.length < 3) {
+    return { score: 100, weight: 0.25, detail: 'Insufficient transactions for timing analysis' }
+  }
+  const sorted = [...timestamps].sort((a, b) => a - b)
+  const intervals: number[] = []
+  for (let i = 1; i < sorted.length; i++) intervals.push(sorted[i] - sorted[i - 1])
+  const avg = intervals.reduce((a, b) => a + b, 0) / intervals.length
+  let regular = 0
+  for (const interval of intervals) {
+    if (Math.abs(interval - avg) < avg * 0.1) regular++
+  }
+  const regularRatio = regular / intervals.length
+  const score = Math.round((1 - regularRatio * 0.8) * 100)
+  const detail = regularRatio > 0.5
+    ? `Regular transfer pattern detected (${regular} of ${intervals.length} intervals are periodic)`
+    : 'No significant timing correlation detected'
+  return { score, weight: 0.25, detail }
+}
+
+function analyzeCounterpartyExposure(
+  transactions: Array<{ to: Set<string> }>,
+): PrivacyFactor {
+  if (transactions.length === 0) {
+    return { score: 100, weight: 0.25, detail: 'No counterparty exposure to analyze' }
+  }
+  let interactions = 0
+  const programs = new Set<string>()
+  for (const tx of transactions) {
+    for (const addr of tx.to) {
+      if (KNOWN_PROGRAMS.has(addr)) {
+        interactions++
+        programs.add(addr)
+      }
+    }
+  }
+  const ratio = Math.min(1, interactions / transactions.length)
+  const score = Math.round((1 - ratio * 0.7) * 100)
+  const detail = programs.size === 0
+    ? 'No interactions with known entities detected'
+    : `Connected to ${programs.size} known entities across ${interactions} interactions`
+  return { score, weight: 0.25, detail }
+}
+
+/**
+ * Returns the 4-factor privacy score for the demo wallet. Mirrors the shape
+ * returned by Mode 2's POST /v1/privacy/score so the FE PrivacyScoreCard
+ * can render the response without modification.
+ */
+export async function getDemoPrivacyScore(
+  wallet: string,
+  limit = 100,
+): Promise<DemoPrivacyScoreResponse> {
+  const network = loadNetworkConfig().clusterName
+  const connection = createConnection(network)
+
+  let pubkey: PublicKey
+  try {
+    pubkey = new PublicKey(wallet)
+  } catch {
+    throw new Error(`Invalid demo wallet address: ${wallet}`)
+  }
+
+  const signatures = await connection.getSignaturesForAddress(pubkey, { limit })
+
+  const txData: Array<{ to: Set<string>; from: string }> = []
+  const amounts: bigint[] = []
+  const timestamps: number[] = []
+
+  for (const sigInfo of signatures) {
+    if (sigInfo.blockTime) timestamps.push(sigInfo.blockTime)
+    try {
+      const tx = await connection.getTransaction(sigInfo.signature, {
+        maxSupportedTransactionVersion: 0,
+      })
+      if (!tx?.meta) continue
+      const accountKeys = tx.transaction.message.getAccountKeys
+        ? tx.transaction.message.getAccountKeys().staticAccountKeys.map((k: PublicKey) => k.toBase58())
+        : ((tx.transaction.message as unknown as { accountKeys?: PublicKey[] }).accountKeys ?? []).map((k) =>
+            k.toBase58(),
+          )
+      const toAddresses = new Set<string>(accountKeys)
+      txData.push({ to: toAddresses, from: wallet })
+      if (tx.meta.preBalances && tx.meta.postBalances) {
+        for (let i = 0; i < tx.meta.preBalances.length; i++) {
+          const diff = Math.abs(tx.meta.postBalances[i] - tx.meta.preBalances[i])
+          if (diff > 0) amounts.push(BigInt(diff))
+        }
+      }
+    } catch {
+      // Skip failed tx parsing — demo is best-effort.
+    }
+  }
+
+  const addressReuse = analyzeAddressReuse(txData, wallet)
+  const amountPatterns = analyzeAmountPatterns(amounts)
+  const timingCorrelation = analyzeTimingCorrelation(timestamps)
+  const counterpartyExposure = analyzeCounterpartyExposure(txData)
+
+  const factors = { addressReuse, amountPatterns, timingCorrelation, counterpartyExposure }
+  const totalWeight = Object.values(factors).reduce((sum, f) => sum + f.weight, 0)
+  const weighted = Object.values(factors).reduce((sum, f) => sum + f.score * f.weight, 0)
+  const score = Math.round(weighted / totalWeight)
+  const grade = computeGrade(score)
+
+  const recommendations: string[] = []
+  if (addressReuse.score < 70) recommendations.push('Use stealth addresses for receiving payments to break linkability.')
+  if (amountPatterns.score < 70) recommendations.push('Use shielded transfers with non-round amounts to defeat heuristics.')
+  if (timingCorrelation.score < 70) recommendations.push('Randomize transaction timing to avoid pattern detection.')
+  if (counterpartyExposure.score < 70) recommendations.push('Use viewing keys for selective disclosure on regulated interactions.')
+  if (recommendations.length === 0) recommendations.push('Maintain good privacy hygiene by using stealth addresses regularly.')
+
+  return {
+    address: wallet,
+    score,
+    grade,
+    transactionsAnalyzed: signatures.length,
+    factors: {
+      addressReuse: { score: addressReuse.score, detail: addressReuse.detail },
+      amountPatterns: { score: amountPatterns.score, detail: amountPatterns.detail },
+      timingCorrelation: { score: timingCorrelation.score, detail: timingCorrelation.detail },
+      counterpartyExposure: { score: counterpartyExposure.score, detail: counterpartyExposure.detail },
+    },
+    recommendations,
+  }
+}

--- a/packages/agent/tests/routes/public/demo.test.ts
+++ b/packages/agent/tests/routes/public/demo.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+
+// Mock the wallet-data service BEFORE importing modules that consume it so
+// the demo routes call our stubs instead of hitting Solana RPC.
+vi.mock('../../../src/services/demo-wallet.js', () => ({
+  getDemoVault: vi.fn(),
+  getDemoActivity: vi.fn(),
+  getDemoPrivacyScore: vi.fn(),
+}))
+
+import express from 'express'
+import request from 'supertest'
+import { _resetForTests as resetIpRateLimit } from '../../../src/lib/ip-rate-limit.js'
+import { _resetForTests as resetCache } from '../../../src/lib/cache.js'
+import {
+  getDemoVault,
+  getDemoActivity,
+  getDemoPrivacyScore,
+} from '../../../src/services/demo-wallet.js'
+
+const DEMO_WALLET = 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr'
+
+const vaultFixture = {
+  wallet: DEMO_WALLET,
+  network: 'devnet',
+  balances: { sol: 1.5, tokens: [], status: 'ok' as const },
+  activity: [],
+}
+
+const activityFixture = [
+  {
+    id: '1',
+    agent: 'sipher',
+    type: 'send.success',
+    level: 'info',
+    title: 'Sent',
+    detail: null,
+    created_at: '2026-05-11T00:00:00Z',
+  },
+]
+
+const privacyScoreFixture = {
+  address: DEMO_WALLET,
+  score: 82,
+  grade: 'B',
+  transactionsAnalyzed: 50,
+  factors: {
+    addressReuse: { score: 80, detail: 'detail-reuse' },
+    amountPatterns: { score: 85, detail: 'detail-amount' },
+    timingCorrelation: { score: 80, detail: 'detail-timing' },
+    counterpartyExposure: { score: 82, detail: 'detail-counterparty' },
+  },
+  recommendations: ['rec1'],
+}
+
+async function buildApp(): Promise<express.Express> {
+  const { publicRouter } = await import('../../../src/routes/public/index.js')
+  const app = express()
+  app.set('trust proxy', 1)
+  app.use('/api/public', publicRouter)
+  return app
+}
+
+describe('/api/public/demo/*', () => {
+  beforeEach(async () => {
+    await resetIpRateLimit()
+    await resetCache()
+    process.env.DEMO_WALLET = DEMO_WALLET
+    vi.mocked(getDemoVault).mockResolvedValue(vaultFixture)
+    vi.mocked(getDemoActivity).mockReturnValue(activityFixture)
+    vi.mocked(getDemoPrivacyScore).mockResolvedValue(privacyScoreFixture)
+  })
+
+  afterEach(() => {
+    delete process.env.DEMO_WALLET
+    vi.clearAllMocks()
+  })
+
+  describe('GET /vault', () => {
+    it('returns the demo wallet vault shape', async () => {
+      const app = await buildApp()
+      const res = await request(app).get('/api/public/demo/vault')
+      expect(res.status).toBe(200)
+      expect(res.body).toMatchObject({
+        wallet: DEMO_WALLET,
+        balances: expect.objectContaining({
+          sol: expect.any(Number),
+          tokens: expect.any(Array),
+          status: expect.any(String),
+        }),
+      })
+    })
+
+    it('returns the cached payload on the 2nd call within 60s (service invoked once)', async () => {
+      const app = await buildApp()
+      const res1 = await request(app).get('/api/public/demo/vault')
+      const res2 = await request(app).get('/api/public/demo/vault')
+      expect(res1.body).toEqual(res2.body)
+      expect(getDemoVault).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns 503 + UNAVAILABLE envelope when DEMO_WALLET env is unset', async () => {
+      delete process.env.DEMO_WALLET
+      const app = await buildApp()
+      const res = await request(app).get('/api/public/demo/vault')
+      expect(res.status).toBe(503)
+      expect(res.body).toEqual({
+        error: { code: 'UNAVAILABLE', message: expect.stringMatching(/demo/i) },
+      })
+      // Service must NOT be invoked when the env gate fails closed.
+      expect(getDemoVault).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('GET /activity', () => {
+    it('returns { activity } shape', async () => {
+      const app = await buildApp()
+      const res = await request(app).get('/api/public/demo/activity')
+      expect(res.status).toBe(200)
+      expect(res.body).toEqual({ activity: activityFixture })
+    })
+
+    it('returns 503 when DEMO_WALLET is unset', async () => {
+      delete process.env.DEMO_WALLET
+      const app = await buildApp()
+      const res = await request(app).get('/api/public/demo/activity')
+      expect(res.status).toBe(503)
+      expect(res.body.error.code).toBe('UNAVAILABLE')
+    })
+
+    it('caches across calls (service invoked once)', async () => {
+      const app = await buildApp()
+      await request(app).get('/api/public/demo/activity')
+      await request(app).get('/api/public/demo/activity')
+      expect(getDemoActivity).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('GET /privacy-score', () => {
+    it('returns the 4-factor privacy score shape', async () => {
+      const app = await buildApp()
+      const res = await request(app).get('/api/public/demo/privacy-score')
+      expect(res.status).toBe(200)
+      expect(res.body).toMatchObject({
+        score: expect.any(Number),
+        grade: expect.any(String),
+        factors: expect.objectContaining({
+          addressReuse: expect.objectContaining({ score: expect.any(Number), detail: expect.any(String) }),
+          amountPatterns: expect.objectContaining({ score: expect.any(Number), detail: expect.any(String) }),
+          timingCorrelation: expect.objectContaining({ score: expect.any(Number), detail: expect.any(String) }),
+          counterpartyExposure: expect.objectContaining({ score: expect.any(Number), detail: expect.any(String) }),
+        }),
+      })
+    })
+
+    it('returns 503 when DEMO_WALLET is unset', async () => {
+      delete process.env.DEMO_WALLET
+      const app = await buildApp()
+      const res = await request(app).get('/api/public/demo/privacy-score')
+      expect(res.status).toBe(503)
+      expect(res.body.error.code).toBe('UNAVAILABLE')
+    })
+
+    it('caches across calls (service invoked once)', async () => {
+      const app = await buildApp()
+      await request(app).get('/api/public/demo/privacy-score')
+      await request(app).get('/api/public/demo/privacy-score')
+      expect(getDemoPrivacyScore).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('rate limiting', () => {
+    it('returns 429 + RATE_LIMITED envelope after 60 requests in <1min', async () => {
+      const app = await buildApp()
+      for (let i = 0; i < 60; i++) {
+        await request(app).get('/api/public/demo/vault')
+      }
+      const res = await request(app).get('/api/public/demo/vault')
+      expect(res.status).toBe(429)
+      expect(res.body.error.code).toBe('RATE_LIMITED')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds a dedicated `/demo` route + CTA on unauthed Dashboard. New `/api/public/demo/{vault,activity,privacy-score}` backend endpoints serve cached, rate-limited, read-only data for the env-configured demo wallet (`FGSkt8…` on devnet by default). First-time visitors can see a populated dashboard before committing their wallet.

## What ships

**Backend (new):**
- `packages/agent/src/routes/public/demo.ts` — 3 public GET endpoints, gated by `ipRateLimitMiddleware('demo', 60, 60_000)` + 60s cache. Returns 503 + UNAVAILABLE envelope when `DEMO_WALLET` env unset.
- `packages/agent/src/services/demo-wallet.ts` — Strategy B (light-touch reuse): re-implements the underlying queries (SOL + SPL balances, activity from db.ts, 4-factor privacy analyzer) without crossing the Mode 2 / Mode 1 boundary. File header documents the choice.

**Frontend (new):**
- `app/src/views/DemoView.tsx` — populates the Dashboard layout from `/api/public/demo/*`. Banner: "Demo mode — read-only preview. [Exit demo] [Connect wallet]". Auto-redirects to `/` when wallet connects.
- `app/src/components/DemoCtaCard.tsx` — "Curious how it looks populated? [View sample dashboard →]" CTA card; placed near the empty PrivacyGraph slot on the unauthed Dashboard.
- `app/src/App.tsx` — registers `/demo` route + hides chrome (Header, BottomNav, ChatSidebar) when `location.pathname === '/demo'` (exact match via `HIDE_CHROME_PATHS` Set — defensive against future `/demo-*` routes).

## Spec / plan

- Spec section: "Cluster F1 — #216 Demo mode" in `docs/superpowers/specs/2026-05-11-qa-sweep-tier-4-wave-2b-design.md`
- Plan section: "Cluster F1 — #216 Demo mode" in `docs/superpowers/plans/2026-05-11-qa-sweep-tier-4-wave-2b.md`
- Locked decisions: D16 (devnet wallet `FGSkt8…`), D17 (3 routes + 60s cache + no SSE), D18 (`/demo` route + CTA + auto-redirect-on-connect)

## Tests

+10 agent (`tests/routes/public/demo.test.ts`) covers each endpoint shape + 503-on-unset + 60s cache hit + 60 req/min/IP rate limit. +14 app (`DemoView.test.tsx` 5, `DemoCtaCard.test.tsx` 2, `DashboardView.test.tsx` Demo CTA describe block 2, `App.test.tsx` route + chrome-hide 5).

App: 518 → 532 (+14). Agent: 1415 → 1425 (+10). Typecheck clean on both.

## Notes

- `DEMO_WALLET` env var documented in `.env.example`.
- Privacy-score analyzer code is duplicated from Mode 2's `/v1/privacy/score` (Strategy B). Tracking consolidation in #248 (`tech-debt,priority:low`) — triggers next time either side changes.
- ChatSidebar, ActivityStreamTable empty state, lib/ip-rate-limit.ts, and lib/cache.ts are untouched per cross-cluster guardrails.

Closes #216