### PR TITLE
feat: #218 unauthed Ask SIPHER (5 educational msgs / IP / 24h)

### DIFF
--- a/app/src/components/ChatSidebar.tsx
+++ b/app/src/components/ChatSidebar.tsx
@@ -11,6 +11,16 @@ import SentinelConfirm from './SentinelConfirm'
 
 const API_URL = import.meta.env.VITE_API_URL ?? ''
 
+// Wave 2b #218 — educational prompts shown in the unauthed empty state.
+// RECTOR may polish copy at PR review; chips are click-to-send.
+const SUGGESTED_QUESTIONS: ReadonlyArray<string> = [
+  'How does a stealth address work?',
+  "What's the difference between SIPHER and Tornado Cash?",
+  'Why are viewing keys important for compliance?',
+]
+
+const UNAUTHED_FREE_CAP = 5
+
 interface Props {
   fullScreen?: boolean
 }
@@ -28,6 +38,10 @@ export default function ChatSidebar({ fullScreen }: Props) {
   const completeTool = useAppStore((s) => s.completeTool)
   const dismissMessage = useAppStore((s) => s.dismissMessage)
   const consumePendingPrompt = useAppStore((s) => s.consumePendingPrompt)
+  const unauthedRemaining = useAppStore((s) => s.unauthedRemaining)
+  const setUnauthedRemaining = useAppStore((s) => s.setUnauthedRemaining)
+
+  const mode: 'authed' | 'unauthed' = token ? 'authed' : 'unauthed'
 
   const [input, setInput] = useState('')
   const [activeTool, setActiveTool] = useState<string | null>(null)
@@ -38,9 +52,16 @@ export default function ChatSidebar({ fullScreen }: Props) {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages, chatLoading])
 
