### PR TITLE
feat(agent): rewrite Torque integration for canonical ingest contract (PR-E)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,8 +106,14 @@ SIPHER_NETWORK=devnet
 # ───────────────────────────────────────────
 # Torque MCP integration (growth loops via Frontier hackathon track)
 # ───────────────────────────────────────────
-TORQUE_API_KEY=
-TORQUE_MCP_URL=
-TORQUE_CAMPAIGN_ID_DEVNET=
-TORQUE_CAMPAIGN_ID_MAINNET=
+# Project-scoped event-ingest API key from platform.torque.so/developer
+# (one-time view at creation — save immediately, rotate via dashboard if lost).
+TORQUE_API_TOKEN=
+
+# Optional — defaults to the production ingester. Override only for
+# staging/test deployments.
+TORQUE_INGESTER_URL=https://ingest.torque.so
+
+# Master kill-switch — set to 'true' to enable post-success event emission
+# after fund-moving sipher tool calls (send/swap/claim/drip/splitSend).
 TORQUE_GROWTH_ENABLED=false

--- a/docs/integrations/torque/FRICTION-LOG.md
+++ b/docs/integrations/torque/FRICTION-LOG.md
@@ -31,3 +31,27 @@ _To be filled. Q&A with @smicktrq during build, with timestamps. Signals real en
 - Growth-hook middleware shipped in PR-B (sipher#258) — fires `custom_events` post-success with per-event privacy decisions (omit amount for send/claim, include for swap).
 - Wired into agent runtime in PR-C (sipher#260) — gated on `TORQUE_GROWTH_ENABLED=true`. SENTINEL preflight runs first; Torque emits after.
 - PR-D (this PR) adds the admin endpoint, opt-in integration + e2e test stubs, README, and this seed Friction Log.
+
+---
+
+## Day 2 — 2026-05-13 (canonical contract probe + rewrite)
+
+### What broke
+
+- **2026-05-12 — Spec built on dashboard assumptions, not live contract.** PR-A through PR-D shipped against `server.torque.so/campaigns/{id}/events` with `x-torque-api-key` header and nested `{event, wallet, ts, metadata: {...}}` body. None of those matched reality. The actual contract is `POST ingest.torque.so/events` with `x-api-key` header and flat `{userPubkey, timestamp, eventName, data}` body. The error was assuming Torque's REST surface mirrored a "campaign" mental model when in fact Torque uses Queries + Incentives + Lists, never a Campaign object.
+- **2026-05-12 — `TORQUE_CAMPAIGN_ID_*` env vars don't exist in Torque's API.** The Custom Event Provider data source binds events to a project by the `x-api-key` header alone (the API key is project-scoped). No campaign UUID in the URL, no `campaignId` in the body. Wasted ~15 lines of code on a non-existent concept.
+- **2026-05-12 — Torque AI wizard hangs.** Three separate attempts to use Torque's "Create with AI" Incentive setup wizard all stalled with "Taking longer than expected..." past 70 seconds. Conclusion: AI dialog is only useful for design discussion, not for actual creation. Direct API or manual form fill required.
+
+### What was confusing
+
+- **2026-05-12 — Three Torque hosts, similar names.** `server.torque.so` (CRUD), `platform.torque.so` (dashboard UI + small internal API), `ingest.torque.so` (events), `ai.torque.so` (AI features). Distinct purposes, similar TLD prefixes — easy to test against the wrong one and get cryptic 404s. The official `@torque-labs/mcp@0.4.7` npm package source code (`dist/index.js`) was the cleanest source for the host map, not the public docs.
+
+### What we'd improve
+
+- **Surface the canonical ingest contract in the public Torque docs.** Right now the only authoritative source is the `@torque-labs/mcp` npm package source. A documented request shape (`{userPubkey, timestamp, eventName, data}`) with server-schema error examples would have saved ~half a day.
+- **Document the mainnet-only constraint for pool funding.** The "devnet first" shadow-testing pattern is widespread in Solana dev practice; surfacing that pool funding requires mainnet earlier would have changed our deployment design upfront.
+
+### What worked well
+
+- **`@torque-labs/mcp` npm package as ground truth.** The published MCP server source carries inline help-text like "`userPubkey` and `timestamp` are required top-level properties on every event" — exactly the missing prose from the public docs. Reading the source confirmed the entire contract in 15 minutes.
+- **Server schema errors are gold for tests.** Torque returns `400 {"status":"BAD_REQUEST","message":"body/eventName Required, body/data Required"}` — the message names the missing fields. We snapshot these as test fixtures: `event_undefined` reason when 400 message contains "Event not found", `validation` reason otherwise. This kept the test suite anchored to real server behavior.

--- a/docs/integrations/torque/FRICTION-LOG.md
+++ b/docs/integrations/torque/FRICTION-LOG.md
@@ -45,6 +45,7 @@ _To be filled. Q&A with @smicktrq during build, with timestamps. Signals real en
 ### What was confusing
 
 - **2026-05-12 — Three Torque hosts, similar names.** `server.torque.so` (CRUD), `platform.torque.so` (dashboard UI + small internal API), `ingest.torque.so` (events), `ai.torque.so` (AI features). Distinct purposes, similar TLD prefixes — easy to test against the wrong one and get cryptic 404s. The official `@torque-labs/mcp@0.4.7` npm package source code (`dist/index.js`) was the cleanest source for the host map, not the public docs.
+- **2026-05-12 — Dashboard onboarding required starting over with a fresh account.** RECTOR initially signed in to platform.torque.so with his default Phantom wallet (`HciZTd6rR7YsaS5ZNThx9KdgqSimxwMzJgs2j98U25En`) and reached the "Create a Project" step. Then realized: Torque has no account merge or transfer flow — whichever wallet creates the project owns it forever. Pivoted to `cipher-admin` (`C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N`, vanity `C1phr...` matching sipher's brand), imported it into Phantom via base58, reconnected, started the onboarding from scratch. The `HciZTd` account on Torque is orphaned (no project, no API key, no campaign — safe to abandon). Also surprising: Torque project IDs use the prefix `cmp` + 24-char nanoid (e.g., `cmp2as15d05pnk01hiyuf7208`), NOT `camp_xxx` as our original spec assumed. And the API key is one-time-view at creation — losing it requires rotation, not retrieval. We saved ours to `~/Documents/secret/sipher-vps-secrets.env` immediately.
 
 ### What we'd improve
 

--- a/docs/superpowers/plans/2026-05-12-torque-canonical-ingest-rewrite.md
+++ b/docs/superpowers/plans/2026-05-12-torque-canonical-ingest-rewrite.md
@@ -1,0 +1,966 @@
+# PR-E: Torque Canonical Ingest Contract Rewrite Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite Sipher's Torque MCP integration to use Torque's canonical ingest contract — `POST ingest.torque.so/events` with `x-api-key` header, flattened `{userPubkey, timestamp, eventName, data}` body shape, and underscored event slugs. Drop the campaign-related env vars since Torque has no Campaign primitive.
+
+**Architecture:** Single bundled PR touching: `types.ts` (flatten + rename), `mcp-client.ts` (URL/header/body), `growth-hook.ts` (event construction), `config/network.ts` (env rename, drop campaign vars), `routes/admin.ts` (replace `campaignFetchOk` with ingester reachability probe), `agent.ts` (drop campaignId from call sites), tests for each, plus README + spec + Friction Log sync. Branch: `feat/torque-canonical-ingest` from `main` at `b6b1e37`.
+
+**Tech Stack:** TypeScript 2-space no-semicolons ESM (`.js` extensions on relative imports), Vitest, fetch API, conventional commit prefixes, GPG-signed commits.
+
+---
+
+## File Structure
+
+**Source files (modify):**
+- `packages/agent/src/integrations/torque/types.ts` — flatten `SipherGrowthEvent`, rename slugs to underscore form, drop campaign types
+- `packages/agent/src/integrations/torque/mcp-client.ts` — rewrite URL/header/body, replace `getCampaign()` with `pingIngester()`
+- `packages/agent/src/integrations/torque/growth-hook.ts` — rewrite event construction; drop `campaignId` from `GrowthHookOptions`
+- `packages/agent/src/integrations/torque/README.md` — sync env names, slug list, dashboard prerequisites
+- `packages/agent/src/config/network.ts` — rename `TorqueConfig` fields, drop `campaignId{Devnet,Mainnet}`
+- `packages/agent/src/routes/admin.ts:130-159` — replace `getCampaign` with `pingIngester`; drop `campaignId` field from response
+- `packages/agent/src/agent.ts:321-336, 448-462` — drop `campaignId` argument; align with new `loadTorqueConfig` shape
+
+**Test files (modify):**
+- `packages/agent/tests/integrations/torque/mcp-client.test.ts` — assert new URL/header/body/error envelopes
+- `packages/agent/tests/integrations/torque/growth-hook.test.ts` — assert new emitted event shape
+- `packages/agent/tests/config/network-torque.test.ts` — assert new env var names + dropped campaign vars
+
+**Doc files (modify):**
+- `docs/superpowers/specs/2026-05-12-torque-mcp-integration-design.md` — sync the contract section
+- `docs/integrations/torque/FRICTION-LOG.md` — append discovery entries from the dashboard probe + rewrite
+
+---
+
+## Task 1: Sync the spec with the locked canonical contract
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-12-torque-mcp-integration-design.md`
+
+- [ ] **Step 1: Read the current spec**
+
+Run: `wc -l docs/superpowers/specs/2026-05-12-torque-mcp-integration-design.md`
+Then `Read` the file to find the sections describing endpoint URL, headers, event payload shape, env vars, and event slugs.
+
+- [ ] **Step 2: Patch the endpoint contract section**
+
+Replace any mention of `${baseUrl}/campaigns/${campaignId}/events` with `${ingesterUrl}/events`. Replace `x-torque-api-key` header references with `x-api-key`. Replace nested `{event, wallet, ts, metadata: {...}}` body example with the new flat `{userPubkey, timestamp, eventName, data: {...}}` shape. The data sub-object is a flat map of string|number|boolean only.
+
+- [ ] **Step 3: Patch the env vars section**
+
+Rename `TORQUE_API_KEY` → `TORQUE_API_TOKEN`. Rename `TORQUE_MCP_URL` → `TORQUE_INGESTER_URL`. Delete any reference to `TORQUE_CAMPAIGN_ID_DEVNET` and `TORQUE_CAMPAIGN_ID_MAINNET` — Torque has no Campaign primitive.
+
+- [ ] **Step 4: Patch the slug list**
+
+Rename event slugs to underscore form everywhere in the spec:
+- `sipher.private_send_completed` → `sipher_private_send_completed`
+- `sipher.private_swap_completed` → `sipher_private_swap_completed`
+- `sipher.private_claim_completed` → `sipher_private_claim_completed`
+- `sipher.recurring_send_tick` → `sipher_recurring_send_tick`
+- `sipher.batch_send_completed` → `sipher_batch_send_completed`
+
+- [ ] **Step 5: Add a "Discovery + rewrite" addendum section at the end of the spec**
+
+Document the four-host architecture (`server.torque.so` CRUD, `platform.torque.so` UI, `ingest.torque.so` events, `ai.torque.so` AI), the Torque primitives (`IncentiveType: REBATE`, `EventDataSource: CUSTOM_EVENT_PROVIDER`), and the mainnet-only constraint for pool funding and reward distribution (event ingestion is network-agnostic).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git checkout -b feat/torque-canonical-ingest
+git add docs/superpowers/specs/2026-05-12-torque-mcp-integration-design.md
+git commit -m "docs(torque): sync spec with canonical ingest contract + four-host architecture"
+```
+
+---
+
+## Task 2: Rewrite `types.ts` + `mcp-client.ts` + their tests as one atomic change
+
+These three files are coupled — the type rename forces the client + tests to update together. Done in one TDD cycle.
+
+**Files:**
+- Modify: `packages/agent/src/integrations/torque/types.ts` (full rewrite)
+- Modify: `packages/agent/src/integrations/torque/mcp-client.ts` (full rewrite)
+- Modify: `packages/agent/src/integrations/torque/index.ts` (drop `TorqueCampaign`, add `TorquePingResult`)
+- Modify: `packages/agent/tests/integrations/torque/mcp-client.test.ts` (full rewrite)
+
+- [ ] **Step 1: Write the new `types.ts`**
+
+Replace the entire file contents with:
+
+```typescript
+/**
+ * Event emitted to Torque ingest after a successful fund-moving sipher tool call.
+ * Shape mirrors Torque's canonical ingest contract — flat top-level fields
+ * with a `data` sub-object whose values are string|number|boolean only.
+ *
+ * userPubkey is required for attribution. `data.rebate_destination` carries
+ * the per-event fresh stealth address so Torque cannot learn the recipient
+ * identity.
+ */
+export interface SipherGrowthEvent {
+  userPubkey: string
+  /** ms-epoch number, NOT ISO string */
+  timestamp: number
+  eventName: SipherEventName
+  data: SipherGrowthEventData
+}
+
+export interface SipherGrowthEventData {
+  tx_signature: string
+  network: 'mainnet-beta' | 'devnet'
+  rebate_destination: string
+  /** Present only on swap events for amount attribution */
+  amount_lamports?: number
+  /** Present only on swap events */
+  asset?: string
+}
+
+export type SipherEventName =
+  | 'sipher_private_send_completed'
+  | 'sipher_private_swap_completed'
+  | 'sipher_private_claim_completed'
+  | 'sipher_recurring_send_tick'
+  | 'sipher_batch_send_completed'
+
+export interface TorqueMCPClientOptions {
+  ingesterUrl: string
+  apiToken: string
+  /** ms; default 8000 */
+  timeoutMs?: number
+}
+
+export type TorqueEmitResult =
+  | { ok: true }
+  | { ok: false; reason: 'auth' | 'rate_limit' | 'network' | 'event_undefined' | 'validation' | 'unknown'; message: string }
+
+export type TorquePingResult =
+  | { ok: true }
+  | { ok: false; reason: 'auth' | 'network' | 'unknown'; message: string }
+```
+
+- [ ] **Step 2: Write the new `mcp-client.ts`**
+
+Replace the entire file contents with:
+
+```typescript
+import type {
+  SipherGrowthEvent,
+  TorqueEmitResult,
+  TorqueMCPClientOptions,
+  TorquePingResult,
+} from './types.js'
+
+const DEFAULT_TIMEOUT_MS = 8000
+
+export class TorqueMCPClient {
+  private readonly ingesterUrl: string
+  private readonly apiToken: string
+  private readonly timeoutMs: number
+
+  constructor(opts: TorqueMCPClientOptions) {
+    this.ingesterUrl = opts.ingesterUrl.replace(/\/+$/, '')
+    this.apiToken = opts.apiToken
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  }
+
+  async emitEvent(event: SipherGrowthEvent): Promise<TorqueEmitResult> {
+    const url = `${this.ingesterUrl}/events`
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': this.apiToken,
+        },
+        body: JSON.stringify(event),
+        signal: AbortSignal.timeout(this.timeoutMs),
+      })
+      if (response.status === 401 || response.status === 403) {
+        return { ok: false, reason: 'auth', message: `Torque rejected api token (${response.status})` }
+      }
+      if (response.status === 429) {
+        return { ok: false, reason: 'rate_limit', message: 'Torque rate limit hit' }
+      }
+      if (response.status === 400) {
+        const body = (await response.json().catch(() => null)) as { message?: string } | null
+        const message = body?.message ?? 'Torque returned 400'
+        if (/Event not found/i.test(message)) {
+          return { ok: false, reason: 'event_undefined', message }
+        }
+        return { ok: false, reason: 'validation', message }
+      }
+      if (!response.ok) {
+        return { ok: false, reason: 'unknown', message: `Torque returned ${response.status}` }
+      }
+      return { ok: true }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return { ok: false, reason: 'network', message }
+    }
+  }
+
+  /**
+   * Reachability ping for ops/admin visibility. POSTs an empty body and treats
+   * any 4xx/2xx as reachable (server is up). Network errors → not reachable.
+   */
+  async pingIngester(): Promise<TorquePingResult> {
+    const url = `${this.ingesterUrl}/events`
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': this.apiToken,
+        },
+        body: '{}',
+        signal: AbortSignal.timeout(this.timeoutMs),
+      })
+      if (response.status === 401 || response.status === 403) {
+        return { ok: false, reason: 'auth', message: `Torque rejected api token (${response.status})` }
+      }
+      // Any other response (including 400 schema rejection) means the host is reachable.
+      return { ok: true }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return { ok: false, reason: 'network', message }
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Write the new `mcp-client.test.ts`**
+
+Replace the entire file contents with:
+
+```typescript
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { TorqueMCPClient } from '../../../src/integrations/torque/mcp-client.js'
+import type { SipherGrowthEvent } from '../../../src/integrations/torque/types.js'
+
+const baseEvent: SipherGrowthEvent = {
+  userPubkey: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
+  timestamp: 1747068000000,
+  eventName: 'sipher_private_send_completed',
+  data: {
+    tx_signature: '3QCoHcJ1NNg',
+    network: 'devnet',
+    rebate_destination: '4HC3vQB5s5c',
+  },
+}
+
+describe('TorqueMCPClient.emitEvent', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('POSTs the event with x-api-key header to /events with flat body', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ status: 'OK' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const client = new TorqueMCPClient({
+      ingesterUrl: 'https://ingest.torque.test',
+      apiToken: 'tk_secret',
+    })
+
+    const result = await client.emitEvent(baseEvent)
+
+    expect(result).toStrictEqual({ ok: true })
+    expect(fetchSpy).toHaveBeenCalledOnce()
+    const [url, init] = fetchSpy.mock.calls[0]!
+    expect(url).toBe('https://ingest.torque.test/events')
+    expect(init?.method).toBe('POST')
+    expect(init?.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      'x-api-key': 'tk_secret',
+    })
+    expect(JSON.parse(init?.body as string)).toStrictEqual(baseEvent)
+  })
+
+  it('strips trailing slash from ingesterUrl', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ status: 'OK' }), { status: 200 }),
+    )
+
+    const client = new TorqueMCPClient({
+      ingesterUrl: 'https://ingest.torque.test/',
+      apiToken: 'tk_secret',
+    })
+
+    await client.emitEvent(baseEvent)
+    expect(fetchSpy.mock.calls[0]![0]).toBe('https://ingest.torque.test/events')
+  })
+})
+
+describe('TorqueMCPClient.emitEvent error paths', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  function clientWithMockedFetch(status: number, body: object | string = ''): TorqueMCPClient {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(typeof body === 'string' ? body : JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+    return new TorqueMCPClient({
+      ingesterUrl: 'https://ingest.torque.test',
+      apiToken: 'tk_secret',
+    })
+  }
+
+  it('returns auth reason on 401', async () => {
+    const client = clientWithMockedFetch(401)
+    const result = await client.emitEvent({
+      userPubkey: 'C1phr',
+      timestamp: 1747068000000,
+      eventName: 'sipher_private_send_completed',
+      data: { tx_signature: 's', network: 'devnet', rebate_destination: 'r' },
+    })
+    expect(result).toStrictEqual({ ok: false, reason: 'auth', message: expect.stringMatching(/401/) })
+  })
+
+  it('returns auth reason on 403', async () => {
+    const client = clientWithMockedFetch(403)
+    const result = await client.emitEvent({
+      userPubkey: 'C1phr',
+      timestamp: 1747068000000,
+      eventName: 'sipher_private_send_completed',
+      data: { tx_signature: 's', network: 'devnet', rebate_destination: 'r' },
+    })
+    expect(result).toStrictEqual({ ok: false, reason: 'auth', message: expect.stringMatching(/403/) })
+  })
+
+  it('returns rate_limit reason on 429', async () => {
+    const client = clientWithMockedFetch(429)
+    const result = await client.emitEvent({
+      userPubkey: 'C1phr',
+      timestamp: 1747068000000,
+      eventName: 'sipher_private_send_completed',
+      data: { tx_signature: 's', network: 'devnet', rebate_destination: 'r' },
+    })
+    expect(result).toStrictEqual({ ok: false, reason: 'rate_limit', message: expect.stringMatching(/rate limit/i) })
+  })
+
+  it('returns event_undefined reason when 400 says "Event not found"', async () => {
+    const client = clientWithMockedFetch(400, { status: 'BAD_REQUEST', message: 'Event not found for this API key' })
+    const result = await client.emitEvent({
+      userPubkey: 'C1phr',
+      timestamp: 1747068000000,
+      eventName: 'sipher_private_send_completed',
+      data: { tx_signature: 's', network: 'devnet', rebate_destination: 'r' },
+    })
+    expect(result).toStrictEqual({
+      ok: false,
+      reason: 'event_undefined',
+      message: 'Event not found for this API key',
+    })
+  })
+
+  it('returns validation reason for other 400 errors', async () => {
+    const client = clientWithMockedFetch(400, { status: 'BAD_REQUEST', message: 'body/data Required' })
+    const result = await client.emitEvent({
+      userPubkey: 'C1phr',
+      timestamp: 1747068000000,
+      eventName: 'sipher_private_send_completed',
+      data: { tx_signature: 's', network: 'devnet', rebate_destination: 'r' },
+    })
+    expect(result).toStrictEqual({
+      ok: false,
+      reason: 'validation',
+      message: 'body/data Required',
+    })
+  })
+
+  it('returns network reason on fetch error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('connection refused'))
+    const client = new TorqueMCPClient({
+      ingesterUrl: 'https://ingest.torque.test',
+      apiToken: 'tk_secret',
+    })
+    const result = await client.emitEvent({
+      userPubkey: 'C1phr',
+      timestamp: 1747068000000,
+      eventName: 'sipher_private_send_completed',
+      data: { tx_signature: 's', network: 'devnet', rebate_destination: 'r' },
+    })
+    expect(result).toStrictEqual({ ok: false, reason: 'network', message: 'connection refused' })
+  })
+})
+
+describe('TorqueMCPClient.pingIngester', () => {
+  beforeEach(() => vi.restoreAllMocks())
+
+  it('returns ok on 2xx', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }))
+    const client = new TorqueMCPClient({
+      ingesterUrl: 'https://ingest.torque.test',
+      apiToken: 'tk_secret',
+    })
+    const result = await client.pingIngester()
+    expect(result).toStrictEqual({ ok: true })
+  })
+
+  it('returns ok on 400 (host reachable, just rejected the empty body)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ status: 'BAD_REQUEST', message: 'body/eventName Required, body/data Required' }), {
+        status: 400,
+      }),
+    )
+    const client = new TorqueMCPClient({
+      ingesterUrl: 'https://ingest.torque.test',
+      apiToken: 'tk_secret',
+    })
+    const result = await client.pingIngester()
+    expect(result).toStrictEqual({ ok: true })
+  })
+
+  it('returns auth reason on 401', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 401 }))
+    const client = new TorqueMCPClient({
+      ingesterUrl: 'https://ingest.torque.test',
+      apiToken: 'tk_secret',
+    })
+    const result = await client.pingIngester()
+    expect(result).toStrictEqual({ ok: false, reason: 'auth', message: expect.stringMatching(/401/) })
+  })
+
+  it('returns network reason on fetch error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('connection refused'))
+    const client = new TorqueMCPClient({
+      ingesterUrl: 'https://ingest.torque.test',
+      apiToken: 'tk_secret',
+    })
+    const result = await client.pingIngester()
+    expect(result).toStrictEqual({ ok: false, reason: 'network', message: 'connection refused' })
+  })
+})
+```
+
+- [ ] **Step 4: Patch `index.ts` re-exports**
+
+Replace the contents of `packages/agent/src/integrations/torque/index.ts` with:
+
+```typescript
+export { TorqueMCPClient } from './mcp-client.js'
+export { deriveRebateDestination, _resetRebateDestinationCacheForTests } from './rebate-destination.js'
+export { wrapExecutorWithGrowthHook } from './growth-hook.js'
+export type {
+  SipherGrowthEvent,
+  SipherGrowthEventData,
+  SipherEventName,
+  TorqueMCPClientOptions,
+  TorqueEmitResult,
+  TorquePingResult,
+} from './types.js'
+export type { RebateDestination, DeriveRebateDestinationParams } from './rebate-destination.js'
+export type { GrowthHookOptions } from './growth-hook.js'
+```
+
+Change: drops `TorqueCampaign`, adds `SipherGrowthEventData` + `TorquePingResult`.
+
+- [ ] **Step 5: Run the new test suite — expect failures from downstream files that haven't been updated yet**
+
+Run: `pnpm --filter @sipher/agent test --run tests/integrations/torque/mcp-client.test.ts`
+Expected: PASS for mcp-client.test.ts itself, but the typecheck/other tests may still fail (deferred to next tasks).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/agent/src/integrations/torque/types.ts \
+        packages/agent/src/integrations/torque/mcp-client.ts \
+        packages/agent/src/integrations/torque/index.ts \
+        packages/agent/tests/integrations/torque/mcp-client.test.ts
+git commit -m "refactor(agent): rewrite TorqueMCPClient + types for canonical ingest contract"
+```
+
+---
+
+## Task 3: Rewrite `growth-hook.ts` + tests
+
+**Files:**
+- Modify: `packages/agent/src/integrations/torque/growth-hook.ts` (drop campaignId, new event construction)
+- Modify: `packages/agent/tests/integrations/torque/growth-hook.test.ts` (assert new shape)
+
+- [ ] **Step 1: Write the new `growth-hook.ts`**
+
+Replace the entire file contents with:
+
+```typescript
+import type { Connection } from '@solana/web3.js'
+import { TorqueMCPClient } from './mcp-client.js'
+import { deriveRebateDestination } from './rebate-destination.js'
+import type { SipherEventName, SipherGrowthEvent, TorqueMCPClientOptions } from './types.js'
+
+export interface GrowthHookOptions extends TorqueMCPClientOptions {
+  growthEnabled: boolean
+  /** Network used to populate SipherGrowthEvent.data.network. */
+  network: 'mainnet-beta' | 'devnet'
+  /** Optional connection for rebate-destination SNS resolution; emission is skipped if omitted. */
+  connection?: Connection
+}
+
+/** Map sipher tool name → growth event name. Read-only tools are intentionally absent. */
+const TOOL_EVENT_MAP: Record<string, SipherEventName> = {
+  send: 'sipher_private_send_completed',
+  swap: 'sipher_private_swap_completed',
+  claim: 'sipher_private_claim_completed',
+  drip: 'sipher_recurring_send_tick',
+  splitSend: 'sipher_batch_send_completed',
+}
+
+/** Swap outputs are on-chain DEX events already; include lamport amount for Torque attribution. */
+const AMOUNT_INCLUDED_TOOLS = new Set(['swap'])
+
+type ToolExecutor = (name: string, input: Record<string, unknown>) => Promise<unknown>
+
+export function wrapExecutorWithGrowthHook(
+  baseExecutor: ToolExecutor,
+  opts: GrowthHookOptions,
+): ToolExecutor {
+  if (!opts.growthEnabled) {
+    return baseExecutor
+  }
+
+  const client = new TorqueMCPClient(opts)
+
+  return async (name, input) => {
+    const result = await baseExecutor(name, input)
+    void emitGrowthEvent(name, input, result, client, opts).catch((err) => {
+      console.warn(
+        `[torque] growth event emission threw (suppressed): ${err instanceof Error ? err.message : String(err)}`,
+      )
+    })
+    return result
+  }
+}
+
+async function emitGrowthEvent(
+  toolName: string,
+  input: Record<string, unknown>,
+  result: unknown,
+  client: TorqueMCPClient,
+  opts: GrowthHookOptions,
+): Promise<void> {
+  const eventName = TOOL_EVENT_MAP[toolName]
+  if (!eventName) return
+
+  const txSignature = extractTxSignature(result)
+  if (!txSignature) return
+
+  const wallet = typeof input.wallet === 'string' ? input.wallet : undefined
+  if (!wallet) return
+
+  if (!opts.connection) return
+
+  const domain =
+    typeof input.recipient === 'string' && input.recipient.endsWith('.sol')
+      ? input.recipient
+      : undefined
+
+  const destination = await deriveRebateDestination({
+    wallet,
+    domain,
+    connection: opts.connection,
+  })
+
+  if (destination.kind !== 'stealth') return
+
+  const amountLamports = AMOUNT_INCLUDED_TOOLS.has(toolName)
+    ? extractAmountLamports(result)
+    : undefined
+  const asset = AMOUNT_INCLUDED_TOOLS.has(toolName) ? extractAsset(result) : undefined
+
+  const event: SipherGrowthEvent = {
+    userPubkey: wallet,
+    timestamp: Date.now(),
+    eventName,
+    data: {
+      tx_signature: txSignature,
+      network: opts.network,
+      rebate_destination: destination.address,
+      ...(amountLamports !== undefined ? { amount_lamports: amountLamports } : {}),
+      ...(asset !== undefined ? { asset } : {}),
+    },
+  }
+
+  await client.emitEvent(event)
+}
+
+function extractTxSignature(result: unknown): string | undefined {
+  if (!result || typeof result !== 'object') return undefined
+  const r = result as Record<string, unknown>
+  if (typeof r.signature === 'string') return r.signature
+  if (typeof r.txSignature === 'string') return r.txSignature
+  return undefined
+}
+
+function extractAmountLamports(result: unknown): number | undefined {
+  if (!result || typeof result !== 'object') return undefined
+  const r = result as Record<string, unknown>
+  if (typeof r.amountInLamports === 'number') return r.amountInLamports
+  if (typeof r.amountLamports === 'number') return r.amountLamports
+  return undefined
+}
+
+function extractAsset(result: unknown): string | undefined {
+  if (!result || typeof result !== 'object') return undefined
+  const r = result as Record<string, unknown>
+  if (typeof r.asset === 'string') return r.asset
+  if (typeof r.outputMint === 'string') return r.outputMint
+  return undefined
+}
+```
+
+Key change: drop the `campaignId` no-op short-circuit because there's no campaign concept any more. Empty `ingesterUrl` or empty `apiToken` is already covered by `loadTorqueConfig()` returning null.
+
+- [ ] **Step 2: Read the existing `growth-hook.test.ts` to see the test patterns and mocks**
+
+Run: `Read packages/agent/tests/integrations/torque/growth-hook.test.ts`
+Note the fixture data, the `vi.mocked()` patterns, and how the test currently mocks `TorqueMCPClient.emitEvent`.
+
+- [ ] **Step 3: Rewrite `growth-hook.test.ts` to assert the new flattened event shape**
+
+Update every test fixture from:
+```typescript
+{ event: 'sipher.private_send_completed', wallet, ts, tx_signature, network, metadata: {...} }
+```
+to:
+```typescript
+{ userPubkey: wallet, timestamp: <number>, eventName: 'sipher_private_send_completed', data: { tx_signature, network, rebate_destination, ... } }
+```
+
+For `timestamp`, use `expect.any(Number)` since `Date.now()` is non-deterministic. Or stub `Date.now` via `vi.spyOn(Date, 'now').mockReturnValue(1747068000000)`.
+
+Drop any test asserting the `campaignId` no-op short-circuit (that behavior was removed). Replace it with a test asserting the wrapper passes through cleanly when `growthEnabled: false`.
+
+Update fixtures' `ingesterUrl` field name (was `baseUrl`) and `apiToken` (was `apiKey`).
+
+- [ ] **Step 4: Run the test**
+
+Run: `pnpm --filter @sipher/agent test --run tests/integrations/torque/growth-hook.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/agent/src/integrations/torque/growth-hook.ts \
+        packages/agent/tests/integrations/torque/growth-hook.test.ts
+git commit -m "refactor(agent): rewrite growth-hook for flat ingest event shape, drop campaign concept"
+```
+
+---
+
+## Task 4: Rewrite `config/network.ts` `loadTorqueConfig` + tests
+
+**Files:**
+- Modify: `packages/agent/src/config/network.ts:72-106`
+- Modify: `packages/agent/tests/config/network-torque.test.ts`
+
+- [ ] **Step 1: Patch `network.ts`**
+
+Replace lines 72-106 of `packages/agent/src/config/network.ts` (the entire "Torque MCP integration config" section) with:
+
+```typescript
+// ─────────────────────────────────────────────────────────────────────────────
+// Torque MCP integration config
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface TorqueConfig {
+  apiToken: string
+  ingesterUrl: string
+}
+
+/**
+ * Load Torque MCP integration config from env. Returns null if integration is
+ * disabled (TORQUE_GROWTH_ENABLED != 'true') or required env vars are missing.
+ * Caller treats null as "Torque integration disabled" — passes baseExecutor
+ * through unchanged.
+ *
+ * Env var names follow the official @torque-labs/mcp convention:
+ * - TORQUE_API_TOKEN: project-scoped event-ingest API key from
+ *   platform.torque.so/developer.
+ * - TORQUE_INGESTER_URL: defaults to https://ingest.torque.so. Override only
+ *   for staging/test deployments.
+ */
+export function loadTorqueConfig(): TorqueConfig | null {
+  const enabled = process.env.TORQUE_GROWTH_ENABLED === 'true'
+  if (!enabled) return null
+
+  const apiToken = process.env.TORQUE_API_TOKEN
+  const ingesterUrl = process.env.TORQUE_INGESTER_URL ?? 'https://ingest.torque.so'
+
+  if (!apiToken) {
+    console.warn(
+      '[torque] TORQUE_GROWTH_ENABLED=true but TORQUE_API_TOKEN missing — disabling integration',
+    )
+    return null
+  }
+
+  return { apiToken, ingesterUrl }
+}
+```
+
+- [ ] **Step 2: Read existing `network-torque.test.ts`**
+
+Run: `Read packages/agent/tests/config/network-torque.test.ts`
+Note the env-stub patterns (likely `vi.stubEnv` or `process.env` assignment with cleanup).
+
+- [ ] **Step 3: Rewrite `network-torque.test.ts`**
+
+Update tests:
+- Assert `loadTorqueConfig()` returns null when `TORQUE_GROWTH_ENABLED` is unset, `'false'`, or any other value.
+- Assert it returns null when `TORQUE_API_TOKEN` is missing (with `TORQUE_GROWTH_ENABLED=true`).
+- Assert it returns `{apiToken, ingesterUrl}` with the new field names when env vars are present.
+- Assert it defaults `ingesterUrl` to `https://ingest.torque.so` when `TORQUE_INGESTER_URL` is unset but `TORQUE_API_TOKEN` is set.
+- Assert it uses the env override when both are set.
+- Drop any test asserting `campaignIdDevnet`/`campaignIdMainnet` (those fields are gone).
+
+Example test for the default ingester URL:
+
+```typescript
+it('defaults ingesterUrl to https://ingest.torque.so when env override absent', () => {
+  vi.stubEnv('TORQUE_GROWTH_ENABLED', 'true')
+  vi.stubEnv('TORQUE_API_TOKEN', 'tk_secret')
+  vi.stubEnv('TORQUE_INGESTER_URL', '')
+  expect(loadTorqueConfig()).toStrictEqual({
+    apiToken: 'tk_secret',
+    ingesterUrl: 'https://ingest.torque.so',
+  })
+})
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `pnpm --filter @sipher/agent test --run tests/config/network-torque.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/agent/src/config/network.ts \
+        packages/agent/tests/config/network-torque.test.ts
+git commit -m "refactor(agent): rename Torque env vars to official names, drop campaign vars"
+```
+
+---
+
+## Task 5: Update `routes/admin.ts` `/api/torque/status` route + tests
+
+**Files:**
+- Modify: `packages/agent/src/routes/admin.ts:130-159`
+- Modify: any admin route test file under `packages/agent/tests/routes/`
+
+- [ ] **Step 1: Identify the admin route test file**
+
+Run: `find packages/agent/tests/routes -name "*admin*" -o -name "*torque*"`
+The relevant file will likely be `packages/agent/tests/routes/admin.test.ts` or similar. Read it to find existing `/api/torque/status` tests.
+
+- [ ] **Step 2: Patch `routes/admin.ts` `/api/torque/status` route**
+
+Replace the existing route (lines 130-159) with:
+
+```typescript
+adminRouter.get('/api/torque/status', async (_req, res) => {
+  const config = loadTorqueConfig()
+  if (!config) {
+    ;(res as any).status(200).json({
+      ok: true,
+      enabled: false,
+      reason: 'TORQUE_GROWTH_ENABLED is false or required env vars missing',
+    })
+    return
+  }
+
+  const network = loadNetworkConfig().clusterName
+
+  const client = new TorqueMCPClient({
+    apiToken: config.apiToken,
+    ingesterUrl: config.ingesterUrl,
+  })
+
+  const ping = await client.pingIngester()
+  ;(res as any).status(200).json({
+    ok: true,
+    enabled: true,
+    network,
+    ingesterUrl: config.ingesterUrl,
+    ingesterReachable: ping.ok,
+    ingesterReason: ping.ok ? undefined : ping.reason,
+  })
+})
+```
+
+- [ ] **Step 3: Update the admin route tests**
+
+For each existing test asserting `campaignId` or `campaignFetchOk` in the response body, rewrite to assert:
+- `enabled: true|false`
+- `network: 'devnet' | 'mainnet-beta'`
+- `ingesterUrl: <expected>`
+- `ingesterReachable: true|false`
+- `ingesterReason?: 'auth' | 'network' | 'unknown'` when not reachable
+
+Mock `TorqueMCPClient.pingIngester` instead of `getCampaign`.
+
+- [ ] **Step 4: Run the test**
+
+Run: `pnpm --filter @sipher/agent test --run tests/routes/admin.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/agent/src/routes/admin.ts packages/agent/tests/routes/admin.test.ts
+git commit -m "refactor(agent): replace /torque/status campaignFetchOk with ingester reachability ping"
+```
+
+---
+
+## Task 6: Update `agent.ts` call sites
+
+**Files:**
+- Modify: `packages/agent/src/agent.ts:321-336, 448-462`
+
+- [ ] **Step 1: Patch `chat()` call site (~line 321-336)**
+
+Replace the existing torqueExecutor block with:
+
+```typescript
+  const baseExecutor = opts.toolExecutor ?? executeTool
+  const torqueConfig = loadTorqueConfig()
+  const torqueExecutor = torqueConfig
+    ? (() => {
+        const net = loadNetworkConfig()
+        return wrapExecutorWithGrowthHook(baseExecutor, {
+          growthEnabled: true,
+          apiToken: torqueConfig.apiToken,
+          ingesterUrl: torqueConfig.ingesterUrl,
+          network: net.clusterName === 'mainnet-beta' ? 'mainnet-beta' : 'devnet',
+          connection: createConnection(net.clusterName, net.rpcUrl),
+        })
+      })()
+    : baseExecutor
+```
+
+- [ ] **Step 2: Patch `chatStream()` call site (~line 448-462)**
+
+Apply the same change pattern to the second `loadTorqueConfig()` block in `chatStream()`. Drop the `campaignId` argument; rename `apiKey` → `apiToken`, `baseUrl` → `ingesterUrl`.
+
+- [ ] **Step 3: Run typecheck + full agent test suite**
+
+```bash
+pnpm --filter @sipher/agent typecheck
+pnpm --filter @sipher/agent test --run
+```
+Expected: typecheck clean, all 1538+ tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/agent/src/agent.ts
+git commit -m "refactor(agent): align chat()/chatStream() Torque wiring with new config shape"
+```
+
+---
+
+## Task 7: Update README + Friction Log
+
+**Files:**
+- Modify: `packages/agent/src/integrations/torque/README.md`
+- Modify: `docs/integrations/torque/FRICTION-LOG.md`
+
+- [ ] **Step 1: Patch the README**
+
+Read the current README to find the env vars section, slug list, dashboard prerequisites section, and example payload.
+
+Update:
+- Env vars: `TORQUE_API_TOKEN` (was `TORQUE_API_KEY`), `TORQUE_INGESTER_URL` (was `TORQUE_MCP_URL`, default `https://ingest.torque.so`). Drop `TORQUE_CAMPAIGN_ID_DEVNET`, `TORQUE_CAMPAIGN_ID_MAINNET`.
+- Slug list: underscore form for all 5 (`sipher_private_send_completed`, etc.).
+- Add a "Dashboard prerequisites" section listing: project created at `platform.torque.so`, API key generated from `/developer`, 5 Custom Events defined with matching slugs + fields, REBATE Incentive with `CUSTOM_EVENT_PROVIDER` data source bound to those slugs.
+- Add a "Network model" note: event ingestion is network-agnostic but pool funding + reward distribution are mainnet only. Hybrid devnet-event / mainnet-pool deployment is supported by Torque since pubkeys are the same across networks.
+- Update the example event payload to the new shape: `{userPubkey, timestamp, eventName, data: {...}}`.
+
+- [ ] **Step 2: Append Friction Log entries**
+
+Append at least 4 dated entries to `docs/integrations/torque/FRICTION-LOG.md`:
+
+1. `2026-05-12 — Dashboard onboarding`: cipher-admin wallet chosen as Torque account owner; HciZTd default account abandoned (no merge/transfer flow exists). Project ID prefix `cmp` + 24-char nanoid (not `camp_xxx` as assumed). API key one-time-view at creation.
+
+2. `2026-05-12 — Canonical contract probe`: Discovered four-host architecture (`server`/`platform`/`ingest`/`ai`.torque.so). Real ingest endpoint is `POST ingest.torque.so/events` with `x-api-key` header — not `server.torque.so/campaigns/{id}/events` as the spec originally assumed. Server schema errors are gold for tests: 401 missing-header, 400 body/eventName Required, 400 Event not found for this API key.
+
+3. `2026-05-12 — Torque primitives model`: Torque has no "Campaign" object. Built around Queries (SQL) + Incentives (binding query → distribution rules) + Lists (epoch snapshots). Our use case = `IncentiveType: REBATE` + `EventDataSource: CUSTOM_EVENT_PROVIDER`. `TORQUE_CAMPAIGN_ID_*` env vars were a misread; removed in this PR.
+
+4. `2026-05-12 — Mainnet-only constraint`: Torque ingests events from any network (pubkeys are strings), but pool escrow and reward distribution are mainnet-only. Devnet wallets receive mainnet rewards because secp256k1/ed25519 pubkeys are network-portable. Hybrid devnet-event/mainnet-payout deployment is viable.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/agent/src/integrations/torque/README.md \
+        docs/integrations/torque/FRICTION-LOG.md
+git commit -m "docs(torque): sync README + log canonical-contract discovery in Friction Log"
+```
+
+---
+
+## Task 8: Final verification, push, open PR-E
+
+- [ ] **Step 1: Run full agent test suite green**
+
+```bash
+pnpm --filter @sipher/agent test --run
+```
+Expected: All 1538+ tests pass (running tests, 2 opt-in skipped). If any test fails, fix before continuing.
+
+- [ ] **Step 2: Run typecheck and lint**
+
+```bash
+pnpm --filter @sipher/agent typecheck
+pnpm --filter @sipher/agent lint
+```
+Expected: clean output.
+
+- [ ] **Step 3: Run sipher-wide test suite to catch any other consumers**
+
+```bash
+pnpm test --run 2>&1 | tail -15
+```
+Expected: no new failures. The PR touches `@sipher/agent` only; other packages should be unaffected.
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push -u origin feat/torque-canonical-ingest
+```
+
+- [ ] **Step 5: Open the PR**
+
+Use `gh pr create` with title `feat(agent): rewrite Torque integration for canonical ingest contract (PR-E)` and a body summarizing:
+- Why: previous integration was built against assumptions (campaigns, x-torque-api-key, nested metadata) that turned out wrong when probed against the live Torque endpoint
+- Discovery: four-host Torque architecture, mainnet-only pool/distribution, official @torque-labs/mcp env names
+- Changes: 5 source files, 3 test files, README, spec, Friction Log
+- Tests: +N net (mcp-client +M, growth-hook +L, network-torque +K) — fill in actuals
+- Blocker context: still depends on sipher#262 for non-claim events; option (c) claim-only scope retained for the hackathon shadow window
+- Manual follow-up before merge: RECTOR creates Custom Events + REBATE Incentive in Torque dashboard, funds mainnet pool
+
+---
+
+## Self-Review Checklist
+
+After completing all tasks, verify:
+
+1. **Spec coverage:** Did each section of the canonical contract in `project_torque-mcp-integration-shipped.md` "Canonical ingest contract" get an implementation? URL/header/body/env-rename/slug-rename/admin-repurpose/test-rewrite/README/Friction-Log — all covered? ✅
+2. **No placeholders:** Every step has actual code or actual command. No "implement later" or "similar to above". ✅
+3. **Type consistency:** Field names match across types.ts → mcp-client.ts → growth-hook.ts → admin.ts → agent.ts. `apiToken` everywhere (not `apiKey`). `ingesterUrl` everywhere (not `baseUrl`). `eventName` everywhere (not `event`). `userPubkey` everywhere (not `wallet` in event payloads). `timestamp` is number everywhere (not ISO string). ✅
+
+---
+
+## Execution notes for the implementer
+
+- TDD discipline: write the test first, run-fail, implement, run-pass, commit. Each Task is one logical commit unit even though it bundles file changes.
+- GPG-sign every commit (`-S` if not default).
+- Conventional commit prefixes: `refactor(agent):`, `docs(torque):`, `test(agent):` depending on the dominant change in each commit.
+- After each commit, run the touched test file to verify still green.
+- If you hit a test you don't understand from the existing code, don't reverse-engineer it — read the file with `Read`, ask if the test still applies under the new contract, and rewrite cleanly.
+- Keep commits small (one logical change per commit) — RECTOR's preference per `feedback_phase4-execution-mode`.

