### PR TITLE
feat(agent): guard empty campaignId in growth-hook emission

### DIFF
--- a/packages/agent/src/integrations/torque/growth-hook.ts
+++ b/packages/agent/src/integrations/torque/growth-hook.ts
@@ -33,6 +33,17 @@ export function wrapExecutorWithGrowthHook(
     return baseExecutor
   }
 
+  // Without a campaign ID the client would POST to https://.../campaigns//events
+  // (note the double slash) — Torque returns 404 and the error envelope swallows
+  // it silently. Bail out loudly instead so misconfigured envs are visible.
+  if (!opts.campaignId || !opts.campaignId.trim()) {
+    const envVar = opts.network === 'mainnet-beta' ? 'TORQUE_CAMPAIGN_ID_MAINNET' : 'TORQUE_CAMPAIGN_ID_DEVNET'
+    console.warn(
+      `[torque] no campaign ID for network=${opts.network} — growth-hook disabled. Set ${envVar} to enable rebate emission.`,
+    )
+    return baseExecutor
+  }
+
   const client = new TorqueMCPClient(opts)
 
   return async (name, input) => {

--- a/packages/agent/tests/integrations/torque/growth-hook.test.ts
+++ b/packages/agent/tests/integrations/torque/growth-hook.test.ts
@@ -160,4 +160,61 @@ describe('wrapExecutorWithGrowthHook', () => {
 
     expect(emitEventMock).not.toHaveBeenCalled()
   })
+
+  it('returns the base executor (no client construction, no emit) when campaignId is empty', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    baseExecutor.mockResolvedValue({ action: 'send', status: 'confirmed', signature: TX_SIG })
+
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, { ...opts, campaignId: '' })
+
+    await wrapped('send', { wallet: WALLET, amount: 1, token: 'SOL', recipient: 'rector.sol' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(TorqueMCPClient).not.toHaveBeenCalled()
+    expect(emitEventMock).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('no campaign ID for network=devnet'),
+    )
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('TORQUE_CAMPAIGN_ID_DEVNET'),
+    )
+    warnSpy.mockRestore()
+  })
+
+  it('treats a whitespace-only campaignId as empty', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    baseExecutor.mockResolvedValue({ action: 'send', status: 'confirmed', signature: TX_SIG })
+
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, { ...opts, campaignId: '   ' })
+
+    await wrapped('send', { wallet: WALLET, amount: 1, token: 'SOL', recipient: 'rector.sol' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(TorqueMCPClient).not.toHaveBeenCalled()
+    expect(emitEventMock).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('names the mainnet env var in the warning when network=mainnet-beta', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    baseExecutor.mockResolvedValue({ action: 'send', status: 'confirmed', signature: TX_SIG })
+
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, {
+      ...opts,
+      campaignId: '',
+      network: 'mainnet-beta',
+    })
+
+    await wrapped('send', { wallet: WALLET, amount: 1, token: 'SOL', recipient: 'rector.sol' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('TORQUE_CAMPAIGN_ID_MAINNET'),
+    )
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('network=mainnet-beta'),
+    )
+    warnSpy.mockRestore()
+  })
 })


### PR DESCRIPTION
Closes #264.

## Symptom

Surfaced by the post-PR-D holistic review. If `TORQUE_GROWTH_ENABLED=true` and `TORQUE_API_KEY` + `TORQUE_MCP_URL` are set but `TORQUE_CAMPAIGN_ID_<NETWORK>` is empty:
- `loadTorqueConfig()` still returned a usable config (campaign IDs default to `''` via `?? ''`)
- `wrapExecutorWithGrowthHook` constructed a `TorqueMCPClient` with `campaignId: ''`
- `emitEvent` POSTed to `https://<baseUrl>/campaigns//events` (double-slash)
- Torque returns 404, error envelope catches it as `{ ok: false, reason: 'unknown' }`
- Event drops silently with no operator-visible warning

## Fix

Guard inside `wrapExecutorWithGrowthHook`, after the `growthEnabled` check and before `TorqueMCPClient` construction:

```ts
if (!opts.campaignId || !opts.campaignId.trim()) {
  const envVar = opts.network === 'mainnet-beta' ? 'TORQUE_CAMPAIGN_ID_MAINNET' : 'TORQUE_CAMPAIGN_ID_DEVNET'
  console.warn(`[torque] no campaign ID for network=\${opts.network} — growth-hook disabled. Set \${envVar} to enable rebate emission.`)
  return baseExecutor
}
```

Whitespace-only campaign IDs are treated as empty (env-file values often carry stray padding).

## Why the chokepoint and not `loadTorqueConfig()`

Both approaches were called out in the issue. Chose the chokepoint because:

- `loadTorqueConfig()` doesn't know the active network — that decision lives at the `agent.ts` call sites (`chat` + `chatStream`)
- The chokepoint covers both call sites without duplication
- A future `SIPHER_NETWORK` rotation between `chat()` calls is handled correctly

## Test plan

- [x] `pnpm --filter @sipher/agent test` — 1528 → **1531 pass / 2 skipped** (+3)
- [x] `pnpm typecheck` — clean
- [x] Existing `does NOT emit when growthEnabled=false` test still passes (guard order: `growthEnabled` is checked first)

New tests under `wrapExecutorWithGrowthHook`:

| Case | Asserts |
|---|---|
| Empty string `campaignId` | No `TorqueMCPClient` construction, no emit, warning names `TORQUE_CAMPAIGN_ID_DEVNET` |
| Whitespace-only `campaignId` (`'   '`) | Same as empty |
| `network: 'mainnet-beta'` | Warning names `TORQUE_CAMPAIGN_ID_MAINNET` instead |

## Related

- #262 — signature callback gap (separate, higher-priority blocker for the demo)