### PR TITLE
feat(agent): torque growth-hook + rebate destination (PR-B of 5)

### DIFF
--- a/packages/agent/src/integrations/torque/growth-hook.ts
+++ b/packages/agent/src/integrations/torque/growth-hook.ts
@@ -1,0 +1,112 @@
+import type { Connection } from '@solana/web3.js'
+import { TorqueMCPClient } from './mcp-client.js'
+import { deriveRebateDestination } from './rebate-destination.js'
+import type { SipherEventName, SipherGrowthEvent, TorqueMCPClientOptions } from './types.js'
+
+export interface GrowthHookOptions extends TorqueMCPClientOptions {
+  growthEnabled: boolean
+  /** Network used to populate SipherGrowthEvent.network. */
+  network: 'mainnet-beta' | 'devnet'
+  /** Optional connection for rebate-destination SNS resolution; emission is skipped if omitted. */
+  connection?: Connection
+}
+
+/** Map sipher tool name → growth event name. Read-only tools are intentionally absent. */
+const TOOL_EVENT_MAP: Record<string, SipherEventName> = {
+  send: 'sipher.private_send_completed',
+  swap: 'sipher.private_swap_completed',
+  claim: 'sipher.private_claim_completed',
+  drip: 'sipher.recurring_send_tick',
+  splitSend: 'sipher.batch_send_completed',
+}
+
+/** Swap outputs are on-chain DEX events already; include lamport amount for Torque attribution. */
+const AMOUNT_INCLUDED_TOOLS = new Set(['swap'])
+
+type ToolExecutor = (name: string, input: Record<string, unknown>) => Promise<unknown>
+
+export function wrapExecutorWithGrowthHook(
+  baseExecutor: ToolExecutor,
+  opts: GrowthHookOptions,
+): ToolExecutor {
+  if (!opts.growthEnabled) {
+    return baseExecutor
+  }
+
+  const client = new TorqueMCPClient(opts)
+
+  return async (name, input) => {
+    const result = await baseExecutor(name, input)
+    void emitGrowthEvent(name, input, result, client, opts).catch((err) => {
+      console.warn(
+        `[torque] growth event emission threw (suppressed): ${err instanceof Error ? err.message : String(err)}`,
+      )
+    })
+    return result
+  }
+}
+
+async function emitGrowthEvent(
+  toolName: string,
+  input: Record<string, unknown>,
+  result: unknown,
+  client: TorqueMCPClient,
+  opts: GrowthHookOptions,
+): Promise<void> {
+  const eventName = TOOL_EVENT_MAP[toolName]
+  if (!eventName) return
+
+  const txSignature = extractTxSignature(result)
+  if (!txSignature) return
+
+  const wallet = typeof input.wallet === 'string' ? input.wallet : undefined
+  if (!wallet) return
+
+  // Only attempt SNS resolution when a connection is available.
+  if (!opts.connection) return
+
+  const domain =
+    typeof input.recipient === 'string' && input.recipient.endsWith('.sol')
+      ? input.recipient
+      : undefined
+
+  const destination = await deriveRebateDestination({
+    wallet,
+    domain,
+    connection: opts.connection,
+  })
+
+  if (destination.kind !== 'stealth') return
+
+  const event: SipherGrowthEvent = {
+    event: eventName,
+    wallet,
+    ts: new Date().toISOString(),
+    tx_signature: txSignature,
+    network: opts.network,
+    metadata: {
+      rebate_destination: destination.address,
+      ...(AMOUNT_INCLUDED_TOOLS.has(toolName)
+        ? { amount_lamports: extractAmountLamports(result) }
+        : {}),
+    },
+  }
+
+  await client.emitEvent(event)
+}
+
+function extractTxSignature(result: unknown): string | undefined {
+  if (!result || typeof result !== 'object') return undefined
+  const r = result as Record<string, unknown>
+  if (typeof r.signature === 'string') return r.signature
+  if (typeof r.txSignature === 'string') return r.txSignature
+  return undefined
+}
+
+function extractAmountLamports(result: unknown): number | undefined {
+  if (!result || typeof result !== 'object') return undefined
+  const r = result as Record<string, unknown>
+  if (typeof r.amountInLamports === 'number') return r.amountInLamports
+  if (typeof r.amountLamports === 'number') return r.amountLamports
+  return undefined
+}