+  // Effective remaining count: null → CAP (no message sent yet this session),
+  // otherwise the clamped number from the last X-RateLimit-Remaining header.
+  const effectiveRemaining = unauthedRemaining ?? UNAUTHED_FREE_CAP
+  const unauthedBudgetExhausted = mode === 'unauthed' && effectiveRemaining <= 0
+
   const sendMessage = useCallback(async (overrideText?: string) => {
     const text = (overrideText ?? input).trim()
-    if (!text || !token || chatLoading) return
+    if (!text || chatLoading) return
+    if (mode === 'authed' && !token) return
+    if (mode === 'unauthed' && unauthedBudgetExhausted) return
 
     const userMsg: ChatMessage = { id: crypto.randomUUID(), role: 'user', content: text }
     addMessage(userMsg)
@@ -58,14 +79,31 @@ export default function ChatSidebar({ fullScreen }: Props) {
 
     try {
       const allMessages = [...messages, userMsg].map((m) => ({ role: m.role, content: m.content }))
-      const res = await fetch(`${API_URL}/api/chat/stream`, {
+      const url = mode === 'authed'
+        ? `${API_URL}/api/chat/stream`
+        : `${API_URL}/api/public/chat/stream`
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+      if (mode === 'authed' && token) headers.Authorization = `Bearer ${token}`
+
+      const res = await fetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        headers,
         body: JSON.stringify({ messages: allMessages }),
       })
 
+      // In unauthed mode, every response (200 or 429) emits X-RateLimit-Remaining.
+      // Sync it before branching on res.ok so the banner stays truthful even
+      // on rate-limit errors.
+      if (mode === 'unauthed') {
+        const remainingHeader = res.headers.get('X-RateLimit-Remaining')
+        if (remainingHeader !== null) {
+          const parsed = Number.parseInt(remainingHeader, 10)
+          if (Number.isFinite(parsed)) setUnauthedRemaining(Math.max(0, parsed))
+        }
+      }
+
       if (!res.ok) {
-        if (res.status === 401) {
+        if (mode === 'authed' && res.status === 401) {
           // Drop the empty assistant placeholder so the user doesn't see a
           // ghost bubble next to the session-expired toast. The toast (wired
           // globally in AuthSyncProvider) carries the re-auth UX.
@@ -73,8 +111,34 @@ export default function ChatSidebar({ fullScreen }: Props) {
           triggerAuthInterceptor()
           return
         }
+
+        if (mode === 'unauthed' && res.status === 429) {
+          // 429 envelope from /api/public/chat/stream:
+          //   { error: { code, message, resetAt } }
+          dismissMessage(assistantMsg.id)
+          const body = (await res.json().catch(() => ({}))) as {
+            error?: { code?: string; message?: string; resetAt?: number }
+          }
+          const resetAt = body.error?.resetAt
+          const resetClock = typeof resetAt === 'number'
+            ? new Date(resetAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+            : 'tomorrow'
+          showToast({
+            kind: 'error',
+            message: `Daily free limit reached. Resets at ${resetClock}.`,
+            durationMs: 6000,
+          })
+          setUnauthedRemaining(0)
+          return
+        }
+
         const err = await res.json().catch(() => ({}))
-        throw new Error((err as { error?: string }).error ?? `Error ${res.status}`)
+        const errMessage =
+          (err as { error?: { message?: string } | string }).error &&
+          typeof (err as { error?: { message?: string } | string }).error === 'object'
+            ? ((err as { error: { message?: string } }).error.message ?? `Error ${res.status}`)
+            : (((err as { error?: string }).error as string | undefined) ?? `Error ${res.status}`)
+        throw new Error(errMessage)
       }
       if (!res.body) throw new Error('No response body')
 
@@ -139,13 +203,45 @@ export default function ChatSidebar({ fullScreen }: Props) {
       setChatLoading(false)
       setActiveTool(null)
     }
-  }, [input, token, chatLoading, messages, addMessage, appendToLast, finishStreaming, setChatLoading, appendTool, completeTool, showToast])
+  }, [
+    input,
+    mode,
+    token,
+    chatLoading,
+    unauthedBudgetExhausted,
+    messages,
+    addMessage,
+    appendToLast,
+    finishStreaming,
+    setChatLoading,
+    appendTool,
+    completeTool,
+    dismissMessage,
+    showToast,
+    setUnauthedRemaining,
+  ])
 
-  // Consume seedChat prompt on mount/change
+  // Consume seedChat prompt on mount/change (authed only — unauthed mode
+  // never receives a pending prompt because deep-link CTAs require auth).
   useEffect(() => {
     const p = consumePendingPrompt()
     if (p && token) sendMessage(p)
   }, [consumePendingPrompt, sendMessage, token])
+
+  // ─── Compute view-state flags shared by render branches ────────────────────
+  const isAuthed = mode === 'authed'
+  const sendDisabled =
+    chatLoading ||
+    (isAuthed ? !input.trim() || !token : unauthedBudgetExhausted || !input.trim())
+  const inputDisabled =
+    chatLoading || (isAuthed ? !token : unauthedBudgetExhausted)
+  const placeholder = isAuthed
+    ? token
+      ? 'Message SIPHER...'
+      : 'Connect wallet first'
+    : unauthedBudgetExhausted
+      ? 'Connect wallet to continue'
+      : 'Ask SIPHER about privacy...'
 
   return (
     <div className={`flex flex-col bg-card ${fullScreen ? 'h-full' : 'h-full w-full'}`}>
@@ -164,8 +260,30 @@ export default function ChatSidebar({ fullScreen }: Props) {
       </div>
 
       <div className="flex-1 overflow-y-auto px-3 py-3 flex flex-col gap-2.5">
-        {messages.length === 0 && (
-          <p className="text-text-muted text-sm text-center py-8">Ask SIPHER anything about your privacy.</p>
+        {messages.length === 0 && isAuthed && (
+          <p className="text-text-muted text-sm text-center py-8">
+            Ask SIPHER anything about your privacy.
+          </p>
+        )}
+        {messages.length === 0 && !isAuthed && (
+          <div className="py-6 flex flex-col gap-3">
+            <p className="text-text-muted text-sm text-center">
+              Ask SIPHER about privacy on Solana
+            </p>
+            <div className="flex flex-col gap-2">
+              {SUGGESTED_QUESTIONS.map((q) => (
+                <button
+                  key={q}
+                  type="button"
+                  onClick={() => sendMessage(q)}
+                  disabled={chatLoading || unauthedBudgetExhausted}
+                  className="text-left bg-elevated border border-border rounded-lg px-3 py-2 text-[12px] text-text hover:border-accent/40 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {q}
+                </button>
+              ))}
+            </div>
+          </div>
         )}
         {messages.filter((m) => !m.dismissed).map((msg) => {
           if (msg.role === 'system' && msg.kind === 'sentinel_pause' && token) {
@@ -205,6 +323,13 @@ export default function ChatSidebar({ fullScreen }: Props) {
       </div>
 
       <div className="px-3 py-3 border-t border-border shrink-0">
+        {!isAuthed && (
+          <div className="mb-2 text-[11px] text-text-muted text-center">
+            {effectiveRemaining > 0
+              ? `${effectiveRemaining} of ${UNAUTHED_FREE_CAP} free messages — connect wallet for unlimited`
+              : 'Connect wallet to continue'}
+          </div>
+        )}
         <div className="flex gap-2">
           <input
             ref={inputRef}
@@ -218,13 +343,13 @@ export default function ChatSidebar({ fullScreen }: Props) {
             }}
             aria-label="Ask SIPHER"
             maxLength={4000}
-            placeholder={token ? 'Message SIPHER...' : 'Connect wallet first'}
+            placeholder={placeholder}
             className="flex-1 bg-elevated border border-border rounded-lg px-3 py-2 text-[13px] text-text placeholder-text-muted focus:outline-none focus:border-accent/40 transition-colors"
-            disabled={!token || chatLoading}
+            disabled={inputDisabled}
           />
           <button
             onClick={() => sendMessage()}
-            disabled={!input.trim() || !token || chatLoading}
+            disabled={sendDisabled}
             className="bg-accent/15 border border-accent/20 rounded-lg px-3 py-2 text-accent hover:bg-accent/25 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
             aria-label="Send"
           >

--- a/app/src/components/__tests__/ChatSidebar.test.tsx
+++ b/app/src/components/__tests__/ChatSidebar.test.tsx
@@ -49,6 +49,32 @@ function resetStore() {
     messages: [],
     chatLoading: false,
     chatOpen: false,
+    unauthedRemaining: null,
+  })
+}
+
+// Build a Response-like object that mimics the SSE shape served by
+// /api/public/chat/stream, including the X-RateLimit-* headers the FE
+// reads to drive the countdown banner.
+function mockSseResponseWithRateLimitHeaders(remaining: number, body = 'Hi'): Response {
+  const encoder = new TextEncoder()
+  const sseBody = new ReadableStream({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode(`data: ${JSON.stringify({ type: 'content_block_delta', text: body })}\n\n`)
+      )
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+      controller.close()
+    },
+  })
+  return new Response(sseBody, {
+    status: 200,
+    headers: {
+      'content-type': 'text/event-stream',
+      'X-RateLimit-Limit': '5',
+      'X-RateLimit-Remaining': String(remaining),
+      'X-RateLimit-Reset': String(Math.floor(Date.now() / 1000) + 3600),
+    },
   })
 }
 
@@ -64,10 +90,11 @@ describe('ChatSidebar', () => {
     vi.restoreAllMocks()
   })
 
-  it('shows connect-wallet placeholder and disables input when unauthenticated', () => {
+  it('shows unauthed educational placeholder and keeps input enabled (Wave 2b #218)', () => {
     render(<ChatSidebar />)
-    const input = screen.getByPlaceholderText('Connect wallet first')
-    expect(input).toBeDisabled()
+    const input = screen.getByPlaceholderText(/ask sipher about privacy/i)
+    // Unauthed users still get a free-message budget — input is interactive.
+    expect(input).not.toBeDisabled()
   })
 
   it('enables input when authenticated', () => {
@@ -214,6 +241,96 @@ describe('ChatSidebar', () => {
       const input = screen.getByLabelText('Ask SIPHER') as HTMLInputElement
       expect(input).toBeInTheDocument()
       expect(input.maxLength).toBe(4000)
+    })
+  })
+
+  describe('unauthed mode', () => {
+    beforeEach(() => {
+      // Default: 4 messages remaining after the click consumes one.
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockSseResponseWithRateLimitHeaders(4)))
+    })
+
+    it('renders 3 suggested questions in empty state', () => {
+      render(<ChatSidebar />)
+      expect(screen.getByText(/how does a stealth address work/i)).toBeInTheDocument()
+      expect(screen.getByText(/sipher and tornado cash/i)).toBeInTheDocument()
+      expect(screen.getByText(/viewing keys/i)).toBeInTheDocument()
+    })
+
+    it('clicking a suggested question pre-fills + sends', async () => {
+      render(<ChatSidebar />)
+      fireEvent.click(screen.getByText(/how does a stealth address work/i))
+      await waitFor(() => expect(global.fetch as ReturnType<typeof vi.fn>).toHaveBeenCalled())
+      const url = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(String(url)).toContain('/api/public/chat/stream')
+    })
+
+    it('banner shows "5 free messages — connect for unlimited" before any send', () => {
+      render(<ChatSidebar />)
+      expect(screen.getByText(/5 .*free messages/i)).toBeInTheDocument()
+    })
+
+    it('banner countdown updates from X-RateLimit-Remaining', async () => {
+      render(<ChatSidebar />)
+      fireEvent.click(screen.getByText(/how does a stealth address work/i))
+      await waitFor(() => {
+        expect(screen.getByText(/4 .*free messages/i)).toBeInTheDocument()
+      })
+    })
+
+    it('on remaining=0 after send, input disabled + button copy is "Connect wallet to continue"', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockSseResponseWithRateLimitHeaders(0)))
+      render(<ChatSidebar />)
+      fireEvent.click(screen.getByText(/how does a stealth address work/i))
+      await waitFor(() => {
+        const input = screen.getByLabelText(/ask sipher/i) as HTMLInputElement
+        expect(input.disabled).toBe(true)
+      })
+      expect(screen.getByText(/connect wallet to continue/i)).toBeInTheDocument()
+    })
+
+    it('on 429 response, input disabled + toast shown', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              error: {
+                code: 'RATE_LIMITED',
+                message: 'Daily free limit reached',
+                resetAt: Date.now() + 3600_000,
+              },
+            }),
+            {
+              status: 429,
+              headers: {
+                'content-type': 'application/json',
+                'X-RateLimit-Remaining': '0',
+                'X-RateLimit-Reset': String(Math.floor(Date.now() / 1000) + 3600),
+              },
+            }
+          )
+        )
+      )
+      render(<ChatSidebar />)
+      fireEvent.click(screen.getByText(/how does a stealth address work/i))
+      await waitFor(() => {
+        const input = screen.getByLabelText(/ask sipher/i) as HTMLInputElement
+        expect(input.disabled).toBe(true)
+      })
+      expect(mockToastShow).toHaveBeenCalledWith(
+        expect.objectContaining({ kind: 'error' })
+      )
+    })
+
+    it('POST has NO Authorization header in unauthed mode', async () => {
+      render(<ChatSidebar />)
+      fireEvent.click(screen.getByText(/how does a stealth address work/i))
+      await waitFor(() => expect(global.fetch as ReturnType<typeof vi.fn>).toHaveBeenCalled())
+      const init = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit
+      const headers = (init.headers ?? {}) as Record<string, string>
+      expect(headers.Authorization).toBeUndefined()
+      expect(headers.authorization).toBeUndefined()
     })
   })
 })