--- a/docs/superpowers/specs/2026-05-12-torque-mcp-integration-design.md
+++ b/docs/superpowers/specs/2026-05-12-torque-mcp-integration-design.md
@@ -41,7 +41,7 @@ sipher agent (existing)
    └─► Torque MCP server (external)
            │
            ▼
-       Torque Campaign Engine
+       Torque Incentive Engine
            │
            ▼
        Rebate → stealth address derived from SNS record
@@ -49,7 +49,7 @@ sipher agent (existing)
 ```
 
 **New module: `packages/agent/src/integrations/torque/`**
-- `mcp-client.ts` — wraps Torque MCP calls (`emit_event`, `get_campaign_status`, `get_campaign`)
+- `mcp-client.ts` — wraps Torque MCP calls (`emitEvent`, `pingIngester`)
 - `growth-hook.ts` — post-success middleware on fund-moving tools
 - `rebate-destination.ts` — derives stealth address from user's published meta-address (cached 60s per wallet+domain)
 - `types.ts` — event payload + MCP response types
@@ -89,7 +89,7 @@ type TorqueIngestBody = {
   eventName: string                // e.g. 'sipher_private_send_completed'
   data: {                          // flat map — only string | number | boolean values
     tx_signature: string           // Solana TX sig (idempotency key)
-    network: 'mainnet-beta' | 'devnet'
+    network: 'mainnet-beta' | 'devnet'  // sipher-internal field; Torque accepts events from any network
     amount_lamports?: number       // OMITTED for `send` + `claim`, INCLUDED for `swap`
     asset?: string                 // 'SOL' | 'USDC' | mint address
     rebate_destination?: string    // derived stealth address (60s cache per wallet+domain)
@@ -122,7 +122,7 @@ This wires sip.sol Phase A-E directly into the Torque growth loop — strong nar
 
 ---
 
-## Campaign + reward pool
+## Incentive + reward pool
 
 **One campaign initially** (multi-campaign later if it proves out):
 

--- a/docs/superpowers/specs/2026-05-12-torque-mcp-integration-design.md
+++ b/docs/superpowers/specs/2026-05-12-torque-mcp-integration-design.md
@@ -71,35 +71,39 @@ sipher agent (existing)
 
 | Sipher tool | Event name | Why we emit |
 |---|---|---|
-| `send` | `sipher.private_send_completed` | Core privacy action |
-| `swap` | `sipher.private_swap_completed` | Privacy + DEX volume signal |
-| `claim` | `sipher.private_claim_completed` | Receiving side of stealth flow |
-| `drip` | `sipher.recurring_send_tick` | Recurring engagement |
-| `splitSend` | `sipher.batch_send_completed` | Power-user signal |
+| `send` | `sipher_private_send_completed` | Core privacy action |
+| `swap` | `sipher_private_swap_completed` | Privacy + DEX volume signal |
+| `claim` | `sipher_private_claim_completed` | Receiving side of stealth flow |
+| `drip` | `sipher_recurring_send_tick` | Recurring engagement |
+| `splitSend` | `sipher_batch_send_completed` | Power-user signal |
 
 **Skipped intentionally:** read-only tools (`balance`, `history`, `viewingKey`, `privacyScore`, `threatCheck`, `assessRisk`), admin tools (`status`, `viewingKey`), and `sipher_vault` deposit/withdraw (devnet-only, CPI complexity, defer to a future sweep).
 
-**Event payload (canonical shape):**
+**Event payload (canonical shape — probed against live `ingest.torque.so`):**
 ```ts
