### PR TITLE
feat: #217 unauthed activity teaser (counter + 5 recent)

### DIFF
--- a/app/src/components/ActivityStreamTable.tsx
+++ b/app/src/components/ActivityStreamTable.tsx
@@ -38,7 +38,7 @@ export function ActivityStreamTable({ rows }: ActivityStreamTableProps) {
   }, [rows, filter])
 
   return (
-    <Card variant="default" className="p-6">
+    <Card variant="default" className="p-6" data-testid="activity-stream-table">
       <div className="flex items-center justify-between mb-4">
         <h3
           className="text-2xs text-text-muted"

--- a/app/src/components/UnauthedActivityFeed.tsx
+++ b/app/src/components/UnauthedActivityFeed.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useRef, useState } from 'react'
+import { Card } from './ui/Card'
+import { Pill } from './ui/Pill'
+
+interface AnonActivityRow {
+  type: string
+  chain: string
+  amountBand: '<1' | '1-10' | '10-100' | '100-1000' | '>1000'
+  relativeTime: string
+}
+
+interface ActivitySummaryResponse {
+  counter: number
+  recent: AnonActivityRow[]
+}
+
+const POLL_INTERVAL_MS = 60_000
+const API_BASE = import.meta.env.VITE_API_URL ?? ''
+const ENDPOINT = `${API_BASE}/api/public/activity-summary`
+
+/**
+ * Live ecosystem-wide activity teaser shown on the unauthed Dashboard in
+ * place of the empty `<ActivityStreamTable />`. Displays an all-time
+ * counter of successful shielded transfers + the 5 most-recent anonymized
+ * rows. Backend: GET /api/public/activity-summary (60s server cache,
+ * 120 req/min/IP rate-limited).
+ *
+ * Polls every 60s while the tab is visible. AbortController on unmount.
+ * Renders a graceful "Live activity unavailable" empty state on fetch error.
+ */
+export default function UnauthedActivityFeed() {
+  const [data, setData] = useState<ActivitySummaryResponse | null>(null)
+  const [error, setError] = useState<boolean>(false)
+  const controllerRef = useRef<AbortController | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      const controller = new AbortController()
+      controllerRef.current = controller
+      try {
+        const res = await fetch(ENDPOINT, { signal: controller.signal })
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const json = (await res.json()) as ActivitySummaryResponse
+        if (cancelled || controller.signal.aborted) return
+        setData(json)
+        setError(false)
+      } catch (err) {
+        if (cancelled || controller.signal.aborted) return
+        if (err instanceof Error && err.name === 'AbortError') return
+        setError(true)
+      }
+    }
+
+    // Initial mount always fetches once. Subsequent polls are gated by tab
+    // visibility — we don't burn API budget on a backgrounded tab.
+    void load()
+
+    const interval = setInterval(() => {
+      if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return
+      void load()
+    }, POLL_INTERVAL_MS)
+
+    return () => {
+      cancelled = true
+      clearInterval(interval)
+      controllerRef.current?.abort()
+    }
+  }, [])
+
+  if (error && !data) {
+    return (
+      <Card variant="default" className="p-6">
+        <div className="flex items-center justify-between">
+          <h3
+            className="text-2xs text-text-muted"
+            style={{ letterSpacing: 'var(--tracking-widest)' }}
+          >
+            LIVE ACTIVITY
+          </h3>
+        </div>
+        <p className="text-sm text-text-muted text-center py-8">Live activity unavailable</p>
+      </Card>
+    )
+  }
+
+  if (!data) {
+    return (
+      <Card variant="default" className="p-6" data-testid="activity-feed-skeleton">
+        <div className="flex items-center justify-between mb-4">
+          <h3
+            className="text-2xs text-text-muted"
+            style={{ letterSpacing: 'var(--tracking-widest)' }}
+          >
+            LIVE ACTIVITY · ECOSYSTEM
+          </h3>
+        </div>
+        <div className="space-y-3">
+          <div className="h-8 w-48 bg-line/40 rounded animate-pulse" />
+          {[0, 1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-6 bg-line/30 rounded animate-pulse" />
+          ))}
+        </div>
+      </Card>
+    )
+  }
+
+  const { counter, recent } = data
+
+  return (
+    <Card variant="default" className="p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h3
+          className="text-2xs text-text-muted"
+          style={{ letterSpacing: 'var(--tracking-widest)' }}
+        >
+          LIVE ACTIVITY · ECOSYSTEM
+        </h3>
+      </div>
+      <div className="mb-5">
+        <div className="text-2xl font-mono text-text">{counter.toLocaleString()}</div>
+        <div
+          className="text-2xs text-text-muted mt-0.5"
+          style={{ letterSpacing: 'var(--tracking-wider)' }}
+        >
+          SHIELDED TRANSFERS · ALL TIME
+        </div>
+      </div>
+      {recent.length === 0 ? (
+        <p className="text-sm text-text-muted text-center py-4">No recent activity.</p>
+      ) : (
+        <ul className="space-y-2">
+          {recent.map((row, idx) => (
+            <li
+              key={idx}
+              className="flex items-center justify-between border-t border-line py-2 text-xs"
+            >
+              <div className="flex items-center gap-2">
+                <Pill label={row.type.toUpperCase()} size="sm" />
+                <span className="text-text-muted uppercase tracking-wider text-2xs">{row.chain}</span>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="font-mono text-text-secondary">{row.amountBand} SOL</span>
+                <span className="text-text-muted">{row.relativeTime}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  )
+}

--- a/app/src/components/__tests__/UnauthedActivityFeed.test.tsx
+++ b/app/src/components/__tests__/UnauthedActivityFeed.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import UnauthedActivityFeed from '../UnauthedActivityFeed'
+
+const mockData = {
+  counter: 12345,
+  recent: [
+    { type: 'send.success', chain: 'solana', amountBand: '1-10', relativeTime: '3 minutes ago' },
+    { type: 'swap.success', chain: 'solana', amountBand: '10-100', relativeTime: '8 minutes ago' },
+    { type: 'deposit.success', chain: 'solana', amountBand: '<1', relativeTime: '12 minutes ago' },
+    { type: 'send.success', chain: 'solana', amountBand: '100-1000', relativeTime: '1 hour ago' },
+    { type: 'swap.completed', chain: 'solana', amountBand: '>1000', relativeTime: '2 hours ago' },
+  ],
+}
+
+function makeResponse(payload: unknown): Response {
+  return {
+    ok: true,
+    json: async () => payload,
+  } as Response
+}
+
+beforeEach(() => {
+  Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
+  global.fetch = vi.fn().mockResolvedValue(makeResponse(mockData))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('<UnauthedActivityFeed />', () => {
+  it('renders skeleton during initial load', () => {
+    // Block the fetch from resolving so we land on the skeleton state.
+    global.fetch = vi.fn().mockImplementation(() => new Promise(() => {}))
+    render(<UnauthedActivityFeed />)
+    expect(screen.getByTestId('activity-feed-skeleton')).toBeInTheDocument()
+  })
+
+  it('renders counter + recent rows after fetch', async () => {
+    render(<UnauthedActivityFeed />)
+    await waitFor(() => expect(screen.getByText(/12,345/)).toBeInTheDocument())
+    expect(screen.getByText(/3 minutes ago/)).toBeInTheDocument()
+    expect(screen.getByText(/swap.success/i)).toBeInTheDocument()
+  })
+
+  it('does not poll when document.visibilityState is hidden', async () => {
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' })
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    render(<UnauthedActivityFeed />)
+    // Initial mount fetches once unconditionally (the visibility gate fires only
+    // inside the interval callback, see component impl).
+    await vi.waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('polls every 60s when visible', async () => {
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' })
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    render(<UnauthedActivityFeed />)
+    await vi.waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+    await vi.waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2))
+  })
+
+  it('renders graceful empty-state on fetch error', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('network'))
+    render(<UnauthedActivityFeed />)
+    await waitFor(() =>
+      expect(screen.getByText(/live activity unavailable/i)).toBeInTheDocument(),
+    )
+  })
+
+  it('aborts in-flight fetch on unmount', async () => {
+    let capturedSignal: AbortSignal | undefined
+    global.fetch = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      capturedSignal = init?.signal ?? undefined
+      return new Promise(() => {}) // never resolves
+    })
+    const { unmount } = render(<UnauthedActivityFeed />)
+    await waitFor(() => expect(capturedSignal).toBeDefined())
+    expect(capturedSignal?.aborted).toBe(false)
+    unmount()
+    expect(capturedSignal?.aborted).toBe(true)
+  })
+})

--- a/app/src/views/DashboardView.tsx
+++ b/app/src/views/DashboardView.tsx
@@ -9,6 +9,7 @@ import { PrivacyGraph } from '../components/PrivacyGraph'
 import { ShieldedVolumeCard } from '../components/ShieldedVolumeCard'
 import { MultiChainVaultGrid } from '../components/MultiChainVaultGrid'
 import DemoCtaCard from '../components/DemoCtaCard'
+import UnauthedActivityFeed from '../components/UnauthedActivityFeed'
 
 interface VaultData {
   wallet: string
@@ -175,7 +176,11 @@ export default function DashboardView({ events }: { events: ActivityEvent[] }) {
 
         <MultiChainVaultGrid />
 
-        <ActivityStreamTable rows={allRows} />
+        {status === 'authed' ? (
+          <ActivityStreamTable rows={allRows} />
+        ) : (
+          <UnauthedActivityFeed />
+        )}
       </div>
     </>
   )

--- a/app/src/views/__tests__/DashboardView.test.tsx
+++ b/app/src/views/__tests__/DashboardView.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import DashboardView from '../DashboardView'
@@ -157,6 +157,44 @@ describe('DashboardView', () => {
         'Multi-chain privacy command center for shielded transfers across 9+ chains.',
       )
     })
+  })
+})
+
+describe('Unauthed activity teaser', () => {
+  beforeEach(() => {
+    // Fetch is consumed by <UnauthedActivityFeed /> when status !== 'authed'.
+    // Block resolution so the skeleton state is observable and the apiFetch
+    // mock (used by the authed path) stays the only data-source for the
+    // existing tests.
+    global.fetch = vi.fn().mockImplementation(() => new Promise(() => {}))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders <UnauthedActivityFeed /> when status is unauthed', () => {
+    currentAuthOverrides = { status: 'unauthed', token: null, publicKey: null }
+    render(
+      <MemoryRouter>
+        <DashboardView events={[]} />
+      </MemoryRouter>,
+    )
+    expect(screen.getByTestId('activity-feed-skeleton')).toBeInTheDocument()
+    expect(screen.queryByTestId('activity-stream-table')).toBeNull()
+  })
+
+  it('renders <ActivityStreamTable /> when authed (existing behavior)', async () => {
+    currentAuthOverrides = { status: 'authed', token: 'tok', publicKey: 'W' }
+    render(
+      <MemoryRouter>
+        <DashboardView events={[]} />
+      </MemoryRouter>,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('activity-stream-table')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('activity-feed-skeleton')).toBeNull()
   })
 })
 

