### PR TITLE
feat(agent): sip.sol tools — resolveSNS + sendPrivateToSNS

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,6 +56,11 @@ jobs:
 
       - run: pnpm --filter @sipher/sdk build
 
+      # Build the agent before playwright spawns it via `node dist/index.js`.
+      # tsx-based dev mode hit an upstream Bonfida ESM bundle issue after the
+      # Phase D sip.sol integration; production already uses the built output.
+      - run: pnpm --filter @sipher/agent build
+
       - run: pnpm exec playwright install --with-deps chromium
 
       - name: Write E2E admin keypair

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -13,6 +13,7 @@
     "@mariozechner/pi-ai": "^0.66.1",
     "@noble/ciphers": "^2.1.1",
     "@sinclair/typebox": "^0.34.49",
+    "@sip-protocol/sns-stealth": "^0.1.0",
     "@sipher/sdk": "workspace:*",
     "better-sqlite3": "^12.8.0",
     "express": "^5.0.0",
@@ -20,8 +21,8 @@
     "jsonwebtoken": "^9.0.3",
     "twitter-api-v2": "^1.29.0",
     "ulid": "^3.0.2",
-    "zod": "^3.24.2",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -45,6 +45,10 @@ import {
   executeConsolidate,
   assessRiskTool,
   executeAssessRisk,
+  resolveSNSTool,
+  executeResolveSNS,
+  sendPrivateToSNSTool,
+  executeSendPrivateToSNS,
 } from './tools/index.js'
 import type { AgentMessage } from '@mariozechner/pi-agent-core'
 import { createPiAgent } from './pi/sipher-agent.js'
@@ -67,7 +71,7 @@ Users deposit tokens, then you execute private sends, swaps, and refunds.
 Tone: Confident, technical, slightly cypherpunk. Never corporate.
 Never say "I'm just an AI." Speak like a privacy engineer who cares.
 
-Available tools: deposit, send, refund, balance, scan, claim, swap, viewingKey, history, status, paymentLink, invoice, privacyScore, threatCheck, roundAmount, scheduleSend, splitSend, drip, recurring, sweep, consolidate, assessRisk.
+Available tools: deposit, send, refund, balance, scan, claim, swap, viewingKey, history, status, paymentLink, invoice, privacyScore, threatCheck, roundAmount, scheduleSend, splitSend, drip, recurring, sweep, consolidate, assessRisk, resolveSNS, sendPrivateToSNS.
 
 Rules:
 - Every fund-moving operation shows a confirmation before executing
@@ -110,6 +114,8 @@ export const TOOLS: AnthropicTool[] = [
   sweepTool,
   consolidateTool,
   assessRiskTool,
+  resolveSNSTool,
+  sendPrivateToSNSTool,
 ]
 
 type ToolExecutor = (params: Record<string, unknown>) => Promise<unknown>