-type SipherGrowthEvent = {
-  event: string                    // 'sipher.private_send_completed'
-  wallet: string                   // user's public Solana pubkey (attribution)
-  ts: string                       // ISO-8601
-  tx_signature: string             // Solana TX sig (idempotency key)
-  network: 'mainnet-beta' | 'devnet'
-  metadata: {
-    amount_lamports?: number       // OMITTED for `send`, INCLUDED for `swap`
+// Wire format sent to POST https://ingest.torque.so/events
+// Header: x-api-key: $TORQUE_API_TOKEN
+type TorqueIngestBody = {
+  userPubkey: string               // user's public Solana pubkey (attribution)
+  timestamp: number                // Unix epoch in milliseconds (ms, not seconds)
+  eventName: string                // e.g. 'sipher_private_send_completed'
+  data: {                          // flat map — only string | number | boolean values
+    tx_signature: string           // Solana TX sig (idempotency key)
+    network: 'mainnet-beta' | 'devnet'
+    amount_lamports?: number       // OMITTED for `send` + `claim`, INCLUDED for `swap`
     asset?: string                 // 'SOL' | 'USDC' | mint address
-    rebate_destination: string     // derived stealth address (60s cache per wallet+domain)
+    rebate_destination?: string    // derived stealth address (60s cache per wallet+domain)
   }
 }
 ```
+
+All four top-level fields (`userPubkey`, `timestamp`, `eventName`, `data`) are required. The `data` object may be `{}` but must be present. Nested objects inside `data` are rejected by the ingest schema with a 400.
 
 **Per-event privacy decisions, not blanket:**
 - `send` events OMIT `amount_lamports` — sender wallet + amount = nearly full deanonymization
 - `swap` events INCLUDE `amount_lamports` — DEX trade is already public on-chain; redaction would be pointless
 - `claim` events OMIT `amount_lamports` — receiver-side flow, amount isn't needed for attribution
-- All events include `tx_signature` for idempotency (Torque deduplicates retries)
+- `data.tx_signature` is the idempotency key — Torque deduplicates on the ingest side
 
 **Emission rules:**
 - Fire **only after** on-chain confirmation. Never on submit. Never on optimistic UI.
@@ -136,19 +140,17 @@ This wires sip.sol Phase A-E directly into the Torque growth loop — strong nar
 **Network strategy:**
 - **Devnet first (shadow week 1)** — shake out the integration, prove the loop, no real money at risk
 - **Mainnet after demo verified (week 2 or post-shadow)** — small pool, monitor for 7 days before scaling
-- Per-network campaign IDs in env: `TORQUE_CAMPAIGN_ID_DEVNET`, `TORQUE_CAMPAIGN_ID_MAINNET`. Sipher routes based on `SIPHER_NETWORK`.
+- Torque has no "Campaign" primitive. Our use case maps to: `IncentiveType: REBATE` + `EventDataSource: CUSTOM_EVENT_PROVIDER`. Sipher routes event ingestion based on `SIPHER_NETWORK`; pool funding + reward distribution are mainnet-only (see addendum).
 
 **Campaign discovery (startup):**
-- On boot, sipher fetches campaign metadata via `TorqueMCPClient.getCampaign(id)`
-- No metadata cache today: `getCampaign()` is re-queried per `/admin/api/torque/status` call. Admin is operator-only and rarely hit, so the upstream RPC cost is negligible. Pre-mainnet, add a short-TTL (≤5min) cache here if `status` polling becomes load-bearing for ops dashboards.
+- On boot, sipher fetches incentive/status metadata via `TorqueMCPClient.getStatus()`
+- No metadata cache today: re-queried per `/admin/api/torque/status` call. Admin is operator-only and rarely hit, so the upstream RPC cost is negligible. Pre-mainnet, add a short-TTL (≤5min) cache here if `status` polling becomes load-bearing for ops dashboards.
 - Failure to fetch ≠ broken sipher. Tools still work; events still emit. Just no rebates land. Logged as warning.
 
 **Env vars (added to sipher's existing config):**
 ```
-TORQUE_API_KEY=               # Per-environment, stored in ~/Documents/secret/sipher-vps-secrets.env
-TORQUE_MCP_URL=               # MCP server endpoint (provided via Torque hackathon TG group)
-TORQUE_CAMPAIGN_ID_DEVNET=
-TORQUE_CAMPAIGN_ID_MAINNET=   # Set after mainnet pool funded
+TORQUE_API_TOKEN=             # Per-environment token, stored in ~/Documents/secret/sipher-vps-secrets.env
+TORQUE_INGESTER_URL=          # https://ingest.torque.so (canonical ingest host)
 TORQUE_GROWTH_ENABLED=true    # Master kill-switch
 ```
 
@@ -175,8 +177,8 @@ Three layers, mirroring sipher's existing test discipline. Patterns locked in PR
 - `rebate-destination.test.ts` — given user has SNS record → derives stealth address; given user has legacy hex meta → derives stealth address; given neither → returns null + logs warning.
 
 **Integration tests** (real Torque devnet API)
-- `torque-emit-roundtrip.test.ts` — fire a real `custom_event` against Torque devnet, poll for ingestion, assert it appears in campaign attribution.
-- Skip predicate (mirrors `sns-stealth/tests/integration.test.ts` pattern shipped today): require explicit `TORQUE_TEST_CAMPAIGN_ID` + `TORQUE_API_KEY` env. No defaults — opt-in only. Skips cleanly for contributors / CI.
+- `torque-emit-roundtrip.test.ts` — fire a real `custom_event` against Torque ingest, poll for ingestion, assert it appears in attribution.
+- Skip predicate (mirrors `sns-stealth/tests/integration.test.ts` pattern shipped today): require explicit `TORQUE_API_TOKEN` + `TORQUE_INGESTER_URL` env. No defaults — opt-in only. Skips cleanly for contributors / CI.
 
 **E2E test** (full sipher flow)
 - `torque-rebate-e2e.test.ts` — invoke `sipher.send` end-to-end on devnet: confirm Solana TX → assert event lands at Torque → poll rebate destination wallet → assert lamport balance increased.
@@ -203,7 +205,7 @@ Single take, no voiceover edits:
 
 1. **Setup shot (5s)** — sipher chat UI, devnet wallet connected, current SOL balance shown. Caption overlay: "Torque rebate pool: 5 SOL"
 2. **Action (15s)** — type `send 0.1 SOL privately to therector.sol`. SENTINEL preflight passes. TX confirms on-chain. Solscan tab opens showing the shielded transfer.
-3. **Attribution (20s)** — flip to Torque dashboard tab, refresh. New event appears: `sipher.private_send_completed`, attributed to user wallet. Caption: "Custom event emitted via Torque MCP"
+3. **Attribution (20s)** — flip to Torque dashboard tab, refresh. New event appears: `sipher_private_send_completed`, attributed to user wallet. Caption: "Custom event emitted via Torque MCP"
 4. **Rebate (30s)** — flip back to a fresh wallet view, derived stealth address. Within ~5s, lamport balance increases by 0.005 SOL. Solscan link to the rebate TX. Caption: "Rebate auto-claimed at fresh stealth address — no doxxing"
 5. **Closing card (20s)** — text card: "Sipher × Torque MCP. Privacy-native growth loops on Solana. github.com/sip-protocol/sipher"
 
@@ -261,9 +263,82 @@ Each PR follows the established sipher pattern: TDD where feasible, `pnpm typech
 ## Open questions deferred to implementation
 
 These don't block design approval but need answers during PR-A:
-- Does Torque MCP server use Anthropic's stdio MCP transport or an HTTP-based MCP variant? (TG group answer)
-- What auth flow does the Torque MCP server use? (API key in header? OAuth? wallet-signature?)
+- ~~Does Torque MCP server use Anthropic's stdio MCP transport or an HTTP-based MCP variant?~~ **Resolved — see Discovery addendum: REST ingest at `ingest.torque.so`, no MCP transport needed for event emission**
+- ~~What auth flow does the Torque MCP server use?~~ **Resolved — `x-api-key: $TORQUE_API_TOKEN` header on every request to `ingest.torque.so`**
 - Are there per-event-type rate limits on the Torque side?
-- Is there a sandbox campaign ID we can use for testing without affecting our real campaign?
+- ~~Is there a sandbox campaign ID we can use for testing without affecting our real campaign?~~ **Resolved — Torque has no Campaign primitive; events are ingested by slug against the Incentive configured in the dashboard. Devnet events are network-agnostic; no separate sandbox ID needed.**
 
-Friction Log captures the answers as they arrive.
+Friction Log captures the remaining answers as they arrive.
+
+---
+
+## Discovery addendum — canonical ingest contract (2026-05-12)
+
+This section documents the ground-truth contract discovered by probing the live Torque API during dashboard onboarding (frontier_sip_9 session). It supersedes any conflicting spec text above. PR-A through PR-D (#256, #258, #260, #261) were shipped against the original (wrong) spec; PR-E (this rewrite + downstream source changes) aligns the codebase with this canonical contract.
+
+### Four-host architecture
+
+| Host | Purpose |
+|---|---|
+| `server.torque.so` | CRUD — read/write Queries, Incentives, Lists, user lookups |
+| `platform.torque.so` | Dashboard UI — browser-facing, not called from code |
+| `ingest.torque.so` | Event ingestion — the only host sipher writes to |
+| `ai.torque.so` | AI features — out of scope for this integration |
+
+### Torque primitives (no "Campaign" entity)
+
+Torque's data model does not have a "Campaign" object. Our integration maps to:
+
+| Torque primitive | Our value |
+|---|---|
+| `IncentiveType` | `REBATE` |
+| `EventDataSource` | `CUSTOM_EVENT_PROVIDER` |
+| `QueryType` options | `ALLOWLIST`, `DENYLIST`, `LIST`, `PREDEFINED_ALLOCATION` |
+
+The Incentive is configured in `platform.torque.so` and references Custom Event slugs by name. Sipher emits events; Torque's engine matches slugs to Incentives and distributes rebates.
+
+### Mainnet-only constraint
+
+Pool funding and reward distribution require mainnet SOL/USDC. There is no Torque devnet. However, **event ingestion is network-agnostic** — `ingest.torque.so` accepts events regardless of which Solana cluster the underlying TX was confirmed on. Pubkeys are network-portable (same keypair exists on devnet and mainnet).
+
+Consequence: a **hybrid mode is viable and deliberate**:
+- Shadow week 1 — emit real devnet events (prove the wire format + ingestion pipeline with no real money at risk)
+- Week 2+ — fund a small mainnet pool; Torque engine begins distributing rebates for events attributed to the same pubkeys
+
+### Canonical ingest contract
+
+```
+POST https://ingest.torque.so/events
+x-api-key: $TORQUE_API_TOKEN
+
+{
+  "userPubkey": "<base58 Solana pubkey>",
+  "timestamp": <unix epoch ms — number, not string>,
+  "eventName": "<slug>",
+  "data": { <flat map of string | number | boolean> }
+}
+```
+
+All four top-level fields are required. Missing any field produces a 400 with `body/<field> Required`. The `data` object must be present (may be `{}`). Nested objects inside `data` are rejected.
+
+### Custom event slugs (underscore form — required by Torque dashboard)
+
+| Event | Slug |
+|---|---|
+| Private send | `sipher_private_send_completed` |
+| Private swap | `sipher_private_swap_completed` |
+| Private claim | `sipher_private_claim_completed` |
+| Recurring send tick | `sipher_recurring_send_tick` |
+| Batch send | `sipher_batch_send_completed` |
+
+Slugs must match exactly as configured in the Torque dashboard (Incentive → Custom Event). Dotted form (`sipher.private_send_completed`) is not accepted.
+
+### Env var names (locked)
+
+```
+TORQUE_API_TOKEN=         # was TORQUE_API_KEY (old spec)
+TORQUE_INGESTER_URL=      # was TORQUE_MCP_URL (old spec); value = https://ingest.torque.so
+TORQUE_GROWTH_ENABLED=    # unchanged
+```
+
+`TORQUE_CAMPAIGN_ID_DEVNET` and `TORQUE_CAMPAIGN_ID_MAINNET` are dropped — Torque has no Campaign primitive and sipher does not need to track an ID to emit events.

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -525,12 +525,8 @@ export async function chat(
         const net = loadNetworkConfig()
         return wrapExecutorWithGrowthHook(baseExecutor, {
           growthEnabled: true,
-          apiKey: torqueConfig.apiKey,
-          baseUrl: torqueConfig.baseUrl,
-          campaignId:
-            net.clusterName === 'mainnet-beta'
-              ? torqueConfig.campaignIdMainnet
-              : torqueConfig.campaignIdDevnet,
+          apiToken: torqueConfig.apiToken,
+          ingesterUrl: torqueConfig.ingesterUrl,
           network: net.clusterName === 'mainnet-beta' ? 'mainnet-beta' : 'devnet',
           connection: createConnection(net.clusterName, net.rpcUrl),
         })
@@ -669,12 +665,8 @@ export async function* chatStream(
   const finalExecutor = torqueConfig
     ? wrapExecutorWithGrowthHook(signingExecutor, {
         growthEnabled: true,
-        apiKey: torqueConfig.apiKey,
-        baseUrl: torqueConfig.baseUrl,
-        campaignId:
-          net.clusterName === 'mainnet-beta'
-            ? torqueConfig.campaignIdMainnet
-            : torqueConfig.campaignIdDevnet,
+        apiToken: torqueConfig.apiToken,
+        ingesterUrl: torqueConfig.ingesterUrl,
         network: net.clusterName === 'mainnet-beta' ? 'mainnet-beta' : 'devnet',
         connection: createConnection(net.clusterName, net.rpcUrl),
       })

--- a/packages/agent/src/config/network.ts
+++ b/packages/agent/src/config/network.ts
@@ -95,7 +95,7 @@ export function loadTorqueConfig(): TorqueConfig | null {
   if (!enabled) return null
 
   const apiToken = process.env.TORQUE_API_TOKEN
-  const ingesterUrl = process.env.TORQUE_INGESTER_URL ?? 'https://ingest.torque.so'
+  const ingesterUrl = process.env.TORQUE_INGESTER_URL || 'https://ingest.torque.so'
 
   if (!apiToken) {
     console.warn(

--- a/packages/agent/src/config/network.ts
+++ b/packages/agent/src/config/network.ts
@@ -74,10 +74,8 @@ export function loadNetworkConfig(): NetworkConfig {
 // ─────────────────────────────────────────────────────────────────────────────
 
 export interface TorqueConfig {
-  apiKey: string
-  baseUrl: string
-  campaignIdDevnet: string
-  campaignIdMainnet: string
+  apiToken: string
+  ingesterUrl: string
 }
 
 /**
@@ -85,22 +83,26 @@ export interface TorqueConfig {
  * disabled (TORQUE_GROWTH_ENABLED != 'true') or required env vars are missing.
  * Caller treats null as "Torque integration disabled" — passes baseExecutor
  * through unchanged.
+ *
+ * Env var names follow the official @torque-labs/mcp convention:
+ * - TORQUE_API_TOKEN: project-scoped event-ingest API key from
+ *   platform.torque.so/developer.
+ * - TORQUE_INGESTER_URL: defaults to https://ingest.torque.so. Override only
+ *   for staging/test deployments.
  */
 export function loadTorqueConfig(): TorqueConfig | null {
   const enabled = process.env.TORQUE_GROWTH_ENABLED === 'true'
   if (!enabled) return null
 
-  const apiKey = process.env.TORQUE_API_KEY
-  const baseUrl = process.env.TORQUE_MCP_URL
-  const campaignIdDevnet = process.env.TORQUE_CAMPAIGN_ID_DEVNET ?? ''
-  const campaignIdMainnet = process.env.TORQUE_CAMPAIGN_ID_MAINNET ?? ''
+  const apiToken = process.env.TORQUE_API_TOKEN
+  const ingesterUrl = process.env.TORQUE_INGESTER_URL ?? 'https://ingest.torque.so'
 
-  if (!apiKey || !baseUrl) {
+  if (!apiToken) {
     console.warn(
-      '[torque] TORQUE_GROWTH_ENABLED=true but TORQUE_API_KEY or TORQUE_MCP_URL missing — disabling integration',
+      '[torque] TORQUE_GROWTH_ENABLED=true but TORQUE_API_TOKEN missing — disabling integration',
     )
     return null
   }
 
-  return { apiKey, baseUrl, campaignIdDevnet, campaignIdMainnet }
+  return { apiToken, ingesterUrl }
 }

--- a/packages/agent/src/integrations/torque/README.md
+++ b/packages/agent/src/integrations/torque/README.md
@@ -1,21 +1,39 @@
 # Torque MCP Integration
 
-Sipher integrates [Torque](https://torque.so) MCP to drive a per-action rebate growth loop. After every successful private send / swap / claim / drip / batch-send via sipher's agent tools, a `custom_event` is emitted to a Torque campaign that distributes a small SOL/USDC rebate to a fresh stealth address derived from the user's published SNS `SIP-STEALTH` record.
+Sipher integrates [Torque](https://torque.so) to drive a per-action rebate growth loop. After every successful private send / swap / claim / drip / batch-send via sipher's agent tools, a custom event is emitted to `ingest.torque.so` which triggers a REBATE Incentive that distributes a small SOL rebate to a fresh stealth address derived from the user's published SNS `SIP-STEALTH` record.
 
 ## Setup
 
 ```bash
 # In ~/Documents/secret/sipher-vps-secrets.env (or .env for local dev)
-TORQUE_API_KEY=tk_...                                     # From Torque dashboard
-TORQUE_MCP_URL=<provided via Torque hackathon Telegram group>   # MCP server endpoint — confirmed by @smicktrq in Frontier TG
-TORQUE_CAMPAIGN_ID_DEVNET=camp_dev_xxx                    # Devnet campaign
-TORQUE_CAMPAIGN_ID_MAINNET=camp_main_xxx                  # Mainnet campaign (optional until rollout)
-TORQUE_GROWTH_ENABLED=true                                # Master kill-switch
+TORQUE_API_TOKEN=tq_...                          # Project-scoped event-ingest API key from platform.torque.so/developer (one-time view at creation)
+TORQUE_INGESTER_URL=https://ingest.torque.so     # Optional — defaults to production ingester; override only for staging/test
+TORQUE_GROWTH_ENABLED=true                       # Master kill-switch — set to 'true' to enable post-success event emission
 ```
 
-> **Note:** `TORQUE_MCP_URL` is TBD pending Torque hackathon Telegram group access. The integration test skip-predicate gates this — tests skip cleanly until the URL is known.
+> **Note:** The canonical ingest contract has been verified against the live `ingest.torque.so` endpoint. The API key (`TORQUE_API_TOKEN`) is project-scoped — no campaign IDs are needed; the key alone routes events to the correct project and incentive.
 
 When `TORQUE_GROWTH_ENABLED=false` (default) the entire integration is bypassed cleanly — sipher tools work as before, no events are emitted, no admin endpoint queries Torque.
+
+## Dashboard prerequisites
+
+Before enabling the integration, the following must be configured at `platform.torque.so`:
+
+1. **Project created** under the Torque-owning wallet (one-time)
+2. **API key generated** from `/developer` — value goes into `TORQUE_API_TOKEN` (one-time view at creation; rotate via dashboard if lost)
+3. **5 Custom Events defined** with these exact slugs + field schemas:
+
+| Slug | Fields |
+|---|---|
+| `sipher_private_send_completed` | `tx_signature` (string), `network` (string), `rebate_destination` (string) |
+| `sipher_private_swap_completed` | `tx_signature` (string), `network` (string), `rebate_destination` (string), `amount_lamports` (number), `asset` (string) |
+| `sipher_private_claim_completed` | same as send |
+| `sipher_recurring_send_tick` | same as send |
+| `sipher_batch_send_completed` | same as send |
+
+4. **REBATE Incentive** configured via `CUSTOM_EVENT_PROVIDER` data source bound to those 5 slugs, with sybil/reward/epoch rules set in the Torque dashboard recipe form (NOT in this code — distribution is dashboard-driven)
+
+Emissions to undefined slugs return `400 Event not found for this API key` — the integration logs the reason and skips without failing the sipher tool.
 
 ## Test commands
 
@@ -26,41 +44,46 @@ pnpm --filter @sipher/agent test -- integrations/torque
 # Admin endpoint tests (always run)
 pnpm --filter @sipher/agent test -- routes/admin-torque
 
-# Integration test — opt-in, hits the real Torque devnet API
-TORQUE_API_KEY=tk_... \
-TORQUE_MCP_URL=https://... \
-TORQUE_TEST_CAMPAIGN_ID=$TORQUE_CAMPAIGN_ID_DEVNET \
+# Integration test — opt-in, hits the real Torque ingest API
+TORQUE_API_TOKEN=tq_... \
+TORQUE_INGESTER_URL=https://ingest.torque.so \
 pnpm --filter @sipher/agent test -- torque-emit-roundtrip
 
 # E2E test — opt-in, requires devnet keypair + published SIP-STEALTH on SIP_TEST_DOMAIN
-TORQUE_API_KEY=tk_... \
-TORQUE_MCP_URL=https://... \
-TORQUE_TEST_CAMPAIGN_ID=$TORQUE_CAMPAIGN_ID_DEVNET \
+TORQUE_API_TOKEN=tq_... \
+TORQUE_INGESTER_URL=https://ingest.torque.so \
 SIP_TEST_DOMAIN=therector.sol \
 pnpm --filter @sipher/agent test -- torque-rebate-e2e
 ```
 
 ## Admin endpoint
 
-`GET /admin/api/torque/status` returns the current campaign state:
+`GET /admin/api/torque/status` returns the current ingester state:
 
 ```json
 {
   "ok": true,
   "enabled": true,
   "network": "devnet",
-  "campaignId": "camp_devnet_1",
-  "campaignFetchOk": true,
-  "campaign": {
-    "id": "camp_devnet_1",
-    "name": "Sipher Private Action Rebate",
-    "status": "ACTIVE",
-    "remainingPool": 4.95,
-    "rewardAmountPerEvent": 0.005,
-    "rewardToken": "SOL"
-  }
+  "ingesterUrl": "https://ingest.torque.so",
+  "ingesterReachable": true
 }
 ```
+
+When the ingester is unreachable, `ingesterReachable` is `false` and `ingesterReason` is included:
+
+```json
+{
+  "ok": true,
+  "enabled": true,
+  "network": "devnet",
+  "ingesterUrl": "https://ingest.torque.so",
+  "ingesterReachable": false,
+  "ingesterReason": "network"
+}
+```
+
+`ingesterReason` is one of `'auth' | 'network' | 'unknown'`, present only when `ingesterReachable` is `false`.
 
 When `TORQUE_GROWTH_ENABLED=false`:
 
@@ -72,6 +95,14 @@ When `TORQUE_GROWTH_ENABLED=false`:
 }
 ```
 
+## Network model
+
+Torque's event ingestion is **network-agnostic** — `ingest.torque.so` accepts events regardless of which Solana cluster the underlying TX was confirmed on. The `network` field inside `data` is sipher-internal record-keeping.
+
+Torque's **pool funding and reward distribution are mainnet-only** — the SOL/USDC pool that backs a REBATE incentive must live on mainnet. Pubkeys are network-portable, so a wallet that fires devnet events still receives mainnet rewards at the same address.
+
+This enables a **hybrid deployment model**: sipher fires devnet events from devnet wallets (no real money during shadow testing), while Torque pays out from a small mainnet pool. The same `cipher-admin` wallet owns both the Torque project and the mainnet pool.
+
 ## Privacy posture
 
 This integration has a known, bounded privacy leak: **Torque learns "wallet X used sipher".**
@@ -80,11 +111,11 @@ To attribute actions and route rebates, the Torque MCP server needs the user's p
 
 | Event | Wallet sent? | Amount sent? | Recipient sent? |
 |---|---|---|---|
-| `private_send_completed` | yes | **no** | no |
-| `private_swap_completed` | yes | yes (already public on-chain) | no |
-| `private_claim_completed` | yes | no | no |
-| `recurring_send_tick` | yes | no | no |
-| `batch_send_completed` | yes | no | no |
+| `sipher_private_send_completed` | yes | **no** | no |
+| `sipher_private_swap_completed` | yes | yes (already public on-chain) | no |
+| `sipher_private_claim_completed` | yes | no | no |
+| `sipher_recurring_send_tick` | yes | no | no |
+| `sipher_batch_send_completed` | yes | no | no |
 
 Users who want zero attribution leakage should set `TORQUE_GROWTH_ENABLED=false`.
 
@@ -101,7 +132,7 @@ Users who want zero attribution leakage should set `TORQUE_GROWTH_ENABLED=false`
 ## Architecture
 
 ```
-sipher tool execution → growth-hook → rebate-destination → TorqueMCPClient → Torque MCP server
+sipher tool execution → growth-hook → rebate-destination → TorqueMCPClient → ingest.torque.so/events
                                           │
                                           └─→ derives an Ed25519 stealth address from the
                                               user's SNS SIP-STEALTH record
@@ -110,6 +141,22 @@ sipher tool execution → growth-hook → rebate-destination → TorqueMCPClient
                                               SNS RPC load — within that window multiple
                                               events from the same wallet rebate to the
                                               same derived address
+```
+
+Event payload shape (canonical contract, verified against live endpoint):
+
+```ts
+{
+  userPubkey: 'C1phr...',       // user's Solana pubkey
+  timestamp: 1747068000000,     // ms-epoch
+  eventName: 'sipher_private_send_completed',
+  data: {
+    tx_signature: '3QCo...',
+    network: 'devnet',           // sipher-internal; Torque is network-agnostic
+    rebate_destination: 'RbT6...', // fresh stealth address derived from SNS SIP-STEALTH record
+    // amount_lamports, asset — present only for swap events
+  }
+}
 ```
 
 See `docs/superpowers/specs/2026-05-12-torque-mcp-integration-design.md` for full design.

--- a/packages/agent/src/integrations/torque/growth-hook.ts
+++ b/packages/agent/src/integrations/torque/growth-hook.ts
@@ -5,7 +5,7 @@ import type { SipherEventName, SipherGrowthEvent, TorqueMCPClientOptions } from 
 
 export interface GrowthHookOptions extends TorqueMCPClientOptions {
   growthEnabled: boolean
-  /** Network used to populate SipherGrowthEvent.network. */
+  /** Network used to populate SipherGrowthEvent.data.network. */
   network: 'mainnet-beta' | 'devnet'
   /** Optional connection for rebate-destination SNS resolution; emission is skipped if omitted. */
   connection?: Connection
@@ -13,11 +13,11 @@ export interface GrowthHookOptions extends TorqueMCPClientOptions {
 
 /** Map sipher tool name → growth event name. Read-only tools are intentionally absent. */
 const TOOL_EVENT_MAP: Record<string, SipherEventName> = {
-  send: 'sipher.private_send_completed',
-  swap: 'sipher.private_swap_completed',
-  claim: 'sipher.private_claim_completed',
-  drip: 'sipher.recurring_send_tick',
-  splitSend: 'sipher.batch_send_completed',
+  send: 'sipher_private_send_completed',
+  swap: 'sipher_private_swap_completed',
+  claim: 'sipher_private_claim_completed',
+  drip: 'sipher_recurring_send_tick',
+  splitSend: 'sipher_batch_send_completed',
 }
 
 /** Swap outputs are on-chain DEX events already; include lamport amount for Torque attribution. */
@@ -30,17 +30,6 @@ export function wrapExecutorWithGrowthHook(
   opts: GrowthHookOptions,
 ): ToolExecutor {
   if (!opts.growthEnabled) {
-    return baseExecutor
-  }
-
-  // Without a campaign ID the client would POST to https://.../campaigns//events
-  // (note the double slash) — Torque returns 404 and the error envelope swallows
-  // it silently. Bail out loudly instead so misconfigured envs are visible.
-  if (!opts.campaignId || !opts.campaignId.trim()) {
-    const envVar = opts.network === 'mainnet-beta' ? 'TORQUE_CAMPAIGN_ID_MAINNET' : 'TORQUE_CAMPAIGN_ID_DEVNET'
-    console.warn(
-      `[torque] no campaign ID for network=${opts.network} — growth-hook disabled. Set ${envVar} to enable rebate emission.`,
-    )
     return baseExecutor
   }
 
@@ -73,7 +62,6 @@ async function emitGrowthEvent(
   const wallet = typeof input.wallet === 'string' ? input.wallet : undefined
   if (!wallet) return
 
-  // Only attempt SNS resolution when a connection is available.
   if (!opts.connection) return
 
   const domain =
@@ -89,17 +77,21 @@ async function emitGrowthEvent(
 
   if (destination.kind !== 'stealth') return
 
+  const amountLamports = AMOUNT_INCLUDED_TOOLS.has(toolName)
+    ? extractAmountLamports(result)
+    : undefined
+  const asset = AMOUNT_INCLUDED_TOOLS.has(toolName) ? extractAsset(result) : undefined
+
   const event: SipherGrowthEvent = {
-    event: eventName,
-    wallet,
-    ts: new Date().toISOString(),
-    tx_signature: txSignature,
-    network: opts.network,
-    metadata: {
+    userPubkey: wallet,
+    timestamp: Date.now(),
+    eventName,
+    data: {
+      tx_signature: txSignature,
+      network: opts.network,
       rebate_destination: destination.address,
-      ...(AMOUNT_INCLUDED_TOOLS.has(toolName)
-        ? { amount_lamports: extractAmountLamports(result) }
-        : {}),
+      ...(amountLamports !== undefined ? { amount_lamports: amountLamports } : {}),
+      ...(asset !== undefined ? { asset } : {}),
     },
   }
 
@@ -119,5 +111,13 @@ function extractAmountLamports(result: unknown): number | undefined {
   const r = result as Record<string, unknown>
   if (typeof r.amountInLamports === 'number') return r.amountInLamports
   if (typeof r.amountLamports === 'number') return r.amountLamports
+  return undefined
+}
+
+function extractAsset(result: unknown): string | undefined {
+  if (!result || typeof result !== 'object') return undefined
+  const r = result as Record<string, unknown>
+  if (typeof r.asset === 'string') return r.asset
+  if (typeof r.outputMint === 'string') return r.outputMint
   return undefined
 }

--- a/packages/agent/src/integrations/torque/index.ts
+++ b/packages/agent/src/integrations/torque/index.ts
@@ -3,10 +3,11 @@ export { deriveRebateDestination, _resetRebateDestinationCacheForTests } from '.
 export { wrapExecutorWithGrowthHook } from './growth-hook.js'
 export type {
   SipherGrowthEvent,
+  SipherGrowthEventData,
   SipherEventName,
-  TorqueCampaign,
   TorqueMCPClientOptions,
   TorqueEmitResult,
+  TorquePingResult,
 } from './types.js'
 export type { RebateDestination, DeriveRebateDestinationParams } from './rebate-destination.js'
 export type { GrowthHookOptions } from './growth-hook.js'

--- a/packages/agent/src/integrations/torque/mcp-client.ts
+++ b/packages/agent/src/integrations/torque/mcp-client.ts
@@ -1,77 +1,83 @@
 import type {
   SipherGrowthEvent,
-  TorqueCampaign,
   TorqueEmitResult,
   TorqueMCPClientOptions,
+  TorquePingResult,
 } from './types.js'
 
 const DEFAULT_TIMEOUT_MS = 8000
 
 export class TorqueMCPClient {
-  private readonly baseUrl: string
-  private readonly apiKey: string
-  private readonly campaignId: string
+  private readonly ingesterUrl: string
+  private readonly apiToken: string
   private readonly timeoutMs: number
 
   constructor(opts: TorqueMCPClientOptions) {
-    this.baseUrl = opts.baseUrl.replace(/\/+$/, '')
-    this.apiKey = opts.apiKey
-    this.campaignId = opts.campaignId
+    this.ingesterUrl = opts.ingesterUrl.replace(/\/+$/, '')
+    this.apiToken = opts.apiToken
     this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
   }
 
   async emitEvent(event: SipherGrowthEvent): Promise<TorqueEmitResult> {
-    const url = `${this.baseUrl}/campaigns/${this.campaignId}/events`
+    const url = `${this.ingesterUrl}/events`
     try {
       const response = await fetch(url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-torque-api-key': this.apiKey,
+          'x-api-key': this.apiToken,
         },
         body: JSON.stringify(event),
         signal: AbortSignal.timeout(this.timeoutMs),
       })
       if (response.status === 401 || response.status === 403) {
-        return { ok: false, reason: 'auth', message: `Torque rejected api key (${response.status})` }
-      }
-      if (response.status === 409) {
-        return { ok: false, reason: 'duplicate', message: 'Event already ingested (idempotency hit)' }
+        return { ok: false, reason: 'auth', message: `Torque rejected api token (${response.status})` }
       }
       if (response.status === 429) {
         return { ok: false, reason: 'rate_limit', message: 'Torque rate limit hit' }
       }
-      if (response.status === 410) {
-        return { ok: false, reason: 'campaign_inactive', message: 'Campaign no longer active' }
+      if (response.status === 400) {
+        const body = (await response.json().catch(() => null)) as { message?: string } | null
+        const message = body?.message ?? 'Torque returned 400'
+        if (/Event not found/i.test(message)) {
+          return { ok: false, reason: 'event_undefined', message }
+        }
+        return { ok: false, reason: 'validation', message }
       }
       if (!response.ok) {
         return { ok: false, reason: 'unknown', message: `Torque returned ${response.status}` }
       }
-      const json = (await response.json()) as { status?: string; data?: { eventId?: string } }
-      const eventId = json?.data?.eventId
-      if (json?.status !== 'SUCCESS' || !eventId) {
-        return { ok: false, reason: 'unknown', message: 'Torque response missing eventId' }
-      }
-      return { ok: true, eventId }
+      return { ok: true }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       return { ok: false, reason: 'network', message }
     }
   }
 
-  async getCampaign(): Promise<TorqueCampaign | null> {
-    const url = `${this.baseUrl}/campaigns/${this.campaignId}`
+  /**
+   * Reachability ping for ops/admin visibility. POSTs an empty body and treats
+   * any 4xx/2xx as reachable (server is up). Network errors → not reachable.
+   */
+  async pingIngester(): Promise<TorquePingResult> {
+    const url = `${this.ingesterUrl}/events`
     try {
       const response = await fetch(url, {
-        headers: { 'x-torque-api-key': this.apiKey },
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': this.apiToken,
+        },
+        body: '{}',
         signal: AbortSignal.timeout(this.timeoutMs),
       })
-      if (!response.ok) return null
-      const json = (await response.json()) as { status?: string; data?: TorqueCampaign }
-      if (json?.status !== 'SUCCESS') return null
-      return json.data ?? null
-    } catch {
-      return null
+      if (response.status === 401 || response.status === 403) {
+        return { ok: false, reason: 'auth', message: `Torque rejected api token (${response.status})` }
+      }
+      // Any other response (including 400 schema rejection) means the host is reachable.
+      return { ok: true }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      return { ok: false, reason: 'network', message }
     }
   }
 }

--- a/packages/agent/src/integrations/torque/types.ts
+++ b/packages/agent/src/integrations/torque/types.ts
@@ -1,46 +1,48 @@
 /**
- * Event emitted to Torque MCP after a successful fund-moving sipher tool call.
- * Wallet field is required for attribution; rebate_destination is a fresh
- * stealth address derived per event so Torque does not learn the user's
- * recipient identity.
+ * Event emitted to Torque ingest after a successful fund-moving sipher tool call.
+ * Shape mirrors Torque's canonical ingest contract — flat top-level fields
+ * with a `data` sub-object whose values are string|number|boolean only.
+ *
+ * userPubkey is required for attribution. `data.rebate_destination` carries
+ * the per-event fresh stealth address so Torque cannot learn the recipient
+ * identity.
  */
 export interface SipherGrowthEvent {
-  event: SipherEventName
-  wallet: string
-  ts: string
+  userPubkey: string
+  /** ms-epoch number, NOT ISO string */
+  timestamp: number
+  eventName: SipherEventName
+  data: SipherGrowthEventData
+}
+
+export interface SipherGrowthEventData {
   tx_signature: string
   network: 'mainnet-beta' | 'devnet'
-  metadata: {
-    amount_lamports?: number
-    asset?: string
-    rebate_destination: string
-  }
+  rebate_destination: string
+  /** Present only on swap events for amount attribution */
+  amount_lamports?: number
+  /** Present only on swap events */
+  asset?: string
 }
 
 export type SipherEventName =
-  | 'sipher.private_send_completed'
-  | 'sipher.private_swap_completed'
-  | 'sipher.private_claim_completed'
-  | 'sipher.recurring_send_tick'
-  | 'sipher.batch_send_completed'
-
-export interface TorqueCampaign {
-  id: string
-  name: string
-  status: 'ACTIVE' | 'PAUSED' | 'ENDED'
-  remainingPool: number
-  rewardAmountPerEvent: number
-  rewardToken: string
-}
+  | 'sipher_private_send_completed'
+  | 'sipher_private_swap_completed'
+  | 'sipher_private_claim_completed'
+  | 'sipher_recurring_send_tick'
+  | 'sipher_batch_send_completed'
 
 export interface TorqueMCPClientOptions {
-  baseUrl: string
-  apiKey: string
-  campaignId: string
+  ingesterUrl: string
+  apiToken: string
   /** ms; default 8000 */
   timeoutMs?: number
 }
 
 export type TorqueEmitResult =
-  | { ok: true; eventId: string }
-  | { ok: false; reason: 'auth' | 'rate_limit' | 'network' | 'duplicate' | 'campaign_inactive' | 'unknown'; message: string }
+  | { ok: true }
+  | { ok: false; reason: 'auth' | 'rate_limit' | 'network' | 'event_undefined' | 'validation' | 'unknown'; message: string }
+
+export type TorquePingResult =
+  | { ok: true }
+  | { ok: false; reason: 'auth' | 'network' | 'unknown'; message: string }

--- a/packages/agent/src/routes/admin.ts
+++ b/packages/agent/src/routes/admin.ts
@@ -139,22 +139,20 @@ adminRouter.get('/api/torque/status', async (_req, res) => {
   }
 
   const network = loadNetworkConfig().clusterName
-  const campaignId = network === 'mainnet-beta' ? config.campaignIdMainnet : config.campaignIdDevnet
 
   const client = new TorqueMCPClient({
-    apiKey: config.apiKey,
-    baseUrl: config.baseUrl,
-    campaignId,
+    apiToken: config.apiToken,
+    ingesterUrl: config.ingesterUrl,
   })
 
-  const campaign = await client.getCampaign()
+  const ping = await client.pingIngester()
   ;(res as any).status(200).json({
     ok: true,
     enabled: true,
     network,
-    campaignId,
-    campaignFetchOk: campaign !== null,
-    campaign,
+    ingesterUrl: config.ingesterUrl,
+    ingesterReachable: ping.ok,
+    ingesterReason: ping.ok ? undefined : ping.reason,
   })
 })
 

--- a/packages/agent/tests/agent-torque-wiring.test.ts
+++ b/packages/agent/tests/agent-torque-wiring.test.ts
@@ -71,10 +71,8 @@ describe('createAgent torque wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     delete process.env.TORQUE_GROWTH_ENABLED
-    delete process.env.TORQUE_API_KEY
-    delete process.env.TORQUE_MCP_URL
-    delete process.env.TORQUE_CAMPAIGN_ID_DEVNET
-    delete process.env.TORQUE_CAMPAIGN_ID_MAINNET
+    delete process.env.TORQUE_API_TOKEN
+    delete process.env.TORQUE_INGESTER_URL
     // Ensure DB does not fail on import
     process.env.DB_PATH = ':memory:'
   })
@@ -87,10 +85,8 @@ describe('createAgent torque wiring', () => {
 
   it('wraps executor with growth hook when env enables it', async () => {
     process.env.TORQUE_GROWTH_ENABLED = 'true'
-    process.env.TORQUE_API_KEY = 'tk_secret'
-    process.env.TORQUE_MCP_URL = 'https://torque.test'
-    process.env.TORQUE_CAMPAIGN_ID_DEVNET = 'camp_d'
-    process.env.TORQUE_CAMPAIGN_ID_MAINNET = 'camp_m'
+    process.env.TORQUE_API_TOKEN = 'tk_secret'
+    process.env.TORQUE_INGESTER_URL = 'https://torque.test'
 
     const { chat } = await import('../src/agent.js')
     await chat('hello')
@@ -99,9 +95,8 @@ describe('createAgent torque wiring', () => {
     const callArgs = vi.mocked(wrapExecutorWithGrowthHook).mock.calls[0]!
     expect(callArgs[1]).toStrictEqual({
       growthEnabled: true,
-      apiKey: 'tk_secret',
-      baseUrl: 'https://torque.test',
-      campaignId: 'camp_d', // devnet cluster → devnet campaign ID
+      apiToken: 'tk_secret',
+      ingesterUrl: 'https://torque.test',
       network: 'devnet',
       connection: { stub: 'connection' },
     })
@@ -109,10 +104,8 @@ describe('createAgent torque wiring', () => {
 
   it('wraps executor in chatStream when env enables it', async () => {
     process.env.TORQUE_GROWTH_ENABLED = 'true'
-    process.env.TORQUE_API_KEY = 'tk_secret'
-    process.env.TORQUE_MCP_URL = 'https://torque.test'
-    process.env.TORQUE_CAMPAIGN_ID_DEVNET = 'camp_d'
-    process.env.TORQUE_CAMPAIGN_ID_MAINNET = 'camp_m'
+    process.env.TORQUE_API_TOKEN = 'tk_secret'
+    process.env.TORQUE_INGESTER_URL = 'https://torque.test'
 
     const { chatStream } = await import('../src/agent.js')
     const gen = chatStream('hello')
@@ -122,9 +115,8 @@ describe('createAgent torque wiring', () => {
     const callArgs = vi.mocked(wrapExecutorWithGrowthHook).mock.calls[0]!
     expect(callArgs[1]).toStrictEqual({
       growthEnabled: true,
-      apiKey: 'tk_secret',
-      baseUrl: 'https://torque.test',
-      campaignId: 'camp_d', // devnet cluster → devnet campaign ID
+      apiToken: 'tk_secret',
+      ingesterUrl: 'https://torque.test',
       network: 'devnet',
       connection: { stub: 'connection' },
     })

--- a/packages/agent/tests/config/network-torque.test.ts
+++ b/packages/agent/tests/config/network-torque.test.ts
@@ -53,6 +53,16 @@ describe('loadTorqueConfig', () => {
     })
   })
 
+  it('defaults ingesterUrl to https://ingest.torque.so when TORQUE_INGESTER_URL is empty string', () => {
+    process.env.TORQUE_GROWTH_ENABLED = 'true'
+    process.env.TORQUE_API_TOKEN = 'tk_secret'
+    process.env.TORQUE_INGESTER_URL = ''
+    expect(loadTorqueConfig()).toStrictEqual({
+      apiToken: 'tk_secret',
+      ingesterUrl: 'https://ingest.torque.so',
+    })
+  })
+
   it('uses TORQUE_INGESTER_URL override when set', () => {
     process.env.TORQUE_GROWTH_ENABLED = 'true'
     process.env.TORQUE_API_TOKEN = 'tq_secret'

--- a/packages/agent/tests/config/network-torque.test.ts
+++ b/packages/agent/tests/config/network-torque.test.ts
@@ -1,37 +1,64 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { loadTorqueConfig } from '../../src/config/network.js'
 
 describe('loadTorqueConfig', () => {
   beforeEach(() => {
     delete process.env.TORQUE_GROWTH_ENABLED
-    delete process.env.TORQUE_API_KEY
-    delete process.env.TORQUE_MCP_URL
-    delete process.env.TORQUE_CAMPAIGN_ID_DEVNET
-    delete process.env.TORQUE_CAMPAIGN_ID_MAINNET
+    delete process.env.TORQUE_API_TOKEN
+    delete process.env.TORQUE_INGESTER_URL
   })
 
-  it('returns null when TORQUE_GROWTH_ENABLED is not "true"', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns null when TORQUE_GROWTH_ENABLED is unset', () => {
     expect(loadTorqueConfig()).toBeNull()
   })
 
-  it('returns null when TORQUE_API_KEY is missing despite enabled=true', () => {
+  it.each([['false'], ['1'], ['yes'], ['TRUE']])(
+    'returns null when TORQUE_GROWTH_ENABLED is %s (non-"true" value)',
+    (value) => {
+      process.env.TORQUE_GROWTH_ENABLED = value
+      expect(loadTorqueConfig()).toBeNull()
+    },
+  )
+
+  it('returns null and warns when TORQUE_API_TOKEN is missing despite enabled=true', () => {
     process.env.TORQUE_GROWTH_ENABLED = 'true'
-    process.env.TORQUE_MCP_URL = 'https://torque.test'
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
     expect(loadTorqueConfig()).toBeNull()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('TORQUE_API_TOKEN'))
   })
 
-  it('returns config when all required vars present', () => {
+  it('returns config when TORQUE_API_TOKEN and TORQUE_INGESTER_URL are both set', () => {
     process.env.TORQUE_GROWTH_ENABLED = 'true'
-    process.env.TORQUE_API_KEY = 'tk_secret'
-    process.env.TORQUE_MCP_URL = 'https://torque.test'
-    process.env.TORQUE_CAMPAIGN_ID_DEVNET = 'camp_d'
-    process.env.TORQUE_CAMPAIGN_ID_MAINNET = 'camp_m'
+    process.env.TORQUE_API_TOKEN = 'tq_secret'
+    process.env.TORQUE_INGESTER_URL = 'https://ingest.torque.test'
 
     expect(loadTorqueConfig()).toStrictEqual({
-      apiKey: 'tk_secret',
-      baseUrl: 'https://torque.test',
-      campaignIdDevnet: 'camp_d',
-      campaignIdMainnet: 'camp_m',
+      apiToken: 'tq_secret',
+      ingesterUrl: 'https://ingest.torque.test',
     })
+  })
+
+  it('defaults ingesterUrl to https://ingest.torque.so when TORQUE_INGESTER_URL is unset', () => {
+    process.env.TORQUE_GROWTH_ENABLED = 'true'
+    process.env.TORQUE_API_TOKEN = 'tq_secret'
+
+    expect(loadTorqueConfig()).toStrictEqual({
+      apiToken: 'tq_secret',
+      ingesterUrl: 'https://ingest.torque.so',
+    })
+  })
+
+  it('uses TORQUE_INGESTER_URL override when set', () => {
+    process.env.TORQUE_GROWTH_ENABLED = 'true'
+    process.env.TORQUE_API_TOKEN = 'tq_secret'
+    process.env.TORQUE_INGESTER_URL = 'https://staging.ingest.torque.so'
+
+    const config = loadTorqueConfig()
+    expect(config?.ingesterUrl).toBe('https://staging.ingest.torque.so')
   })
 })

--- a/packages/agent/tests/integrations/torque/growth-hook.test.ts
+++ b/packages/agent/tests/integrations/torque/growth-hook.test.ts
@@ -25,9 +25,8 @@ const baseExecutor = vi.fn()
 let emitEventMock: ReturnType<typeof vi.fn>
 
 const opts = {
-  baseUrl: 'https://torque.test',
-  apiKey: 'tk_secret',
-  campaignId: 'camp_devnet_1',
+  ingesterUrl: 'https://ingest.torque.test',
+  apiToken: 'tq_secret',
   network: 'devnet' as const,
   growthEnabled: true,
   // connection must be truthy so the implementation routes through deriveRebateDestination.
@@ -39,7 +38,7 @@ describe('wrapExecutorWithGrowthHook', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     // Re-wire the TorqueMCPClient factory so each test gets a fresh emitEvent mock.
-    emitEventMock = vi.fn().mockResolvedValue({ ok: true, eventId: 'evt_1' })
+    emitEventMock = vi.fn().mockResolvedValue({ ok: true })
     vi.mocked(TorqueMCPClient).mockImplementation(() => ({ emitEvent: emitEventMock } as never))
     vi.mocked(deriveRebateDestination).mockResolvedValue({ kind: 'stealth', address: 'RbT6X9' })
   })
@@ -54,7 +53,7 @@ describe('wrapExecutorWithGrowthHook', () => {
     expect(baseExecutor).toHaveBeenCalledOnce()
   })
 
-  it('emits sipher.private_send_completed after a successful send', async () => {
+  it('emits sipher_private_send_completed after a successful send', async () => {
     baseExecutor.mockResolvedValue({ action: 'send', status: 'confirmed', signature: TX_SIG })
     const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)
 
@@ -64,12 +63,12 @@ describe('wrapExecutorWithGrowthHook', () => {
 
     expect(emitEventMock).toHaveBeenCalledOnce()
     expect(emitEventMock).toHaveBeenCalledWith({
-      event: 'sipher.private_send_completed',
-      wallet: WALLET,
-      ts: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/),
-      tx_signature: TX_SIG,
-      network: 'devnet',
-      metadata: {
+      userPubkey: WALLET,
+      timestamp: expect.any(Number),
+      eventName: 'sipher_private_send_completed',
+      data: {
+        tx_signature: TX_SIG,
+        network: 'devnet',
         rebate_destination: 'RbT6X9',
       },
     })
@@ -83,18 +82,53 @@ describe('wrapExecutorWithGrowthHook', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     const call = emitEventMock.mock.calls[0]![0]
-    expect(call.metadata.amount_lamports).toBeUndefined()
+    expect(call.data.amount_lamports).toBeUndefined()
   })
 
-  it('INCLUDES amount_lamports for swap events (DEX is already public)', async () => {
-    baseExecutor.mockResolvedValue({ action: 'swap', status: 'confirmed', signature: TX_SIG, amountInLamports: 1_000_000 })
+  it('INCLUDES amount_lamports and asset for swap events (DEX is already public)', async () => {
+    baseExecutor.mockResolvedValue({
+      action: 'swap',
+      status: 'confirmed',
+      signature: TX_SIG,
+      amountInLamports: 1_000_000,
+      outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+    })
     const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)
 
     await wrapped('swap', { wallet: WALLET, fromToken: 'SOL', toToken: 'USDC', amount: 1 })
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     const call = emitEventMock.mock.calls[0]![0]
-    expect(call.metadata.amount_lamports).toBe(1_000_000)
+    expect(call.data.amount_lamports).toBe(1_000_000)
+    expect(call.data.asset).toBe('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')
+  })
+
+  it('emits sipher_private_swap_completed for swap tool', async () => {
+    baseExecutor.mockResolvedValue({
+      action: 'swap',
+      status: 'confirmed',
+      signature: TX_SIG,
+      amountInLamports: 500_000,
+      asset: 'So11111111111111111111111111111111111111112',
+    })
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)
+
+    await wrapped('swap', { wallet: WALLET, fromToken: 'SOL', toToken: 'USDC', amount: 0.5 })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(emitEventMock).toHaveBeenCalledOnce()
+    expect(emitEventMock).toHaveBeenCalledWith({
+      userPubkey: WALLET,
+      timestamp: expect.any(Number),
+      eventName: 'sipher_private_swap_completed',
+      data: {
+        tx_signature: TX_SIG,
+        network: 'devnet',
+        rebate_destination: 'RbT6X9',
+        amount_lamports: 500_000,
+        asset: 'So11111111111111111111111111111111111111112',
+      },
+    })
   })
 
   it('does NOT emit when base executor throws', async () => {
@@ -115,13 +149,14 @@ describe('wrapExecutorWithGrowthHook', () => {
     expect(emitEventMock).not.toHaveBeenCalled()
   })
 
-  it('does NOT emit when growthEnabled=false', async () => {
+  it('does NOT emit when growthEnabled=false (returns base executor unchanged)', async () => {
     baseExecutor.mockResolvedValue({ action: 'send', status: 'confirmed', signature: TX_SIG })
     const wrapped = wrapExecutorWithGrowthHook(baseExecutor, { ...opts, growthEnabled: false })
 
     await wrapped('send', { wallet: WALLET, amount: 1, token: 'SOL', recipient: 'rector.sol' })
     await new Promise((resolve) => setTimeout(resolve, 0))
 
+    expect(TorqueMCPClient).not.toHaveBeenCalled()
     expect(emitEventMock).not.toHaveBeenCalled()
   })
 
@@ -161,60 +196,35 @@ describe('wrapExecutorWithGrowthHook', () => {
     expect(emitEventMock).not.toHaveBeenCalled()
   })
 
-  it('returns the base executor (no client construction, no emit) when campaignId is empty', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+  it('skips emit when result has no wallet in input', async () => {
     baseExecutor.mockResolvedValue({ action: 'send', status: 'confirmed', signature: TX_SIG })
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)
 
-    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, { ...opts, campaignId: '' })
-
-    await wrapped('send', { wallet: WALLET, amount: 1, token: 'SOL', recipient: 'rector.sol' })
+    // wallet field intentionally absent from input
+    await wrapped('send', { amount: 1, token: 'SOL', recipient: 'rector.sol' })
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect(TorqueMCPClient).not.toHaveBeenCalled()
     expect(emitEventMock).not.toHaveBeenCalled()
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('no campaign ID for network=devnet'),
-    )
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('TORQUE_CAMPAIGN_ID_DEVNET'),
-    )
-    warnSpy.mockRestore()
   })
 
-  it('treats a whitespace-only campaignId as empty', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+  it('skips emit when connection is not provided', async () => {
     baseExecutor.mockResolvedValue({ action: 'send', status: 'confirmed', signature: TX_SIG })
-
-    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, { ...opts, campaignId: '   ' })
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, { ...opts, connection: undefined })
 
     await wrapped('send', { wallet: WALLET, amount: 1, token: 'SOL', recipient: 'rector.sol' })
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect(TorqueMCPClient).not.toHaveBeenCalled()
     expect(emitEventMock).not.toHaveBeenCalled()
-    expect(warnSpy).toHaveBeenCalled()
-    warnSpy.mockRestore()
   })
 
-  it('names the mainnet env var in the warning when network=mainnet-beta', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+  it('skips emit when rebate destination is not a stealth address', async () => {
+    vi.mocked(deriveRebateDestination).mockResolvedValue({ kind: 'unavailable', address: null, reason: 'no_domain' })
     baseExecutor.mockResolvedValue({ action: 'send', status: 'confirmed', signature: TX_SIG })
-
-    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, {
-      ...opts,
-      campaignId: '',
-      network: 'mainnet-beta',
-    })
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)
 
     await wrapped('send', { wallet: WALLET, amount: 1, token: 'SOL', recipient: 'rector.sol' })
     await new Promise((resolve) => setTimeout(resolve, 0))
 
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('TORQUE_CAMPAIGN_ID_MAINNET'),
-    )
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('network=mainnet-beta'),
-    )
-    warnSpy.mockRestore()
+    expect(emitEventMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/agent/tests/integrations/torque/mcp-client.test.ts
+++ b/packages/agent/tests/integrations/torque/mcp-client.test.ts
@@ -38,7 +38,7 @@ describe('TorqueMCPClient.emitEvent', () => {
     const [url, init] = fetchSpy.mock.calls[0]!
     expect(url).toBe('https://ingest.torque.test/events')
     expect(init?.method).toBe('POST')
-    expect(init?.headers).toMatchObject({
+    expect(init?.headers).toStrictEqual({
       'Content-Type': 'application/json',
       'x-api-key': 'tk_secret',
     })
@@ -136,6 +136,21 @@ describe('TorqueMCPClient.emitEvent error paths', () => {
       ok: false,
       reason: 'validation',
       message: 'body/data Required',
+    })
+  })
+
+  it('returns unknown reason on 5xx', async () => {
+    const client = clientWithMockedFetch(503)
+    const result = await client.emitEvent({
+      userPubkey: 'C1phr',
+      timestamp: 1747068000000,
+      eventName: 'sipher_private_send_completed',
+      data: { tx_signature: 's', network: 'devnet', rebate_destination: 'r' },
+    })
+    expect(result).toStrictEqual({
+      ok: false,
+      reason: 'unknown',
+      message: expect.stringMatching(/503/),
     })
   })
 

--- a/packages/agent/tests/integrations/torque/mcp-client.test.ts
+++ b/packages/agent/tests/integrations/torque/mcp-client.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { TorqueMCPClient } from '../../../src/integrations/torque/mcp-client.js'
-import type { SipherGrowthEvent, TorqueCampaign } from '../../../src/integrations/torque/types.js'
+import type { SipherGrowthEvent } from '../../../src/integrations/torque/types.js'
 
 const baseEvent: SipherGrowthEvent = {
-  event: 'sipher.private_send_completed',
-  wallet: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
-  ts: '2026-05-12T12:00:00Z',
-  tx_signature: '3QCoHcJ1NNg',
-  network: 'devnet',
-  metadata: {
+  userPubkey: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
+  timestamp: 1747068000000,
+  eventName: 'sipher_private_send_completed',
+  data: {
+    tx_signature: '3QCoHcJ1NNg',
+    network: 'devnet',
     rebate_destination: '4HC3vQB5s5c',
   },
 }
@@ -18,32 +18,45 @@ describe('TorqueMCPClient.emitEvent', () => {
     vi.restoreAllMocks()
   })
 
-  it('POSTs the event with x-torque-api-key header and JSON body', async () => {
+  it('POSTs the event with x-api-key header to /events with flat body', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ status: 'SUCCESS', data: { eventId: 'evt_1' } }), {
+      new Response(JSON.stringify({ status: 'OK' }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }),
     )
 
     const client = new TorqueMCPClient({
-      baseUrl: 'https://torque.test',
-      apiKey: 'tk_secret',
-      campaignId: 'camp_devnet_1',
+      ingesterUrl: 'https://ingest.torque.test',
+      apiToken: 'tk_secret',
     })
 
     const result = await client.emitEvent(baseEvent)
 
-    expect(result).toStrictEqual({ ok: true, eventId: 'evt_1' })
+    expect(result).toStrictEqual({ ok: true })
     expect(fetchSpy).toHaveBeenCalledOnce()
     const [url, init] = fetchSpy.mock.calls[0]!
-    expect(url).toBe('https://torque.test/campaigns/camp_devnet_1/events')
+    expect(url).toBe('https://ingest.torque.test/events')
     expect(init?.method).toBe('POST')
     expect(init?.headers).toMatchObject({
       'Content-Type': 'application/json',
-      'x-torque-api-key': 'tk_secret',
+      'x-api-key': 'tk_secret',
     })
     expect(JSON.parse(init?.body as string)).toStrictEqual(baseEvent)
+  })
+
+  it('strips trailing slash from ingesterUrl', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ status: 'OK' }), { status: 200 }),
+    )
+
+    const client = new TorqueMCPClient({
+      ingesterUrl: 'https://ingest.torque.test/',
+      apiToken: 'tk_secret',
+    })
+
+    await client.emitEvent(baseEvent)
+    expect(fetchSpy.mock.calls[0]![0]).toBe('https://ingest.torque.test/events')
   })
 })
 
@@ -58,181 +71,134 @@ describe('TorqueMCPClient.emitEvent error paths', () => {
       }),
     )
     return new TorqueMCPClient({
-      baseUrl: 'https://torque.test',
-      apiKey: 'tk_secret',
-      campaignId: 'camp_devnet_1',
+      ingesterUrl: 'https://ingest.torque.test',
+      apiToken: 'tk_secret',
     })
   }
 
   it('returns auth reason on 401', async () => {
     const client = clientWithMockedFetch(401)
-    const result = await client.emitEvent(baseEvent)
+    const result = await client.emitEvent({
+      userPubkey: 'C1phr',
+      timestamp: 1747068000000,
+      eventName: 'sipher_private_send_completed',
+      data: { tx_signature: 's', network: 'devnet', rebate_destination: 'r' },
+    })
     expect(result).toStrictEqual({ ok: false, reason: 'auth', message: expect.stringMatching(/401/) })
   })
 
   it('returns auth reason on 403', async () => {
     const client = clientWithMockedFetch(403)
-    const result = await client.emitEvent(baseEvent)
+    const result = await client.emitEvent({
+      userPubkey: 'C1phr',
+      timestamp: 1747068000000,
+      eventName: 'sipher_private_send_completed',
+      data: { tx_signature: 's', network: 'devnet', rebate_destination: 'r' },
+    })
     expect(result).toStrictEqual({ ok: false, reason: 'auth', message: expect.stringMatching(/403/) })
-  })
-
-  it('returns duplicate reason on 409', async () => {
-    const client = clientWithMockedFetch(409)
-    const result = await client.emitEvent(baseEvent)
-    expect(result).toStrictEqual({ ok: false, reason: 'duplicate', message: expect.stringMatching(/idempotency/i) })
   })
 
   it('returns rate_limit reason on 429', async () => {
     const client = clientWithMockedFetch(429)
-    const result = await client.emitEvent(baseEvent)
+    const result = await client.emitEvent({
+      userPubkey: 'C1phr',
+      timestamp: 1747068000000,
+      eventName: 'sipher_private_send_completed',
+      data: { tx_signature: 's', network: 'devnet', rebate_destination: 'r' },
+    })
     expect(result).toStrictEqual({ ok: false, reason: 'rate_limit', message: expect.stringMatching(/rate limit/i) })
   })
 
-  it('returns campaign_inactive reason on 410', async () => {
-    const client = clientWithMockedFetch(410)
-    const result = await client.emitEvent(baseEvent)
-    expect(result).toStrictEqual({ ok: false, reason: 'campaign_inactive', message: expect.stringMatching(/no longer active/i) })
-  })
-
-  it('returns unknown reason on other 5xx', async () => {
-    const client = clientWithMockedFetch(503)
-    const result = await client.emitEvent(baseEvent)
-    expect(result).toStrictEqual({ ok: false, reason: 'unknown', message: expect.stringMatching(/503/) })
-  })
-
-  it('returns network reason on fetch throw', async () => {
-    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'))
-    const client = new TorqueMCPClient({
-      baseUrl: 'https://torque.test',
-      apiKey: 'tk_secret',
-      campaignId: 'camp_devnet_1',
+  it('returns event_undefined reason when 400 says "Event not found"', async () => {
+    const client = clientWithMockedFetch(400, { status: 'BAD_REQUEST', message: 'Event not found for this API key' })
+    const result = await client.emitEvent({
+      userPubkey: 'C1phr',
+      timestamp: 1747068000000,
+      eventName: 'sipher_private_send_completed',
+      data: { tx_signature: 's', network: 'devnet', rebate_destination: 'r' },
     })
-    const result = await client.emitEvent(baseEvent)
-    expect(result).toStrictEqual({ ok: false, reason: 'network', message: 'ECONNREFUSED' })
+    expect(result).toStrictEqual({
+      ok: false,
+      reason: 'event_undefined',
+      message: 'Event not found for this API key',
+    })
   })
 
-  it('returns unknown reason when response missing eventId', async () => {
-    const client = clientWithMockedFetch(200, { status: 'SUCCESS', data: {} })
-    const result = await client.emitEvent(baseEvent)
-    expect(result).toStrictEqual({ ok: false, reason: 'unknown', message: expect.stringMatching(/missing eventId/) })
+  it('returns validation reason for other 400 errors', async () => {
+    const client = clientWithMockedFetch(400, { status: 'BAD_REQUEST', message: 'body/data Required' })
+    const result = await client.emitEvent({
+      userPubkey: 'C1phr',
+      timestamp: 1747068000000,
+      eventName: 'sipher_private_send_completed',
+      data: { tx_signature: 's', network: 'devnet', rebate_destination: 'r' },
+    })
+    expect(result).toStrictEqual({
+      ok: false,
+      reason: 'validation',
+      message: 'body/data Required',
+    })
+  })
+
+  it('returns network reason on fetch error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('connection refused'))
+    const client = new TorqueMCPClient({
+      ingesterUrl: 'https://ingest.torque.test',
+      apiToken: 'tk_secret',
+    })
+    const result = await client.emitEvent({
+      userPubkey: 'C1phr',
+      timestamp: 1747068000000,
+      eventName: 'sipher_private_send_completed',
+      data: { tx_signature: 's', network: 'devnet', rebate_destination: 'r' },
+    })
+    expect(result).toStrictEqual({ ok: false, reason: 'network', message: 'connection refused' })
   })
 })
 
-describe('TorqueMCPClient.getCampaign', () => {
+describe('TorqueMCPClient.pingIngester', () => {
   beforeEach(() => vi.restoreAllMocks())
 
-  const campaign: TorqueCampaign = {
-    id: 'camp_devnet_1',
-    name: 'Sipher Private Action Rebate',
-    status: 'ACTIVE',
-    remainingPool: 4.95,
-    rewardAmountPerEvent: 0.005,
-    rewardToken: 'SOL',
-  }
-
-  it('GETs /campaigns/:id with x-torque-api-key header and returns campaign on SUCCESS', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ status: 'SUCCESS', data: campaign }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    )
-
+  it('returns ok on 2xx', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }))
     const client = new TorqueMCPClient({
-      baseUrl: 'https://torque.test',
-      apiKey: 'tk_secret',
-      campaignId: 'camp_devnet_1',
+      ingesterUrl: 'https://ingest.torque.test',
+      apiToken: 'tk_secret',
     })
-
-    const result = await client.getCampaign()
-
-    expect(result).toStrictEqual(campaign)
-    expect(fetchSpy).toHaveBeenCalledOnce()
-    const [url, init] = fetchSpy.mock.calls[0]!
-    expect(url).toBe('https://torque.test/campaigns/camp_devnet_1')
-    // GET is the default; the client passes no `method`, so init.method is undefined
-    expect(init?.method).toBeUndefined()
-    expect(init?.headers).toMatchObject({ 'x-torque-api-key': 'tk_secret' })
-    expect(init?.body).toBeUndefined()
+    const result = await client.pingIngester()
+    expect(result).toStrictEqual({ ok: true })
   })
 
-  it('returns null on non-ok HTTP (404)', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 404 }))
-    const client = new TorqueMCPClient({
-      baseUrl: 'https://torque.test',
-      apiKey: 'tk_secret',
-      campaignId: 'camp_missing',
-    })
-    const result = await client.getCampaign()
-    expect(result).toBeNull()
-  })
-
-  it('returns null on non-ok HTTP (500)', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 500 }))
-    const client = new TorqueMCPClient({
-      baseUrl: 'https://torque.test',
-      apiKey: 'tk_secret',
-      campaignId: 'camp_devnet_1',
-    })
-    const result = await client.getCampaign()
-    expect(result).toBeNull()
-  })
-
-  it('returns null when response envelope is not SUCCESS', async () => {
+  it('returns ok on 400 (host reachable, just rejected the empty body)', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ status: 'ERROR', data: campaign }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
+      new Response(JSON.stringify({ status: 'BAD_REQUEST', message: 'body/eventName Required, body/data Required' }), {
+        status: 400,
       }),
     )
     const client = new TorqueMCPClient({
-      baseUrl: 'https://torque.test',
-      apiKey: 'tk_secret',
-      campaignId: 'camp_devnet_1',
+      ingesterUrl: 'https://ingest.torque.test',
+      apiToken: 'tk_secret',
     })
-    const result = await client.getCampaign()
-    expect(result).toBeNull()
+    const result = await client.pingIngester()
+    expect(result).toStrictEqual({ ok: true })
   })
 
-  it('returns null when SUCCESS envelope has no data field', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ status: 'SUCCESS' }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    )
+  it('returns auth reason on 401', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 401 }))
     const client = new TorqueMCPClient({
-      baseUrl: 'https://torque.test',
-      apiKey: 'tk_secret',
-      campaignId: 'camp_devnet_1',
+      ingesterUrl: 'https://ingest.torque.test',
+      apiToken: 'tk_secret',
     })
-    const result = await client.getCampaign()
-    expect(result).toBeNull()
+    const result = await client.pingIngester()
+    expect(result).toStrictEqual({ ok: false, reason: 'auth', message: expect.stringMatching(/401/) })
   })
 
-  it('returns null and does not propagate when fetch throws', async () => {
-    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'))
+  it('returns network reason on fetch error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('connection refused'))
     const client = new TorqueMCPClient({
-      baseUrl: 'https://torque.test',
-      apiKey: 'tk_secret',
-      campaignId: 'camp_devnet_1',
+      ingesterUrl: 'https://ingest.torque.test',
+      apiToken: 'tk_secret',
     })
-    await expect(client.getCampaign()).resolves.toBeNull()
-  })
-
-  it('strips trailing slashes from baseUrl', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ status: 'SUCCESS', data: campaign }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    )
-    const client = new TorqueMCPClient({
-      baseUrl: 'https://torque.test///',
-      apiKey: 'tk_secret',
-      campaignId: 'camp_devnet_1',
-    })
-    await client.getCampaign()
-    expect(fetchSpy.mock.calls[0]![0]).toBe('https://torque.test/campaigns/camp_devnet_1')
+    const result = await client.pingIngester()
+    expect(result).toStrictEqual({ ok: false, reason: 'network', message: 'connection refused' })
   })
 })

--- a/packages/agent/tests/integrations/torque/torque-emit-roundtrip.test.ts
+++ b/packages/agent/tests/integrations/torque/torque-emit-roundtrip.test.ts
@@ -2,31 +2,29 @@ import { describe, it, expect, beforeAll } from 'vitest'
 import { TorqueMCPClient } from '../../../src/integrations/torque/mcp-client.js'
 import type { SipherGrowthEvent } from '../../../src/integrations/torque/types.js'
 
-const apiKey = process.env.TORQUE_API_KEY
-const baseUrl = process.env.TORQUE_MCP_URL
-const campaignId = process.env.TORQUE_TEST_CAMPAIGN_ID
+const apiToken = process.env.TORQUE_API_TOKEN
+const ingesterUrl = process.env.TORQUE_INGESTER_URL
 
-const skip = !apiKey || !baseUrl || !campaignId
+const skip = !apiToken || !ingesterUrl
 
 describe.skipIf(skip)('integration: torque devnet emit roundtrip', () => {
   let client: TorqueMCPClient
 
   beforeAll(() => {
     client = new TorqueMCPClient({
-      apiKey: apiKey!,
-      baseUrl: baseUrl!,
-      campaignId: campaignId!,
+      apiToken: apiToken!,
+      ingesterUrl: ingesterUrl!,
     })
   })
 
-  it('emits a custom_event and receives an eventId', async () => {
+  it('emits a custom_event and receives ok', async () => {
     const event: SipherGrowthEvent = {
-      event: 'sipher.private_send_completed',
-      wallet: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
-      ts: new Date().toISOString(),
-      tx_signature: `test_${Date.now()}`,
-      network: 'devnet',
-      metadata: {
+      userPubkey: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
+      timestamp: Date.now(),
+      eventName: 'sipher_private_send_completed',
+      data: {
+        tx_signature: `test_${Date.now()}`,
+        network: 'devnet',
         rebate_destination: '11111111111111111111111111111111',
       },
     }
@@ -34,8 +32,5 @@ describe.skipIf(skip)('integration: torque devnet emit roundtrip', () => {
     const result = await client.emitEvent(event)
 
     expect(result.ok).toBe(true)
-    if (result.ok) {
-      expect(result.eventId).toMatch(/^evt_/)
-    }
   }, 15_000)
 })

--- a/packages/agent/tests/integrations/torque/torque-rebate-e2e.test.ts
+++ b/packages/agent/tests/integrations/torque/torque-rebate-e2e.test.ts
@@ -5,11 +5,10 @@ import { homedir } from 'node:os'
 
 const KEYPAIR_PATH = `${homedir()}/Documents/secret/solana-devnet.json`
 const TEST_DOMAIN = process.env.SIP_TEST_DOMAIN
-const apiKey = process.env.TORQUE_API_KEY
-const baseUrl = process.env.TORQUE_MCP_URL
-const campaignId = process.env.TORQUE_TEST_CAMPAIGN_ID
+const apiToken = process.env.TORQUE_API_TOKEN
+const ingesterUrl = process.env.TORQUE_INGESTER_URL
 
-const skip = !existsSync(KEYPAIR_PATH) || !TEST_DOMAIN || !apiKey || !baseUrl || !campaignId
+const skip = !existsSync(KEYPAIR_PATH) || !TEST_DOMAIN || !apiToken || !ingesterUrl
 
 describe.skipIf(skip)('e2e: sipher send → torque rebate (devnet)', () => {
   let connection: Connection

--- a/packages/agent/tests/routes/admin-torque.test.ts
+++ b/packages/agent/tests/routes/admin-torque.test.ts
@@ -3,18 +3,13 @@ import express from 'express'
 import supertest from 'supertest'
 
 // Fixture variable read by the mock — tests override before each request
-let mockCampaignReturn: object | null = {
-  id: 'camp_devnet_1',
-  name: 'Sipher Private Action Rebate',
-  status: 'ACTIVE',
-  remainingPool: 4.95,
-  rewardAmountPerEvent: 0.005,
-  rewardToken: 'SOL',
+let mockPingReturn: { ok: true } | { ok: false; reason: 'auth' | 'network' | 'unknown'; message: string } = {
+  ok: true,
 }
 
 vi.mock('../../src/integrations/torque/mcp-client.js', () => ({
   TorqueMCPClient: vi.fn().mockImplementation(() => ({
-    getCampaign: vi.fn().mockImplementation(() => Promise.resolve(mockCampaignReturn)),
+    pingIngester: vi.fn().mockImplementation(() => Promise.resolve(mockPingReturn)),
   })),
 }))
 
@@ -49,27 +44,16 @@ function createApp() {
 describe('GET /admin/api/torque/status', () => {
   beforeEach(() => {
     delete process.env.TORQUE_GROWTH_ENABLED
-    delete process.env.TORQUE_API_KEY
-    delete process.env.TORQUE_MCP_URL
-    delete process.env.TORQUE_CAMPAIGN_ID_DEVNET
-    delete process.env.TORQUE_CAMPAIGN_ID_MAINNET
-    // Reset fixture to default ACTIVE campaign for each test
-    mockCampaignReturn = {
-      id: 'camp_devnet_1',
-      name: 'Sipher Private Action Rebate',
-      status: 'ACTIVE',
-      remainingPool: 4.95,
-      rewardAmountPerEvent: 0.005,
-      rewardToken: 'SOL',
-    }
+    delete process.env.TORQUE_API_TOKEN
+    delete process.env.TORQUE_INGESTER_URL
+    // Reset fixture to reachable for each test
+    mockPingReturn = { ok: true }
   })
 
   afterEach(() => {
     delete process.env.TORQUE_GROWTH_ENABLED
-    delete process.env.TORQUE_API_KEY
-    delete process.env.TORQUE_MCP_URL
-    delete process.env.TORQUE_CAMPAIGN_ID_DEVNET
-    delete process.env.TORQUE_CAMPAIGN_ID_MAINNET
+    delete process.env.TORQUE_API_TOKEN
+    delete process.env.TORQUE_INGESTER_URL
   })
 
   it('returns enabled=false when TORQUE_GROWTH_ENABLED is unset', async () => {
@@ -79,48 +63,61 @@ describe('GET /admin/api/torque/status', () => {
     expect(res.body.reason).toMatch(/TORQUE_GROWTH_ENABLED/)
   })
 
-  it('returns campaign metadata when env enables Torque', async () => {
+  it('returns ingesterReachable=true when ingester is reachable', async () => {
     process.env.TORQUE_GROWTH_ENABLED = 'true'
-    process.env.TORQUE_API_KEY = 'tk_test_key'
-    process.env.TORQUE_MCP_URL = 'https://torque.test'
-    process.env.TORQUE_CAMPAIGN_ID_DEVNET = 'camp_devnet_1'
-    process.env.TORQUE_CAMPAIGN_ID_MAINNET = 'camp_main_1'
+    process.env.TORQUE_API_TOKEN = 'tk_test_token'
+    process.env.TORQUE_INGESTER_URL = 'https://torque.test'
+
+    mockPingReturn = { ok: true }
 
     const res = await supertest(createApp()).get('/admin/api/torque/status')
     expect(res.status).toBe(200)
-    expect(res.body).toMatchObject({
+    expect(res.body).toStrictEqual({
       ok: true,
       enabled: true,
       network: 'devnet',
-      campaignId: 'camp_devnet_1',
-      campaignFetchOk: true,
-      campaign: {
-        id: 'camp_devnet_1',
-        name: 'Sipher Private Action Rebate',
-        status: 'ACTIVE',
-      },
+      ingesterUrl: 'https://torque.test',
+      ingesterReachable: true,
+    })
+    // ingesterReason must not appear in the JSON when reachable
+    expect(Object.prototype.hasOwnProperty.call(res.body, 'ingesterReason')).toBe(false)
+  })
+
+  it('returns ingesterReachable=false with reason=network when ingester is unreachable', async () => {
+    process.env.TORQUE_GROWTH_ENABLED = 'true'
+    process.env.TORQUE_API_TOKEN = 'tk_test_token'
+    process.env.TORQUE_INGESTER_URL = 'https://torque.test'
+
+    mockPingReturn = { ok: false, reason: 'network', message: 'connection refused' }
+
+    const res = await supertest(createApp()).get('/admin/api/torque/status')
+    expect(res.status).toBe(200)
+    expect(res.body).toStrictEqual({
+      ok: true,
+      enabled: true,
+      network: 'devnet',
+      ingesterUrl: 'https://torque.test',
+      ingesterReachable: false,
+      ingesterReason: 'network',
     })
   })
 
-  it('returns campaignFetchOk=false when getCampaign returns null', async () => {
+  it('returns ingesterReachable=false with reason=auth when api token is rejected', async () => {
     process.env.TORQUE_GROWTH_ENABLED = 'true'
-    process.env.TORQUE_API_KEY = 'tk_test_key'
-    process.env.TORQUE_MCP_URL = 'https://torque.test'
-    process.env.TORQUE_CAMPAIGN_ID_DEVNET = 'camp_devnet_1'
-    process.env.TORQUE_CAMPAIGN_ID_MAINNET = 'camp_main_1'
+    process.env.TORQUE_API_TOKEN = 'tk_test_token'
+    process.env.TORQUE_INGESTER_URL = 'https://torque.test'
 
-    // Simulate Torque unreachable or wrong campaign ID
-    mockCampaignReturn = null
+    mockPingReturn = { ok: false, reason: 'auth', message: 'Torque rejected api token (401)' }
 
     const res = await supertest(createApp()).get('/admin/api/torque/status')
     expect(res.status).toBe(200)
-    expect(res.body).toMatchObject({
+    expect(res.body).toStrictEqual({
       ok: true,
       enabled: true,
       network: 'devnet',
-      campaignId: 'camp_devnet_1',
-      campaignFetchOk: false,
-      campaign: null,
+      ingesterUrl: 'https://torque.test',
+      ingesterReachable: false,
+      ingesterReason: 'auth',
     })
   })
 })


### PR DESCRIPTION
## Summary

PR-E rewrites Sipher's Torque MCP integration to use Torque's canonical ingest contract — discovered by probing the live `ingest.torque.so` endpoint in `frontier_sip_8`. The previous 4 PRs (#256, #258, #260, #261) shipped against assumptions (campaign-scoped URL, `x-torque-api-key` header, nested `metadata` body) that turned out wrong when verified against the platform.

**The contract that actually works:**
- URL: `POST ingest.torque.so/events`
- Header: `x-api-key: $TORQUE_API_TOKEN`
- Body: `{ userPubkey, timestamp (ms-epoch number), eventName, data: object (flat string|number|boolean) }`
- Event slugs: underscore form (e.g. `sipher_private_send_completed`)
- No "Campaign" primitive — Torque uses Queries + Incentives + Lists. Our use case is `IncentiveType: REBATE` + `EventDataSource: CUSTOM_EVENT_PROVIDER`
- Mainnet-only for pool funding + reward distribution (event ingestion is network-agnostic — pubkeys are network-portable so hybrid devnet-event / mainnet-pool deployment is viable)

## Discovery

Probed against the live endpoint after onboarding to `platform.torque.so` via the `cipher-admin` wallet (`C1phrE76…x85N`). The default Phantom account (`HciZTd…`) was abandoned because Torque has no account merge/transfer flow — whichever wallet creates the project owns it forever. The `@torque-labs/mcp@0.4.7` npm package source was the cleanest ground-truth reference (inline help text spelled out the required top-level fields). Server schema errors (`400 body/eventName Required`, `400 Event not found for this API key`, `401 Missing x-api-key header`) are snapshotted as test fixtures.

Full discovery story in `docs/integrations/torque/FRICTION-LOG.md` Day 2 section.

## Changes

| File | Change |
|---|---|
| `packages/agent/src/integrations/torque/types.ts` | Flat `SipherGrowthEvent`, new `TorquePingResult`, dropped `TorqueCampaign`. Underscore-form `SipherEventName`. |
| `packages/agent/src/integrations/torque/mcp-client.ts` | URL/header/body rewritten. `pingIngester()` replaces `getCampaign()`. 400 splits into `event_undefined` vs `validation`. |
| `packages/agent/src/integrations/torque/index.ts` | Re-exports updated (drop `TorqueCampaign`, add `SipherGrowthEventData` + `TorquePingResult`). |
| `packages/agent/src/integrations/torque/growth-hook.ts` | Drops `campaignId` guard. Builds flat event shape (`userPubkey/timestamp/eventName/data`). Adds `extractAsset` for swap. |
| `packages/agent/src/integrations/torque/README.md` | Env-var rename, slug table, Dashboard prerequisites section, Network model section, new admin endpoint shape. |
| `packages/agent/src/config/network.ts` | `TorqueConfig` → `{apiToken, ingesterUrl}` only. Reads `TORQUE_API_TOKEN` + `TORQUE_INGESTER_URL` (defaults to `https://ingest.torque.so`). |
| `packages/agent/src/routes/admin.ts` | `/api/torque/status` now returns `{ingesterUrl, ingesterReachable, ingesterReason?}` instead of `{campaignId, campaignFetchOk, campaign}`. |
| `packages/agent/src/agent.ts` | `chat()` + `chatStream()` wiring aligned with new options shape (apiToken/ingesterUrl, no campaignId). |
| `.env.example` | Stale env var block replaced with canonical names. |
| `docs/superpowers/specs/2026-05-12-torque-mcp-integration-design.md` | Spec synced; addendum documents four-host architecture + Torque primitives. |
| `docs/superpowers/plans/2026-05-12-torque-canonical-ingest-rewrite.md` | Implementation plan checked in alongside the change. |
| `docs/integrations/torque/FRICTION-LOG.md` | Day 2 section appended with 8 dated discovery entries. |

Test files updated in lock-step with their source modules: `mcp-client.test.ts` (13 tests, +1 5xx unknown path), `growth-hook.test.ts` (14 tests, +3 guard-path tests, –3 campaign-warning tests), `network-torque.test.ts` (10 tests, +7 incl. empty-string fallback), `admin-torque.test.ts` (4 tests, all rewritten for `pingIngester`), `agent-torque-wiring.test.ts` (assertions realigned). Opt-in stubs `torque-emit-roundtrip.test.ts` + `torque-rebate-e2e.test.ts` compile against new types.

**Tests:** 1538 → 1544 passing (+6 net), 2 skipped (opt-in integration + E2E). Agent typecheck clean. Sipher-wide test suite green.

## Blocker context

Still depends on sipher#262 (HIGH, open) for non-claim events. Per the previous session's decision: option (c) claim-only scope retained for the 15-day hackathon shadow window (judges score May 27). `send`/`swap`/`drip`/`splitSend` currently return `{status: 'awaiting_signature'}` with no signature, so the growth-hook silently no-ops for those tools. Only `claim` events emit today. Option (a) `/api/confirm` callback is the proper fix and scope for the post-judging follow-up.

## Manual follow-up before merge

RECTOR-driven, not in this PR's scope:

1. **Torque dashboard:** Finalize REBATE Incentive bound to the 5 Custom Events (slugs + field schemas documented in the integration README). The 5 Custom Events are already created and attached to project `cmp2as15d05pnk01hiyuf7208` under `cipher-admin`.
2. **Mainnet pool funding:** ~0.5 SOL on mainnet (Torque is mainnet-only for pool funding + reward distribution). Pool address surfaces in the dashboard after Incentive activation.
3. **VPS env vars:** Rename in `~/Documents/secret/sipher-vps-secrets.env`:
   - `TORQUE_API_KEY` → `TORQUE_API_TOKEN` (same value)
   - `TORQUE_MCP_URL` → `TORQUE_INGESTER_URL` (value: `https://ingest.torque.so`)
   - Drop `TORQUE_CAMPAIGN_ID_DEVNET`, `TORQUE_CAMPAIGN_ID_MAINNET`
   - Restart sipher container
4. **Devnet shadow loop:** Fire ≥10 `claim` events from sipher chat after VPS env update + this PR merges
5. **Verify rebate distribution** on mainnet (epoch-bound, daily, may need 24h+)
6. **Demo video + reply to announcement tweet** on `@sipprotocol`

## Test plan

- [x] `pnpm --filter @sipher/agent test --run` — 1544 passed, 2 skipped
- [x] `pnpm test --run` (sipher-wide) — green, no regressions
- [x] Agent package typecheck clean (`tsc --noEmit`)
- [x] Spec compliance review per task (8/8)
- [x] Code quality review per task (8/8)
- [x] Final holistic cross-cutting review
- [ ] RECTOR: 3-wallet manual smoke of `claim` event emission against live ingester (post-VPS env update)
- [ ] RECTOR: Verify rebate distribution on mainnet after epoch close