### PR TITLE
docs(integrations/torque): reconcile cache claims across spec + README

### DIFF
--- a/docs/superpowers/specs/2026-05-12-torque-mcp-integration-design.md
+++ b/docs/superpowers/specs/2026-05-12-torque-mcp-integration-design.md
@@ -44,13 +44,14 @@ sipher agent (existing)
        Torque Campaign Engine
            │
            ▼
-       Rebate → fresh stealth address derived per-event
+       Rebate → stealth address derived from SNS record
+                (cached 60s per wallet+domain)
 ```
 
 **New module: `packages/agent/src/integrations/torque/`**
 - `mcp-client.ts` — wraps Torque MCP calls (`emit_event`, `get_campaign_status`, `get_campaign`)
 - `growth-hook.ts` — post-success middleware on fund-moving tools
-- `rebate-destination.ts` — derives fresh stealth address per event from user's published meta-address
+- `rebate-destination.ts` — derives stealth address from user's published meta-address (cached 60s per wallet+domain)
 - `types.ts` — event payload + MCP response types
 - `README.md` — setup, env vars, privacy posture disclosure
 - `tests/...` — unit + integration + e2e
@@ -89,7 +90,7 @@ type SipherGrowthEvent = {
   metadata: {
     amount_lamports?: number       // OMITTED for `send`, INCLUDED for `swap`
     asset?: string                 // 'SOL' | 'USDC' | mint address
-    rebate_destination: string     // fresh stealth address
+    rebate_destination: string     // derived stealth address (60s cache per wallet+domain)
   }
 }
 ```
@@ -111,6 +112,7 @@ type SipherGrowthEvent = {
 - Preferred: SNS `SIP-STEALTH` record via `@sip-protocol/sns-stealth@0.1.1` (just shipped today)
 - Fallback: legacy hex stealth meta-address from sipher's existing identity flow
 - Neither available: rebate skipped silently; event still emitted for analytics; log warning ("publish your sip.sol record to claim rebates")
+- Result is cached 60s per `(wallet, domain)` to reduce SNS RPC load. Within that window multiple events from the same wallet rebate to the **same** derived stealth address; this is not a privacy regression because Torque already correlates rebates by wallet on its side, so the 60s reuse adds no new linkage.
 
 This wires sip.sol Phase A-E directly into the Torque growth loop — strong narrative composition for the Friction Log + demo video.
 
@@ -138,7 +140,7 @@ This wires sip.sol Phase A-E directly into the Torque growth loop — strong nar
 
 **Campaign discovery (startup):**
 - On boot, sipher fetches campaign metadata via `TorqueMCPClient.getCampaign(id)`
-- Caches for 5 minutes (mirrors the existing `TorqueReader` cache TTL in sip-app for consistency)
+- No metadata cache today: `getCampaign()` is re-queried per `/admin/api/torque/status` call. Admin is operator-only and rarely hit, so the upstream RPC cost is negligible. Pre-mainnet, add a short-TTL (≤5min) cache here if `status` polling becomes load-bearing for ops dashboards.
 - Failure to fetch ≠ broken sipher. Tools still work; events still emit. Just no rebates land. Logged as warning.
 
 **Env vars (added to sipher's existing config):**

--- a/packages/agent/src/integrations/torque/README.md
+++ b/packages/agent/src/integrations/torque/README.md
@@ -93,9 +93,13 @@ Users who want zero attribution leakage should set `TORQUE_GROWTH_ENABLED=false`
 ```
 sipher tool execution → growth-hook → rebate-destination → TorqueMCPClient → Torque MCP server
                                           │
-                                          └─→ derives a fresh Ed25519 stealth address
-                                              from the user's SNS SIP-STEALTH record
-                                              (via @sip-protocol/sns-stealth@0.1.1)
+                                          └─→ derives an Ed25519 stealth address from the
+                                              user's SNS SIP-STEALTH record
+                                              (via @sip-protocol/sns-stealth@0.1.1),
+                                              cached 60s per (wallet, domain) to reduce
+                                              SNS RPC load — within that window multiple
+                                              events from the same wallet rebate to the
+                                              same derived address
 ```
 
 See `docs/superpowers/specs/2026-05-12-torque-mcp-integration-design.md` for full design.


### PR DESCRIPTION
Closes #263.

## Summary

The post-PR-D review surfaced a 5min-vs-60s cache drift between the spec and the implementation. The drift was deeper than the issue described — two distinct caches were conflated:

| Cache | Spec said | Code does | Resolution |
|---|---|---|---|
| Campaign metadata (`getCampaign()`) | "Caches for 5 minutes" | **No cache** — re-queried per `/admin/api/torque/status` call | Spec rewritten to describe reality + add a note to revisit pre-mainnet if admin polling becomes load-bearing |
| Rebate destination SNS lookup | (not mentioned) | 60s TTL per `(wallet, domain)` in `rebate-destination.ts:15` | Spec gains a bullet under "Rebate destination derivation" documenting the 60s TTL + privacy posture |

## What changed

- `docs/superpowers/specs/2026-05-12-torque-mcp-integration-design.md`:
  - Architecture box: `Rebate → fresh stealth address derived per-event` → `Rebate → stealth address derived from SNS record (cached 60s per wallet+domain)`
  - Module table: `rebate-destination.ts — derives fresh stealth address per event` → `derives stealth address from user's published meta-address (cached 60s per wallet+domain)`
  - Event payload comment: `rebate_destination: string     // fresh stealth address` → `// derived stealth address (60s cache per wallet+domain)`
  - "Rebate destination derivation" section: added cache + privacy-posture bullet
  - "Campaign discovery" section: dropped the false 5-min cache claim, replaced with a truthful "no cache today + pre-mainnet revisit" note
- `packages/agent/src/integrations/torque/README.md`:
  - Architecture diagram comment expanded to call out the 60s `(wallet, domain)` cache instead of saying "fresh"

## Test plan

- [x] No code change → no test impact
- [x] Spec + README still render correctly (no markdown formatting drift)
- [x] Rebate-destination test name `"caches resolution per wallet+domain for 60s"` already matches the now-documented 60s TTL — no test rename needed

## Why prefer 60s over bumping code to 5min

- The cached value is the derived stealth address. Within the cache window, multiple events from the same wallet rebate to the same address — privacy regression scales with TTL.
- Torque already correlates by wallet on its side, so the linkage exists regardless of TTL — but a longer TTL means more on-chain rebate TXs share the same recipient, which slightly weakens block-explorer plausible-deniability for users who fast-fire multiple actions.
- 60s is enough to absorb the realistic "user clicks send → swap → claim in 30 seconds" burst pattern without doing 3 SNS lookups, and short enough that the address rotates on the next user session.