### PR TITLE
test(agent): add TorqueMCPClient.getCampaign coverage

### DIFF
--- a/packages/agent/tests/integrations/torque/mcp-client.test.ts
+++ b/packages/agent/tests/integrations/torque/mcp-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { TorqueMCPClient } from '../../../src/integrations/torque/mcp-client.js'
-import type { SipherGrowthEvent } from '../../../src/integrations/torque/types.js'
+import type { SipherGrowthEvent, TorqueCampaign } from '../../../src/integrations/torque/types.js'
 
 const baseEvent: SipherGrowthEvent = {
   event: 'sipher.private_send_completed',
@@ -115,5 +115,124 @@ describe('TorqueMCPClient.emitEvent error paths', () => {
     const client = clientWithMockedFetch(200, { status: 'SUCCESS', data: {} })
     const result = await client.emitEvent(baseEvent)
     expect(result).toStrictEqual({ ok: false, reason: 'unknown', message: expect.stringMatching(/missing eventId/) })
+  })
+})
+
+describe('TorqueMCPClient.getCampaign', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  const campaign: TorqueCampaign = {
+    id: 'camp_devnet_1',
+    name: 'Sipher Private Action Rebate',
+    status: 'ACTIVE',
+    remainingPool: 4.95,
+    rewardAmountPerEvent: 0.005,
+    rewardToken: 'SOL',
+  }
+
+  it('GETs /campaigns/:id with x-torque-api-key header and returns campaign on SUCCESS', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ status: 'SUCCESS', data: campaign }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const client = new TorqueMCPClient({
+      baseUrl: 'https://torque.test',
+      apiKey: 'tk_secret',
+      campaignId: 'camp_devnet_1',
+    })
+
+    const result = await client.getCampaign()
+
+    expect(result).toStrictEqual(campaign)
+    expect(fetchSpy).toHaveBeenCalledOnce()
+    const [url, init] = fetchSpy.mock.calls[0]!
+    expect(url).toBe('https://torque.test/campaigns/camp_devnet_1')
+    // GET is the default; the client passes no `method`, so init.method is undefined
+    expect(init?.method).toBeUndefined()
+    expect(init?.headers).toMatchObject({ 'x-torque-api-key': 'tk_secret' })
+    expect(init?.body).toBeUndefined()
+  })
+
+  it('returns null on non-ok HTTP (404)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 404 }))
+    const client = new TorqueMCPClient({
+      baseUrl: 'https://torque.test',
+      apiKey: 'tk_secret',
+      campaignId: 'camp_missing',
+    })
+    const result = await client.getCampaign()
+    expect(result).toBeNull()
+  })
+
+  it('returns null on non-ok HTTP (500)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 500 }))
+    const client = new TorqueMCPClient({
+      baseUrl: 'https://torque.test',
+      apiKey: 'tk_secret',
+      campaignId: 'camp_devnet_1',
+    })
+    const result = await client.getCampaign()
+    expect(result).toBeNull()
+  })
+
+  it('returns null when response envelope is not SUCCESS', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ status: 'ERROR', data: campaign }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    const client = new TorqueMCPClient({
+      baseUrl: 'https://torque.test',
+      apiKey: 'tk_secret',
+      campaignId: 'camp_devnet_1',
+    })
+    const result = await client.getCampaign()
+    expect(result).toBeNull()
+  })
+
+  it('returns null when SUCCESS envelope has no data field', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ status: 'SUCCESS' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    const client = new TorqueMCPClient({
+      baseUrl: 'https://torque.test',
+      apiKey: 'tk_secret',
+      campaignId: 'camp_devnet_1',
+    })
+    const result = await client.getCampaign()
+    expect(result).toBeNull()
+  })
+
+  it('returns null and does not propagate when fetch throws', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'))
+    const client = new TorqueMCPClient({
+      baseUrl: 'https://torque.test',
+      apiKey: 'tk_secret',
+      campaignId: 'camp_devnet_1',
+    })
+    await expect(client.getCampaign()).resolves.toBeNull()
+  })
+
+  it('strips trailing slashes from baseUrl', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ status: 'SUCCESS', data: campaign }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    const client = new TorqueMCPClient({
+      baseUrl: 'https://torque.test///',
+      apiKey: 'tk_secret',
+      campaignId: 'camp_devnet_1',
+    })
+    await client.getCampaign()
+    expect(fetchSpy.mock.calls[0]![0]).toBe('https://torque.test/campaigns/camp_devnet_1')
   })
 })


### PR DESCRIPTION
Closes #257.

## Summary

PR-A's `mcp-client.test.ts` covered `emitEvent` only (1 happy + 8 error paths) and left `getCampaign` with zero tests, even though `routes/admin.ts:150` depends on it via `GET /admin/api/torque/status` and a regression at the PR-C integration point would be invisible.

## What's covered

| # | Case | Assertion |
|---|---|---|
| 1 | Happy path — 200 + `{ status: 'SUCCESS', data }` | Returns campaign + URL = `\${baseUrl}/campaigns/\${campaignId}` + `x-torque-api-key` header forwarded + GET (no method override) + no body |
| 2 | Non-ok HTTP — 404 | Returns null |
| 3 | Non-ok HTTP — 500 | Returns null |
| 4 | 200 + `{ status: 'ERROR' }` envelope | Returns null |
| 5 | 200 + `{ status: 'SUCCESS' }` with no `data` field | Returns null |
| 6 | fetch throws | Returns null without propagating |
| 7 | Trailing slashes on baseUrl | Stripped before URL is built |

Cases 1–4 + 6 are the minimum requested in the issue. 5 + 7 are defensive extras that mirror the existing `emitEvent` test posture and tighten the statement/branch coverage on `mcp-client.ts:62-76`.

## Test plan

- [x] `pnpm --filter @sipher/agent test` — 1528 → **1535 pass / 2 skipped** (+7)
- [x] All existing `emitEvent` happy + error tests still green