### PR TITLE
feat(agent): TorqueMCPClient foundation (PR-A of 5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,3 +102,12 @@ SIPHER_NETWORK=devnet
 # SOLANA_NETWORK is read by 11 agent tool files (deposit, send, refund, balance, scan, etc.) for
 # actual RPC calls; SIPHER_NETWORK drives UI chrome + /api/config. A mismatch produces a footgun
 # where UI shows 'devnet' banner while tools transact on mainnet (or vice versa).
+
+# ───────────────────────────────────────────
+# Torque MCP integration (growth loops via Frontier hackathon track)
+# ───────────────────────────────────────────
+TORQUE_API_KEY=
+TORQUE_MCP_URL=
+TORQUE_CAMPAIGN_ID_DEVNET=
+TORQUE_CAMPAIGN_ID_MAINNET=
+TORQUE_GROWTH_ENABLED=false

--- a/packages/agent/src/integrations/torque/index.ts
+++ b/packages/agent/src/integrations/torque/index.ts
@@ -1,0 +1,8 @@
+export { TorqueMCPClient } from './mcp-client.js'
+export type {
+  SipherGrowthEvent,
+  SipherEventName,
+  TorqueCampaign,
+  TorqueMCPClientOptions,
+  TorqueEmitResult,
+} from './types.js'

--- a/packages/agent/src/integrations/torque/mcp-client.ts
+++ b/packages/agent/src/integrations/torque/mcp-client.ts
@@ -1,0 +1,83 @@
+import type {
+  SipherGrowthEvent,
+  TorqueCampaign,
+  TorqueEmitResult,
+  TorqueMCPClientOptions,
+} from './types.js'
+
+const DEFAULT_TIMEOUT_MS = 8000
+
+export class TorqueMCPClient {
+  private readonly baseUrl: string
+  private readonly apiKey: string
+  private readonly campaignId: string
+  private readonly network: 'mainnet-beta' | 'devnet'
+  private readonly timeoutMs: number
+
+  constructor(opts: TorqueMCPClientOptions) {
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, '')
+    this.apiKey = opts.apiKey
+    this.campaignId = opts.campaignId
+    this.network = opts.network
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  }
+
+  async emitEvent(event: SipherGrowthEvent): Promise<TorqueEmitResult> {
+    const url = `${this.baseUrl}/campaigns/${this.campaignId}/events`
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs)
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-torque-api-key': this.apiKey,
+        },
+        body: JSON.stringify(event),
+        signal: controller.signal,
+      })
+      if (response.status === 401 || response.status === 403) {
+        return { ok: false, reason: 'auth', message: `Torque rejected api key (${response.status})` }
+      }
+      if (response.status === 409) {
+        return { ok: false, reason: 'duplicate', message: 'Event already ingested (idempotency hit)' }
+      }
+      if (response.status === 429) {
+        return { ok: false, reason: 'rate_limit', message: 'Torque rate limit hit' }
+      }
+      if (response.status === 410) {
+        return { ok: false, reason: 'campaign_inactive', message: 'Campaign no longer active' }
+      }
+      if (!response.ok) {
+        return { ok: false, reason: 'unknown', message: `Torque returned ${response.status}` }
+      }
+      const json = (await response.json()) as { status?: string; data?: { eventId?: string } }
+      const eventId = json?.data?.eventId
+      if (json?.status !== 'SUCCESS' || !eventId) {
+        return { ok: false, reason: 'unknown', message: 'Torque response missing eventId' }
+      }
+      return { ok: true, eventId }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return { ok: false, reason: 'network', message }
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+
+  async getCampaign(): Promise<TorqueCampaign | null> {
+    const url = `${this.baseUrl}/campaigns/${this.campaignId}`
+    try {
+      const response = await fetch(url, {
+        headers: { 'x-torque-api-key': this.apiKey },
+        signal: AbortSignal.timeout(this.timeoutMs),
+      })
+      if (!response.ok) return null
+      const json = (await response.json()) as { status?: string; data?: TorqueCampaign }
+      if (json?.status !== 'SUCCESS') return null
+      return json.data ?? null
+    } catch {
+      return null
+    }
+  }
+}

