### PR TITLE
chore(agent): bump @sip-protocol/sns-stealth to ^0.1.1

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -13,7 +13,7 @@
     "@mariozechner/pi-ai": "^0.66.1",
     "@noble/ciphers": "^2.1.1",
     "@sinclair/typebox": "^0.34.49",
-    "@sip-protocol/sns-stealth": "^0.1.0",
+    "@sip-protocol/sns-stealth": "^0.1.1",
     "@sipher/sdk": "workspace:*",
     "better-sqlite3": "^12.8.0",
     "express": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,8 +217,8 @@ importers:
         specifier: ^0.34.49
         version: 0.34.49
       '@sip-protocol/sns-stealth':
-        specifier: ^0.1.0
-        version: 0.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+        specifier: ^0.1.1
+        version: 0.1.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@sipher/sdk':
         specifier: workspace:*
         version: link:../sdk
@@ -1874,8 +1874,8 @@ packages:
   '@sip-protocol/sdk@0.7.4':
     resolution: {integrity: sha512-tbdoto6okq7C8zQjqulNbXp5oqCPjj8tWe5K/uKIres32ouFjrN7lXytTPB+zQkB1Gv4ECHvGoaqf5EV4AaDrQ==}
 
-  '@sip-protocol/sns-stealth@0.1.0':
-    resolution: {integrity: sha512-XPb7gSQf+ie7MmNXr9vpZU69UvO5/XWDqrfECel1m65UBu20F+/3ohFeD4TmowkJ4f6UHkA1HCNxMv9y6Slc4A==}
+  '@sip-protocol/sns-stealth@0.1.1':
+    resolution: {integrity: sha512-11UD+wXDVnDisN6h432FKB3hHvi5jed/Bd9EOChmO2tV+JOd9R9Bg53E2aJ5zdxCdH9HXKos3RpqeKaLdkv8Lg==}
 
   '@sip-protocol/types@0.2.2':
     resolution: {integrity: sha512-FvJosQIp/dnADchEFmjdqCBlKolL4RrW15W2MPR1zlSZax9UbIR3vZjkm/j3mWewjO/bBfXii3FSxnqFlSBSkQ==}
@@ -9939,7 +9939,7 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  '@sip-protocol/sns-stealth@0.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@sip-protocol/sns-stealth@0.1.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@bonfida/spl-name-service': 3.0.21(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@noble/curves': 1.9.7


### PR DESCRIPTION
## Summary

Picks up [\`@sip-protocol/sns-stealth@0.1.1\`](https://www.npmjs.com/package/@sip-protocol/sns-stealth/v/0.1.1) which fixes the v0.1.0 publish bug: \`buildPublishTx\` only allocated the SNS record account but never wrote the data.

We're a resolver-only consumer right now (\`resolveSNS\` tool + \`sendPrivateToSNS\` preflight read records via \`resolveSIPStealth\`), so this is a forward-compat bump — no behavior change in production. The fixed package is the right baseline for any future agent tool that publishes records.

Upstream fix: [sip-protocol/sip-protocol#1083](https://github.com/sip-protocol/sip-protocol/pull/1083).

## Test plan

- [x] \`pnpm install\` clean
- [ ] Production VPS auto-deploys on merge; smoke-test \`resolveSNS\` against \`therector.sol\` after RECTOR re-publishes via the fixed sip-app UI