### PR TITLE
feat(agent): torque admin + opt-in tests + README + friction log (PR-D of 5)

### DIFF
--- a/docs/integrations/torque/FRICTION-LOG.md
+++ b/docs/integrations/torque/FRICTION-LOG.md
@@ -1,0 +1,33 @@
+# Torque MCP Integration — Friction Log
+
+Live build journal during the Torque MCP integration sprint (May 12-26, 2026). Updated daily.
+
+## What broke
+
+_To be filled during build. Capture: concrete API errors, MCP server endpoint surprises, SDK ↔ MCP semantic mismatches, doc contradictions._
+
+## What was confusing
+
+_To be filled. Onboarding gaps, missing examples, unclear which primitive maps to which use case._
+
+## What we'd improve
+
+_To be filled. Concrete suggestions tagged by priority (would-block-adoption / nice-to-have)._
+
+## What worked well
+
+_To be filled. Genuine praise where deserved — keeps the log honest._
+
+## Telegram interactions
+
+_To be filled. Q&A with @smicktrq during build, with timestamps. Signals real engagement._
+
+---
+
+## Day 1 — 2026-05-12
+
+- (Open Telegram group access pending; integration tests are skip-predicated to allow shadow build before TG access is granted.)
+- TorqueMCPClient + types shipped in PR-A (sipher#256) against assumed API shape: HTTP+SSE, `x-torque-api-key` header, `POST /campaigns/{id}/events`. Will reconcile against actual API once TG group provides MCP URL.
+- Growth-hook middleware shipped in PR-B (sipher#258) — fires `custom_events` post-success with per-event privacy decisions (omit amount for send/claim, include for swap).
+- Wired into agent runtime in PR-C (sipher#260) — gated on `TORQUE_GROWTH_ENABLED=true`. SENTINEL preflight runs first; Torque emits after.
+- PR-D (this PR) adds the admin endpoint, opt-in integration + e2e test stubs, README, and this seed Friction Log.

--- a/packages/agent/src/integrations/torque/README.md
+++ b/packages/agent/src/integrations/torque/README.md
@@ -7,11 +7,13 @@ Sipher integrates [Torque](https://torque.so) MCP to drive a per-action rebate g
 ```bash
 # In ~/Documents/secret/sipher-vps-secrets.env (or .env for local dev)
 TORQUE_API_KEY=tk_...                                     # From Torque dashboard
-TORQUE_MCP_URL=https://api.torque.so                      # MCP server endpoint
+TORQUE_MCP_URL=<provided via Torque hackathon Telegram group>   # MCP server endpoint — confirmed by @smicktrq in Frontier TG
 TORQUE_CAMPAIGN_ID_DEVNET=camp_dev_xxx                    # Devnet campaign
 TORQUE_CAMPAIGN_ID_MAINNET=camp_main_xxx                  # Mainnet campaign (optional until rollout)
 TORQUE_GROWTH_ENABLED=true                                # Master kill-switch
 ```
+
+> **Note:** `TORQUE_MCP_URL` is TBD pending Torque hackathon Telegram group access. The integration test skip-predicate gates this — tests skip cleanly until the URL is known.
 
 When `TORQUE_GROWTH_ENABLED=false` (default) the entire integration is bypassed cleanly — sipher tools work as before, no events are emitted, no admin endpoint queries Torque.
 
@@ -24,11 +26,18 @@ pnpm --filter @sipher/agent test -- integrations/torque
 # Admin endpoint tests (always run)
 pnpm --filter @sipher/agent test -- routes/admin-torque
 
-# Integration test (opt-in, requires TORQUE_API_KEY + TORQUE_MCP_URL + TORQUE_TEST_CAMPAIGN_ID)
-TORQUE_TEST_CAMPAIGN_ID=$TORQUE_CAMPAIGN_ID_DEVNET pnpm --filter @sipher/agent test -- torque-emit-roundtrip
+# Integration test — opt-in, hits the real Torque devnet API
+TORQUE_API_KEY=tk_... \
+TORQUE_MCP_URL=https://... \
+TORQUE_TEST_CAMPAIGN_ID=$TORQUE_CAMPAIGN_ID_DEVNET \
+pnpm --filter @sipher/agent test -- torque-emit-roundtrip
 
-# E2E test (opt-in, requires devnet keypair + SIP_TEST_DOMAIN)
-SIP_TEST_DOMAIN=therector.sol pnpm --filter @sipher/agent test -- torque-rebate-e2e
+# E2E test — opt-in, requires devnet keypair + published SIP-STEALTH on SIP_TEST_DOMAIN
+TORQUE_API_KEY=tk_... \
+TORQUE_MCP_URL=https://... \
+TORQUE_TEST_CAMPAIGN_ID=$TORQUE_CAMPAIGN_ID_DEVNET \
+SIP_TEST_DOMAIN=therector.sol \
+pnpm --filter @sipher/agent test -- torque-rebate-e2e
 ```
 
 ## Admin endpoint
@@ -41,6 +50,7 @@ SIP_TEST_DOMAIN=therector.sol pnpm --filter @sipher/agent test -- torque-rebate-
   "enabled": true,
   "network": "devnet",
   "campaignId": "camp_devnet_1",
+  "campaignFetchOk": true,
   "campaign": {
     "id": "camp_devnet_1",
     "name": "Sipher Private Action Rebate",

--- a/packages/agent/src/integrations/torque/README.md
+++ b/packages/agent/src/integrations/torque/README.md
@@ -1,0 +1,95 @@
+# Torque MCP Integration
+
+Sipher integrates [Torque](https://torque.so) MCP to drive a per-action rebate growth loop. After every successful private send / swap / claim / drip / batch-send via sipher's agent tools, a `custom_event` is emitted to a Torque campaign that distributes a small SOL/USDC rebate to a fresh stealth address derived from the user's published SNS `SIP-STEALTH` record.
+
+## Setup
+
+```bash
+# In ~/Documents/secret/sipher-vps-secrets.env (or .env for local dev)
+TORQUE_API_KEY=tk_...                                     # From Torque dashboard
+TORQUE_MCP_URL=https://api.torque.so                      # MCP server endpoint
+TORQUE_CAMPAIGN_ID_DEVNET=camp_dev_xxx                    # Devnet campaign
+TORQUE_CAMPAIGN_ID_MAINNET=camp_main_xxx                  # Mainnet campaign (optional until rollout)
+TORQUE_GROWTH_ENABLED=true                                # Master kill-switch
+```
+
+When `TORQUE_GROWTH_ENABLED=false` (default) the entire integration is bypassed cleanly — sipher tools work as before, no events are emitted, no admin endpoint queries Torque.
+
+## Test commands
+
+```bash
+# Unit tests (always run)
+pnpm --filter @sipher/agent test -- integrations/torque
+
+# Admin endpoint tests (always run)
+pnpm --filter @sipher/agent test -- routes/admin-torque
+
+# Integration test (opt-in, requires TORQUE_API_KEY + TORQUE_MCP_URL + TORQUE_TEST_CAMPAIGN_ID)
+TORQUE_TEST_CAMPAIGN_ID=$TORQUE_CAMPAIGN_ID_DEVNET pnpm --filter @sipher/agent test -- torque-emit-roundtrip
+
+# E2E test (opt-in, requires devnet keypair + SIP_TEST_DOMAIN)
+SIP_TEST_DOMAIN=therector.sol pnpm --filter @sipher/agent test -- torque-rebate-e2e
+```
+
+## Admin endpoint
+
+`GET /admin/api/torque/status` returns the current campaign state:
+
+```json
+{
+  "ok": true,
+  "enabled": true,
+  "network": "devnet",
+  "campaignId": "camp_devnet_1",
+  "campaign": {
+    "id": "camp_devnet_1",
+    "name": "Sipher Private Action Rebate",
+    "status": "ACTIVE",
+    "remainingPool": 4.95,
+    "rewardAmountPerEvent": 0.005,
+    "rewardToken": "SOL"
+  }
+}
+```
+
+When `TORQUE_GROWTH_ENABLED=false`:
+
+```json
+{
+  "ok": true,
+  "enabled": false,
+  "reason": "TORQUE_GROWTH_ENABLED is false or required env vars missing"
+}
+```
+
+## Privacy posture
+
+This integration has a known, bounded privacy leak: **Torque learns "wallet X used sipher".**
+
+To attribute actions and route rebates, the Torque MCP server needs the user's public Solana wallet. The recipient of the user's private action stays opaque to Torque (we never send recipient addresses or commitment data). Per-event privacy decisions:
+
+| Event | Wallet sent? | Amount sent? | Recipient sent? |
+|---|---|---|---|
+| `private_send_completed` | yes | **no** | no |
+| `private_swap_completed` | yes | yes (already public on-chain) | no |
+| `private_claim_completed` | yes | no | no |
+| `recurring_send_tick` | yes | no | no |
+| `batch_send_completed` | yes | no | no |
+
+Users who want zero attribution leakage should set `TORQUE_GROWTH_ENABLED=false`.
+
+## Architecture
+
+```
+sipher tool execution → growth-hook → rebate-destination → TorqueMCPClient → Torque MCP server
+                                          │
+                                          └─→ derives a fresh Ed25519 stealth address
+                                              from the user's SNS SIP-STEALTH record
+                                              (via @sip-protocol/sns-stealth@0.1.1)
+```
+
+See `docs/superpowers/specs/2026-05-12-torque-mcp-integration-design.md` for full design.
+
+## Friction Log
+
+`docs/integrations/torque/FRICTION-LOG.md` — live build journal capturing API surprises, doc gaps, and praise during the 2-week Frontier hackathon shadow build.

--- a/packages/agent/src/routes/admin.ts
+++ b/packages/agent/src/routes/admin.ts
@@ -153,6 +153,7 @@ adminRouter.get('/api/torque/status', async (_req, res) => {
     enabled: true,
     network,
     campaignId,
+    campaignFetchOk: campaign !== null,
     campaign,
   })
 })

--- a/packages/agent/src/routes/admin.ts
+++ b/packages/agent/src/routes/admin.ts
@@ -8,6 +8,8 @@ import {
 import { renderLoginPage, renderDashboardPage } from '../views/admin-page.js'
 import type { DashboardStats } from '../views/admin-page.js'
 import { createStore } from '../state/ephemeral.js'
+import { loadTorqueConfig, loadNetworkConfig } from '../config/network.js'
+import { TorqueMCPClient } from '../integrations/torque/mcp-client.js'
 
 export const adminRouter = Router()
 
@@ -119,6 +121,40 @@ adminRouter.get('/dashboard', requireAuth as any, (_req, res) => {
 adminRouter.get('/api/stats', requireAuth as any, (_req, res) => {
   const stats = buildStats()
   ;(res as any).json(stats)
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Torque integration status (no auth required — no sensitive data returned)
+// ─────────────────────────────────────────────────────────────────────────────
+
+adminRouter.get('/api/torque/status', async (_req, res) => {
+  const config = loadTorqueConfig()
+  if (!config) {
+    ;(res as any).status(200).json({
+      ok: true,
+      enabled: false,
+      reason: 'TORQUE_GROWTH_ENABLED is false or required env vars missing',
+    })
+    return
+  }
+
+  const network = loadNetworkConfig().clusterName
+  const campaignId = network === 'mainnet-beta' ? config.campaignIdMainnet : config.campaignIdDevnet
+
+  const client = new TorqueMCPClient({
+    apiKey: config.apiKey,
+    baseUrl: config.baseUrl,
+    campaignId,
+  })
+
+  const campaign = await client.getCampaign()
+  ;(res as any).status(200).json({
+    ok: true,
+    enabled: true,
+    network,
+    campaignId,
+    campaign,
+  })
 })
 
 // Background cleanup is centralized in the ephemeral store (sweep loop +

--- a/packages/agent/tests/integrations/torque/torque-emit-roundtrip.test.ts
+++ b/packages/agent/tests/integrations/torque/torque-emit-roundtrip.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { TorqueMCPClient } from '../../../src/integrations/torque/mcp-client.js'
+import type { SipherGrowthEvent } from '../../../src/integrations/torque/types.js'
+
+const apiKey = process.env.TORQUE_API_KEY
+const baseUrl = process.env.TORQUE_MCP_URL
+const campaignId = process.env.TORQUE_TEST_CAMPAIGN_ID
+
+const skip = !apiKey || !baseUrl || !campaignId
+
+describe.skipIf(skip)('integration: torque devnet emit roundtrip', () => {
+  let client: TorqueMCPClient
+
+  beforeAll(() => {
+    client = new TorqueMCPClient({
+      apiKey: apiKey!,
+      baseUrl: baseUrl!,
+      campaignId: campaignId!,
+    })
+  })
+
+  it('emits a custom_event and receives an eventId', async () => {
+    const event: SipherGrowthEvent = {
+      event: 'sipher.private_send_completed',
+      wallet: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
+      ts: new Date().toISOString(),
+      tx_signature: `test_${Date.now()}`,
+      network: 'devnet',
+      metadata: {
+        rebate_destination: '11111111111111111111111111111111',
+      },
+    }
+
+    const result = await client.emitEvent(event)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.eventId).toMatch(/^evt_/)
+    }
+  }, 15_000)
+})

--- a/packages/agent/tests/integrations/torque/torque-rebate-e2e.test.ts
+++ b/packages/agent/tests/integrations/torque/torque-rebate-e2e.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { Connection, Keypair } from '@solana/web3.js'
+import { readFileSync, existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+
+const KEYPAIR_PATH = `${homedir()}/Documents/secret/solana-devnet.json`
+const TEST_DOMAIN = process.env.SIP_TEST_DOMAIN
+const apiKey = process.env.TORQUE_API_KEY
+const baseUrl = process.env.TORQUE_MCP_URL
+const campaignId = process.env.TORQUE_TEST_CAMPAIGN_ID
+
+const skip = !existsSync(KEYPAIR_PATH) || !TEST_DOMAIN || !apiKey || !baseUrl || !campaignId
+
+describe.skipIf(skip)('e2e: sipher send → torque rebate (devnet)', () => {
+  let connection: Connection
+  let payer: Keypair
+
+  beforeAll(() => {
+    connection = new Connection('https://api.devnet.solana.com', 'confirmed')
+    const secret = JSON.parse(readFileSync(KEYPAIR_PATH, 'utf8'))
+    payer = Keypair.fromSecretKey(new Uint8Array(secret))
+  })
+
+  it('emits event and rebate lands at derived stealth address (STUB — fill in at execution time)', async () => {
+    // STUB — full implementation deferred per plan's self-review (line 1561).
+    // Requires: funded devnet pool + published SIP-STEALTH on SIP_TEST_DOMAIN.
+    //
+    // Implementation order at execution time:
+    //   1. executeSend (real sipher tool) returns { signature, ... }
+    //   2. wrapExecutorWithGrowthHook fires emission
+    //   3. Poll the derived stealth address for ~10s
+    //   4. Assert balance increased by the campaign's rewardAmountPerEvent
+
+    // Silence "unused" warnings for the scaffolded values until implementation lands
+    void connection
+    void payer
+
+    expect(true).toBe(true)
+  }, 60_000)
+})

--- a/packages/agent/tests/routes/admin-torque.test.ts
+++ b/packages/agent/tests/routes/admin-torque.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import express from 'express'
+import supertest from 'supertest'
+
+vi.mock('../../src/integrations/torque/mcp-client.js', () => ({
+  TorqueMCPClient: vi.fn().mockImplementation(() => ({
+    getCampaign: vi.fn().mockResolvedValue({
+      id: 'camp_devnet_1',
+      name: 'Sipher Private Action Rebate',
+      status: 'ACTIVE',
+      remainingPool: 4.95,
+      rewardAmountPerEvent: 0.005,
+      rewardToken: 'SOL',
+    }),
+  })),
+}))
+
+vi.mock('../../src/config/network.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/config/network.js')>()
+  return {
+    ...actual,
+    loadNetworkConfig: vi.fn().mockReturnValue({
+      network: 'devnet',
+      clusterName: 'devnet',
+      rpcUrl: 'https://devnet.helius-rpc.com/?api-key=test',
+      publicRpcUrl: 'https://api.devnet.solana.com',
+      programIds: {
+        sipherVault: 'S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB',
+        sipPrivacy: 'S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at',
+      },
+      vaultConfig: 'CpL4qyHFJYkU5WKdcjTJUu52fYFzjrvHZo4fjPp9T76u',
+      beta: true,
+      solscanSuffix: '?cluster=devnet',
+    }),
+  }
+})
+
+const { adminRouter } = await import('../../src/routes/admin.js')
+
+function createApp() {
+  const app = express()
+  app.use('/admin', adminRouter)
+  return app
+}
+
+describe('GET /admin/api/torque/status', () => {
+  beforeEach(() => {
+    delete process.env.TORQUE_GROWTH_ENABLED
+    delete process.env.TORQUE_API_KEY
+    delete process.env.TORQUE_MCP_URL
+    delete process.env.TORQUE_CAMPAIGN_ID_DEVNET
+    delete process.env.TORQUE_CAMPAIGN_ID_MAINNET
+  })
+
+  it('returns enabled=false when TORQUE_GROWTH_ENABLED is unset', async () => {
+    const res = await supertest(createApp()).get('/admin/api/torque/status')
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({ ok: true, enabled: false })
+    expect(res.body.reason).toMatch(/TORQUE_GROWTH_ENABLED/)
+  })
+
+  it('returns campaign metadata when env enables Torque', async () => {
+    process.env.TORQUE_GROWTH_ENABLED = 'true'
+    process.env.TORQUE_API_KEY = 'tk_test_key'
+    process.env.TORQUE_MCP_URL = 'https://torque.test'
+    process.env.TORQUE_CAMPAIGN_ID_DEVNET = 'camp_devnet_1'
+    process.env.TORQUE_CAMPAIGN_ID_MAINNET = 'camp_main_1'
+
+    const res = await supertest(createApp()).get('/admin/api/torque/status')
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({
+      ok: true,
+      enabled: true,
+      network: 'devnet',
+      campaignId: 'camp_devnet_1',
+      campaign: {
+        id: 'camp_devnet_1',
+        name: 'Sipher Private Action Rebate',
+        status: 'ACTIVE',
+      },
+    })
+  })
+})

--- a/packages/agent/tests/routes/admin-torque.test.ts
+++ b/packages/agent/tests/routes/admin-torque.test.ts
@@ -1,17 +1,20 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import express from 'express'
 import supertest from 'supertest'
 
+// Fixture variable read by the mock — tests override before each request
+let mockCampaignReturn: object | null = {
+  id: 'camp_devnet_1',
+  name: 'Sipher Private Action Rebate',
+  status: 'ACTIVE',
+  remainingPool: 4.95,
+  rewardAmountPerEvent: 0.005,
+  rewardToken: 'SOL',
+}
+
 vi.mock('../../src/integrations/torque/mcp-client.js', () => ({
   TorqueMCPClient: vi.fn().mockImplementation(() => ({
-    getCampaign: vi.fn().mockResolvedValue({
-      id: 'camp_devnet_1',
-      name: 'Sipher Private Action Rebate',
-      status: 'ACTIVE',
-      remainingPool: 4.95,
-      rewardAmountPerEvent: 0.005,
-      rewardToken: 'SOL',
-    }),
+    getCampaign: vi.fn().mockImplementation(() => Promise.resolve(mockCampaignReturn)),
   })),
 }))
 
@@ -50,6 +53,23 @@ describe('GET /admin/api/torque/status', () => {
     delete process.env.TORQUE_MCP_URL
     delete process.env.TORQUE_CAMPAIGN_ID_DEVNET
     delete process.env.TORQUE_CAMPAIGN_ID_MAINNET
+    // Reset fixture to default ACTIVE campaign for each test
+    mockCampaignReturn = {
+      id: 'camp_devnet_1',
+      name: 'Sipher Private Action Rebate',
+      status: 'ACTIVE',
+      remainingPool: 4.95,
+      rewardAmountPerEvent: 0.005,
+      rewardToken: 'SOL',
+    }
+  })
+
+  afterEach(() => {
+    delete process.env.TORQUE_GROWTH_ENABLED
+    delete process.env.TORQUE_API_KEY
+    delete process.env.TORQUE_MCP_URL
+    delete process.env.TORQUE_CAMPAIGN_ID_DEVNET
+    delete process.env.TORQUE_CAMPAIGN_ID_MAINNET
   })
 
   it('returns enabled=false when TORQUE_GROWTH_ENABLED is unset', async () => {
@@ -73,11 +93,34 @@ describe('GET /admin/api/torque/status', () => {
       enabled: true,
       network: 'devnet',
       campaignId: 'camp_devnet_1',
+      campaignFetchOk: true,
       campaign: {
         id: 'camp_devnet_1',
         name: 'Sipher Private Action Rebate',
         status: 'ACTIVE',
       },
+    })
+  })
+
+  it('returns campaignFetchOk=false when getCampaign returns null', async () => {
+    process.env.TORQUE_GROWTH_ENABLED = 'true'
+    process.env.TORQUE_API_KEY = 'tk_test_key'
+    process.env.TORQUE_MCP_URL = 'https://torque.test'
+    process.env.TORQUE_CAMPAIGN_ID_DEVNET = 'camp_devnet_1'
+    process.env.TORQUE_CAMPAIGN_ID_MAINNET = 'camp_main_1'
+
+    // Simulate Torque unreachable or wrong campaign ID
+    mockCampaignReturn = null
+
+    const res = await supertest(createApp()).get('/admin/api/torque/status')
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({
+      ok: true,
+      enabled: true,
+      network: 'devnet',
+      campaignId: 'camp_devnet_1',
+      campaignFetchOk: false,
+      campaign: null,
     })
   })
 })


### PR DESCRIPTION
## Summary

Fourth of 5 PRs implementing the Torque MCP integration per `docs/superpowers/specs/2026-05-12-torque-mcp-integration-design.md`. Adds the operational surface for the upcoming 2-week Frontier hackathon shadow build: admin endpoint, opt-in tests (skip cleanly without env), README with privacy posture disclosure, and Friction Log seed.

## Changes

- `packages/agent/src/routes/admin.ts` (modified) — adds `GET /admin/api/torque/status` route directly on `adminRouter`, returns campaign metadata when enabled, `{ enabled: false, reason }` when disabled
- `packages/agent/src/integrations/torque/README.md` (new) — setup, env vars, test commands, admin endpoint shape, privacy posture (per-event leak matrix), architecture diagram
- `packages/agent/tests/routes/admin-torque.test.ts` (new) — 2 admin tests (disabled / enabled paths), mocks both `TorqueMCPClient` and `loadNetworkConfig` to avoid env throws
- `packages/agent/tests/integrations/torque/torque-emit-roundtrip.test.ts` (new) — opt-in real-Torque test, skips when `TORQUE_TEST_CAMPAIGN_ID` unset
- `packages/agent/tests/integrations/torque/torque-rebate-e2e.test.ts` (new) — opt-in e2e STUB, skips when keypair + `SIP_TEST_DOMAIN` unset; full implementation deferred per plan
- `docs/integrations/torque/FRICTION-LOG.md` (new) — Day-1 seed with the build journey through PR-D

## Test plan

- [x] `pnpm --filter @sipher/agent test` — 1527 passing + 2 skipped (opt-in tests), no regressions
- [x] `pnpm typecheck` — clean

## Deferred to RECTOR / future work

- **Devnet campaign provisioning (plan Step 4.0.2)** — requires Torque hackathon Telegram group access. Captures `TORQUE_TEST_CAMPAIGN_ID` once granted. Opt-in test skip predicate already handles this.
- **E2E test implementation (plan Step 4.3.1)** — STUB only. Full flow (signed devnet send → growth-hook fires → rebate poll → balance assertion) deferred to execution time, requires both devnet pool funding AND published `SIP-STEALTH` record on `SIP_TEST_DOMAIN`.
- **Demo recording + X post (plan Step 4.7)** — RECTOR-driven, post-merge.
- **Mainnet rollout** — PR-E (optional, gated on this PR + 7-day green devnet flow).

## Plan deviation

**Admin router structure:** The plan assumed a factory function pattern (`createTorqueAdminRouter()`) and a new `packages/agent/src/routes/admin/index.ts` sub-router file. The actual codebase uses a single `adminRouter` exported from `admin.ts` with routes added directly. The torque status route is added directly to `adminRouter` at the bottom of `admin.ts` — matching the existing pattern exactly.

**Test file location:** Plan specified `tests/routes/admin/torque.test.ts` (subdirectory). Actual pattern is flat files in `tests/routes/` — placed as `tests/routes/admin-torque.test.ts`.

**`TorqueMCPClient` constructor:** Per adaptation 1, no `network` field passed to `new TorqueMCPClient({...})` anywhere in this PR. The `SipherGrowthEvent.network` field on event payloads is unaffected.