@@ -137,6 +143,9 @@ const TOOL_EXECUTORS: Record<string, ToolExecutor> = {
   sweep: (p) => executeSweep(p as unknown as Parameters<typeof executeSweep>[0]),
   consolidate: (p) => executeConsolidate(p as unknown as Parameters<typeof executeConsolidate>[0]),
   assessRisk: (p) => executeAssessRisk(p as unknown as Parameters<typeof executeAssessRisk>[0]),
+  resolveSNS: (p) => executeResolveSNS(p as unknown as Parameters<typeof executeResolveSNS>[0]),
+  sendPrivateToSNS: (p) =>
+    executeSendPrivateToSNS(p as unknown as Parameters<typeof executeSendPrivateToSNS>[0]),
 }
 
 /**

--- a/packages/agent/src/sentinel/preflight-rules.ts
+++ b/packages/agent/src/sentinel/preflight-rules.ts
@@ -4,6 +4,7 @@ import { getSentinelConfig } from './config.js'
 export const FUND_MOVING_TOOLS: ReadonlySet<string> = new Set([
   'send', 'deposit', 'swap', 'sweep', 'consolidate',
   'splitSend', 'scheduleSend', 'drip', 'recurring', 'refund',
+  'sendPrivateToSNS',
 ])
 
 export type PreflightRule =

--- a/packages/agent/src/tools/index.ts
+++ b/packages/agent/src/tools/index.ts
@@ -62,3 +62,6 @@ export { consolidateTool, executeConsolidate } from './consolidate.js'
 export type { ConsolidateParams, ConsolidateToolResult } from './consolidate.js'
 
 export { assessRiskTool, executeAssessRisk } from './assess-risk.js'
+
+export { resolveSNSTool, executeResolveSNS } from './resolve-sns.js'
+export type { ResolveSNSParams, ResolveSNSToolResult } from './resolve-sns.js'

--- a/packages/agent/src/tools/index.ts
+++ b/packages/agent/src/tools/index.ts
@@ -65,3 +65,9 @@ export { assessRiskTool, executeAssessRisk } from './assess-risk.js'
 
 export { resolveSNSTool, executeResolveSNS } from './resolve-sns.js'
 export type { ResolveSNSParams, ResolveSNSToolResult } from './resolve-sns.js'
+
+export { sendPrivateToSNSTool, executeSendPrivateToSNS } from './send-private-to-sns.js'
+export type {
+  SendPrivateToSNSParams,
+  SendPrivateToSNSToolResult,
+} from './send-private-to-sns.js'

--- a/packages/agent/src/tools/resolve-sns.ts
+++ b/packages/agent/src/tools/resolve-sns.ts
@@ -1,0 +1,103 @@
+import type { AnthropicTool } from '../pi/tool-adapter.js'
+import {
+  resolveSIPStealth,
+  MetaAddress,
+  NotFound,
+  Malformed,
+  NetworkError,
+} from '@sip-protocol/sns-stealth'
+import { createConnection } from '@sipher/sdk'
+import { loadNetworkConfig } from '../config/network.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// resolveSNS tool — read-only resolution of .sol → SIP-STEALTH meta-address
+//
+// NOTE: Read-only. NOT a fund-mover. Intentionally NOT registered in
+// preflight-rules.ts FUND_MOVING_TOOLS. The composite sendPrivateToSNS tool
+// (which calls this + executeSend) IS a fund-mover and goes through the gate.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ResolveSNSParams {
+  domain: string
+}
+
+export type ResolveSNSToolResult =
+  | {
+      status: 'resolved'
+      domain: string
+      chain: 'solana'
+      spending: string
+      viewing: string
+    }
+  | { status: 'not-found'; domain: string; subject: 'domain' | 'record' }
+  | { status: 'malformed'; domain: string; reason: 'json-parse' | 'schema' }
+  | { status: 'network-error'; domain: string; message: string }
+
+export const resolveSNSTool: AnthropicTool = {
+  name: 'resolveSNS',
+  description:
+    'Resolve a .sol domain to its SIP-STEALTH meta-address. ' +
+    'Returns one of: resolved (spending + viewing hex keys), not-found (no domain or no record), ' +
+    'malformed (record schema error), network-error (RPC unavailable). ' +
+    'Read-only — does not move funds.',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      domain: {
+        type: 'string',
+        description: 'The .sol domain to resolve (e.g. "rector.sol"). Case-insensitive.',
+      },
+    },
+    required: ['domain'],
+  },
+}
+
+export async function executeResolveSNS(
+  params: ResolveSNSParams,
+): Promise<ResolveSNSToolResult> {
+  if (!params.domain || params.domain.trim().length === 0) {
+    throw new Error('Domain is required')
+  }
+
+  const domain = params.domain.trim().toLowerCase()
+  if (!domain.endsWith('.sol')) {
+    throw new Error('Domain must end in .sol')
+  }
+
+  const connection = createConnection(loadNetworkConfig().clusterName)
+
+  let result
+  try {
+    result = await resolveSIPStealth(connection, domain)
+  } catch (err) {
+    if (err instanceof NetworkError) {
+      return { status: 'network-error', domain, message: err.message }
+    }
+    throw err
+  }
+
+  if (result instanceof MetaAddress) {
+    return {
+      status: 'resolved',
+      domain: result.domain,
+      chain: result.chain,
+      spending: bytesToHex(result.spending),
+      viewing: bytesToHex(result.viewing),
+    }
+  }
+  if (result instanceof NotFound) {
+    return { status: 'not-found', domain, subject: result.subject }
+  }
+  if (result instanceof Malformed) {
+    return { status: 'malformed', domain, reason: result.reason }
+  }
+  throw new Error('Unexpected resolveSIPStealth result')
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let hex = ''
+  for (let i = 0; i < bytes.length; i++) {
+    hex += bytes[i].toString(16).padStart(2, '0')
+  }
+  return hex
+}

--- a/packages/agent/src/tools/send-private-to-sns.ts
+++ b/packages/agent/src/tools/send-private-to-sns.ts
@@ -1,0 +1,156 @@
+import type { AnthropicTool } from '../pi/tool-adapter.js'
+import { executeResolveSNS, type ResolveSNSToolResult } from './resolve-sns.js'
+import { executeSend, type SendToolResult } from './send.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// sendPrivateToSNS — composite tool
+//
+// Resolves a .sol domain to its SIP-STEALTH meta-address, builds the sip:
+// URI in the 0x-hex form that sendTool expects, then delegates to executeSend
+// (which derives the one-time stealth address, builds the Pedersen commitment,
+// encrypts the amount + blinding, and serializes the unsigned withdraw tx).
+//
+// SENTINEL preflight: registered in preflight-rules.ts FUND_MOVING_TOOLS.
+// The gate at agent.ts:executeTool reads input.recipient (= the .sol domain)
+// for blacklist/known-repeat/dust evaluation BEFORE this executor runs.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface SendPrivateToSNSParams {
+  /** Recipient .sol domain (case-insensitive). Naming matches the preflight gate's input.recipient read. */
+  recipient: string
+  amount: number
+  token: string
+  wallet?: string
+  memo?: string
+}
+
+export type SendPrivateToSNSToolResult =
+  | {
+      action: 'sendPrivateToSNS'
+      status: 'ok'
+      domain: string
+      resolved: { chain: 'solana'; spending: string; viewing: string }
+      send: SendToolResult
+    }
+  | {
+      action: 'sendPrivateToSNS'
+      status: 'cannot-send'
+      domain: string
+      reason: 'no-domain' | 'no-record' | 'malformed-record' | 'network-error'
+      detail?: string
+    }
+
+export const sendPrivateToSNSTool: AnthropicTool = {
+  name: 'sendPrivateToSNS',
+  description:
+    'Send a private payment to a .sol domain by name. Resolves the SIP-STEALTH ' +
+    'record on the domain, builds the sip: meta-address URI, then routes through ' +
+    'the send tool. Returns status=ok with the unsigned withdraw tx (status: ' +
+    'awaiting_signature) when the domain has a SIP-STEALTH record, or status=' +
+    'cannot-send with a reason when the record is missing, malformed, or the RPC ' +
+    'is unreachable.',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      recipient: {
+        type: 'string',
+        description: 'Recipient .sol domain (e.g. "rector.sol"). Case-insensitive.',
+      },
+      amount: {
+        type: 'number',
+        description: 'Amount to send (in human-readable units)',
+      },
+      token: {
+        type: 'string',
+        description: 'Token symbol — SOL, USDC, USDT, or SPL mint address',
+      },
+      wallet: {
+        type: 'string',
+        description:
+          'Sender wallet address (base58). Required to build the unsigned transaction; ' +
+          'omit for a preview result with no tx.',
+      },
+      memo: {
+        type: 'string',
+        description: 'Optional encrypted memo for the recipient',
+      },
+    },
+    required: ['recipient', 'amount', 'token'],
+  },
+}
+
+export async function executeSendPrivateToSNS(
+  params: SendPrivateToSNSParams,
+): Promise<SendPrivateToSNSToolResult> {
+  if (!params.recipient || params.recipient.trim().length === 0) {
+    throw new Error('Recipient .sol domain is required')
+  }
+  const domain = params.recipient.trim().toLowerCase()
+  if (!domain.endsWith('.sol')) {
+    throw new Error('Recipient must be a .sol domain')
+  }
+
+  const resolved: ResolveSNSToolResult = await executeResolveSNS({ domain })
+
+  if (resolved.status !== 'resolved') {
+    return mapResolveFailure(domain, resolved)
+  }
+
+  const recipientUri = `sip:solana:0x${resolved.spending}:0x${resolved.viewing}`
+
+  const sendResult = await executeSend({
+    amount: params.amount,
+    token: params.token,
+    recipient: recipientUri,
+    wallet: params.wallet,
+    memo: params.memo,
+  })
+
+  return {
+    action: 'sendPrivateToSNS',
+    status: 'ok',
+    domain: resolved.domain,
+    resolved: {
+      chain: resolved.chain,
+      spending: resolved.spending,
+      viewing: resolved.viewing,
+    },
+    send: sendResult,
+  }
+}
+
+function mapResolveFailure(
+  domain: string,
+  result: Exclude<ResolveSNSToolResult, { status: 'resolved' }>,
+): SendPrivateToSNSToolResult {
+  if (result.status === 'not-found') {
+    return {
+      action: 'sendPrivateToSNS',
+      status: 'cannot-send',
+      domain,
+      reason: result.subject === 'domain' ? 'no-domain' : 'no-record',
+    }
+  }
+  if (result.status === 'malformed') {
+    return {
+      action: 'sendPrivateToSNS',
+      status: 'cannot-send',
+      domain,
+      reason: 'malformed-record',
+      detail: result.reason,
+    }
+  }
+  if (result.status === 'network-error') {
+    return {
+      action: 'sendPrivateToSNS',
+      status: 'cannot-send',
+      domain,
+      reason: 'network-error',
+      detail: result.message,
+    }
+  }
+  const exhaustive: never = result
+  throw new Error(
+    `Unexpected resolveSNS status: ${(exhaustive as { status: string }).status}`,
+  )
+}

--- a/packages/agent/tests/integration/pi-migration.test.ts
+++ b/packages/agent/tests/integration/pi-migration.test.ts
@@ -19,10 +19,10 @@ describe('Pi SDK Migration — Integration', () => {
     expect(typeof mod.executeTool).toBe('function')
     expect(typeof mod.SYSTEM_PROMPT).toBe('string')
     expect(Array.isArray(mod.TOOLS)).toBe(true)
-    expect(mod.TOOLS.length).toBe(22)
+    expect(mod.TOOLS.length).toBe(24)
   })
 