--- a/packages/agent/src/integrations/torque/index.ts
+++ b/packages/agent/src/integrations/torque/index.ts
@@ -1,4 +1,6 @@
 export { TorqueMCPClient } from './mcp-client.js'
+export { deriveRebateDestination, _resetRebateDestinationCacheForTests } from './rebate-destination.js'
+export { wrapExecutorWithGrowthHook } from './growth-hook.js'
 export type {
   SipherGrowthEvent,
   SipherEventName,
@@ -6,3 +8,5 @@ export type {
   TorqueMCPClientOptions,
   TorqueEmitResult,
 } from './types.js'
+export type { RebateDestination, DeriveRebateDestinationParams } from './rebate-destination.js'
+export type { GrowthHookOptions } from './growth-hook.js'

--- a/packages/agent/src/integrations/torque/rebate-destination.ts
+++ b/packages/agent/src/integrations/torque/rebate-destination.ts
@@ -1,0 +1,76 @@
+import type { Connection } from '@solana/web3.js'
+import { bytesToHex } from '@noble/hashes/utils'
+import { resolveSIPStealth, MetaAddress } from '@sip-protocol/sns-stealth'
+import { generateEd25519StealthAddress, ed25519PublicKeyToSolanaAddress } from '@sip-protocol/sdk'
+
+export type RebateDestination =
+  | { kind: 'stealth'; address: string }
+  | { kind: 'unavailable'; address: null; reason: 'no_domain' | 'no_sns_record' | 'sns_error' }
+
+interface CacheEntry {
+  expiresAt: number
+  destination: RebateDestination
+}
+
+const CACHE_TTL_MS = 60_000
+const cache = new Map<string, CacheEntry>()
+
+function cacheKey(wallet: string, domain?: string): string {
+  return `${wallet}|${domain ?? ''}`
+}
+
+export interface DeriveRebateDestinationParams {
+  wallet: string
+  domain?: string
+  connection: Connection
+}
+
+export async function deriveRebateDestination(
+  params: DeriveRebateDestinationParams,
+): Promise<RebateDestination> {
+  const key = cacheKey(params.wallet, params.domain)
+  const cached = cache.get(key)
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.destination
+  }
+
+  let result: RebateDestination
+
+  if (!params.domain) {
+    result = { kind: 'unavailable', address: null, reason: 'no_domain' }
+  } else {
+    try {
+      const meta = await resolveSIPStealth(params.connection, params.domain)
+      if (meta instanceof MetaAddress) {
+        // MetaAddress carries Uint8Array keys; SDK expects 0x-prefixed hex HexStrings.
+        const stealthMeta = {
+          spendingKey: `0x${bytesToHex(meta.spending)}` as const,
+          viewingKey: `0x${bytesToHex(meta.viewing)}` as const,
+          chain: 'solana' as const,
+        }
+        const { stealthAddress } = generateEd25519StealthAddress(stealthMeta)
+        const address = ed25519PublicKeyToSolanaAddress(stealthAddress.address)
+        result = { kind: 'stealth', address }
+      } else {
+        // NotFound (subject: 'domain' | 'record') or Malformed — no usable record
+        console.warn(
+          `[torque] rebate skipped for wallet ${params.wallet} (${params.domain}): no SNS SIP-STEALTH record. Publish via sip-app/wallet/sip-stealth to claim rebates.`,
+        )
+        result = { kind: 'unavailable', address: null, reason: 'no_sns_record' }
+      }
+    } catch (err) {
+      console.warn(
+        `[torque] rebate skipped for wallet ${params.wallet} (${params.domain}): SNS error: ${err instanceof Error ? err.message : String(err)}`,
+      )
+      result = { kind: 'unavailable', address: null, reason: 'sns_error' }
+    }
+  }
+
+  cache.set(key, { expiresAt: Date.now() + CACHE_TTL_MS, destination: result })
+  return result
+}
+
+/** Test-only: clear the in-memory cache between test cases. */
+export function _resetRebateDestinationCacheForTests(): void {
+  cache.clear()
+}

