### PR TITLE
test(agent): add afterEach restoreAllMocks in rebate-destination.test.ts

### DIFF
--- a/packages/agent/tests/integrations/torque/rebate-destination.test.ts
+++ b/packages/agent/tests/integrations/torque/rebate-destination.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { Connection } from '@solana/web3.js'
 
 vi.mock('@sip-protocol/sns-stealth', () => ({
@@ -31,6 +31,10 @@ describe('deriveRebateDestination', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     _resetRebateDestinationCacheForTests()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('derives a stealth address from the SNS SIP-STEALTH record when present', async () => {


### PR DESCRIPTION
Closes #259.

## Summary

- Add `afterEach(() => vi.restoreAllMocks())` to the `deriveRebateDestination` describe block in `packages/agent/tests/integrations/torque/rebate-destination.test.ts`.
- Defensive test hygiene — `vi.clearAllMocks()` in `beforeEach` only resets call history; it does not restore spies created via `vi.spyOn(console, 'warn').mockImplementation(...)`.
- Two existing tests stack a `warnSpy` independently. A third test that expects `console.warn` NOT to be called would surface order-dependent failures today.

## Test plan

- [x] `pnpm --filter @sipher/agent test` — 1528 pass / 2 skipped (no delta from main `c28127a`)
- [x] All 5 existing `deriveRebateDestination` tests still green
- [x] No behavior change