-  it('TOOLS contains all 22 expected tool names', async () => {
+  it('TOOLS contains all 24 expected tool names', async () => {
     const { TOOLS } = await import('../../src/agent.js')
     const names = TOOLS.map((t) => t.name).sort()
     expect(names).toContain('deposit')
@@ -47,6 +47,8 @@ describe('Pi SDK Migration — Integration', () => {
     expect(names).toContain('sweep')
     expect(names).toContain('consolidate')
     expect(names).toContain('assessRisk')
+    expect(names).toContain('resolveSNS')
+    expect(names).toContain('sendPrivateToSNS')
   })
 
   it('every TOOL is in valid AnthropicTool format', async () => {

--- a/packages/agent/tests/resolve-sns.test.ts
+++ b/packages/agent/tests/resolve-sns.test.ts
@@ -1,0 +1,239 @@
+// packages/agent/tests/resolve-sns.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mockResolveSIPStealth, mockCreateConnection } = vi.hoisted(() => ({
+  mockResolveSIPStealth: vi.fn(),
+  mockCreateConnection: vi.fn(),
+}))
+
+vi.mock('@sip-protocol/sns-stealth', async () => {
+  const actual = await vi.importActual<typeof import('@sip-protocol/sns-stealth')>(
+    '@sip-protocol/sns-stealth',
+  )
+  return {
+    ...actual,
+    resolveSIPStealth: mockResolveSIPStealth,
+  }
+})
+
+vi.mock('@sipher/sdk', () => ({
+  createConnection: mockCreateConnection,
+}))
+
+import { MetaAddress, NotFound, Malformed, NetworkError } from '@sip-protocol/sns-stealth'
+import { resolveSNSTool, executeResolveSNS } from '../src/tools/resolve-sns.js'
+
+const SPENDING_BYTES = new Uint8Array(32).fill(0xaa)
+const VIEWING_BYTES = new Uint8Array(32).fill(0xbb)
+const EXPECTED_SPENDING_HEX = 'aa'.repeat(32)
+const EXPECTED_VIEWING_HEX = 'bb'.repeat(32)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockCreateConnection.mockReturnValue({})
+})
+
+describe('resolveSNSTool descriptor', () => {
+  it('has correct name', () => {
+    expect(resolveSNSTool.name).toBe('resolveSNS')
+  })
+
+  it('declares domain as the only required field', () => {
+    expect(resolveSNSTool.input_schema.required).toEqual(['domain'])
+    expect(resolveSNSTool.input_schema.properties).toHaveProperty('domain')
+  })
+
+  it('description identifies the tool as read-only', () => {
+    expect(resolveSNSTool.description).toMatch(/does not move funds/i)
+  })
+})
+
+describe('executeResolveSNS — input validation', () => {
+  it.each(['', ' ', '   ', '\t', '\n'])(
+    'rejects empty/whitespace domain (%j)',
+    async (input) => {
+      await expect(executeResolveSNS({ domain: input })).rejects.toThrow(
+        /domain is required/i,
+      )
+      expect(mockResolveSIPStealth).not.toHaveBeenCalled()
+    },
+  )
+
+  it('rejects non-.sol domains', async () => {
+    await expect(executeResolveSNS({ domain: 'rector.eth' })).rejects.toThrow(
+      /must end in \.sol/i,
+    )
+    expect(mockResolveSIPStealth).not.toHaveBeenCalled()
+  })
+
+  it('rejects bare domain without TLD', async () => {
+    await expect(executeResolveSNS({ domain: 'rector' })).rejects.toThrow(
+      /must end in \.sol/i,
+    )
+  })
+
+  it('lowercases + trims domain before resolving', async () => {
+    mockResolveSIPStealth.mockResolvedValueOnce(
+      new MetaAddress(SPENDING_BYTES, VIEWING_BYTES, 'solana', 'rector.sol'),
+    )
+
+    await executeResolveSNS({ domain: '  RECTOR.SOL  ' })
+
+    expect(mockResolveSIPStealth).toHaveBeenCalledTimes(1)
+    expect(mockResolveSIPStealth.mock.calls[0][1]).toBe('rector.sol')
+  })
+})
+
+describe('executeResolveSNS — resolved path', () => {
+  it('returns resolved status with hex pair', async () => {
+    mockResolveSIPStealth.mockResolvedValueOnce(
+      new MetaAddress(SPENDING_BYTES, VIEWING_BYTES, 'solana', 'rector.sol'),
+    )
+
+    const result = await executeResolveSNS({ domain: 'rector.sol' })
+
+    expect(result).toStrictEqual({
+      status: 'resolved',
+      domain: 'rector.sol',
+      chain: 'solana',
+      spending: EXPECTED_SPENDING_HEX,
+      viewing: EXPECTED_VIEWING_HEX,
+    })
+  })
+
+  it('returns lowercase hex without 0x prefix', async () => {
+    mockResolveSIPStealth.mockResolvedValueOnce(
+      new MetaAddress(SPENDING_BYTES, VIEWING_BYTES, 'solana', 'rector.sol'),
+    )
+
+    const result = await executeResolveSNS({ domain: 'rector.sol' })
+
+    if (result.status !== 'resolved') throw new Error('expected resolved')
+    expect(result.spending).toMatch(/^[0-9a-f]{64}$/)
+    expect(result.viewing).toMatch(/^[0-9a-f]{64}$/)
+    expect(result.spending.startsWith('0x')).toBe(false)
+    expect(result.viewing.startsWith('0x')).toBe(false)
+  })
+
+  it('uses the MetaAddress.domain field in the result (echoes resolver normalization)', async () => {
+    // Resolver returns its own canonical form; we surface it as-is.
+    mockResolveSIPStealth.mockResolvedValueOnce(
+      new MetaAddress(SPENDING_BYTES, VIEWING_BYTES, 'solana', 'normalized.sol'),
+    )
+
+    const result = await executeResolveSNS({ domain: 'rector.sol' })
+
+    if (result.status !== 'resolved') throw new Error('expected resolved')
+    expect(result.domain).toBe('normalized.sol')
+  })
+})
+
+describe('executeResolveSNS — not-found path', () => {
+  it('returns subject="record" when SIP-STEALTH record missing', async () => {
+    mockResolveSIPStealth.mockResolvedValueOnce(new NotFound('record'))
+
+    const result = await executeResolveSNS({ domain: 'rector.sol' })
+
+    expect(result).toStrictEqual({
+      status: 'not-found',
+      domain: 'rector.sol',
+      subject: 'record',
+    })
+  })
+
+  it('returns subject="domain" when .sol domain not registered', async () => {
+    mockResolveSIPStealth.mockResolvedValueOnce(new NotFound('domain'))
+
+    const result = await executeResolveSNS({ domain: 'unclaimed.sol' })
+
+    expect(result).toStrictEqual({
+      status: 'not-found',
+      domain: 'unclaimed.sol',
+      subject: 'domain',
+    })
+  })
+})
+
+describe('executeResolveSNS — malformed path', () => {
+  it('returns reason="schema" for schema validation failure', async () => {
+    mockResolveSIPStealth.mockResolvedValueOnce(new Malformed('schema'))
+
+    const result = await executeResolveSNS({ domain: 'rector.sol' })
+
+    expect(result).toStrictEqual({
+      status: 'malformed',
+      domain: 'rector.sol',
+      reason: 'schema',
+    })
+  })
+
+  it('returns reason="json-parse" for invalid JSON record', async () => {
+    mockResolveSIPStealth.mockResolvedValueOnce(new Malformed('json-parse'))
+
+    const result = await executeResolveSNS({ domain: 'rector.sol' })
+
+    expect(result).toStrictEqual({
+      status: 'malformed',
+      domain: 'rector.sol',
+      reason: 'json-parse',
+    })
+  })
+})
+
+describe('executeResolveSNS — network-error path', () => {
+  it('returns network-error when resolveSIPStealth throws NetworkError', async () => {
+    mockResolveSIPStealth.mockRejectedValueOnce(
+      new NetworkError('RPC timeout', new Error('socket hang up')),
+    )
+
+    const result = await executeResolveSNS({ domain: 'rector.sol' })
+
+    expect(result).toStrictEqual({
+      status: 'network-error',
+      domain: 'rector.sol',
+      message: 'RPC timeout',
+    })
+  })
+
+  it('re-throws non-NetworkError exceptions', async () => {
+    mockResolveSIPStealth.mockRejectedValueOnce(new Error('unexpected boom'))
+
+    await expect(executeResolveSNS({ domain: 'rector.sol' })).rejects.toThrow(
+      /unexpected boom/i,
+    )
+  })
+})
+
+describe('executeResolveSNS — service interaction', () => {
+  it('passes the connection from createConnection to resolveSIPStealth', async () => {
+    const sentinelConnection = { __sentinel: true }
+    mockCreateConnection.mockReturnValueOnce(sentinelConnection)
+    mockResolveSIPStealth.mockResolvedValueOnce(
+      new MetaAddress(SPENDING_BYTES, VIEWING_BYTES, 'solana', 'rector.sol'),
+    )
+
+    await executeResolveSNS({ domain: 'rector.sol' })
+
+    expect(mockResolveSIPStealth).toHaveBeenCalledWith(sentinelConnection, 'rector.sol')
+  })
+
+  it('uses devnet cluster (vitest env)', async () => {
+    mockResolveSIPStealth.mockResolvedValueOnce(
+      new MetaAddress(SPENDING_BYTES, VIEWING_BYTES, 'solana', 'rector.sol'),
+    )
+
+    await executeResolveSNS({ domain: 'rector.sol' })
+
+    expect(mockCreateConnection).toHaveBeenCalledWith('devnet')
+  })
+})
+
+describe('executeResolveSNS — unexpected resolver shape', () => {
+  it('throws on resolver returning a non-recognized result', async () => {
+    mockResolveSIPStealth.mockResolvedValueOnce({ unexpected: true } as never)
+
+    await expect(executeResolveSNS({ domain: 'rector.sol' })).rejects.toThrow(
+      /unexpected resolveSIPStealth result/i,
+    )
+  })
+})

--- a/packages/agent/tests/send-private-to-sns.test.ts
+++ b/packages/agent/tests/send-private-to-sns.test.ts
@@ -1,0 +1,366 @@
+// packages/agent/tests/send-private-to-sns.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { mockExecuteResolveSNS, mockExecuteSend } = vi.hoisted(() => ({
+  mockExecuteResolveSNS: vi.fn(),
+  mockExecuteSend: vi.fn(),
+}))
+
+vi.mock('../src/tools/resolve-sns.js', () => ({
+  executeResolveSNS: mockExecuteResolveSNS,
+}))
+
+vi.mock('../src/tools/send.js', () => ({
+  executeSend: mockExecuteSend,
+}))
+
+import {
+  sendPrivateToSNSTool,
+  executeSendPrivateToSNS,
+} from '../src/tools/send-private-to-sns.js'
+
+const SPENDING_HEX = 'aa'.repeat(32)
+const VIEWING_HEX = 'bb'.repeat(32)
+const RESOLVED_URI = `sip:solana:0x${SPENDING_HEX}:0x${VIEWING_HEX}`
+
+const makeResolvedOk = (domain = 'rector.sol') => ({
+  status: 'resolved' as const,
+  domain,
+  chain: 'solana' as const,
+  spending: SPENDING_HEX,
+  viewing: VIEWING_HEX,
+})
+
+const makeSendOk = () => ({
+  action: 'send' as const,
+  amount: 10,
+  token: 'USDC',
+  recipient: RESOLVED_URI,
+  status: 'awaiting_signature' as const,
+  message: 'Private send prepared: 10 USDC',
+  serializedTx: 'BASE64_TX_BYTES',
+  privacy: {
+    stealthAddress: 'Stealth111',
+    commitmentGenerated: true,
+    viewingKeyHashIncluded: true,
+    feeBps: 50,
+    estimatedFee: '0.05 USDC',
+    netAmount: '9.95',
+  },
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('sendPrivateToSNSTool descriptor', () => {
+  it('has correct name', () => {
+    expect(sendPrivateToSNSTool.name).toBe('sendPrivateToSNS')
+  })
+
+  it('declares recipient, amount, token as required — wallet/memo optional', () => {
+    expect(sendPrivateToSNSTool.input_schema.required).toEqual([
+      'recipient',
+      'amount',
+      'token',
+    ])
+    const props = sendPrivateToSNSTool.input_schema.properties
+    expect(props).toHaveProperty('wallet')
+    expect(props).toHaveProperty('memo')
+  })
+
+  it('description mentions .sol resolution + delegation to send', () => {
+    expect(sendPrivateToSNSTool.description).toMatch(/\.sol/i)
+    expect(sendPrivateToSNSTool.description).toMatch(/SIP-STEALTH/i)
+  })
+})
+
+describe('executeSendPrivateToSNS — input validation', () => {
+  it.each(['', ' ', '   ', '\t'])(
+    'rejects empty/whitespace recipient (%j)',
+    async (input) => {
+      await expect(
+        executeSendPrivateToSNS({ recipient: input, amount: 10, token: 'USDC' }),
+      ).rejects.toThrow(/recipient \.sol domain is required/i)
+      expect(mockExecuteResolveSNS).not.toHaveBeenCalled()
+      expect(mockExecuteSend).not.toHaveBeenCalled()
+    },
+  )
+
+  it('rejects non-.sol recipient', async () => {
+    await expect(
+      executeSendPrivateToSNS({
+        recipient: 'rector.eth',
+        amount: 10,
+        token: 'USDC',
+      }),
+    ).rejects.toThrow(/recipient must be a \.sol domain/i)
+    expect(mockExecuteResolveSNS).not.toHaveBeenCalled()
+  })
+
+  it('rejects bare recipient without TLD', async () => {
+    await expect(
+      executeSendPrivateToSNS({
+        recipient: 'rector',
+        amount: 10,
+        token: 'USDC',
+      }),
+    ).rejects.toThrow(/recipient must be a \.sol domain/i)
+  })
+
+  it('normalizes recipient (trim + lowercase) before resolving', async () => {
+    mockExecuteResolveSNS.mockResolvedValueOnce(makeResolvedOk())
+    mockExecuteSend.mockResolvedValueOnce(makeSendOk())
+
+    await executeSendPrivateToSNS({
+      recipient: '  RECTOR.SOL  ',
+      amount: 10,
+      token: 'USDC',
+      wallet: 'walletXyz',
+    })
+
+    expect(mockExecuteResolveSNS).toHaveBeenCalledWith({ domain: 'rector.sol' })
+  })
+})
+
+describe('executeSendPrivateToSNS — happy path', () => {
+  it('returns composite ok result with resolved + send blocks', async () => {
+    mockExecuteResolveSNS.mockResolvedValueOnce(makeResolvedOk())
+    const sendResult = makeSendOk()
+    mockExecuteSend.mockResolvedValueOnce(sendResult)
+
+    const result = await executeSendPrivateToSNS({
+      recipient: 'rector.sol',
+      amount: 10,
+      token: 'USDC',
+      wallet: 'walletXyz',
+    })
+
+    expect(result).toStrictEqual({
+      action: 'sendPrivateToSNS',
+      status: 'ok',
+      domain: 'rector.sol',
+      resolved: {
+        chain: 'solana',
+        spending: SPENDING_HEX,
+        viewing: VIEWING_HEX,
+      },
+      send: sendResult,
+    })
+  })
+
+  it('builds sip: URI with 0x-prefixed hex (matching send.ts contract)', async () => {
+    mockExecuteResolveSNS.mockResolvedValueOnce(makeResolvedOk())
+    mockExecuteSend.mockResolvedValueOnce(makeSendOk())
+
+    await executeSendPrivateToSNS({
+      recipient: 'rector.sol',
+      amount: 10,
+      token: 'USDC',
+      wallet: 'walletXyz',
+    })
+
+    expect(mockExecuteSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipient: RESOLVED_URI,
+      }),
+    )
+  })
+
+  it('forwards wallet + memo + amount + token to executeSend', async () => {
+    mockExecuteResolveSNS.mockResolvedValueOnce(makeResolvedOk())
+    mockExecuteSend.mockResolvedValueOnce(makeSendOk())
+
+    await executeSendPrivateToSNS({
+      recipient: 'rector.sol',
+      amount: 1.5,
+      token: 'sol',
+      wallet: 'walletXyz',
+      memo: 'lunch money',
+    })
+
+    expect(mockExecuteSend).toHaveBeenCalledWith({
+      amount: 1.5,
+      token: 'sol',
+      recipient: RESOLVED_URI,
+      wallet: 'walletXyz',
+      memo: 'lunch money',
+    })
+  })
+
+  it('forwards undefined wallet for preview path', async () => {
+    mockExecuteResolveSNS.mockResolvedValueOnce(makeResolvedOk())
+    mockExecuteSend.mockResolvedValueOnce({ ...makeSendOk(), serializedTx: null })
+
+    await executeSendPrivateToSNS({
+      recipient: 'rector.sol',
+      amount: 10,
+      token: 'USDC',
+    })
+
+    expect(mockExecuteSend).toHaveBeenCalledWith(
+      expect.objectContaining({ wallet: undefined }),
+    )
+  })
+
+  it('echoes resolver-canonical domain in result', async () => {
+    mockExecuteResolveSNS.mockResolvedValueOnce(makeResolvedOk('canonical.sol'))
+    mockExecuteSend.mockResolvedValueOnce(makeSendOk())
+
+    const result = await executeSendPrivateToSNS({
+      recipient: 'rector.sol',
+      amount: 10,
+      token: 'USDC',
+      wallet: 'walletXyz',
+    })
+
+    if (result.status !== 'ok') throw new Error('expected ok')
+    expect(result.domain).toBe('canonical.sol')
+  })
+})
+
+describe('executeSendPrivateToSNS — cannot-send paths', () => {
+  it('returns no-record when SIP-STEALTH record missing', async () => {
+    mockExecuteResolveSNS.mockResolvedValueOnce({
+      status: 'not-found',
+      domain: 'rector.sol',
+      subject: 'record',
+    })
+
+    const result = await executeSendPrivateToSNS({
+      recipient: 'rector.sol',
+      amount: 10,
+      token: 'USDC',
+      wallet: 'walletXyz',
+    })
+
+    expect(result).toStrictEqual({
+      action: 'sendPrivateToSNS',
+      status: 'cannot-send',
+      domain: 'rector.sol',
+      reason: 'no-record',
+    })
+    expect(mockExecuteSend).not.toHaveBeenCalled()
+  })
+
+  it('returns no-domain when .sol domain not registered', async () => {
+    mockExecuteResolveSNS.mockResolvedValueOnce({
+      status: 'not-found',
+      domain: 'unclaimed.sol',
+      subject: 'domain',
+    })
+
+    const result = await executeSendPrivateToSNS({
+      recipient: 'unclaimed.sol',
+      amount: 10,
+      token: 'USDC',
+      wallet: 'walletXyz',
+    })
+
+    expect(result).toStrictEqual({
+      action: 'sendPrivateToSNS',
+      status: 'cannot-send',
+      domain: 'unclaimed.sol',
+      reason: 'no-domain',
+    })
+  })
+
+  it('returns malformed-record + reason detail for schema failure', async () => {
+    mockExecuteResolveSNS.mockResolvedValueOnce({
+      status: 'malformed',
+      domain: 'rector.sol',
+      reason: 'schema',
+    })
+
+    const result = await executeSendPrivateToSNS({
+      recipient: 'rector.sol',
+      amount: 10,
+      token: 'USDC',
+      wallet: 'walletXyz',
+    })
+
+    expect(result).toStrictEqual({
+      action: 'sendPrivateToSNS',
+      status: 'cannot-send',
+      domain: 'rector.sol',
+      reason: 'malformed-record',
+      detail: 'schema',
+    })
+    expect(mockExecuteSend).not.toHaveBeenCalled()
+  })
+
+  it('returns malformed-record + reason detail for json-parse failure', async () => {
+    mockExecuteResolveSNS.mockResolvedValueOnce({
+      status: 'malformed',
+      domain: 'rector.sol',
+      reason: 'json-parse',
+    })
+
+    const result = await executeSendPrivateToSNS({
+      recipient: 'rector.sol',
+      amount: 10,
+      token: 'USDC',
+      wallet: 'walletXyz',
+    })
+
+    if (result.status !== 'cannot-send') throw new Error('expected cannot-send')
+    expect(result.reason).toBe('malformed-record')
+    expect(result.detail).toBe('json-parse')
+  })
+
+  it('returns network-error + message detail when resolver unreachable', async () => {
+    mockExecuteResolveSNS.mockResolvedValueOnce({
+      status: 'network-error',
+      domain: 'rector.sol',
+      message: 'RPC timeout',
+    })
+
+    const result = await executeSendPrivateToSNS({
+      recipient: 'rector.sol',
+      amount: 10,
+      token: 'USDC',
+      wallet: 'walletXyz',
+    })
+
+    expect(result).toStrictEqual({
+      action: 'sendPrivateToSNS',
+      status: 'cannot-send',
+      domain: 'rector.sol',
+      reason: 'network-error',
+      detail: 'RPC timeout',
+    })
+    expect(mockExecuteSend).not.toHaveBeenCalled()
+  })
+})
+
+describe('executeSendPrivateToSNS — service error propagation', () => {
+  it('propagates errors from executeResolveSNS (unexpected throw)', async () => {
+    mockExecuteResolveSNS.mockRejectedValueOnce(new Error('boom from resolver'))
+
+    await expect(
+      executeSendPrivateToSNS({
+        recipient: 'rector.sol',
+        amount: 10,
+        token: 'USDC',
+        wallet: 'walletXyz',
+      }),
+    ).rejects.toThrow(/boom from resolver/i)
+    expect(mockExecuteSend).not.toHaveBeenCalled()
+  })
+
+  it('propagates errors from executeSend (e.g. insufficient balance)', async () => {
+    mockExecuteResolveSNS.mockResolvedValueOnce(makeResolvedOk())
+    mockExecuteSend.mockRejectedValueOnce(
+      new Error('insufficient available balance'),
+    )
+
+    await expect(
+      executeSendPrivateToSNS({
+        recipient: 'rector.sol',
+        amount: 10,
+        token: 'USDC',
+        wallet: 'walletXyz',
+      }),
+    ).rejects.toThrow(/insufficient available balance/i)
+  })
+})