--- a/app/src/stores/app.ts
+++ b/app/src/stores/app.ts
@@ -50,6 +50,13 @@ interface AppState {
 
   chatSheetOpen: boolean
   setChatSheetOpen: (open: boolean) => void
+
+  // Wave 2b #218 — unauthed chat budget. Null = unknown (no message sent yet
+  // in this session). Number = X-RateLimit-Remaining from the last public
+  // chat response. Reset to null on auth state changes so authed→unauthed
+  // transitions start fresh.
+  unauthedRemaining: number | null
+  setUnauthedRemaining: (n: number | null) => void
 }
 
 export const useAppStore = create<AppState>()(
@@ -58,9 +65,16 @@ export const useAppStore = create<AppState>()(
       token: null,
       isAdmin: false,
       expiresAt: null,
-      setAuth: (token, isAdmin, expiresAt = null) => set({ token, isAdmin, expiresAt }),
+      setAuth: (token, isAdmin, expiresAt = null) =>
+        set({ token, isAdmin, expiresAt, unauthedRemaining: null }),
       clearAuth: () => {
-        set({ token: null, isAdmin: false, expiresAt: null, messages: [] })
+        set({
+          token: null,
+          isAdmin: false,
+          expiresAt: null,
+          messages: [],
+          unauthedRemaining: null,
+        })
         onAuthClear.clearAll()
       },
 
@@ -125,6 +139,9 @@ export const useAppStore = create<AppState>()(
 
       chatSheetOpen: false,
       setChatSheetOpen: (chatSheetOpen) => set({ chatSheetOpen }),
+
+      unauthedRemaining: null,
+      setUnauthedRemaining: (unauthedRemaining) => set({ unauthedRemaining }),
     }),
     {
       name: 'sipher-auth',

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -16,7 +16,7 @@ test.describe('Ask SIPHER sheet', () => {
       await expect(page.getByRole('dialog', { name: /ask sipher/i })).toHaveCount(0)
     })
 
-    test('chat input is disabled inside the sheet when unauthenticated', async ({ page }) => {
+    test('chat input is enabled with free-message UX when unauthenticated (#218)', async ({ page }) => {
       const errors: string[] = []
       page.on('pageerror', (err) => errors.push(err.message))
       page.on('console', (msg) => {
@@ -25,9 +25,13 @@ test.describe('Ask SIPHER sheet', () => {
 
       await page.goto('/')
       await page.getByRole('button', { name: /ask sipher/i }).click()
-      const input = page.getByPlaceholder('Connect wallet first')
+      const input = page.getByPlaceholder(/ask sipher about privacy/i)
       await expect(input).toBeVisible()
-      await expect(input).toBeDisabled()
+      await expect(input).toBeEnabled()
+      // Free-message banner present before any send
+      await expect(page.getByText(/5 .*free messages.*connect wallet/i)).toBeVisible()
+      // 3 educational suggested-question chips render in empty state
+      await expect(page.getByRole('button', { name: /stealth address/i })).toBeVisible()
       expect(errors).toEqual([])
     })
   })

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -30,8 +30,9 @@ test.describe('Ask SIPHER sheet', () => {
       await expect(input).toBeEnabled()
       // Free-message banner present before any send
       await expect(page.getByText(/5 .*free messages.*connect wallet/i)).toBeVisible()
-      // 3 educational suggested-question chips render in empty state
-      await expect(page.getByRole('button', { name: /stealth address/i })).toBeVisible()
+      // 3 educational suggested-question chips render in empty state (inside the sheet)
+      const sheet = page.getByRole('dialog', { name: /ask sipher/i })
+      await expect(sheet.getByRole('button', { name: /how does a stealth address/i })).toBeVisible()
       expect(errors).toEqual([])
     })
   })

--- a/packages/agent/src/routes/public/chat.ts
+++ b/packages/agent/src/routes/public/chat.ts
@@ -1,0 +1,111 @@
+import { Router, type Request, type Response } from 'express'
+import { ipRateLimitMiddleware } from '../../lib/ip-rate-limit.js'
+import { chatStream, type SSEEvent } from '../../agent.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public, unauthenticated SSE chat endpoint (POST /api/public/chat/stream).
+//
+// Wave 2b D20 contract:
+//   - 5 messages per IP per 24 hours (rate-limit key 'chat')
+//   - No tools (empty array passed to chatStream — Pi runtime emits no
+//     tool_use / tool_result events because the agent has no tools to call)
+//   - Restricted system prompt (UNAUTHED_SYSTEM_PROMPT below) — model
+//     refuses wallet/tool/balance queries and stays on privacy education
+//   - SSE shape mirrors authed /api/chat/stream so the FE's existing parser
+//     handles both modes. Only content_block_delta + error + message_complete
+//     events are emitted in practice (no tools → no tool/sentinel events).
+//
+// Pattern selected: Strategy A from the implementation plan — call chatStream
+// directly with `tools: []` and `systemPrompt: UNAUTHED_SYSTEM_PROMPT`. This
+// keeps the blast radius surgical (no new agent loop, no AgentCore profile
+// duplication, no chatStream signature drift). The Pi runtime cleanly
+// degrades to a tool-less conversation when the tools array is empty.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const UNAUTHED_SYSTEM_PROMPT = `You are SIPHER's educational assistant. Answer concise general questions about: SIPHER (multi-chain privacy command center), shielded payments, stealth addresses, Pedersen commitments, viewing keys, and privacy tradeoffs on Solana and EVM chains.
+
+If the user asks about their wallet, balances, transactions, prices, accounts, or anything that would require running a tool, politely refuse and suggest they connect their wallet to use SIPHER fully.
+
+Never claim to do anything on-chain. You have no tools available in this mode. Keep answers under 200 words. If asked something off-topic, politely redirect to SIPHER topics.`
+
+const MAX_MESSAGE_LENGTH = 4000
+
+interface InboundMessage {
+  role: 'user' | 'assistant' | 'system'
+  content: string
+}
+
+/**
+ * Extract the last user message from a chat-style messages array.
+ * Mirrors the authed `extractLastUserMessage` helper in adapters/web.ts.
+ */
+function extractLastUserMessage(messages: unknown): string | null {
+  if (!Array.isArray(messages) || messages.length === 0) return null
+  const userMessages = (messages as InboundMessage[]).filter((m) => m?.role === 'user')
+  if (userMessages.length === 0) return null
+  const last = userMessages[userMessages.length - 1]?.content
+  return typeof last === 'string' && last.length > 0 ? last : null
+}
+
+export const chatRouter = Router()
+
+chatRouter.post(
+  '/stream',
+  ipRateLimitMiddleware('chat', 5, 24 * 60 * 60 * 1000),
+  async (req: Request, res: Response) => {
+    const lastUserMsg = extractLastUserMessage(req.body?.messages)
+    if (!lastUserMsg) {
+      res.status(400).json({
+        error: {
+          code: 'VALIDATION_FAILED',
+          message: 'messages array is required and must contain at least one user message',
+        },
+      })
+      return
+    }
+    if (lastUserMsg.length > MAX_MESSAGE_LENGTH) {
+      res.status(400).json({
+        error: {
+          code: 'VALIDATION_FAILED',
+          message: `message exceeds ${MAX_MESSAGE_LENGTH} character limit`,
+        },
+      })
+      return
+    }
+
+    // SSE headers — flushHeaders commits the X-RateLimit-* headers set by
+    // ipRateLimitMiddleware so the FE can read remaining before the body
+    // arrives, and prevents nginx buffering from delaying the first event.
+    res.setHeader('Content-Type', 'text/event-stream')
+    res.setHeader('Cache-Control', 'no-cache')
+    res.setHeader('Connection', 'keep-alive')
+    res.setHeader('X-Accel-Buffering', 'no')
+    res.flushHeaders()
+
+    let aborted = false
+    res.on('close', () => {
+      aborted = true
+    })
+
+    try {
+      const stream: AsyncGenerator<SSEEvent> = chatStream(lastUserMsg, {
+        systemPrompt: UNAUTHED_SYSTEM_PROMPT,
+        tools: [],
+      })
+      for await (const event of stream) {
+        if (aborted || res.writableEnded) break
+        res.write(`data: ${JSON.stringify(event)}\n\n`)
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Internal error'
+      if (!res.writableEnded) {
+        res.write(`data: ${JSON.stringify({ type: 'error', message })}\n\n`)
+      }
+    }
+
+    if (!res.writableEnded) {
+      res.write('data: [DONE]\n\n')
+      res.end()
+    }
+  },
+)

--- a/packages/agent/src/routes/public/chat.ts
+++ b/packages/agent/src/routes/public/chat.ts
@@ -1,4 +1,4 @@
-import { Router, type Request, type Response } from 'express'
+import { Router, type NextFunction, type Request, type Response } from 'express'
 import { ipRateLimitMiddleware } from '../../lib/ip-rate-limit.js'
 import { chatStream, type SSEEvent } from '../../agent.js'
 
@@ -38,78 +38,118 @@ interface InboundMessage {
 /**
  * Extract the last user message from a chat-style messages array.
  * Mirrors the authed `extractLastUserMessage` helper in adapters/web.ts.
+ * Assumes the input has already passed `validateChatBody` — the array shape
+ * and per-message structure are guaranteed at this point.
  */
-function extractLastUserMessage(messages: unknown): string | null {
-  if (!Array.isArray(messages) || messages.length === 0) return null
-  const userMessages = (messages as InboundMessage[]).filter((m) => m?.role === 'user')
+function extractLastUserMessage(messages: InboundMessage[]): string | null {
+  const userMessages = messages.filter((m) => m.role === 'user')
   if (userMessages.length === 0) return null
   const last = userMessages[userMessages.length - 1]?.content
   return typeof last === 'string' && last.length > 0 ? last : null
 }
 
+/**
+ * Validate the chat body BEFORE the rate-limit middleware runs.
+ *
+ * Why before rate-limit: malformed requests must not consume a 5/24h slot.
+ * If validation ran after rate-limiting, an attacker who can spoof IPs could
+ * deplete a victim's budget with junk payloads. Behind nginx with trust
+ * proxy=1 the IP-spoof surface is small, but the Vercel migration changes
+ * the exposure profile, so we lock the safer order in now.
+ */
+function validateChatBody(req: Request, res: Response, next: NextFunction): void {
+  const messages = req.body?.messages
+  if (!Array.isArray(messages) || messages.length === 0) {
+    res.status(400).json({
+      error: {
+        code: 'VALIDATION_FAILED',
+        message: 'messages array is required and must contain at least one user message',
+      },
+    })
+    return
+  }
+  for (const m of messages) {
+    if (!m || typeof m !== 'object' || typeof m.role !== 'string' || typeof m.content !== 'string') {
+      res.status(400).json({
+        error: { code: 'VALIDATION_FAILED', message: 'invalid message shape' },
+      })
+      return
+    }
+  }
+  const lastUserMsg = extractLastUserMessage(messages as InboundMessage[])
+  if (!lastUserMsg) {
+    res.status(400).json({
+      error: {
+        code: 'VALIDATION_FAILED',
+        message: 'messages array is required and must contain at least one user message',
+      },
+    })
+    return
+  }
+  if (lastUserMsg.length > MAX_MESSAGE_LENGTH) {
+    res.status(400).json({
+      error: {
+        code: 'VALIDATION_FAILED',
+        message: `message exceeds ${MAX_MESSAGE_LENGTH} character limit`,
+      },
+    })
+    return
+  }
+  next()
+}
+
+async function handleChatStream(req: Request, res: Response): Promise<void> {
+  // validateChatBody guarantees a non-empty user message — extractLastUserMessage
+  // cannot return null here.
+  const lastUserMsg = extractLastUserMessage(req.body.messages as InboundMessage[])!
+
+  // SSE headers — flushHeaders commits the X-RateLimit-* headers set by
+  // ipRateLimitMiddleware so the FE can read remaining before the body
+  // arrives, and prevents nginx buffering from delaying the first event.
+  res.setHeader('Content-Type', 'text/event-stream')
+  res.setHeader('Cache-Control', 'no-cache')
+  res.setHeader('Connection', 'keep-alive')
+  res.setHeader('X-Accel-Buffering', 'no')
+  res.flushHeaders()
+
+  let aborted = false
+  res.on('close', () => {
+    aborted = true
+  })
+
+  try {
+    const stream: AsyncGenerator<SSEEvent> = chatStream(lastUserMsg, {
+      systemPrompt: UNAUTHED_SYSTEM_PROMPT,
+      tools: [],
+    })
+    for await (const event of stream) {
+      if (aborted || res.writableEnded) break
+      res.write(`data: ${JSON.stringify(event)}\n\n`)
+    }
+  } catch (err) {
+    // Sanitize before writing to the stream. Anonymous clients receive a
+    // generic message; the raw error stays in server logs (operator
+    // visibility) so we don't leak OpenRouter/model/infra details into
+    // the assistant bubble where the FE paints SSE error events.
+    console.error('[public/chat] chatStream error:', err)
+    if (!res.writableEnded) {
+      res.write(`data: ${JSON.stringify({ type: 'error', message: 'Service temporarily unavailable' })}\n\n`)
+    }
+  }
+
+  if (!res.writableEnded) {
+    res.write('data: [DONE]\n\n')
+    res.end()
+  }
+}
+
 export const chatRouter = Router()
 
+// Middleware order matters: validateChatBody → rate-limit → handler.
+// Malformed requests return 400 without consuming a rate-limit slot.
 chatRouter.post(
   '/stream',
+  validateChatBody,
   ipRateLimitMiddleware('chat', 5, 24 * 60 * 60 * 1000),
-  async (req: Request, res: Response) => {
-    const lastUserMsg = extractLastUserMessage(req.body?.messages)
-    if (!lastUserMsg) {
-      res.status(400).json({
-        error: {
-          code: 'VALIDATION_FAILED',
-          message: 'messages array is required and must contain at least one user message',
-        },
-      })
-      return
-    }
-    if (lastUserMsg.length > MAX_MESSAGE_LENGTH) {
-      res.status(400).json({
-        error: {
-          code: 'VALIDATION_FAILED',
-          message: `message exceeds ${MAX_MESSAGE_LENGTH} character limit`,
-        },
-      })
-      return
-    }
-
-    // SSE headers — flushHeaders commits the X-RateLimit-* headers set by
-    // ipRateLimitMiddleware so the FE can read remaining before the body
-    // arrives, and prevents nginx buffering from delaying the first event.
-    res.setHeader('Content-Type', 'text/event-stream')
-    res.setHeader('Cache-Control', 'no-cache')
-    res.setHeader('Connection', 'keep-alive')
-    res.setHeader('X-Accel-Buffering', 'no')
-    res.flushHeaders()
-
-    let aborted = false
-    res.on('close', () => {
-      aborted = true
-    })
-
-    try {
-      const stream: AsyncGenerator<SSEEvent> = chatStream(lastUserMsg, {
-        systemPrompt: UNAUTHED_SYSTEM_PROMPT,
-        tools: [],
-      })
-      for await (const event of stream) {
-        if (aborted || res.writableEnded) break
-        res.write(`data: ${JSON.stringify(event)}\n\n`)
-      }
-    } catch (err) {
-      // Sanitize before writing to the stream. Anonymous clients receive a
-      // generic message; the raw error stays in server logs (operator
-      // visibility) so we don't leak OpenRouter/model/infra details into
-      // the assistant bubble where the FE paints SSE error events.
-      console.error('[public/chat] chatStream error:', err)
-      if (!res.writableEnded) {
-        res.write(`data: ${JSON.stringify({ type: 'error', message: 'Service temporarily unavailable' })}\n\n`)
-      }
-    }
-
-    if (!res.writableEnded) {
-      res.write('data: [DONE]\n\n')
-      res.end()
-    }
-  },
+  handleChatStream,
 )

--- a/packages/agent/src/routes/public/chat.ts
+++ b/packages/agent/src/routes/public/chat.ts
@@ -97,9 +97,13 @@ chatRouter.post(
         res.write(`data: ${JSON.stringify(event)}\n\n`)
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Internal error'
+      // Sanitize before writing to the stream. Anonymous clients receive a
+      // generic message; the raw error stays in server logs (operator
+      // visibility) so we don't leak OpenRouter/model/infra details into
+      // the assistant bubble where the FE paints SSE error events.
+      console.error('[public/chat] chatStream error:', err)
       if (!res.writableEnded) {
-        res.write(`data: ${JSON.stringify({ type: 'error', message })}\n\n`)
+        res.write(`data: ${JSON.stringify({ type: 'error', message: 'Service temporarily unavailable' })}\n\n`)
       }
     }
 

--- a/packages/agent/src/routes/public/index.ts
+++ b/packages/agent/src/routes/public/index.ts
@@ -1,12 +1,10 @@
 import { Router } from 'express'
 import { demoRouter } from './demo.js'
 import { activitySummaryRouter } from './activity-summary.js'
+import { chatRouter } from './chat.js'
 
 /**
  * Public, unauthenticated routes mounted at /api/public.
- * Wave 2b subagents (F3) extend this router by appending sub-routers.
- * F1 (/demo) and F2 (/activity-summary) already wired below.
- *
  * All sub-routers MUST apply ipRateLimitMiddleware with their own key/cap.
  */
 export const publicRouter = Router()
@@ -15,3 +13,5 @@ export const publicRouter = Router()
 publicRouter.use('/demo', demoRouter)
 // #217 — unauthed activity teaser (counter + 5 recent rows)
 publicRouter.use('/activity-summary', activitySummaryRouter)
+// #218 — unauthed Ask SIPHER chat (POST /api/public/chat/stream, 5 msgs/IP/24h)
+publicRouter.use('/chat', chatRouter)

--- a/packages/agent/tests/routes/public/chat.test.ts
+++ b/packages/agent/tests/routes/public/chat.test.ts
@@ -126,6 +126,49 @@ describe('/api/public/chat/stream', () => {
     })
   })
 
+  it('does not consume a rate-limit slot on validation 400 (empty messages)', async () => {
+    // Five malformed POSTs MUST NOT touch the rate-limit counter. If they
+    // did, an attacker who can spoof IPs could deplete a victim's 5-message
+    // budget with junk payloads. After 5 malformed requests, a 6th valid
+    // request should still be accepted with X-RateLimit-Remaining=4.
+    for (let i = 0; i < 5; i++) {
+      const res = await request(app)
+        .post('/api/public/chat/stream')
+        .send({ messages: [] })
+      expect(res.status).toBe(400)
+    }
+    const res = await request(app)
+      .post('/api/public/chat/stream')
+      .send({ messages: [{ role: 'user', content: 'hi' }] })
+    expect(res.status).toBe(200)
+    expect(res.headers['x-ratelimit-remaining']).toBe('4')
+  })
+
+  it('does not consume a rate-limit slot on validation 400 (malformed message shape)', async () => {
+    // Same protection for malformed message objects (missing role/content).
+    for (let i = 0; i < 5; i++) {
+      const res = await request(app)
+        .post('/api/public/chat/stream')
+        .send({ messages: [{ foo: 'bar' }] })
+      expect(res.status).toBe(400)
+    }
+    const res = await request(app)
+      .post('/api/public/chat/stream')
+      .send({ messages: [{ role: 'user', content: 'hi' }] })
+    expect(res.status).toBe(200)
+    expect(res.headers['x-ratelimit-remaining']).toBe('4')
+  })
+
+  it('rejects malformed message objects with 400 VALIDATION_FAILED', async () => {
+    const res = await request(app)
+      .post('/api/public/chat/stream')
+      .send({ messages: [{ role: 'user' }] }) // missing content
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({
+      error: { code: 'VALIDATION_FAILED', message: expect.any(String) },
+    })
+  })
+
   it('sanitizes upstream errors before writing to SSE stream', async () => {
     // Reach into the mocked agent module and force chatStream to throw a
     // message that mimics an internal infra leak (OpenRouter API key in

--- a/packages/agent/tests/routes/public/chat.test.ts
+++ b/packages/agent/tests/routes/public/chat.test.ts
@@ -125,4 +125,30 @@ describe('/api/public/chat/stream', () => {
       error: { code: 'VALIDATION_FAILED', message: expect.any(String) },
     })
   })
+
+  it('sanitizes upstream errors before writing to SSE stream', async () => {
+    // Reach into the mocked agent module and force chatStream to throw a
+    // message that mimics an internal infra leak (OpenRouter API key in
+    // stack, model timeout details, etc.). The route MUST NOT forward this
+    // verbatim — anonymous clients receive a generic 'Service temporarily
+    // unavailable' message and the detailed error stays in server logs.
+    const agentModule = await import('../../../src/agent.js')
+    const spy = vi.spyOn(agentModule, 'chatStream').mockImplementation(async function* (): AsyncGenerator<SSEEvent> {
+      throw new Error('OpenRouter API error: invalid key sk-or-v1-LEAKED_SECRET_xxx')
+    })
+
+    const res = await request(app)
+      .post('/api/public/chat/stream')
+      .send({ messages: [{ role: 'user', content: 'hello' }] })
+
+    expect(res.status).toBe(200)
+    // The sanitized generic message MUST be present
+    expect(res.text).toContain('Service temporarily unavailable')
+    // The raw error text (model name, API key fragment, internal noise) MUST NOT leak
+    expect(res.text).not.toContain('OpenRouter')
+    expect(res.text).not.toContain('sk-or-v1-LEAKED_SECRET_xxx')
+    expect(res.text).not.toContain('invalid key')
+
+    spy.mockRestore()
+  })
 })

--- a/packages/agent/tests/routes/public/chat.test.ts
+++ b/packages/agent/tests/routes/public/chat.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+import type { SSEEvent } from '../../../src/agent.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock chatStream — prevent real LLM calls. The mock yields a deterministic
+// SSE stream so the route handler exercises every code path (write deltas,
+// forward sentinel-free events, terminate with [DONE]).
+//
+// We retain a handle to inspect ChatOptions the route passes through so we
+// can assert no-tools + UNAUTHED_SYSTEM_PROMPT enforcement without depending
+// on a live model.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const chatStreamCalls: Array<{ userMessage: string; opts: Record<string, unknown> }> = []
+
+vi.mock('../../../src/agent.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/agent.js')>(
+    '../../../src/agent.js',
+  )
+  return {
+    ...actual,
+    chatStream: vi.fn().mockImplementation(async function* (
+      userMessage: string,
+      opts: Record<string, unknown>,
+    ): AsyncGenerator<SSEEvent> {
+      chatStreamCalls.push({ userMessage, opts })
+      yield { type: 'content_block_delta', text: 'stealth address ' } as SSEEvent
+      yield { type: 'content_block_delta', text: 'is a one-time recipient address.' } as SSEEvent
+      yield { type: 'message_complete', content: 'stealth address is a one-time recipient address.' } as SSEEvent
+    }),
+  }
+})
+
+import express from 'express'
+import request from 'supertest'
+import { _resetForTests as resetIpRateLimit } from '../../../src/lib/ip-rate-limit.js'
+
+describe('/api/public/chat/stream', () => {
+  let app: express.Express
+
+  beforeEach(async () => {
+    chatStreamCalls.length = 0
+    await resetIpRateLimit()
+    const { publicRouter } = await import('../../../src/routes/public/index.js')
+    app = express()
+    app.set('trust proxy', 1)
+    app.use(express.json())
+    app.use('/api/public', publicRouter)
+  })
+
+  it('returns SSE stream on valid POST', async () => {
+    const res = await request(app)
+      .post('/api/public/chat/stream')
+      .send({ messages: [{ role: 'user', content: 'What is a stealth address?' }] })
+    expect(res.status).toBe(200)
+    expect(res.headers['content-type']).toContain('text/event-stream')
+    expect(res.text).toContain('data: ')
+    expect(res.text).toContain('[DONE]')
+  })
+
+  it('emits X-RateLimit-* headers', async () => {
+    const res = await request(app)
+      .post('/api/public/chat/stream')
+      .send({ messages: [{ role: 'user', content: 'hello' }] })
+    expect(res.headers['x-ratelimit-limit']).toBe('5')
+    expect(Number(res.headers['x-ratelimit-remaining'])).toBeGreaterThanOrEqual(0)
+    expect(Number(res.headers['x-ratelimit-remaining'])).toBeLessThanOrEqual(4)
+    expect(res.headers['x-ratelimit-reset']).toBeDefined()
+  })
+
+  it('returns 429 + RATE_LIMITED envelope after 5 requests in 24h', async () => {
+    for (let i = 0; i < 5; i++) {
+      await request(app)
+        .post('/api/public/chat/stream')
+        .send({ messages: [{ role: 'user', content: 'q' }] })
+    }
+    const res = await request(app)
+      .post('/api/public/chat/stream')
+      .send({ messages: [{ role: 'user', content: 'q' }] })
+    expect(res.status).toBe(429)
+    expect(res.body).toEqual({
+      error: { code: 'RATE_LIMITED', message: expect.any(String), resetAt: expect.any(Number) },
+    })
+  })
+
+  it('different IPs have independent budgets', async () => {
+    for (let i = 0; i < 5; i++) {
+      await request(app)
+        .post('/api/public/chat/stream')
+        .send({ messages: [{ role: 'user', content: 'q' }] })
+        .set('X-Forwarded-For', '1.1.1.1')
+    }
+    const res = await request(app)
+      .post('/api/public/chat/stream')
+      .send({ messages: [{ role: 'user', content: 'q' }] })
+      .set('X-Forwarded-For', '2.2.2.2')
+    expect(res.status).toBe(200)
+  })
+
+  it('exports UNAUTHED_SYSTEM_PROMPT as a string', async () => {
+    const mod = await import('../../../src/routes/public/chat.js')
+    expect(typeof mod.UNAUTHED_SYSTEM_PROMPT).toBe('string')
+    expect(mod.UNAUTHED_SYSTEM_PROMPT).toMatch(/SIPHER/)
+    expect(mod.UNAUTHED_SYSTEM_PROMPT).toMatch(/no tools/i)
+  })
+
+  it('invokes chatStream with empty tools array and UNAUTHED_SYSTEM_PROMPT', async () => {
+    const mod = await import('../../../src/routes/public/chat.js')
+    await request(app)
+      .post('/api/public/chat/stream')
+      .send({ messages: [{ role: 'user', content: 'How does a stealth address work?' }] })
+    expect(chatStreamCalls.length).toBe(1)
+    const call = chatStreamCalls[0]
+    expect(call.userMessage).toBe('How does a stealth address work?')
+    expect(call.opts.systemPrompt).toBe(mod.UNAUTHED_SYSTEM_PROMPT)
+    expect(call.opts.tools).toEqual([])
+  })
+
+  it('rejects empty messages array with 400', async () => {
+    const res = await request(app)
+      .post('/api/public/chat/stream')
+      .send({ messages: [] })
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({
+      error: { code: 'VALIDATION_FAILED', message: expect.any(String) },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Lets unauthenticated visitors ask SIPHER conceptual privacy questions — 5 free messages per IP per 24h. Empty-state chat shows 3 suggested questions. Educational on-ramp before wallet connect.

## What ships

**Backend (new):**
- `packages/agent/src/routes/public/chat.ts` — `POST /api/public/chat/stream` SSE endpoint. Pipeline: `validateChatBody → ipRateLimitMiddleware('chat', 5, 24h) → handleChatStream`. Validation runs FIRST so a malformed request returns 400 WITHOUT consuming a rate-limit slot (defense-in-depth against budget-depletion attacks).
- **Strategy A** for the agent invocation: calls existing `chatStream` with explicit `tools: []` + `systemPrompt: UNAUTHED_SYSTEM_PROMPT` overrides. No tool execution path exists in unauthed mode (defense-in-depth via `attachToolGuard` cap if Pi tried anyway).
- 429 envelope: `{ error: { code: 'RATE_LIMITED', message, resetAt } }` (JSON, not SSE).
- SSE error events sanitized: clients see "Service temporarily unavailable"; raw error stays in `console.error` for operators.
- `UNAUTHED_SYSTEM_PROMPT` constraints: topics restricted to general SIPHER / privacy / Solana concepts; refuses wallet/transaction-specific Qs; "no tools available in this mode"; <200 word responses.

**Frontend (extended):**
- `app/src/components/ChatSidebar.tsx` — mode-branches on `token ? 'authed' : 'unauthed'`. Unauthed empty state: 3 educational chip suggestions (click pre-fills + sends). Banner shows countdown: "{N} of 5 free messages — connect wallet for unlimited" reading from `useAppStore.unauthedRemaining`. POSTs to `/api/public/chat/stream` with NO Authorization header. On 429 or remaining=0: input disabled + "Connect wallet to continue" button copy.
- `app/src/stores/app.ts` — adds `unauthedRemaining: number | null` state + `setUnauthedRemaining` action. Reset to null on both `setAuth` and `clearAuth`.

## Spec / plan

- Spec section: "Cluster F3 — #218 Unauthed Ask SIPHER"
- Plan section: same
- Locked decision: D20 (5 msgs/IP/24h, no tools, restricted prompt, 3 suggested questions, countdown UX)

## Tests

+9 agent tests in `tests/routes/public/chat.test.ts`: SSE stream shape, X-RateLimit-* headers, 6th-req 429 envelope, IP isolation via X-Forwarded-For, UNAUTHED_SYSTEM_PROMPT export+content assertions, chatStream-options spy (proves Strategy A: empty tools + system prompt propagation), validation 400 + rate-limit-not-consumed regression (3 sub-tests), sanitized SSE error event (does NOT leak raw error).

+7 app tests in `ChatSidebar.test.tsx` unauthed-mode describe block: 3 suggested chips render, click pre-fills+sends, banner before send shows "5 free", countdown updates from X-RateLimit-Remaining, 0-remaining disables input + Connect-to-continue, 429 disables + toast, no Authorization header in unauthed POST.

App: 518 → 525 (+7). Agent: 1415 → 1426 (+11). Existing authed-mode chat tests stay green (no regression). Typecheck clean.

## Notes

- DemoView/DemoCtaCard, UnauthedActivityFeed, DashboardView (any slot), lib/ip-rate-limit.ts, lib/cache.ts, trust-proxy config — all untouched per cross-cluster guardrails.
- No captcha, no content classification, no auto-ban (out of scope per D20). System prompt is the v1 guardrail.
- `UNAUTHED_SYSTEM_PROMPT` is a constant; subject to RECTOR polish at review or post-merge.
- 3 suggested questions are educational drafts — subject to RECTOR polish.

Closes #218