--- a/packages/agent/src/integrations/torque/mcp-client.ts
+++ b/packages/agent/src/integrations/torque/mcp-client.ts
@@ -11,21 +11,17 @@ export class TorqueMCPClient {
   private readonly baseUrl: string
   private readonly apiKey: string
   private readonly campaignId: string
-  private readonly network: 'mainnet-beta' | 'devnet'
   private readonly timeoutMs: number
 
   constructor(opts: TorqueMCPClientOptions) {
     this.baseUrl = opts.baseUrl.replace(/\/+$/, '')
     this.apiKey = opts.apiKey
     this.campaignId = opts.campaignId
-    this.network = opts.network
     this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
   }
 
   async emitEvent(event: SipherGrowthEvent): Promise<TorqueEmitResult> {
     const url = `${this.baseUrl}/campaigns/${this.campaignId}/events`
-    const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), this.timeoutMs)
     try {
       const response = await fetch(url, {
         method: 'POST',
@@ -34,7 +30,7 @@ export class TorqueMCPClient {
           'x-torque-api-key': this.apiKey,
         },
         body: JSON.stringify(event),
-        signal: controller.signal,
+        signal: AbortSignal.timeout(this.timeoutMs),
       })
       if (response.status === 401 || response.status === 403) {
         return { ok: false, reason: 'auth', message: `Torque rejected api key (${response.status})` }
@@ -60,8 +56,6 @@ export class TorqueMCPClient {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       return { ok: false, reason: 'network', message }
-    } finally {
-      clearTimeout(timeout)
     }
   }
 

--- a/packages/agent/src/integrations/torque/types.ts
+++ b/packages/agent/src/integrations/torque/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Event emitted to Torque MCP after a successful fund-moving sipher tool call.
+ * Wallet field is required for attribution; rebate_destination is a fresh
+ * stealth address derived per event so Torque does not learn the user's
+ * recipient identity.
+ */
+export interface SipherGrowthEvent {
+  event: SipherEventName
+  wallet: string
+  ts: string
+  tx_signature: string
+  network: 'mainnet-beta' | 'devnet'
+  metadata: {
+    amount_lamports?: number
+    asset?: string
+    rebate_destination: string
+  }
+}
+
+export type SipherEventName =
+  | 'sipher.private_send_completed'
+  | 'sipher.private_swap_completed'
+  | 'sipher.private_claim_completed'
+  | 'sipher.recurring_send_tick'
+  | 'sipher.batch_send_completed'
+
+export interface TorqueCampaign {
+  id: string
+  name: string
+  status: 'ACTIVE' | 'PAUSED' | 'ENDED'
+  remainingPool: number
+  rewardAmountPerEvent: number
+  rewardToken: string
+}
+
+export interface TorqueMCPClientOptions {
+  baseUrl: string
+  apiKey: string
+  campaignId: string
+  network: 'mainnet-beta' | 'devnet'
+  /** ms; default 8000 */
+  timeoutMs?: number
+}
+
+export type TorqueEmitResult =
+  | { ok: true; eventId: string }
+  | { ok: false; reason: 'auth' | 'rate_limit' | 'network' | 'duplicate' | 'campaign_inactive' | 'unknown'; message: string }

--- a/packages/agent/src/integrations/torque/types.ts
+++ b/packages/agent/src/integrations/torque/types.ts
@@ -37,7 +37,6 @@ export interface TorqueMCPClientOptions {
   baseUrl: string
   apiKey: string
   campaignId: string
-  network: 'mainnet-beta' | 'devnet'
   /** ms; default 8000 */
   timeoutMs?: number
 }

--- a/packages/agent/tests/integrations/torque/mcp-client.test.ts
+++ b/packages/agent/tests/integrations/torque/mcp-client.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { TorqueMCPClient } from '../../../src/integrations/torque/mcp-client.js'
 import type { SipherGrowthEvent } from '../../../src/integrations/torque/types.js'
-import type { TorqueEmitResult } from '../../../src/integrations/torque/types.js'
 
 const baseEvent: SipherGrowthEvent = {
   event: 'sipher.private_send_completed',
@@ -31,7 +30,6 @@ describe('TorqueMCPClient.emitEvent', () => {
       baseUrl: 'https://torque.test',
       apiKey: 'tk_secret',
       campaignId: 'camp_devnet_1',
-      network: 'devnet',
     })
 
     const result = await client.emitEvent(baseEvent)
@@ -63,7 +61,6 @@ describe('TorqueMCPClient.emitEvent error paths', () => {
       baseUrl: 'https://torque.test',
       apiKey: 'tk_secret',
       campaignId: 'camp_devnet_1',
-      network: 'devnet',
     })
   }
 
@@ -109,7 +106,6 @@ describe('TorqueMCPClient.emitEvent error paths', () => {
       baseUrl: 'https://torque.test',
       apiKey: 'tk_secret',
       campaignId: 'camp_devnet_1',
-      network: 'devnet',
     })
     const result = await client.emitEvent(baseEvent)
     expect(result).toStrictEqual({ ok: false, reason: 'network', message: 'ECONNREFUSED' })

--- a/packages/agent/tests/integrations/torque/mcp-client.test.ts
+++ b/packages/agent/tests/integrations/torque/mcp-client.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { TorqueMCPClient } from '../../../src/integrations/torque/mcp-client.js'
+import type { SipherGrowthEvent } from '../../../src/integrations/torque/types.js'
+import type { TorqueEmitResult } from '../../../src/integrations/torque/types.js'
+
+const baseEvent: SipherGrowthEvent = {
+  event: 'sipher.private_send_completed',
+  wallet: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
+  ts: '2026-05-12T12:00:00Z',
+  tx_signature: '3QCoHcJ1NNg',
+  network: 'devnet',
+  metadata: {
+    rebate_destination: '4HC3vQB5s5c',
+  },
+}
+
+describe('TorqueMCPClient.emitEvent', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('POSTs the event with x-torque-api-key header and JSON body', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ status: 'SUCCESS', data: { eventId: 'evt_1' } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const client = new TorqueMCPClient({
+      baseUrl: 'https://torque.test',
+      apiKey: 'tk_secret',
+      campaignId: 'camp_devnet_1',
+      network: 'devnet',
+    })
+
+    const result = await client.emitEvent(baseEvent)
+
+    expect(result).toStrictEqual({ ok: true, eventId: 'evt_1' })
+    expect(fetchSpy).toHaveBeenCalledOnce()
+    const [url, init] = fetchSpy.mock.calls[0]!
+    expect(url).toBe('https://torque.test/campaigns/camp_devnet_1/events')
+    expect(init?.method).toBe('POST')
+    expect(init?.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      'x-torque-api-key': 'tk_secret',
+    })
+    expect(JSON.parse(init?.body as string)).toStrictEqual(baseEvent)
+  })
+})
+
+describe('TorqueMCPClient.emitEvent error paths', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  function clientWithMockedFetch(status: number, body: object | string = ''): TorqueMCPClient {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(typeof body === 'string' ? body : JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    return new TorqueMCPClient({
+      baseUrl: 'https://torque.test',
+      apiKey: 'tk_secret',
+      campaignId: 'camp_devnet_1',
+      network: 'devnet',
+    })
+  }
+
+  it('returns auth reason on 401', async () => {
+    const client = clientWithMockedFetch(401)
+    const result = await client.emitEvent(baseEvent)
+    expect(result).toStrictEqual({ ok: false, reason: 'auth', message: expect.stringMatching(/401/) })
+  })
+
+  it('returns auth reason on 403', async () => {
+    const client = clientWithMockedFetch(403)
+    const result = await client.emitEvent(baseEvent)
+    expect(result).toStrictEqual({ ok: false, reason: 'auth', message: expect.stringMatching(/403/) })
+  })
+
+  it('returns duplicate reason on 409', async () => {
+    const client = clientWithMockedFetch(409)
+    const result = await client.emitEvent(baseEvent)
+    expect(result).toStrictEqual({ ok: false, reason: 'duplicate', message: expect.stringMatching(/idempotency/i) })
+  })
+
+  it('returns rate_limit reason on 429', async () => {
+    const client = clientWithMockedFetch(429)
+    const result = await client.emitEvent(baseEvent)
+    expect(result).toStrictEqual({ ok: false, reason: 'rate_limit', message: expect.stringMatching(/rate limit/i) })
+  })
+
+  it('returns campaign_inactive reason on 410', async () => {
+    const client = clientWithMockedFetch(410)
+    const result = await client.emitEvent(baseEvent)
+    expect(result).toStrictEqual({ ok: false, reason: 'campaign_inactive', message: expect.stringMatching(/no longer active/i) })
+  })
+
+  it('returns unknown reason on other 5xx', async () => {
+    const client = clientWithMockedFetch(503)
+    const result = await client.emitEvent(baseEvent)
+    expect(result).toStrictEqual({ ok: false, reason: 'unknown', message: expect.stringMatching(/503/) })
+  })
+
+  it('returns network reason on fetch throw', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'))
+    const client = new TorqueMCPClient({
+      baseUrl: 'https://torque.test',
+      apiKey: 'tk_secret',
+      campaignId: 'camp_devnet_1',
+      network: 'devnet',
+    })
+    const result = await client.emitEvent(baseEvent)
+    expect(result).toStrictEqual({ ok: false, reason: 'network', message: 'ECONNREFUSED' })
+  })
+
+  it('returns unknown reason when response missing eventId', async () => {
+    const client = clientWithMockedFetch(200, { status: 'SUCCESS', data: {} })
+    const result = await client.emitEvent(baseEvent)
+    expect(result).toStrictEqual({ ok: false, reason: 'unknown', message: expect.stringMatching(/missing eventId/) })
+  })
+})