--- a/packages/agent/tests/tools.test.ts
+++ b/packages/agent/tests/tools.test.ts
@@ -36,6 +36,8 @@ import {
   sweepTool,
   consolidateTool,
   assessRiskTool,
+  resolveSNSTool,
+  sendPrivateToSNSTool,
 } from '../src/tools/index.js'
 import { TOOLS, SYSTEM_PROMPT, executeTool } from '../src/agent.js'
 
@@ -124,6 +126,7 @@ describe('tool definitions', () => {
     paymentLinkTool, invoiceTool, privacyScoreTool, threatCheckTool,
     roundAmountTool, scheduleSendTool, splitSendTool, dripTool,
     recurringTool, sweepTool, consolidateTool, assessRiskTool,
+    resolveSNSTool, sendPrivateToSNSTool,
   ]
   const toolNames = [
     'deposit', 'send', 'refund', 'balance', 'scan', 'claim',
@@ -131,11 +134,12 @@ describe('tool definitions', () => {
     'paymentLink', 'invoice', 'privacyScore', 'threatCheck',
     'roundAmount', 'scheduleSend', 'splitSend', 'drip',
     'recurring', 'sweep', 'consolidate', 'assessRisk',
+    'resolveSNS', 'sendPrivateToSNS',
   ]
 
-  it('exports exactly 22 tools', () => {
-    expect(allTools).toHaveLength(22)
-    expect(TOOLS).toHaveLength(22)
+  it('exports exactly 24 tools', () => {
+    expect(allTools).toHaveLength(24)
+    expect(TOOLS).toHaveLength(24)
   })
 
   it('all tools have unique names', () => {
@@ -187,7 +191,7 @@ describe('system prompt', () => {
     expect(SYSTEM_PROMPT).toContain('Plug in. Go private.')
   })
 
-  it('references all 22 tools', () => {
+  it('references all 24 tools', () => {
     expect(SYSTEM_PROMPT).toContain('deposit')
     expect(SYSTEM_PROMPT).toContain('send')
     expect(SYSTEM_PROMPT).toContain('refund')
@@ -210,6 +214,8 @@ describe('system prompt', () => {
     expect(SYSTEM_PROMPT).toContain('sweep')
     expect(SYSTEM_PROMPT).toContain('consolidate')
     expect(SYSTEM_PROMPT).toContain('assessRisk')
+    expect(SYSTEM_PROMPT).toContain('resolveSNS')
+    expect(SYSTEM_PROMPT).toContain('sendPrivateToSNS')
   })
 
   it('includes the confirmation rule for fund-moving operations', () => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,7 +28,13 @@ export default defineConfig({
   ],
   webServer: [
     {
-      command: 'pnpm --filter @sipher/agent dev',
+      // Use the built output (`node dist/index.js`) instead of `tsx watch`.
+      // tsx's ESM loader hits a transitive Bonfida ESM bundle bug
+      // (@bonfida/spl-name-service@3.0.21 vendored borsh) introduced when
+      // @sip-protocol/sns-stealth was added in Phase D. Production uses
+      // `node dist/index.js` via Docker and is unaffected; the build step
+      // is added explicitly in .github/workflows/e2e.yml.
+      command: 'pnpm --filter @sipher/agent start',
       url: `http://localhost:${PORT_BACKEND}/api/health`,
       reuseExistingServer: !process.env.CI,
       timeout: 60_000,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
         version: 1.8.0
       '@sip-protocol/sdk':
         specifier: ^0.7.4
-        version: 0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))
+        version: 0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))
       '@sip-protocol/types':
         specifier: ^0.2.2
         version: 0.2.2
@@ -216,6 +216,9 @@ importers:
       '@sinclair/typebox':
         specifier: ^0.34.49
         version: 0.34.49
+      '@sip-protocol/sns-stealth':
+        specifier: ^0.1.0
+        version: 0.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@sipher/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -629,6 +632,16 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bonfida/sns-records@0.1.0':
+    resolution: {integrity: sha512-/viuqvsjvAUjFxzqX0L3ZntfK1S5K1Nj+j2avxq2tCXhA2Ee7Qt0gPCaQKuMv3hh8cKAEMaZ8crZHomns3UuqA==}
+    peerDependencies:
+      '@solana/web3.js': ^1.87.3
+
+  '@bonfida/spl-name-service@3.0.21':
+    resolution: {integrity: sha512-dYKZwG2ColaDUvX+ZrzcPtE6sQcNNwXywMsLit57Z+bKSEYQdIFxncrDSSzjLKcxQRFPUQObptaSEcv+ZwcMQA==}
+    peerDependencies:
+      '@solana/web3.js': ^1.98.2
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
@@ -1861,6 +1874,9 @@ packages:
   '@sip-protocol/sdk@0.7.4':
     resolution: {integrity: sha512-tbdoto6okq7C8zQjqulNbXp5oqCPjj8tWe5K/uKIres32ouFjrN7lXytTPB+zQkB1Gv4ECHvGoaqf5EV4AaDrQ==}
 
+  '@sip-protocol/sns-stealth@0.1.0':
+    resolution: {integrity: sha512-XPb7gSQf+ie7MmNXr9vpZU69UvO5/XWDqrfECel1m65UBu20F+/3ohFeD4TmowkJ4f6UHkA1HCNxMv9y6Slc4A==}
+
   '@sip-protocol/types@0.2.2':
     resolution: {integrity: sha512-FvJosQIp/dnADchEFmjdqCBlKolL4RrW15W2MPR1zlSZax9UbIR3vZjkm/j3mWewjO/bBfXii3FSxnqFlSBSkQ==}
 
@@ -2163,6 +2179,9 @@ packages:
     resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
     engines: {node: '>=5.10'}
 
+  '@solana/codecs-core@2.0.0-preview.2':
+    resolution: {integrity: sha512-gLhCJXieSCrAU7acUJjbXl+IbGnqovvxQLlimztPoGgfLQ1wFYu+XJswrEVQqknZYK1pgxpxH3rZ+OKFs0ndQg==}
+
   '@solana/codecs-core@2.0.0-rc.1':
     resolution: {integrity: sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==}
     peerDependencies:
@@ -2189,6 +2208,9 @@ packages:
       typescript:
         optional: true
 
+  '@solana/codecs-data-structures@2.0.0-preview.2':
+    resolution: {integrity: sha512-Xf5vIfromOZo94Q8HbR04TbgTwzigqrKII0GjYr21K7rb3nba4hUW2ir8kguY7HWFBcjHGlU5x3MevKBOLp3Zg==}
+
   '@solana/codecs-data-structures@2.0.0-rc.1':
     resolution: {integrity: sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==}
     peerDependencies:
@@ -2208,6 +2230,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/codecs-numbers@2.0.0-preview.2':
+    resolution: {integrity: sha512-aLZnDTf43z4qOnpTcDsUVy1Ci9im1Md8thWipSWbE+WM9ojZAx528oAql+Cv8M8N+6ALKwgVRhPZkto6E59ARw==}
 
   '@solana/codecs-numbers@2.0.0-rc.1':
     resolution: {integrity: sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==}
@@ -2234,6 +2259,11 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/codecs-strings@2.0.0-preview.2':
+    resolution: {integrity: sha512-EgBwY+lIaHHgMJIqVOGHfIfpdmmUDNoNO/GAUGeFPf+q0dF+DtwhJPEMShhzh64X2MeCZcmSO6Kinx0Bvmmz2g==}
+    peerDependencies:
+      fastestsmallesttextencoderdecoder: ^1.0.22
 
   '@solana/codecs-strings@2.0.0-rc.1':
     resolution: {integrity: sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==}
@@ -2267,6 +2297,9 @@ packages:
       typescript:
         optional: true
 
+  '@solana/codecs@2.0.0-preview.2':
+    resolution: {integrity: sha512-4HHzCD5+pOSmSB71X6w9ptweV48Zj1Vqhe732+pcAQ2cMNnN0gMPMdDq7j3YwaZDZ7yrILVV/3+HTnfT77t2yA==}
+
   '@solana/codecs@2.0.0-rc.1':
     resolution: {integrity: sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==}
     peerDependencies:
@@ -2295,6 +2328,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/errors@2.0.0-preview.2':
+    resolution: {integrity: sha512-H2DZ1l3iYF5Rp5pPbJpmmtCauWeQXRJapkDg8epQ8BJ7cA2Ut/QEtC3CMmw/iMTcuS6uemFNLcWvlOfoQhvQuA==}
+    hasBin: true
 
   '@solana/errors@2.0.0-rc.1':
     resolution: {integrity: sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==}
@@ -2433,6 +2470,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@solana/options@2.0.0-preview.2':
+    resolution: {integrity: sha512-FAHqEeH0cVsUOTzjl5OfUBw2cyT8d5Oekx4xcn5hn+NyPAfQJgM3CEThzgRD6Q/4mM5pVUnND3oK/Mt1RzSE/w==}
 
   '@solana/options@2.0.0-rc.1':
     resolution: {integrity: sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==}
@@ -2689,6 +2729,12 @@ packages:
       typescript:
         optional: true
 
+  '@solana/spl-token-group@0.0.4':
+    resolution: {integrity: sha512-7+80nrEMdUKlK37V6kOe024+T7J4nNss0F8LQ9OOPYdWCCfJmsGUzVx2W3oeizZR4IHM6N4yC9v1Xqwc3BTPWw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.91.6
+
   '@solana/spl-token-group@0.0.7':
     resolution: {integrity: sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==}
     engines: {node: '>=16'}
@@ -2706,6 +2752,16 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       '@solana/web3.js': ^1.95.5
+
+  '@solana/spl-token@0.4.6':
+    resolution: {integrity: sha512-1nCnUqfHVtdguFciVWaY/RKcQz1IF4b31jnKgAmjU9QVN1q7dRUkTEWJZgTYIEtsULjVnC9jRqlhgGN39WbKKA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.91.6
+
+  '@solana/spl-type-length-value@0.1.0':
+    resolution: {integrity: sha512-JBMGB0oR4lPttOZ5XiUGyvylwLQjt1CPJa6qQ5oM+MBCndfjz2TKKkw0eATlLLcYmq1jBVsNlJ2cD6ns2GR7lA==}
+    engines: {node: '>=16'}
 
   '@solana/subscribable@2.3.0':
     resolution: {integrity: sha512-DkgohEDbMkdTWiKAoatY02Njr56WXx9e/dKKfmne8/Ad6/2llUIrax78nCdlvZW9quXMaXPTxZvdQqo9N669Og==}
@@ -4115,6 +4171,12 @@ packages:
   borsh@0.7.0:
     resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
 
+  borsh@1.0.0:
+    resolution: {integrity: sha512-fSVWzzemnyfF89EPwlUNsrS5swF5CrtiN4e+h0/lLf4dz2he4L3ndM20PS9wj7ICSkXJe/TQUHdaPTq15b1mNQ==}
+
+  borsh@2.0.0:
+    resolution: {integrity: sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg==}
+
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
@@ -5114,6 +5176,9 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  graphemesplit@2.6.0:
+    resolution: {integrity: sha512-rG9w2wAfkpg0DILa1pjnjNfucng3usON360shisqIMUBw/87pojcBSrHmeE4UwryAuBih7g8m1oilf5/u8EWdQ==}
+
   h3@1.15.10:
     resolution: {integrity: sha512-YzJeWSkDZxAhvmp8dexjRK5hxziRO7I9m0N53WhvYL5NiWfkUkzssVzY9jvGu0HBoLFW6+duYmNSn6MaZBCCtg==}
 
@@ -5257,6 +5322,10 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
+    engines: {node: '>= 10'}
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -6186,6 +6255,9 @@ packages:
     resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
     engines: {node: '>= 14'}
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
   pako@2.1.0:
     resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
 
@@ -6999,6 +7071,9 @@ packages:
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
 
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
   tiny-secp256k1@1.1.7:
     resolution: {integrity: sha512-eb+F6NabSnjbLwNoC+2o5ItbmP1kg7HliWue71JgLegQt6A5mTN8YbvTLCazdlg6e5SV6A+r8OGvZYskdlmhqQ==}
     engines: {node: '>=6.0.0'}
@@ -7187,6 +7262,9 @@ packages:
   undici@7.24.7:
     resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
     engines: {node: '>=20.18.1'}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
   unidragger@3.0.1:
     resolution: {integrity: sha512-RngbGSwBFmqGBWjkaH+yB677uzR95blSQyxq6hYbrQCejH3Mx1nm8DVOuh3M9k2fQyTstWUG5qlgCnNqV/9jVw==}
@@ -8322,6 +8400,32 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bonfida/sns-records@0.1.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      borsh: 1.0.0
+      bs58: 5.0.0
+      buffer: 6.0.3
+
+  '@bonfida/spl-name-service@3.0.21(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@bonfida/sns-records': 0.1.0(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@noble/curves': 1.9.7
+      '@scure/base': 1.2.6
+      '@solana/spl-token': 0.4.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      borsh: 2.0.0
+      buffer: 6.0.3
+      graphemesplit: 2.6.0
+      ipaddr.js: 2.4.0
+      punycode: 2.3.1
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+
   '@cfworker/json-schema@4.1.1': {}
 
   '@coral-xyz/anchor-errors@0.30.1': {}
@@ -8852,14 +8956,14 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))':
+  '@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.3.87(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      langsmith: 0.3.87(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -8892,26 +8996,26 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
 
-  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))':
+  '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@langchain/langgraph-sdk@1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       p-queue: 9.1.0
       p-retry: 7.1.1
       uuid: 13.0.0
     optionalDependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)':
+  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
-      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 3.25.76
@@ -8921,11 +9025,11 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)':
+  '@langchain/langgraph@1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
-      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      '@langchain/langgraph-sdk': 1.5.5(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
       zod: 3.25.76
@@ -8935,9 +9039,20 @@ snapshots:
       - react
       - react-dom
 
-  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      js-tiktoken: 1.0.21
+      openai: 4.104.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - encoding
+      - ws
+
+  '@langchain/openai@0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       js-tiktoken: 1.0.21
       openai: 4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       zod: 3.25.76
@@ -9730,13 +9845,13 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@sip-protocol/sdk@0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))':
+  '@sip-protocol/sdk@0.7.4(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod-to-json-schema@3.25.1(zod@3.25.76))':
     dependencies:
       '@aztec/bb.js': 3.0.2
       '@ethereumjs/rlp': 10.1.1
       '@jup-ag/api': 6.0.48
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@magicblock-labs/ephemeral-rollups-sdk': 0.8.5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
       '@noble/ciphers': 2.1.1
       '@noble/curves': 1.9.7
@@ -9755,7 +9870,7 @@ snapshots:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@triton-one/yellowstone-grpc': 4.0.2(patch_hash=3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a)
-      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))
+      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))
       pino: 10.3.0
       zod: 4.3.6
     optionalDependencies:
@@ -9783,7 +9898,7 @@ snapshots:
       '@ethereumjs/rlp': 10.1.1
       '@jup-ag/api': 6.0.48
       '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
-      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@langchain/openai': 0.4.9(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@magicblock-labs/ephemeral-rollups-sdk': 0.8.5(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(utf-8-validate@5.0.10)
       '@noble/ciphers': 2.1.1
       '@noble/curves': 1.9.7
@@ -9802,7 +9917,7 @@ snapshots:
       '@solana/spl-token': 0.4.14(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@triton-one/yellowstone-grpc': 4.0.2(patch_hash=3c931d1254c03781b9157ae6af31fea02733a207f5b9b6523b506f0a32d8a16a)
-      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))
+      langchain: 1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))
       pino: 10.3.0
       zod: 4.3.6
     optionalDependencies:
@@ -9823,6 +9938,20 @@ snapshots:
       - utf-8-validate
       - ws
       - zod-to-json-schema
+
+  '@sip-protocol/sns-stealth@0.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@bonfida/spl-name-service': 3.0.21(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
 
   '@sip-protocol/types@0.2.2': {}
 
@@ -10293,6 +10422,10 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
+  '@solana/codecs-core@2.0.0-preview.2':
+    dependencies:
+      '@solana/errors': 2.0.0-preview.2
+
   '@solana/codecs-core@2.0.0-rc.1(typescript@5.9.3)':
     dependencies:
       '@solana/errors': 2.0.0-rc.1(typescript@5.9.3)
@@ -10313,6 +10446,12 @@ snapshots:
       '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
+
+  '@solana/codecs-data-structures@2.0.0-preview.2':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/codecs-numbers': 2.0.0-preview.2
+      '@solana/errors': 2.0.0-preview.2
 
   '@solana/codecs-data-structures@2.0.0-rc.1(typescript@5.9.3)':
     dependencies:
@@ -10335,6 +10474,11 @@ snapshots:
       '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
+
+  '@solana/codecs-numbers@2.0.0-preview.2':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/errors': 2.0.0-preview.2
 
   '@solana/codecs-numbers@2.0.0-rc.1(typescript@5.9.3)':
     dependencies:
@@ -10360,6 +10504,13 @@ snapshots:
       '@solana/errors': 5.5.1(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
+
+  '@solana/codecs-strings@2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/codecs-numbers': 2.0.0-preview.2
+      '@solana/errors': 2.0.0-preview.2
+      fastestsmallesttextencoderdecoder: 1.0.22
 
   '@solana/codecs-strings@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -10393,6 +10544,16 @@ snapshots:
     optionalDependencies:
       fastestsmallesttextencoderdecoder: 1.0.22
       typescript: 5.9.3
+
+  '@solana/codecs@2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/codecs-data-structures': 2.0.0-preview.2
+      '@solana/codecs-numbers': 2.0.0-preview.2
+      '@solana/codecs-strings': 2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/options': 2.0.0-preview.2
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
 
   '@solana/codecs@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -10440,6 +10601,11 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/errors@2.0.0-preview.2':
+    dependencies:
+      chalk: 5.6.2
+      commander: 12.1.0
 
   '@solana/errors@2.0.0-rc.1(typescript@5.9.3)':
     dependencies:
@@ -10609,6 +10775,11 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+
+  '@solana/options@2.0.0-preview.2':
+    dependencies:
+      '@solana/codecs-core': 2.0.0-preview.2
+      '@solana/codecs-numbers': 2.0.0-preview.2
 
   '@solana/options@2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
@@ -10967,6 +11138,14 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  '@solana/spl-token-group@0.0.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)':
+    dependencies:
+      '@solana/codecs': 2.0.0-preview.2(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/spl-type-length-value': 0.1.0
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
   '@solana/spl-token-group@0.0.7(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
       '@solana/codecs': 2.0.0-rc.1(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -10997,6 +11176,25 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
       - utf-8-validate
+
+  '@solana/spl-token@0.4.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@solana/buffer-layout': 4.0.1
+      '@solana/buffer-layout-utils': 0.2.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/spl-token-group': 0.0.4(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)
+      '@solana/spl-token-metadata': 0.1.6(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      buffer: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - fastestsmallesttextencoderdecoder
+      - typescript
+      - utf-8-validate
+
+  '@solana/spl-type-length-value@0.1.0':
+    dependencies:
+      buffer: 6.0.3
 
   '@solana/subscribable@2.3.0(typescript@5.9.3)':
     dependencies:
@@ -13413,6 +13611,10 @@ snapshots:
       bs58: 4.0.1
       text-encoding-utf-8: 1.0.2
 
+  borsh@1.0.0: {}
+
+  borsh@2.0.0: {}
+
   bowser@2.14.1: {}
 
   brace-expansion@1.1.13:
@@ -14549,6 +14751,11 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  graphemesplit@2.6.0:
+    dependencies:
+      js-base64: 3.7.8
+      unicode-trie: 2.0.0
+
   h3@1.15.10:
     dependencies:
       cookie-es: 1.2.2
@@ -14706,6 +14913,8 @@ snapshots:
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
+
+  ipaddr.js@2.4.0: {}
 
   iron-webcrypto@1.2.1: {}
 
@@ -15009,12 +15218,12 @@ snapshots:
 
   keyvaluestorage-interface@1.0.0: {}
 
-  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76)):
+  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76)):
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
-      langsmith: 0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@3.25.76))(zod@3.25.76)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      langsmith: 0.4.12(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
       uuid: 10.0.0
       zod: 3.25.76
     transitivePeerDependencies:
@@ -15026,11 +15235,11 @@ snapshots:
       - react-dom
       - zod-to-json-schema
 
-  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6)):
+  langchain@1.2.17(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6)):
     dependencies:
-      '@langchain/core': 0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
-      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)
-      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
+      '@langchain/core': 0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76))
+      '@langchain/langgraph': 1.1.3(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@3.25.76)
+      '@langchain/langgraph-checkpoint': 1.0.0(@langchain/core@0.3.80(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)))
       langsmith: 0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6))
       uuid: 10.0.0
       zod: 3.25.76
@@ -15043,7 +15252,7 @@ snapshots:
       - react-dom
       - zod-to-json-schema
 
-  langsmith@0.3.87(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
+  langsmith@0.3.87(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -15052,7 +15261,7 @@ snapshots:
       semver: 7.7.3
       uuid: 10.0.0
     optionalDependencies:
-      openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      openai: 6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
 
   langsmith@0.3.87(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)):
     dependencies:
@@ -15065,7 +15274,7 @@ snapshots:
     optionalDependencies:
       openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
 
-  langsmith@0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
+  langsmith@0.4.12(openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -15074,7 +15283,7 @@ snapshots:
       semver: 7.7.3
       uuid: 10.0.0
     optionalDependencies:
-      openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      openai: 6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
 
   langsmith@0.4.12(openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)):
     dependencies:
@@ -15649,6 +15858,21 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  openai@4.104.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    optionalDependencies:
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - encoding
+
   openai@4.104.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
@@ -15663,6 +15887,12 @@ snapshots:
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
+
+  openai@6.26.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
+    optionalDependencies:
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      zod: 3.25.76
+    optional: true
 
   openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
     optionalDependencies:
@@ -15790,6 +16020,8 @@ snapshots:
     dependencies:
       degenerator: 5.0.1
       netmask: 2.1.1
+
+  pako@0.2.9: {}
 
   pako@2.1.0: {}
 
@@ -16832,6 +17064,8 @@ snapshots:
 
   throat@5.0.0: {}
 
+  tiny-inflate@1.0.3: {}
+
   tiny-secp256k1@1.1.7:
     dependencies:
       bindings: 1.5.0
@@ -17006,6 +17240,11 @@ snapshots:
   undici-types@7.20.0: {}
 
   undici@7.24.7: {}
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
 
   unidragger@3.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
Phase D of the sip.sol foundation — adds two new tools to the SIPHER agent so HERALD/Sipher chat can route private payments by `.sol` name.

- **`resolveSNS`** — read-only `.sol` → SIP-STEALTH meta-address lookup via `@sip-protocol/sns-stealth@^0.1.0`. Returns discriminated union: `resolved | not-found | malformed | network-error`. NOT in `FUND_MOVING_TOOLS` — pure read.
- **`sendPrivateToSNS`** — composite tool. Resolves the domain, builds `sip:solana:0x<spending>:0x<viewing>` URI (matching `send.ts`'s 0x-hex contract — NOT bs58), then delegates to `executeSend`. Returns `ok` with composite `resolved + send` blocks or `cannot-send` with reason.
- **SENTINEL preflight integration** — `sendPrivateToSNS` added to `FUND_MOVING_TOOLS`. Input field named `recipient` (the `.sol` domain) so the existing gate at `agent.ts:169` reads it unchanged for blacklist / known-repeat / dust evaluation before execution. `agent.ts` registry + `SYSTEM_PROMPT` updated.

Tests: **+47** (resolve-sns: 23, send-private-to-sns: 22, registry updates: 2). `pnpm test` 1446 → 1495 across 124 files.

## Plan deviations from `2026-05-11-sip-sol-foundation.md` lines 2118–2472
1. **Task 18 — wrapper architecture inverted.** Plan called for a module-level `new Connection(process.env.SIPHER_SOLANA_RPC ?? 'mainnet-beta')` at the top of the tool file. That crashes at test load because `loadNetworkConfig()` throws fatal on unset `SIPHER_NETWORK`/`SIPHER_HELIUS_API_KEY`. Adapted to construct the `Connection` via `createConnection(loadNetworkConfig().clusterName)` inside the executor — matches `send.ts` precedent, picks up the configured cluster, and works under vitest (which presets these env vars).
2. **Tool shape.** Plan used Pi-style `{ name, description, inputSchema, handler }`. Sipher's convention is `AnthropicTool { name, description, input_schema }` paired with a separate `executeXxx(params)` function (per `send.ts`, `deposit.ts`, etc.). All new tools follow the established shape.
3. **Test location.** Plan put tests at `src/tools/<name>.test.ts` (co-located). Sipher's convention is `tests/<kebab-name>.test.ts` (per all existing tool tests). Moved accordingly.
4. **URI hex, not bs58.** The Phase C handoff suggested `bs58.encode(meta.spending)` for the sip-URI build, but sipher's `send.ts:166-167` rejects non-`0x`-prefixed keys: `parts[2].startsWith('0x')`. The composite builds `sip:solana:0x${hex}:0x${hex}` to satisfy the existing contract.
5. **Task 20 scoped down** — Plan's HERALD smoke test (`handleHeraldDM`, expecting `toolsCalled` to include `sendPrivateToSNS`) targeted a non-existent entry point and would have required adding `sendPrivateToSNS` to `HERALD_TOOLS`, expanding HERALD's X-only surface into fund-moving territory. Replaced with the composite integration test built into `send-private-to-sns.test.ts` — exercises `resolveSNS` + URI build + delegate-to-`send` end-to-end via mocks, without coupling to LLM intent classification.

## Test Plan
- [x] `cd packages/agent && pnpm test -- --run` — 1495 / 1495 passing
- [x] `pnpm test -- --run` (root REST suite) — 555 / 555 passing
- [x] `cd packages/agent && npx tsc --noEmit` — clean
- [x] `pnpm typecheck` (root) — clean
- [ ] Manual sanity once mainnet/devnet `.sol` domain is registered with SIP-STEALTH record:
  - [ ] Hit `/v1/health` to confirm process boots with the new tools registered
  - [ ] From Command Center chat: ask Sipher to "resolve rector.sol" and confirm the LLM dispatches `resolveSNS`
  - [ ] From chat: "send 0.001 SOL to rector.sol privately" and confirm SENTINEL preflight runs (advisory/yolo mode) and the unsigned tx is returned for the connected wallet to sign

## Notes
- `@sip-protocol/sns-stealth@^0.1.0` was published to npm in Phase A (PR sip-protocol#1082 `5a85d11`). pnpm-lock now references that version.
- Phase B (sip-app) + Phase C (sip-mobile) used a separate `src/lib/sns-stealth-*.ts` wrapper because their UI consumers imported it from multiple call sites. Sipher has only the two tools as callers, so the wrapper is inlined into `resolve-sns.ts` — `executeResolveSNS` is the wrapper boundary.
- `bytesToHex` is inlined as a small helper (matching `send.ts`'s inline `hexToBytes`) rather than pulling in `@noble/hashes/utils` as a direct dep — it's not in `packages/agent/package.json` explicitly.
- HERALD remains X-only. Decision deferred on whether to add `sendPrivateToSNS` to `HERALD_TOOLS` (would need DM-triggered fund-movement trust review).

## Phase D acceptance
- Task 18 ✅ `resolveSNS` tool + 23 tests, registered in agent loop
- Task 19 ✅ `sendPrivateToSNS` composite tool + 22 tests, SENTINEL preflight wired
- Task 20 ✅ Composite integration test (option (a), per RECTOR's confirmation)