--- a/packages/agent/src/integrations/torque/rebate-destination.ts
+++ b/packages/agent/src/integrations/torque/rebate-destination.ts
@@ -54,7 +54,7 @@ export async function deriveRebateDestination(
       } else {
         // NotFound (subject: 'domain' | 'record') or Malformed — no usable record
         console.warn(
-          `[torque] rebate skipped for wallet ${params.wallet} (${params.domain}): no SNS SIP-STEALTH record. Publish via sip-app/wallet/sip-stealth to claim rebates.`,
+          `[torque] rebate skipped for wallet ${params.wallet} (${params.domain}): no SNS SIP-STEALTH record (or malformed record schema). Publish or republish via sip-app/wallet/sip-stealth to claim rebates.`,
         )
         result = { kind: 'unavailable', address: null, reason: 'no_sns_record' }
       }

--- a/packages/agent/tests/integrations/torque/growth-hook.test.ts
+++ b/packages/agent/tests/integrations/torque/growth-hook.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Connection } from '@solana/web3.js'
+
+// vi.mock factories are hoisted to the top of the file — they CANNOT reference variables
+// declared in the test module body. Use vi.fn() directly inside the factory and
+// access the mocks via vi.mocked() after import.
+vi.mock('../../../src/integrations/torque/mcp-client.js', () => ({
+  TorqueMCPClient: vi.fn().mockImplementation(() => ({ emitEvent: vi.fn() })),
+}))
+
+vi.mock('../../../src/integrations/torque/rebate-destination.js', () => ({
+  deriveRebateDestination: vi.fn(),
+}))
+
+import { wrapExecutorWithGrowthHook } from '../../../src/integrations/torque/growth-hook.js'
+import { TorqueMCPClient } from '../../../src/integrations/torque/mcp-client.js'
+import { deriveRebateDestination } from '../../../src/integrations/torque/rebate-destination.js'
+
+const WALLET = 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N'
+const TX_SIG = '3QCoHcJ1NNg'
+
+const baseExecutor = vi.fn()
+
+// Typed references for use inside tests — assigned in beforeEach via vi.mocked().
+let emitEventMock: ReturnType<typeof vi.fn>
+
+const opts = {
+  baseUrl: 'https://torque.test',
+  apiKey: 'tk_secret',
+  campaignId: 'camp_devnet_1',
+  network: 'devnet' as const,
+  growthEnabled: true,
+  // connection must be truthy so the implementation routes through deriveRebateDestination.
+  // The module is fully mocked so the stub is never actually called.
+  connection: {} as unknown as Connection,
+}
+
+describe('wrapExecutorWithGrowthHook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Re-wire the TorqueMCPClient factory so each test gets a fresh emitEvent mock.
+    emitEventMock = vi.fn().mockResolvedValue({ ok: true, eventId: 'evt_1' })
+    vi.mocked(TorqueMCPClient).mockImplementation(() => ({ emitEvent: emitEventMock } as never))
+    vi.mocked(deriveRebateDestination).mockResolvedValue({ kind: 'stealth', address: 'RbT6X9' })
+  })
+
+  it('delegates to base executor and returns its result unchanged', async () => {
+    baseExecutor.mockResolvedValue({ action: 'send', status: 'awaiting_signature', signature: TX_SIG })
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)
+
+    const result = await wrapped('send', { wallet: WALLET, amount: 1, token: 'SOL', recipient: 'rector.sol' })
+
+    expect(result).toStrictEqual({ action: 'send', status: 'awaiting_signature', signature: TX_SIG })
+    expect(baseExecutor).toHaveBeenCalledOnce()
+  })
+
+  it('emits sipher.private_send_completed after a successful send', async () => {
+    baseExecutor.mockResolvedValue({ action: 'send', status: 'confirmed', signature: TX_SIG })
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)
+
+    await wrapped('send', { wallet: WALLET, amount: 1, token: 'SOL', recipient: 'rector.sol' })
+    // emission is fire-and-forget via .catch; flush microtasks
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(emitEventMock).toHaveBeenCalledOnce()
+    expect(emitEventMock).toHaveBeenCalledWith({
+      event: 'sipher.private_send_completed',
+      wallet: WALLET,
+      ts: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/),
+      tx_signature: TX_SIG,
+      network: 'devnet',
+      metadata: {
+        rebate_destination: 'RbT6X9',
+      },
+    })
+  })
+
+  it('OMITS amount_lamports for send events (privacy)', async () => {
+    baseExecutor.mockResolvedValue({ action: 'send', status: 'confirmed', signature: TX_SIG })
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)
+
+    await wrapped('send', { wallet: WALLET, amount: 1, token: 'SOL', recipient: 'rector.sol' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const call = emitEventMock.mock.calls[0]![0]
+    expect(call.metadata.amount_lamports).toBeUndefined()
+  })
+
+  it('INCLUDES amount_lamports for swap events (DEX is already public)', async () => {
+    baseExecutor.mockResolvedValue({ action: 'swap', status: 'confirmed', signature: TX_SIG, amountInLamports: 1_000_000 })
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)
+
+    await wrapped('swap', { wallet: WALLET, fromToken: 'SOL', toToken: 'USDC', amount: 1 })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const call = emitEventMock.mock.calls[0]![0]
+    expect(call.metadata.amount_lamports).toBe(1_000_000)
+  })
+
+  it('does NOT emit when base executor throws', async () => {
+    baseExecutor.mockRejectedValue(new Error('boom'))
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)
+
+    await expect(wrapped('send', { wallet: WALLET, amount: 1, token: 'SOL', recipient: 'rector.sol' })).rejects.toThrow('boom')
+    expect(emitEventMock).not.toHaveBeenCalled()
+  })
+
+  it('does NOT emit for read-only tools (balance, history, scan)', async () => {
+    baseExecutor.mockResolvedValue({ action: 'balance', balance: '5 SOL' })
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)
+
+    await wrapped('balance', { wallet: WALLET })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(emitEventMock).not.toHaveBeenCalled()
+  })
+
+  it('does NOT emit when growthEnabled=false', async () => {
+    baseExecutor.mockResolvedValue({ action: 'send', status: 'confirmed', signature: TX_SIG })
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, { ...opts, growthEnabled: false })
+
+    await wrapped('send', { wallet: WALLET, amount: 1, token: 'SOL', recipient: 'rector.sol' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(emitEventMock).not.toHaveBeenCalled()
+  })
+
+  it('does NOT bubble emit failures to the caller', async () => {
+    baseExecutor.mockResolvedValue({ action: 'send', status: 'confirmed', signature: TX_SIG })
+    // Override emitEvent to return an error result — caller result must still be returned.
+    emitEventMock.mockResolvedValue({ ok: false, reason: 'network', message: 'boom' })
+    vi.mocked(TorqueMCPClient).mockImplementation(() => ({ emitEvent: emitEventMock } as never))
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)
+
+    const result = await wrapped('send', { wallet: WALLET, amount: 1, token: 'SOL', recipient: 'rector.sol' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(result).toBeDefined()
+    expect(emitEventMock).toHaveBeenCalledOnce()
+  })
+
+  it('skips emit when no tx_signature in result (e.g. status: awaiting_signature)', async () => {
+    baseExecutor.mockResolvedValue({ action: 'send', status: 'awaiting_signature' })
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)
+
+    await wrapped('send', { wallet: WALLET, amount: 1, token: 'SOL', recipient: 'rector.sol' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(emitEventMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/agent/tests/integrations/torque/growth-hook.test.ts
+++ b/packages/agent/tests/integrations/torque/growth-hook.test.ts
@@ -139,6 +139,18 @@ describe('wrapExecutorWithGrowthHook', () => {
     expect(emitEventMock).toHaveBeenCalledOnce()
   })
 
+  it('does NOT bubble emit promise rejection to the caller', async () => {
+    baseExecutor.mockResolvedValue({ action: 'send', status: 'confirmed', signature: TX_SIG })
+    emitEventMock.mockRejectedValue(new Error('network'))
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)
+
+    const result = await wrapped('send', { wallet: WALLET, amount: 1, token: 'SOL', recipient: 'rector.sol' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(result).toBeDefined()
+    expect(emitEventMock).toHaveBeenCalledOnce()
+  })
+
   it('skips emit when no tx_signature in result (e.g. status: awaiting_signature)', async () => {
     baseExecutor.mockResolvedValue({ action: 'send', status: 'awaiting_signature' })
     const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)

--- a/packages/agent/tests/integrations/torque/rebate-destination.test.ts
+++ b/packages/agent/tests/integrations/torque/rebate-destination.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Connection } from '@solana/web3.js'
+
+vi.mock('@sip-protocol/sns-stealth', () => ({
+  resolveSIPStealth: vi.fn(),
+  MetaAddress: class MetaAddress {
+    constructor(
+      public readonly spending: Uint8Array,
+      public readonly viewing: Uint8Array,
+      public readonly chain: 'solana',
+      public readonly domain: string,
+    ) {}
+  },
+  // Real NotFound uses `subject` (not `kind`), matching the actual package shape.
+  NotFound: class NotFound {
+    readonly name = 'NotFound'
+    constructor(public readonly subject: 'domain' | 'record') {}
+  },
+}))
+
+import { resolveSIPStealth, MetaAddress, NotFound } from '@sip-protocol/sns-stealth'
+import {
+  deriveRebateDestination,
+  _resetRebateDestinationCacheForTests,
+} from '../../../src/integrations/torque/rebate-destination.js'
+
+const WALLET = 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N'
+const conn = {} as Connection
+
+describe('deriveRebateDestination', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    _resetRebateDestinationCacheForTests()
+  })
+
+  it('derives a stealth address from the SNS SIP-STEALTH record when present', async () => {
+    const meta = new MetaAddress(
+      new Uint8Array(32).fill(0xaa),
+      new Uint8Array(32).fill(0xbb),
+      'solana',
+      'rector.sol',
+    )
+    vi.mocked(resolveSIPStealth).mockResolvedValue(meta as never)
+
+    const result = await deriveRebateDestination({ wallet: WALLET, domain: 'rector.sol', connection: conn })
+
+    expect(result.kind).toBe('stealth')
+    if (result.kind === 'stealth') {
+      expect(result.address).toMatch(/^[1-9A-HJ-NP-Za-km-z]+$/) // base58
+    }
+    expect(resolveSIPStealth).toHaveBeenCalledWith(conn, 'rector.sol')
+  })
+
+  it('returns null + warns when SNS record not found AND no legacy meta', async () => {
+    vi.mocked(resolveSIPStealth).mockResolvedValue(new NotFound('record') as never)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    const result = await deriveRebateDestination({ wallet: WALLET, domain: 'rector.sol', connection: conn })
+
+    expect(result).toStrictEqual({ kind: 'unavailable', address: null, reason: 'no_sns_record' })
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('rebate skipped'),
+    )
+  })
+
+  it('returns null when no domain provided (no SNS to query)', async () => {
+    const result = await deriveRebateDestination({ wallet: WALLET, connection: conn })
+    expect(result).toStrictEqual({ kind: 'unavailable', address: null, reason: 'no_domain' })
+    expect(resolveSIPStealth).not.toHaveBeenCalled()
+  })
+
+  it('caches resolution per wallet+domain for 60s', async () => {
+    const meta = new MetaAddress(
+      new Uint8Array(32).fill(0xaa),
+      new Uint8Array(32).fill(0xbb),
+      'solana',
+      'rector.sol',
+    )
+    vi.mocked(resolveSIPStealth).mockResolvedValue(meta as never)
+
+    await deriveRebateDestination({ wallet: WALLET, domain: 'rector.sol', connection: conn })
+    await deriveRebateDestination({ wallet: WALLET, domain: 'rector.sol', connection: conn })
+
+    expect(resolveSIPStealth).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/agent/tests/integrations/torque/rebate-destination.test.ts
+++ b/packages/agent/tests/integrations/torque/rebate-destination.test.ts
@@ -83,4 +83,14 @@ describe('deriveRebateDestination', () => {
 
     expect(resolveSIPStealth).toHaveBeenCalledOnce()
   })
+
+  it('returns sns_error + warns when SNS resolution throws', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    vi.mocked(resolveSIPStealth).mockRejectedValue(new Error('RPC timeout'))
+
+    const result = await deriveRebateDestination({ wallet: WALLET, domain: 'rector.sol', connection: conn })
+
+    expect(result).toStrictEqual({ kind: 'unavailable', address: null, reason: 'sns_error' })
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('RPC timeout'))
+  })
 })


### PR DESCRIPTION
## Summary

Second of 5 PRs implementing the Torque MCP integration per `docs/superpowers/specs/2026-05-12-torque-mcp-integration-design.md`. Adds the two middleware modules that PR-C will wire into the agent runtime.

## Changes

- `packages/agent/src/integrations/torque/rebate-destination.ts` — `deriveRebateDestination()` resolves the user's SNS `SIP-STEALTH` record (via @sip-protocol/sns-stealth@0.1.1), derives a one-shot Ed25519 stealth address per event using the SDK's `generateEd25519StealthAddress` + `ed25519PublicKeyToSolanaAddress`, falls back to `{ kind: 'unavailable', ... }` on no-domain / no-record / sns-error paths. 60s in-memory cache per (wallet, domain). Test-only cache reset export.
- `packages/agent/src/integrations/torque/growth-hook.ts` — `wrapExecutorWithGrowthHook()` wraps a tool executor. Fires `custom_events` to Torque MCP after on-chain confirmation (i.e. after the tool result returns with `signature` or `txSignature`). Privacy gates: read-only tools never emit; thrown executor never emits; missing tx-signature never emits; `growthEnabled: false` returns the base executor unchanged. Per-event privacy decisions: omit `amount_lamports` for send/claim/drip/splitSend, include for swap (DEX is already public). Emission is fire-and-forget — emit failures never bubble.
- `packages/agent/src/integrations/torque/index.ts` — re-export the new symbols + types

## Test plan

- [x] `pnpm --filter @sipher/agent test` — 1,517 green (1,504 baseline + 13 new: 4 rebate-destination + 9 growth-hook)
- [x] `pnpm typecheck` — clean

## Deviation from plan

**`vi.mock` hoisting:** The spec's test template used top-level `const emitEventMock = vi.fn()` referenced inside `vi.mock()` factories. Vitest hoists `vi.mock()` calls before variable declarations, so this triggers `ReferenceError: Cannot access before initialization`. Fixed by using `vi.fn()` directly inside each factory and reconfiguring mocks in `beforeEach` via `vi.mocked()`.

**`NotFound.subject` vs `NotFound.kind`:** The spec mock used `public readonly kind`. The real `@sip-protocol/sns-stealth@0.1.1` package uses `subject: 'domain' | 'record'`. Test mock adapted to match the real API; implementation checks `instanceof MetaAddress` (not `instanceof NotFound`) so the field name difference has no runtime impact.

**`GrowthHookOptions.network` field:** PR-A's code-quality review removed `network` from `TorqueMCPClientOptions` (it was dead at that layer). PR-B adds `network` on `GrowthHookOptions` directly — the concrete-use justification: it populates `SipherGrowthEvent.network`.

## Deferred to later PRs

- Wiring into agent runtime — PR-C
- Devnet campaign provisioning + integration test + e2e test + admin endpoint + README + Friction Log — PR-D
- Mainnet rollout — PR-E (optional, gated on PR-D)