### PR DESCRIPTION
## Summary

First of 5 PRs implementing the Torque MCP integration per docs/superpowers/specs/2026-05-12-torque-mcp-integration-design.md. Adds the type surface and the HTTP MCP client with full error-path coverage. No production code paths reach the client yet — wiring lands in PR-B (growth-hook) + PR-C (agent runtime).

## Changes

- `packages/agent/src/integrations/torque/types.ts` — `SipherGrowthEvent`, `SipherEventName` (5 event types), `TorqueCampaign`, `TorqueMCPClientOptions`, `TorqueEmitResult` discriminated union
- `packages/agent/src/integrations/torque/mcp-client.ts` — `TorqueMCPClient.emitEvent` + `getCampaign` with status-code → reason mapping (auth/duplicate/rate_limit/campaign_inactive/network/unknown)
- `packages/agent/src/integrations/torque/index.ts` — public re-exports
- `packages/agent/tests/integrations/torque/mcp-client.test.ts` — 9 tests covering happy path + 8 error paths
- `.env.example` — TORQUE_* stubs

## Test plan

- [x] `pnpm --filter @sipher/agent test` — 1,504 green (1,495 existing + 9 new)
- [x] `pnpm typecheck` — clean (root tsc --noEmit, no errors)
- [x] All 9 client tests pass with mocked fetch (no real Torque traffic)

## Deferred to later PRs

- **Step 1.0.1 + 1.0.2 (Torque MCP API surface introspection)** — pending RECTOR's Torque hackathon Telegram group join + env var population. Any delta vs the assumed shape will be reconciled in PR-D's integration test phase and logged in FRICTION-LOG.md.
- **Wiring into agent runtime** — PR-C
- **Rebate destination derivation** — PR-B
- **Devnet campaign + admin endpoint + e2e + README + Friction Log** — PR-D
- **Mainnet rollout** — PR-E (optional, gated on PR-D)