--- a/packages/agent/src/lib/queries/public.ts
+++ b/packages/agent/src/lib/queries/public.ts
@@ -44,3 +44,51 @@ export interface ActivitySummaryResponse {
   counter: number
   recent: AnonActivityRow[]
 }
+
+/**
+ * Bucket a raw chain-equivalent amount (SOL, ETH, etc.) into one of five
+ * coarse bands. Used by `/api/public/activity-summary` so we never leak the
+ * exact transfer size of any individual user's transaction.
+ */
+export function toAmountBand(amount: number): AmountBand {
+  if (!Number.isFinite(amount) || amount < 1) return '<1'
+  if (amount < 10) return '1-10'
+  if (amount < 100) return '10-100'
+  if (amount < 1000) return '100-1000'
+  return '>1000'
+}
+
+/**
+ * Format an ISO timestamp as a coarse relative-time string ("3 minutes ago").
+ * Granularity intentionally low — same anonymization guard as `toAmountBand`.
+ */
+export function relativeTime(createdAt: string): string {
+  const ts = new Date(createdAt).getTime()
+  if (!Number.isFinite(ts)) return 'just now'
+  const diffMs = Math.max(0, Date.now() - ts)
+  const minutes = Math.floor(diffMs / 60_000)
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`
+  const days = Math.floor(hours / 24)
+  return `${days} day${days === 1 ? '' : 's'} ago`
+}
+
+/**
+ * Defensively parse the `detail` column from `activity_stream` rows. Stored as
+ * JSON-serialized text — match the pattern from `app/src/views/DashboardView.tsx`.
+ */
+export function parseActivityDetail(detail: unknown): Record<string, unknown> {
+  if (detail == null) return {}
+  if (typeof detail === 'string') {
+    try {
+      const parsed = JSON.parse(detail) as unknown
+      return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {}
+    } catch {
+      return {}
+    }
+  }
+  if (typeof detail === 'object') return detail as Record<string, unknown>
+  return {}
+}

--- a/packages/agent/src/routes/public/activity-summary.ts
+++ b/packages/agent/src/routes/public/activity-summary.ts
@@ -46,9 +46,12 @@ activitySummaryRouter.get('/', async (_req: Request, res: Response) => {
     await setCached(CACHE_KEY, payload, CACHE_TTL_SECONDS)
     res.json(payload)
   } catch (e) {
+    // Log raw message server-side for operator debugging, but return a generic
+    // envelope to anonymous callers — this endpoint is unauthed, so the response
+    // body must never leak SQLite errors, stack-frame paths, or infra state.
     const message = e instanceof Error ? e.message : 'activity-summary failed'
     console.error('[activity-summary]', message)
-    res.status(500).json({ error: { code: 'INTERNAL', message } })
+    res.status(500).json({ error: { code: 'INTERNAL', message: 'activity-summary unavailable' } })
   }
 })
 

--- a/packages/agent/src/routes/public/activity-summary.ts
+++ b/packages/agent/src/routes/public/activity-summary.ts
@@ -19,6 +19,15 @@ const CACHE_TTL_SECONDS = 60
 const RATE_CAP = 120
 const RATE_WINDOW_MS = 60_000
 
+// Whitelist of chain identifiers allowed in the public teaser. Defense-in-depth
+// against value-injection: if a future ingest path writes a wallet probe or
+// arbitrary string into `detail.chain`, the unauthed response would leak it.
+// Anything not on this list collapses to the `solana` fallback.
+const KNOWN_CHAINS = new Set([
+  'solana', 'ethereum', 'polygon', 'arbitrum', 'base', 'optimism',
+  'avalanche', 'bsc', 'fantom', 'linea', 'scroll', 'mantle', 'blast',
+])
+
 activitySummaryRouter.use(ipRateLimitMiddleware('activity-summary', RATE_CAP, RATE_WINDOW_MS))
 
 /**
@@ -97,7 +106,12 @@ function computeRecent(): AnonActivityRow[] {
   for (const row of rows) {
     const type = typeof row.type === 'string' ? row.type : ''
     const detail = parseActivityDetail(row.detail)
-    const chain = typeof detail.chain === 'string' ? detail.chain : 'solana'
+    // Whitelist-only: any unknown chain value is replaced with `solana`. This
+    // guards against value-injection in the public teaser — the
+    // anonymization test catches extra keys, this guard catches malicious
+    // values under the allow-listed `chain` key.
+    const rawChain = typeof detail.chain === 'string' ? detail.chain.toLowerCase() : ''
+    const chain = KNOWN_CHAINS.has(rawChain) ? rawChain : 'solana'
     const rawAmount = typeof detail.amount === 'number'
       ? detail.amount
       : typeof detail.amount === 'string'

--- a/packages/agent/src/routes/public/activity-summary.ts
+++ b/packages/agent/src/routes/public/activity-summary.ts
@@ -1,0 +1,111 @@
+import { Router, type Request, type Response } from 'express'
+import { getDb, getActivity } from '../../db.js'
+import { ipRateLimitMiddleware } from '../../lib/ip-rate-limit.js'
+import { getCached, setCached } from '../../lib/cache.js'
+import {
+  parseActivityDetail,
+  relativeTime,
+  toAmountBand,
+  type ActivitySummaryResponse,
+  type AnonActivityRow,
+} from '../../lib/queries/public.js'
+
+export const activitySummaryRouter: Router = Router()
+
+const CACHE_KEY = 'public-activity-summary'
+const CACHE_TTL_SECONDS = 60
+// Rate limit: 120 req/min/IP. Generous enough that an unauthed page mounting
+// + 60s polling never trips it under normal browsing patterns.
+const RATE_CAP = 120
+const RATE_WINDOW_MS = 60_000
+
+activitySummaryRouter.use(ipRateLimitMiddleware('activity-summary', RATE_CAP, RATE_WINDOW_MS))
+
+/**
+ * GET /api/public/activity-summary
+ *
+ * Returns an anonymized snapshot of ecosystem-wide shielded-transfer activity
+ * — counter of all-time successful fund-mover events + the 5 most recent
+ * rows, stripped of any wallet-identifiable fields.
+ *
+ * Cached for 60s server-side. NO sender, recipient, exact amount, transaction
+ * hash, wallet address, agent identifier, or activity id is exposed.
+ */
+activitySummaryRouter.get('/', async (_req: Request, res: Response) => {
+  try {
+    const cached = await getCached<ActivitySummaryResponse>(CACHE_KEY)
+    if (cached) {
+      res.json(cached)
+      return
+    }
+
+    const counter = computeCounter()
+    const recent = computeRecent()
+    const payload: ActivitySummaryResponse = { counter, recent }
+
+    await setCached(CACHE_KEY, payload, CACHE_TTL_SECONDS)
+    res.json(payload)
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'activity-summary failed'
+    console.error('[activity-summary]', message)
+    res.status(500).json({ error: { code: 'INTERNAL', message } })
+  }
+})
+
+/**
+ * SELECT COUNT(*) of completed fund-mover events across all wallets.
+ * Matches the suffix pattern used by the agent's activity logger
+ * (e.g., `send.success`, `swap.completed`) — see DashboardView's
+ * `fundMoverPattern` for the canonical type-name conventions.
+ */
+function computeCounter(): number {
+  const db = getDb()
+  const row = db
+    .prepare(
+      'SELECT COUNT(*) AS n FROM activity_stream WHERE type LIKE ? OR type LIKE ?',
+    )
+    .get('%.success', '%.completed') as { n: number } | undefined
+  return row?.n ?? 0
+}
+
+/**
+ * Pull the 5 most recent successful fund-mover rows across all wallets,
+ * defensively parse `detail`, and project to the anonymized output shape.
+ * Only allow-listed keys (`type`, `chain`, `amountBand`, `relativeTime`)
+ * make it into the response.
+ */
+function computeRecent(): AnonActivityRow[] {
+  // getActivity(null) returns rows across all wallets — exactly the
+  // ecosystem-wide teaser we want. Over-fetch by a small factor so the
+  // post-filter still has 5 fund-mover rows in the (rare) case where most
+  // recent rows are non-completion levels (e.g., `info`, `warning`).
+  const rows = getActivity(null, { limit: 50 })
+
+  const fundMoverPattern = /\.(success|completed)$/
+  const out: AnonActivityRow[] = []
+
+  for (const row of rows) {
+    const type = typeof row.type === 'string' ? row.type : ''
+    if (!fundMoverPattern.test(type)) continue
+
+    const detail = parseActivityDetail(row.detail)
+    const chain = typeof detail.chain === 'string' ? detail.chain : 'solana'
+    const rawAmount = typeof detail.amount === 'number'
+      ? detail.amount
+      : typeof detail.amount === 'string'
+        ? Number(detail.amount)
+        : 0
+    const createdAt = typeof row.created_at === 'string' ? row.created_at : new Date().toISOString()
+
+    out.push({
+      type,
+      chain,
+      amountBand: toAmountBand(rawAmount),
+      relativeTime: relativeTime(createdAt),
+    })
+
+    if (out.length >= 5) break
+  }
+
+  return out
+}

--- a/packages/agent/src/routes/public/activity-summary.ts
+++ b/packages/agent/src/routes/public/activity-summary.ts
@@ -1,5 +1,5 @@
 import { Router, type Request, type Response } from 'express'
-import { getDb, getActivity } from '../../db.js'
+import { getDb } from '../../db.js'
 import { ipRateLimitMiddleware } from '../../lib/ip-rate-limit.js'
 import { getCached, setCached } from '../../lib/cache.js'
 import {
@@ -73,21 +73,26 @@ function computeCounter(): number {
  * defensively parse `detail`, and project to the anonymized output shape.
  * Only allow-listed keys (`type`, `chain`, `amountBand`, `relativeTime`)
  * make it into the response.
+ *
+ * The filter runs at SQL level — a JS post-filter over an over-fetched window
+ * silently degrades as the activity stream grows (non-fund-mover events can
+ * push fund-movers out of the limit window entirely). Mirrors the inline-SQL
+ * pattern from `computeCounter`.
  */
 function computeRecent(): AnonActivityRow[] {
-  // getActivity(null) returns rows across all wallets — exactly the
-  // ecosystem-wide teaser we want. Over-fetch by a small factor so the
-  // post-filter still has 5 fund-mover rows in the (rare) case where most
-  // recent rows are non-completion levels (e.g., `info`, `warning`).
-  const rows = getActivity(null, { limit: 50 })
+  const db = getDb()
+  const rows = db
+    .prepare(
+      `SELECT type, detail, created_at FROM activity_stream
+       WHERE type LIKE ? OR type LIKE ?
+       ORDER BY created_at DESC, rowid DESC
+       LIMIT 5`,
+    )
+    .all('%.success', '%.completed') as Array<Record<string, unknown>>
 
-  const fundMoverPattern = /\.(success|completed)$/
   const out: AnonActivityRow[] = []
-
   for (const row of rows) {
     const type = typeof row.type === 'string' ? row.type : ''
-    if (!fundMoverPattern.test(type)) continue
-
     const detail = parseActivityDetail(row.detail)
     const chain = typeof detail.chain === 'string' ? detail.chain : 'solana'
     const rawAmount = typeof detail.amount === 'number'
@@ -103,8 +108,6 @@ function computeRecent(): AnonActivityRow[] {
       amountBand: toAmountBand(rawAmount),
       relativeTime: relativeTime(createdAt),
     })
-
-    if (out.length >= 5) break
   }
 
   return out

--- a/packages/agent/src/routes/public/index.ts
+++ b/packages/agent/src/routes/public/index.ts
@@ -1,11 +1,11 @@
 import { Router } from 'express'
 import { demoRouter } from './demo.js'
+import { activitySummaryRouter } from './activity-summary.js'
 
 /**
  * Public, unauthenticated routes mounted at /api/public.
- * Feature subagents (Wave 2b F1/F2/F3) extend this router by appending:
- *   import { demoRouter } from './demo.js'
- *   publicRouter.use('/demo', demoRouter)
+ * Wave 2b subagents (F3) extend this router by appending sub-routers.
+ * F1 (/demo) and F2 (/activity-summary) already wired below.
  *
  * All sub-routers MUST apply ipRateLimitMiddleware with their own key/cap.
  */
@@ -13,3 +13,5 @@ export const publicRouter = Router()
 
 // #216 — demo mode (vault / activity / privacy-score snapshots for /demo)
 publicRouter.use('/demo', demoRouter)
+// #217 — unauthed activity teaser (counter + 5 recent rows)
+publicRouter.use('/activity-summary', activitySummaryRouter)

--- a/packages/agent/tests/routes/activity-summary.test.ts
+++ b/packages/agent/tests/routes/activity-summary.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 import express from 'express'
 import request from 'supertest'
 import { _resetForTests as resetIpRateLimit } from '../../src/lib/ip-rate-limit.js'
@@ -99,6 +99,38 @@ describe('/api/public/activity-summary', () => {
     expect(toAmountBand(50)).toBe('10-100')
     expect(toAmountBand(500)).toBe('100-1000')
     expect(toAmountBand(5_000)).toBe('>1000')
+  })
+
+  // Regression: 500 responses on this unauthed endpoint must NOT leak the raw
+  // error message — defense-in-depth against anonymous callers fingerprinting
+  // SQLite version, infra state, or stack-frame paths via 500 bodies.
+  it('returns generic 500 envelope when computation throws — raw error not leaked', async () => {
+    const dbModule = await import('../../src/db.js')
+    const spy = vi.spyOn(dbModule, 'getDb').mockImplementation(() => {
+      throw new Error('PRIVATE_INTERNAL_DETAIL: sqlite3_step failure at /opt/secret/path')
+    })
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    try {
+      const res = await request(app).get('/api/public/activity-summary')
+
+      expect(res.status).toBe(500)
+      expect(res.body).toEqual({
+        error: { code: 'INTERNAL', message: 'activity-summary unavailable' },
+      })
+      // Defense-in-depth: response body must NEVER contain the raw error detail.
+      expect(JSON.stringify(res.body)).not.toContain('PRIVATE_INTERNAL_DETAIL')
+      expect(JSON.stringify(res.body)).not.toContain('/opt/secret/path')
+      expect(JSON.stringify(res.body)).not.toContain('sqlite3_step')
+      // But the raw message MUST still hit server logs so operators can debug.
+      expect(errSpy).toHaveBeenCalledWith(
+        '[activity-summary]',
+        expect.stringContaining('PRIVATE_INTERNAL_DETAIL'),
+      )
+    } finally {
+      spy.mockRestore()
+      errSpy.mockRestore()
+    }
   })
 
   // Regression: previously the route fetched the last 50 rows then JS-filtered

--- a/packages/agent/tests/routes/activity-summary.test.ts
+++ b/packages/agent/tests/routes/activity-summary.test.ts
@@ -100,4 +100,39 @@ describe('/api/public/activity-summary', () => {
     expect(toAmountBand(500)).toBe('100-1000')
     expect(toAmountBand(5_000)).toBe('>1000')
   })
+
+  // Regression: previously the route fetched the last 50 rows then JS-filtered
+  // for fund-mover types. If non-fund-mover events dominate the recent window,
+  // the teaser silently degrades — the SQL filter is the only way to keep the
+  // teaser useful as the activity stream grows.
+  it('recent rows are SQL-filtered to fund-mover types even when non-fund-mover rows dominate the recent window', async () => {
+    // Seed 5 OLDER fund-mover events first.
+    for (let i = 0; i < 5; i++) {
+      insertActivity({
+        agent: 'sipher',
+        level: 'info',
+        type: 'send.success',
+        title: `fund-${i}`,
+        detail: JSON.stringify({ amount: i + 1, chain: 'solana' }),
+      })
+    }
+    // Then seed 60 NEWER non-fund-mover events. With the old JS-filter
+    // (over-fetch limit=50, then filter), the 5 fund-mover rows are pushed
+    // out of the limit window entirely → recent becomes [].
+    for (let i = 0; i < 60; i++) {
+      insertActivity({
+        agent: 'sipher',
+        level: 'info',
+        type: 'agent.info',
+        title: `noise-${i}`,
+        detail: JSON.stringify({ chain: 'solana' }),
+      })
+    }
+    const res = await request(app).get('/api/public/activity-summary')
+    expect(res.status).toBe(200)
+    expect(res.body.recent).toHaveLength(5)
+    for (const row of res.body.recent) {
+      expect(['send.success', 'swap.success', 'send.completed', 'swap.completed']).toContain(row.type)
+    }
+  })
 })

--- a/packages/agent/tests/routes/activity-summary.test.ts
+++ b/packages/agent/tests/routes/activity-summary.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { _resetForTests as resetIpRateLimit } from '../../src/lib/ip-rate-limit.js'
+import { _resetForTests as resetCache } from '../../src/lib/cache.js'
+import { closeDb, insertActivity } from '../../src/db.js'
+
+describe('/api/public/activity-summary', () => {
+  let app: express.Express
+
+  beforeEach(async () => {
+    process.env.DB_PATH = ':memory:'
+    await resetIpRateLimit()
+    await resetCache()
+    const { publicRouter } = await import('../../src/routes/public/index.js')
+    app = express()
+    app.set('trust proxy', 1)
+    app.use('/api/public', publicRouter)
+  })
+
+  afterEach(() => {
+    closeDb()
+    delete process.env.DB_PATH
+  })
+
+  it('returns counter + recent rows shape', async () => {
+    insertActivity({
+      agent: 'sipher',
+      level: 'info',
+      type: 'send.success',
+      title: 'Sent 1 SOL',
+      detail: JSON.stringify({ amount: 1, chain: 'solana' }),
+    })
+    const res = await request(app).get('/api/public/activity-summary')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({
+      counter: expect.any(Number),
+      recent: expect.any(Array),
+    })
+    expect(res.body.counter).toBeGreaterThan(0)
+  })
+
+  it('recent rows have only the anonymized fields', async () => {
+    insertActivity({
+      agent: 'sipher',
+      level: 'info',
+      type: 'send.success',
+      title: 'Sent',
+      wallet: 'SecretWallet1111111111111111111111111111111',
+      detail: JSON.stringify({ amount: 0.5, chain: 'solana', recipient: 'SecretRecipient', signature: 'tx-hash' }),
+    })
+    const res = await request(app).get('/api/public/activity-summary')
+    expect(res.status).toBe(200)
+    expect(res.body.recent.length).toBeGreaterThan(0)
+    for (const row of res.body.recent) {
+      expect(Object.keys(row).sort()).toEqual(['amountBand', 'chain', 'relativeTime', 'type'])
+      expect(['<1', '1-10', '10-100', '100-1000', '>1000']).toContain(row.amountBand)
+    }
+  })
+
+  it('returns counter = 0 and recent = [] when no matching events exist', async () => {
+    const res = await request(app).get('/api/public/activity-summary')
+    expect(res.status).toBe(200)
+    expect(res.body.counter).toBe(0)
+    expect(res.body.recent).toEqual([])
+  })
+
+  it('caches response within 60s window', async () => {
+    insertActivity({
+      agent: 'sipher',
+      level: 'info',
+      type: 'send.success',
+      title: 'first',
+      detail: JSON.stringify({ amount: 1, chain: 'solana' }),
+    })
+    const res1 = await request(app).get('/api/public/activity-summary')
+    // Insert another row that should NOT appear if cache is honored
+    insertActivity({
+      agent: 'sipher',
+      level: 'info',
+      type: 'send.success',
+      title: 'second',
+      detail: JSON.stringify({ amount: 50, chain: 'solana' }),
+    })
+    const res2 = await request(app).get('/api/public/activity-summary')
+    expect(res2.body).toEqual(res1.body)
+  })
+
+  it('rate-limited at 120 req/min/IP', async () => {
+    for (let i = 0; i < 120; i++) await request(app).get('/api/public/activity-summary')
+    const res = await request(app).get('/api/public/activity-summary')
+    expect(res.status).toBe(429)
+  })
+
+  it('amount band buckets work as documented', async () => {
+    const { toAmountBand } = await import('../../src/lib/queries/public.js')
+    expect(toAmountBand(0.5)).toBe('<1')
+    expect(toAmountBand(5)).toBe('1-10')
+    expect(toAmountBand(50)).toBe('10-100')
+    expect(toAmountBand(500)).toBe('100-1000')
+    expect(toAmountBand(5_000)).toBe('>1000')
+  })
+})

--- a/packages/agent/tests/routes/activity-summary.test.ts
+++ b/packages/agent/tests/routes/activity-summary.test.ts
@@ -92,6 +92,52 @@ describe('/api/public/activity-summary', () => {
     expect(res.status).toBe(429)
   })
 
+  // Regression: anonymization test catches extra KEYS but not malicious VALUES.
+  // If a future ingest path writes a wallet-probe string into `detail.chain`,
+  // the unauthed teaser would leak it. Whitelist guard must replace any
+  // unknown chain with the `solana` fallback.
+  it('replaces unknown chain values with solana fallback (defense against value injection)', async () => {
+    insertActivity({
+      agent: 'sipher',
+      level: 'info',
+      type: 'send.success',
+      title: 'malicious',
+      detail: JSON.stringify({
+        amount: 1,
+        chain: 'C1phr1nj3ct3d-wallet-probe-value',
+      }),
+    })
+    const res = await request(app).get('/api/public/activity-summary')
+    expect(res.status).toBe(200)
+    expect(res.body.recent).toHaveLength(1)
+    expect(res.body.recent[0].chain).toBe('solana')
+    // Defense-in-depth: the injected sentinel string must appear nowhere in
+    // the response body, under any key.
+    expect(JSON.stringify(res.body)).not.toContain('C1phr1nj3ct3d')
+    expect(JSON.stringify(res.body)).not.toContain('wallet-probe')
+  })
+
+  it('preserves known chain values from the whitelist (case-insensitive)', async () => {
+    insertActivity({
+      agent: 'sipher',
+      level: 'info',
+      type: 'send.success',
+      title: 'eth-event',
+      detail: JSON.stringify({ amount: 1, chain: 'ETHEREUM' }),
+    })
+    insertActivity({
+      agent: 'sipher',
+      level: 'info',
+      type: 'swap.completed',
+      title: 'arb-event',
+      detail: JSON.stringify({ amount: 1, chain: 'arbitrum' }),
+    })
+    const res = await request(app).get('/api/public/activity-summary')
+    expect(res.status).toBe(200)
+    const chains = res.body.recent.map((r: { chain: string }) => r.chain).sort()
+    expect(chains).toEqual(['arbitrum', 'ethereum'])
+  })
+
   it('amount band buckets work as documented', async () => {
     const { toAmountBand } = await import('../../src/lib/queries/public.js')
     expect(toAmountBand(0.5)).toBe('<1')


### PR DESCRIPTION
## Summary

Replaces the empty "No activity in the last 24h." state on the unauthed Dashboard with a live counter + 5 most-recent (anonymized) fund-mover events from across the protocol. First-time visitors see proof the product works.

## What ships

**Backend (new):**
- `packages/agent/src/routes/public/activity-summary.ts` — `GET /api/public/activity-summary` returning `{ counter: number, recent: AnonActivityRow[] }`. Counter = `SELECT COUNT(*) FROM activity_stream WHERE type LIKE '%.success' OR '%.completed'`. Recent = same SQL filter + LIMIT 5 (SQL-level filter — JS post-filter approach would have silently lost rows as activity grew).
- Anonymization: strict 4-key allow-list `{ type, chain, amountBand, relativeTime }`. NO sender, recipient, exact amount, transaction hash. `chain` is whitelisted against 13 known chains (lowercase normalized) — adversarial values collapse to `'solana'`.
- 500 envelope sanitized: `{ error: { code: 'INTERNAL', message: 'activity-summary unavailable' } }` regardless of underlying failure. Raw error stays in server logs.
- Rate-limited via `ipRateLimitMiddleware('activity-summary', 120, 60_000)` + 60s cache.

**Frontend (new):**
- `app/src/components/UnauthedActivityFeed.tsx` — fetches on mount, polls every 60s while `document.visibilityState === 'visible'`. Skeleton during initial load. Graceful "Live activity unavailable" empty-state on fetch error. AbortController cleanup on unmount.
- `app/src/views/DashboardView.tsx` — ternary on `status === 'authed'` swaps `<ActivityStreamTable>` (authed) ↔ `<UnauthedActivityFeed />` (unauthed). PrivacyGraph slot UNTOUCHED (F1 territory).

**Shared helpers (extended):**
- `packages/agent/src/lib/queries/public.ts` — adds `toAmountBand`, `relativeTime`, `parseActivityDetail` helpers + matching types.

## Spec / plan

- Spec section: "Cluster F2 — #217 Unauthed activity teaser"
- Plan section: same
- Locked decision: D19 (counter + 5-recent, periodic poll not SSE, anonymized)

## Tests

+10 agent tests (`tests/routes/activity-summary.test.ts` 10): shape, anonymization strict allow-list, empty events, cache hit, rate limit at 121st req, amount-band boundaries, SQL filter regression (proves old JS-filter approach lost fund-movers), error envelope sanitization, chain whitelist normalization.

+8 app tests (`UnauthedActivityFeed.test.tsx` 6, `DashboardView.test.tsx` "Unauthed activity teaser" describe 2).

App: 518 → 526 (+8). Agent: 1415 → 1425 (+10). Typecheck clean.

## Notes

- ChatSidebar, DemoView/DemoCtaCard, PrivacyGraph slot, lib/ip-rate-limit.ts, and lib/cache.ts are untouched per cross-cluster guardrails.
- The amount-band labels currently read "`<1-10>` SOL" — Solana-dominated chain assumption is documented in spec; chain-aware unit labeling is a future-tier follow-up.

Closes #217