### PR TITLE
chore(scripts): add Torque MCP preflight verification

### DIFF
--- a/docs/integrations/torque/PREFLIGHT.md
+++ b/docs/integrations/torque/PREFLIGHT.md
@@ -1,0 +1,138 @@
+# Torque MCP Preflight
+
+`scripts/torque-preflight.sh` is the single-command verification step RECTOR runs
+between (a) renaming the production VPS env vars to the canonical Torque names
+and (b) recording the Frontier Hackathon "Build with Torque MCP" demo video.
+
+The script is **read-only** against Torque dashboard state, idempotent, and safe
+to re-run as many times as you want. The only outbound POST it makes is a
+synthetic event with an intentionally-unregistered slug, which is rejected by
+Torque's schema validator — that rejection is the success signal.
+
+## Invocation
+
+```bash
+# Default: colored summary, human-readable
+scripts/torque-preflight.sh
+
+# Dump full HTTP response bodies for debugging
+scripts/torque-preflight.sh --verbose
+
+# Machine-readable JSON (for CI gating later)
+scripts/torque-preflight.sh --json
+
+# Disable color (CI logs, pipes, etc.)
+NO_COLOR=1 scripts/torque-preflight.sh
+```
+
+Exit codes: `0` = READY, `1` = NOT READY, `2` = script misuse / missing dep.
+
+## The seven checks
+
+| # | Check | What it proves | What FAIL means |
+|---|-------|----------------|-----------------|
+| 1 | VPS health | `GET /api/health` returns 200 | sipher container is down or DNS broken. SSH the `sip` user and run `docker compose ps && docker compose logs --tail 200 sipher`. |
+| 2 | Torque integration enabled | `GET /admin/api/torque/status` returns `enabled: true` | VPS env vars not loaded. Set `TORQUE_GROWTH_ENABLED=true`, `TORQUE_API_TOKEN=<token>`, `TORQUE_INGESTER_URL=https://ingest.torque.so` and **restart** the sipher container. Remove any stale `TORQUE_API_KEY`, `TORQUE_MCP_URL`, or `TORQUE_CAMPAIGN_ID_*`. |
+| 3 | Ingester reachable from VPS | Same endpoint, `ingesterReachable: true` | The VPS cannot reach `https://ingest.torque.so`. Either the token is invalid (reason=`auth`), egress is blocked (reason=`network`), or Torque is down. |
+| 4 | Network correctness | `network: mainnet-beta` | The pool is funded on mainnet — devnet events would route incentives nowhere. Set `SOLANA_CLUSTER=mainnet-beta` (or whatever `loadNetworkConfig()` reads in `packages/agent/src/config/network.ts`) and restart. |
+| 5 | Local env vars sanity | No stale `TORQUE_CAMPAIGN_ID_*` / `TORQUE_API_KEY` / `TORQUE_MCP_URL` in your shell or repo `.env` | Cosmetic only. Torque has no Campaign primitive (see [FRICTION-LOG.md](./FRICTION-LOG.md) entry from 2026-05-12). Remove the keys to avoid future confusion. **The VPS is what matters for the demo, not your laptop.** This emits WARN, never FAIL. |
+| 6 | Ingester auth verified (synthetic event) | A `POST` to `https://ingest.torque.so/events` with `eventName=sipher_preflight_test` is rejected with HTTP 400 | Either the network is broken (`HTTP 000`), the token is rejected (`401`/`403`), or Torque silently accepted an unregistered slug (rare — would emit WARN, not FAIL). |
+| 7 | Frontend reachable | `GET /` returns 200 with the sipher SPA bundle (not the nginx default page) | Reverse proxy may be up but no upstream serving. Check `docker compose ps` and `/etc/nginx/sites-enabled/sipher.conf` on the VPS. |
+
+## Why check 6 expects a 400
+
+The Torque ingest contract is:
+
+```
+POST https://ingest.torque.so/events
+Headers: x-api-key: $TORQUE_API_TOKEN
+Body:    { userPubkey, timestamp (ms-epoch), eventName, data }
+```
+
+The `eventName` field must match a Custom Event slug pre-registered in the
+Torque project. Our project (`cmp2as15d05pnk01hiyuf7208`) has five real slugs
+plus whatever variants we've added since. The slug `sipher_preflight_test` is
+deliberately NOT registered, so the server validates the request body, finds
+the slug doesn't match any known Custom Event, and returns HTTP 400 with a
+validation message.
+
+That 400 simultaneously proves three things:
+
+1. The host `ingest.torque.so` is reachable from your machine.
+2. The `x-api-key` header authenticated successfully (otherwise we'd see 401/403).
+3. The request reached Torque's schema validator (otherwise we'd see a 5xx).
+
+Per `packages/agent/src/integrations/torque/mcp-client.ts`, the `TorqueMCPClient`
+treats a 400 from the ingester as `validation` / `event_undefined` — not an
+auth or network failure. The preflight script mirrors that classification.
+
+## Token handling and the operator-scoped secrets
+
+The script is forbidden from reading
+`~/Documents/secret/sipher-vps-secrets.env` (operator-scoped, iCloud encrypted).
+Two tokens it may need are sourced as follows:
+
+- **`SIPHER_ADMIN_TOKEN`** (optional, currently unused) — the `/admin/api/torque/status`
+  endpoint is public per the comment in `packages/agent/src/routes/admin.ts`
+  ("no sensitive data returned"). If the endpoint is later moved behind auth,
+  set `SIPHER_ADMIN_TOKEN` in your shell env (or drop a token at
+  `~/Documents/secret/sipher-admin-token`) and the script will pass it as a
+  Bearer header. The script never echoes the token value.
+- **`TORQUE_API_TOKEN`** (optional but recommended) — only used in Check 6,
+  the synthetic event probe. Without it, Check 6 is skipped with a WARN.
+  Check 3 (ingester reachable **from the VPS**) is the higher-signal version
+  of this check anyway, so a skipped Check 6 doesn't block the demo.
+
+## Interpreting common output
+
+### Everything green
+
+```
+[OK]   VPS health
+[OK]   Torque integration enabled (network: mainnet-beta)
+[OK]   Ingester reachable from VPS
+[OK]   Network correctness: mainnet-beta
+[OK]   Local env vars sanity
+[OK]   Ingester auth verified
+[OK]   Frontend reachable
+
+Verdict: READY FOR DEMO
+```
+
+You're done. Next step: trigger a real `send` or `swap` from the sipher chat,
+sign the transaction in your wallet, and verify the event lands in the Torque
+dashboard custom_event stream.
+
+### Check 2 returns non-JSON
+
+If `/admin/api/torque/status` returns HTML (the SPA index page), the request
+is being caught by the SPA fallback BEFORE the admin router. Either:
+
+- The deployed build pre-dates PR #269 (canonical-ingest rewrite). Force a
+  fresh deploy: `docker compose pull && docker compose up -d`.
+- Or the express route ordering changed and the catch-all is registered before
+  `/admin`. Inspect `packages/agent/src/index.ts` around the `app.use('/admin', adminRouter)` line.
+
+### Check 4 says `network: devnet`
+
+Pool is mainnet. Emitting devnet events is a no-op for incentive distribution.
+Either update the VPS to `SOLANA_CLUSTER=mainnet-beta` (so growth events flow
+into the mainnet pool) or accept that we're running in hybrid mode and the
+demo will only show ingest correctness, not actual incentive distribution.
+
+### Check 6 returns 200 instead of 400
+
+Torque accepted our `sipher_preflight_test` slug. That means either someone
+registered it in the dashboard (rename the slug in the script) or Torque
+relaxed schema validation. Script emits WARN, not FAIL, because reachability
++ auth are still proven.
+
+## Frontier Hackathon timeline
+
+Judges score on **2026-05-27**. As of 2026-05-15 we have 12 days. Suggested
+cadence:
+
+1. **Now** — RECTOR renames VPS env vars manually
+2. **Now + 5 min** — run `scripts/torque-preflight.sh`, iterate until all green
+3. **+1 day** — record demo video on a green preflight run
+4. **+1 day** — submit demo + pinned reply on @sipprotocol announcement tweet

--- a/docs/integrations/torque/PREFLIGHT.md
+++ b/docs/integrations/torque/PREFLIGHT.md
@@ -34,7 +34,7 @@ Exit codes: `0` = READY, `1` = NOT READY, `2` = script misuse / missing dep.
 | 1 | VPS health | `GET /api/health` returns 200 | sipher container is down or DNS broken. SSH the `sip` user and run `docker compose ps && docker compose logs --tail 200 sipher`. |
 | 2 | Torque integration enabled | `GET /admin/api/torque/status` returns `enabled: true` | VPS env vars not loaded. Set `TORQUE_GROWTH_ENABLED=true`, `TORQUE_API_TOKEN=<token>`, `TORQUE_INGESTER_URL=https://ingest.torque.so` and **restart** the sipher container. Remove any stale `TORQUE_API_KEY`, `TORQUE_MCP_URL`, or `TORQUE_CAMPAIGN_ID_*`. |
 | 3 | Ingester reachable from VPS | Same endpoint, `ingesterReachable: true` | The VPS cannot reach `https://ingest.torque.so`. Either the token is invalid (reason=`auth`), egress is blocked (reason=`network`), or Torque is down. |
-| 4 | Network correctness | `network: mainnet-beta` | The pool is funded on mainnet — devnet events would route incentives nowhere. Set `SOLANA_CLUSTER=mainnet-beta` (or whatever `loadNetworkConfig()` reads in `packages/agent/src/config/network.ts`) and restart. |
+| 4 | Network correctness | `network: devnet` (hybrid mode) or `network: mainnet-beta` (full mainnet) | Unexpected value. Check `SIPHER_NETWORK` on the VPS. Event ingestion is network-agnostic (payload has no network field), so devnet events still attribute to the mainnet pool's REBATE Incentive — hybrid mode is the canonical setup. |
 | 5 | Local env vars sanity | No stale `TORQUE_CAMPAIGN_ID_*` / `TORQUE_API_KEY` / `TORQUE_MCP_URL` in your shell or repo `.env` | Cosmetic only. Torque has no Campaign primitive (see [FRICTION-LOG.md](./FRICTION-LOG.md) entry from 2026-05-12). Remove the keys to avoid future confusion. **The VPS is what matters for the demo, not your laptop.** This emits WARN, never FAIL. |
 | 6 | Ingester auth verified (synthetic event) | A `POST` to `https://ingest.torque.so/events` with `eventName=sipher_preflight_test` is rejected with HTTP 400 | Either the network is broken (`HTTP 000`), the token is rejected (`401`/`403`), or Torque silently accepted an unregistered slug (rare — would emit WARN, not FAIL). |
 | 7 | Frontend reachable | `GET /` returns 200 with the sipher SPA bundle (not the nginx default page) | Reverse proxy may be up but no upstream serving. Check `docker compose ps` and `/etc/nginx/sites-enabled/sipher.conf` on the VPS. |
@@ -89,9 +89,9 @@ Two tokens it may need are sourced as follows:
 
 ```
 [OK]   VPS health
-[OK]   Torque integration enabled (network: mainnet-beta)
+[OK]   Torque integration enabled (network: devnet ingester: https://ingest.torque.so)
 [OK]   Ingester reachable from VPS
-[OK]   Network correctness: mainnet-beta
+[OK]   Network correctness: devnet (hybrid mode — events on devnet, pool on mainnet)
 [OK]   Local env vars sanity
 [OK]   Ingester auth verified
 [OK]   Frontend reachable
@@ -113,12 +113,16 @@ is being caught by the SPA fallback BEFORE the admin router. Either:
 - Or the express route ordering changed and the catch-all is registered before
   `/admin`. Inspect `packages/agent/src/index.ts` around the `app.use('/admin', adminRouter)` line.
 
-### Check 4 says `network: devnet`
+### Check 4 reports `network: devnet`
 
-Pool is mainnet. Emitting devnet events is a no-op for incentive distribution.
-Either update the VPS to `SOLANA_CLUSTER=mainnet-beta` (so growth events flow
-into the mainnet pool) or accept that we're running in hybrid mode and the
-demo will only show ingest correctness, not actual incentive distribution.
+This is the canonical hybrid-mode setup: events emit on devnet (cheap, safe
+for testing), pool is funded on mainnet (real money for rebate distribution).
+Event ingestion at `ingest.torque.so` is **network-agnostic** — the payload
+has no network field — so devnet events still attribute to the mainnet pool's
+REBATE Incentive. Check passes OK.
+
+To flip to full mainnet (everything on mainnet, events + pool), set
+`SIPHER_NETWORK=mainnet` on the VPS and restart.
 
 ### Check 6 returns 200 instead of 400
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "gm": "bash scripts/gm.sh",
     "thanks": "bash scripts/thanks.sh",
     "openapi:export": "tsx scripts/export-openapi.ts",
+    "preflight:torque": "bash scripts/torque-preflight.sh",
     "sdks:generate": "bash sdks/generator/generate.sh",
     "devnet-demo": "tsx scripts/devnet-shielded-transfer.ts",
     "test:e2e": "playwright test",

--- a/scripts/torque-preflight.sh
+++ b/scripts/torque-preflight.sh
@@ -1,0 +1,535 @@
+#!/usr/bin/env bash
+#
+# torque-preflight.sh — Verify the sipher Torque MCP integration is judge-ready.
+#
+# Runs seven checks against the production sipher API and the Torque ingest host
+# to confirm that the canonical ingest contract is live, auth works, and the
+# frontend SignTxCard surface is reachable. Designed to be run AFTER the VPS
+# env var rename (TORQUE_API_KEY -> TORQUE_API_TOKEN, TORQUE_MCP_URL ->
+# TORQUE_INGESTER_URL, drop TORQUE_CAMPAIGN_ID_*) and BEFORE recording the
+# Frontier Hackathon "Build with Torque MCP" demo video.
+#
+# Usage:
+#   scripts/torque-preflight.sh              # default run (color, summary only)
+#   scripts/torque-preflight.sh --verbose    # also dump full response bodies
+#   scripts/torque-preflight.sh --json       # machine-readable JSON output
+#   NO_COLOR=1 scripts/torque-preflight.sh   # disable color
+#
+# Environment overrides (optional):
+#   SIPHER_BASE_URL       default https://sipher.sip-protocol.org
+#   TORQUE_INGEST_URL     default https://ingest.torque.so
+#   SIPHER_ADMIN_TOKEN    optional Bearer token. If unset, the script reads
+#                         from $SIPHER_ADMIN_TOKEN_FILE (default
+#                         ~/Documents/secret/sipher-admin-token) only if it
+#                         already exists. Token is OPTIONAL — the
+#                         /admin/api/torque/status endpoint is currently
+#                         public (no auth required) per packages/agent/src/
+#                         routes/admin.ts. The token is included as a Bearer
+#                         header only when present, so this script is
+#                         forward-compatible if the endpoint moves behind
+#                         auth later.
+#   TORQUE_API_TOKEN      optional. If set, used for Check 6 (synthetic event
+#                         probe). If unset, Check 6 is skipped with a WARN.
+#
+# Exit codes:
+#   0  all critical checks passed (verdict: READY FOR DEMO)
+#   1  one or more critical checks failed (verdict: NOT READY)
+#   2  script misuse (bad flag, missing dependency, etc.)
+#
+# Hard constraints honored:
+#   - Never reads ~/Documents/secret/sipher-vps-secrets.env (operator-scoped)
+#   - Never reads the admin-token file contents into a printable buffer; only
+#     into the curl Authorization header, which the script does not echo.
+#   - No DELETE/PATCH/PUT against Torque dashboard. The only POST is the
+#     synthetic event probe to ingest.torque.so/events with eventName =
+#     "sipher_preflight_test" (a slug deliberately NOT registered in the
+#     Torque project, so it gets rejected with 400 — that 400 IS the success
+#     signal: it proves the ingester is reachable AND the API key auths AND
+#     the request reached the schema validator. Per
+#     packages/agent/src/integrations/torque/mcp-client.ts, Torque returns
+#     400 with a "validation" / "event_undefined" reason for unknown slugs.)
+#   - Idempotent: safe to run repeatedly. No state mutation.
+
+set -euo pipefail
+
+# ────────────────────────────────────────────────────────────────────────────
+# Config & defaults
+# ────────────────────────────────────────────────────────────────────────────
+
+SIPHER_BASE_URL="${SIPHER_BASE_URL:-https://sipher.sip-protocol.org}"
+TORQUE_INGEST_URL="${TORQUE_INGEST_URL:-https://ingest.torque.so}"
+SIPHER_ADMIN_TOKEN_FILE="${SIPHER_ADMIN_TOKEN_FILE:-$HOME/Documents/secret/sipher-admin-token}"
+
+VERBOSE=0
+JSON_MODE=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --verbose|-v) VERBOSE=1 ;;
+    --json) JSON_MODE=1 ;;
+    -h|--help)
+      sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown flag: $arg" >&2
+      echo "Use --help for usage." >&2
+      exit 2
+      ;;
+  esac
+done
+
+# ────────────────────────────────────────────────────────────────────────────
+# Dependency check
+# ────────────────────────────────────────────────────────────────────────────
+
+for cmd in curl jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing required dependency: $cmd" >&2
+    echo "Install it (e.g. 'brew install $cmd') and re-run." >&2
+    exit 2
+  fi
+done
+
+# ────────────────────────────────────────────────────────────────────────────
+# Color setup (respect NO_COLOR and non-TTY)
+# ────────────────────────────────────────────────────────────────────────────
+
+if [[ "${NO_COLOR:-}" != "" || ! -t 1 || "$JSON_MODE" -eq 1 ]]; then
+  C_OK=""
+  C_WARN=""
+  C_FAIL=""
+  C_DIM=""
+  C_BOLD=""
+  C_RESET=""
+else
+  C_OK=$'\033[0;32m'
+  C_WARN=$'\033[1;33m'
+  C_FAIL=$'\033[0;31m'
+  C_DIM=$'\033[2m'
+  C_BOLD=$'\033[1m'
+  C_RESET=$'\033[0m'
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
+# Result tracking
+# ────────────────────────────────────────────────────────────────────────────
+
+# Arrays of "STATUS|LABEL|DETAIL|FIX"
+RESULTS=()
+FAIL_COUNT=0
+WARN_COUNT=0
+
+record() {
+  local status="$1"
+  local label="$2"
+  local detail="${3:-}"
+  local fix="${4:-}"
+  RESULTS+=("${status}|${label}|${detail}|${fix}")
+  case "$status" in
+    FAIL) FAIL_COUNT=$((FAIL_COUNT + 1)) ;;
+    WARN) WARN_COUNT=$((WARN_COUNT + 1)) ;;
+  esac
+}
+
+trace() {
+  if [[ "$VERBOSE" -eq 1 && "$JSON_MODE" -eq 0 ]]; then
+    echo "${C_DIM}    $*${C_RESET}" >&2
+  fi
+}
+
+# Make a temp directory for response bodies (auto-cleaned)
+TMPDIR_PREFLIGHT="$(mktemp -d -t torque-preflight.XXXXXX)"
+trap 'rm -rf "$TMPDIR_PREFLIGHT"' EXIT
+
+# curl wrapper that writes body to a file, returns HTTP code on stdout
+# Args: $1 method, $2 url, $3 body-out-file, then optional extra args
+http() {
+  local method="$1"
+  local url="$2"
+  local out="$3"
+  shift 3
+  local code
+  code="$(curl -sS -o "$out" -w '%{http_code}' -X "$method" --max-time 15 "$@" "$url" 2>>"$out.err" || true)"
+  if [[ -z "$code" ]]; then
+    code="000"
+  fi
+  echo "$code"
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Check 1: VPS health
+# ────────────────────────────────────────────────────────────────────────────
+# Note: the deployed sipher uses /api/health (see packages/agent/src/index.ts
+# line 300). The original task spec said /healthz but that path is not mounted
+# in the codebase, so we hit the real endpoint here.
+
+check_vps_health() {
+  local url="${SIPHER_BASE_URL}/api/health"
+  local body="$TMPDIR_PREFLIGHT/health.json"
+  trace "GET $url"
+  local code
+  code="$(http GET "$url" "$body")"
+  if [[ "$code" == "200" ]]; then
+    record OK "VPS health" "$url -> 200"
+  else
+    record FAIL "VPS health" "$url -> HTTP $code" \
+      "Check that the sipher container is running on the VPS. SSH 'sip' user and run: docker compose ps && docker compose logs --tail 200 sipher"
+  fi
+  if [[ "$VERBOSE" -eq 1 ]]; then
+    trace "Response body:"
+    [[ -s "$body" ]] && trace "$(head -c 500 "$body")"
+  fi
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Check 2 & 3 & 4: Torque integration status (single endpoint, three assertions)
+# ────────────────────────────────────────────────────────────────────────────
+# Endpoint: GET /admin/api/torque/status
+# Auth: currently public per routes/admin.ts (comment "no sensitive data
+#   returned"). If SIPHER_ADMIN_TOKEN is provided we attach it as a Bearer
+#   header — forward-compatible if the endpoint moves behind auth.
+# Expected shape (enabled):
+#   { ok, enabled: true, network, ingesterUrl, ingesterReachable, ingesterReason? }
+# Expected shape (disabled):
+#   { ok, enabled: false, reason }
+
+resolve_admin_token() {
+  if [[ -n "${SIPHER_ADMIN_TOKEN:-}" ]]; then
+    echo "$SIPHER_ADMIN_TOKEN"
+    return
+  fi
+  # File is operator-scoped; we never echo its contents anywhere. We only
+  # forward into curl's -H argument via stdin-fed env-injected variable below.
+  if [[ -r "$SIPHER_ADMIN_TOKEN_FILE" ]]; then
+    cat "$SIPHER_ADMIN_TOKEN_FILE"
+    return
+  fi
+  echo ""
+}
+
+TORQUE_STATUS_BODY=""  # populated by check 2, reused by 3 & 4
+TORQUE_STATUS_OK=0
+
+check_torque_status() {
+  local url="${SIPHER_BASE_URL}/admin/api/torque/status"
+  local body="$TMPDIR_PREFLIGHT/torque-status.json"
+  TORQUE_STATUS_BODY="$body"
+  trace "GET $url"
+
+  local token
+  token="$(resolve_admin_token)"
+  local code
+  if [[ -n "$token" ]]; then
+    code="$(http GET "$url" "$body" -H "Authorization: Bearer $token")"
+  else
+    code="$(http GET "$url" "$body")"
+  fi
+
+  if [[ "$code" != "200" ]]; then
+    record FAIL "Torque integration enabled" "$url -> HTTP $code" \
+      "Endpoint not reachable. Confirm sipher container is up and admin router is mounted at /admin."
+    record FAIL "Ingester reachable from VPS" "skipped (status endpoint not reachable)" \
+      "Resolve check 2 first."
+    record FAIL "Network correctness" "skipped (status endpoint not reachable)" \
+      "Resolve check 2 first."
+    return
+  fi
+
+  if ! jq -e . "$body" >/dev/null 2>&1; then
+    record FAIL "Torque integration enabled" "Non-JSON response from $url" \
+      "Inspect raw body: $body"
+    record FAIL "Ingester reachable from VPS" "skipped (status endpoint returned non-JSON)" ""
+    record FAIL "Network correctness" "skipped (status endpoint returned non-JSON)" ""
+    return
+  fi
+
+  local enabled reason network ingester_url reachable reachable_reason
+  enabled="$(jq -r '.enabled // false' "$body")"
+  reason="$(jq -r '.reason // ""' "$body")"
+  network="$(jq -r '.network // ""' "$body")"
+  ingester_url="$(jq -r '.ingesterUrl // ""' "$body")"
+  reachable="$(jq -r '.ingesterReachable // false' "$body")"
+  reachable_reason="$(jq -r '.ingesterReason // ""' "$body")"
+
+  # Check 2: enabled
+  if [[ "$enabled" == "true" ]]; then
+    record OK "Torque integration enabled" "network=${network:-unknown} ingester=${ingester_url:-unknown}"
+    TORQUE_STATUS_OK=1
+  else
+    record FAIL "Torque integration enabled" "enabled=false reason=${reason:-unknown}" \
+      "VPS env vars not loaded. Set TORQUE_GROWTH_ENABLED=true, TORQUE_API_TOKEN=<token>, TORQUE_INGESTER_URL=https://ingest.torque.so on the VPS (and remove any stale TORQUE_API_KEY / TORQUE_MCP_URL / TORQUE_CAMPAIGN_ID_*). Restart the sipher container."
+  fi
+
+  # Check 3: ingester reachable
+  if [[ "$enabled" != "true" ]]; then
+    record FAIL "Ingester reachable from VPS" "skipped (integration disabled)" \
+      "Resolve check 2 first."
+  elif [[ "$reachable" == "true" ]]; then
+    record OK "Ingester reachable from VPS" "no ingesterReason"
+  else
+    record FAIL "Ingester reachable from VPS" "ingesterReachable=false reason=${reachable_reason:-unknown}" \
+      "VPS cannot reach ${ingester_url:-https://ingest.torque.so}. Common causes: (a) TORQUE_API_TOKEN invalid → reason=auth; (b) Egress firewall → reason=network; (c) Torque outage — check status.torque.so. SSH 'sip' user and run: docker compose exec sipher curl -v ${ingester_url:-https://ingest.torque.so}/events -H 'x-api-key: <token>'"
+  fi
+
+  # Check 4: network correctness
+  if [[ "$enabled" != "true" ]]; then
+    record FAIL "Network correctness" "skipped (integration disabled)" \
+      "Resolve check 2 first."
+  elif [[ "$network" == "mainnet-beta" ]]; then
+    record OK "Network correctness: mainnet-beta"
+  else
+    record FAIL "Network correctness" "expected mainnet-beta, got ${network:-empty}" \
+      "Pool is funded on mainnet; emitting devnet events would route incentives nowhere. Set SOLANA_CLUSTER=mainnet-beta on the VPS (or whatever loadNetworkConfig() reads) and restart."
+  fi
+
+  if [[ "$VERBOSE" -eq 1 ]]; then
+    trace "Response body:"
+    trace "$(jq -c . "$body" 2>/dev/null || cat "$body")"
+  fi
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Check 5: Local env vars sanity
+# ────────────────────────────────────────────────────────────────────────────
+# We scan the local shell env AND the repo's root .env (if any) for stale
+# TORQUE_CAMPAIGN_ID_* keys. These are cosmetic warnings — Torque has no
+# Campaign primitive (see docs/integrations/torque/FRICTION-LOG.md). Leaving
+# them in your local .env is harmless but confusing.
+
+check_local_env_sanity() {
+  local stale_keys=()
+
+  # Walk live shell env
+  while IFS='=' read -r k _; do
+    case "$k" in
+      TORQUE_CAMPAIGN_ID_*|TORQUE_API_KEY|TORQUE_MCP_URL)
+        stale_keys+=("$k")
+        ;;
+    esac
+  done < <(env)
+
+  # Walk repo root .env if present (best-effort; tolerate weird quoting)
+  local repo_root
+  repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+  if [[ -r "$repo_root/.env" ]]; then
+    while IFS= read -r line; do
+      # Strip comments / blanks
+      [[ "$line" =~ ^[[:space:]]*# ]] && continue
+      [[ -z "${line// /}" ]] && continue
+      local key="${line%%=*}"
+      key="${key// /}"
+      case "$key" in
+        TORQUE_CAMPAIGN_ID_*|TORQUE_API_KEY|TORQUE_MCP_URL)
+          stale_keys+=("$key (.env)")
+          ;;
+      esac
+    done < "$repo_root/.env"
+  fi
+
+  if [[ ${#stale_keys[@]} -eq 0 ]]; then
+    record OK "Local env vars sanity" "no stale TORQUE_CAMPAIGN_ID_* / TORQUE_API_KEY / TORQUE_MCP_URL"
+  else
+    local joined
+    joined="$(printf '%s, ' "${stale_keys[@]}")"
+    joined="${joined%, }"
+    record WARN "Local stale env var(s) present" "$joined" \
+      "Cosmetic only — Torque has no Campaign primitive. Remove from your local .env / shell rc to avoid future confusion. The VPS is what matters for the demo."
+  fi
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Check 6: Custom Events probe (synthetic event with unregistered slug)
+# ────────────────────────────────────────────────────────────────────────────
+# We POST to https://ingest.torque.so/events with eventName=sipher_preflight_test
+# (a slug deliberately NOT registered in the Torque dashboard project). The
+# expected response is HTTP 400 with a validation message — that 400 IS the
+# success signal: it proves
+#   (a) the ingest host is reachable from THIS machine (not the VPS),
+#   (b) the x-api-key auths successfully (otherwise we'd get 401/403),
+#   (c) the request reached the schema validator (otherwise some other 5xx).
+#
+# This check is SKIPPED with a WARN if TORQUE_API_TOKEN is unset, because we
+# never read ~/Documents/secret/sipher-vps-secrets.env (operator-scoped).
+
+check_synthetic_event() {
+  if [[ -z "${TORQUE_API_TOKEN:-}" ]]; then
+    record WARN "Ingester auth verified (synthetic event)" \
+      "skipped — TORQUE_API_TOKEN not set in shell env" \
+      "Optional: 'export TORQUE_API_TOKEN=<token>' from your operator-scoped secrets file and re-run. The VPS's own ingester reachability is already verified by Check 3, so this is a redundant local probe."
+    return
+  fi
+
+  local url="${TORQUE_INGEST_URL}/events"
+  local body_file="$TMPDIR_PREFLIGHT/synthetic.json"
+  local payload
+  payload="$(jq -n \
+    --arg pk "SipherPreflight11111111111111111111111111111" \
+    --arg name "sipher_preflight_test" \
+    --argjson ts "$(date +%s)000" \
+    '{userPubkey: $pk, timestamp: $ts, eventName: $name, data: {note: "preflight-script-probe"}}')"
+  trace "POST $url with eventName=sipher_preflight_test"
+  local code
+  code="$(http POST "$url" "$body_file" \
+    -H "Content-Type: application/json" \
+    -H "x-api-key: ${TORQUE_API_TOKEN}" \
+    --data-raw "$payload")"
+
+  if [[ "$code" == "400" ]]; then
+    # Confirm it's the EXPECTED 400 (validation about the unregistered slug),
+    # not some other 400. We accept either the codebase's pattern ("Event not
+    # found") or the spec'd pattern ("body/eventName Invalid" / "Required").
+    local msg
+    msg="$(jq -r '.message // .error // .detail // ""' "$body_file" 2>/dev/null || echo "")"
+    if [[ "$msg" =~ [Ee]vent.*[Nn]ot.*[Ff]ound \
+       || "$msg" =~ eventName \
+       || "$msg" =~ [Vv]alidation \
+       || "$msg" =~ [Ii]nvalid \
+       || "$msg" =~ [Uu]ndefined ]]; then
+      record OK "Ingester auth verified" "synthetic event rejected with expected 400: $(printf '%s' "$msg" | head -c 80)"
+    else
+      record OK "Ingester auth verified" "synthetic event rejected with 400 (unrecognized message body, but 400 alone proves auth+reach)"
+    fi
+  elif [[ "$code" == "401" || "$code" == "403" ]]; then
+    record FAIL "Ingester auth verified" "HTTP $code — TORQUE_API_TOKEN rejected by ingester" \
+      "Token is invalid or revoked. Reissue from platform.torque.so/developer for project cmp2as15d05pnk01hiyuf7208 and update VPS env."
+  elif [[ "$code" == "200" || "$code" == "201" || "$code" == "202" || "$code" == "204" ]]; then
+    record WARN "Ingester auth verified" "HTTP $code — ingester ACCEPTED 'sipher_preflight_test'. This means either (a) the slug is registered in the Torque project (unintended) or (b) Torque relaxed its schema validation." \
+      "Investigate: if (a), rename the slug in this script. If (b), the probe still passes as a reachability check."
+  elif [[ "$code" == "000" ]]; then
+    record FAIL "Ingester auth verified" "Network error reaching $url" \
+      "Check internet connectivity, DNS for ingest.torque.so, and any local egress firewall."
+  else
+    record FAIL "Ingester auth verified" "Unexpected HTTP $code from synthetic probe" \
+      "Inspect $body_file for details. Run with --verbose to see body."
+  fi
+
+  if [[ "$VERBOSE" -eq 1 ]]; then
+    trace "Response body:"
+    trace "$(head -c 500 "$body_file" 2>/dev/null || true)"
+  fi
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Check 7: Frontend SignTxCard surface reachable
+# ────────────────────────────────────────────────────────────────────────────
+# We hit the root URL and verify it returns 200 with HTML served by the sipher
+# container (not the nginx default page). Heuristic: response body must
+# contain a marker that identifies the sipher SPA (e.g. "sipher" or a known
+# Vite/asset path). We don't render the page, just confirm the container is
+# serving the bundle.
+
+check_frontend() {
+  local url="${SIPHER_BASE_URL}/"
+  local body="$TMPDIR_PREFLIGHT/frontend.html"
+  trace "GET $url"
+  local code
+  code="$(http GET "$url" "$body")"
+  if [[ "$code" != "200" ]]; then
+    record FAIL "Frontend reachable" "$url -> HTTP $code" \
+      "sipher SPA not served. Check nginx config + container port 5006."
+    return
+  fi
+
+  # Detect nginx default page (very small body or contains "Welcome to nginx")
+  local size
+  size="$(wc -c <"$body" | tr -d ' ')"
+  if grep -qi 'welcome to nginx' "$body" 2>/dev/null; then
+    record FAIL "Frontend reachable" "$url -> 200 but body is nginx default page" \
+      "Reverse proxy is up but no upstream is serving /. Check docker compose ps for sipher container, and nginx upstream config in /etc/nginx/sites-enabled/."
+    return
+  fi
+
+  # Heuristic: sipher SPA should be a non-trivial HTML bundle.
+  if [[ "$size" -lt 200 ]]; then
+    record WARN "Frontend reachable" "$url -> 200 but body is suspiciously small ($size bytes)" \
+      "Confirm by curling and inspecting body — could be a temporary holding page."
+    return
+  fi
+
+  if grep -qi 'sipher\|<title>SIPHER\|/assets/' "$body" 2>/dev/null; then
+    record OK "Frontend reachable" "$url -> 200 ($size bytes, sipher SPA marker found)"
+  else
+    record WARN "Frontend reachable" "$url -> 200 ($size bytes) but no sipher marker in body" \
+      "Body returned by upstream is HTML but lacks identifying tokens. Inspect with: curl -s ${SIPHER_BASE_URL}/ | head -50"
+  fi
+}
+
+# ────────────────────────────────────────────────────────────────────────────
+# Run all checks
+# ────────────────────────────────────────────────────────────────────────────
+
+if [[ "$JSON_MODE" -eq 0 ]]; then
+  echo
+  echo "${C_BOLD}=== Torque MCP Preflight ===${C_RESET}"
+  echo "${C_DIM}Target: ${SIPHER_BASE_URL}${C_RESET}"
+  echo "${C_DIM}Ingest: ${TORQUE_INGEST_URL}${C_RESET}"
+  echo
+fi
+
+check_vps_health
+check_torque_status
+check_local_env_sanity
+check_synthetic_event
+check_frontend
+
+# ────────────────────────────────────────────────────────────────────────────
+# Render summary
+# ────────────────────────────────────────────────────────────────────────────
+
+if [[ "$JSON_MODE" -eq 1 ]]; then
+  # Emit a single JSON object for machine consumption
+  jq -n \
+    --arg target "$SIPHER_BASE_URL" \
+    --arg ingest "$TORQUE_INGEST_URL" \
+    --argjson fail "$FAIL_COUNT" \
+    --argjson warn "$WARN_COUNT" \
+    --arg verdict "$([[ $FAIL_COUNT -eq 0 ]] && echo 'READY' || echo 'NOT_READY')" \
+    --argjson results "$(printf '%s\n' "${RESULTS[@]}" | jq -R 'split("|") | {status: .[0], label: .[1], detail: .[2], fix: .[3]}' | jq -s .)" \
+    '{
+       target: $target,
+       ingest: $ingest,
+       fail_count: $fail,
+       warn_count: $warn,
+       verdict: $verdict,
+       results: $results
+     }'
+  exit $([[ $FAIL_COUNT -eq 0 ]] && echo 0 || echo 1)
+fi
+
+for line in "${RESULTS[@]}"; do
+  IFS='|' read -r status label detail fix <<<"$line"
+  case "$status" in
+    OK)   prefix="${C_OK}[OK]${C_RESET}  " ;;
+    WARN) prefix="${C_WARN}[WARN]${C_RESET}" ;;
+    FAIL) prefix="${C_FAIL}[FAIL]${C_RESET}" ;;
+    *)    prefix="[??]" ;;
+  esac
+  if [[ -n "$detail" ]]; then
+    printf '%b %s — %s\n' "$prefix" "$label" "$detail"
+  else
+    printf '%b %s\n' "$prefix" "$label"
+  fi
+  if [[ "$status" == "FAIL" && -n "$fix" ]]; then
+    # Wrap fix text by tabbing it under the label
+    printf '       %bFix:%b %s\n' "$C_DIM" "$C_RESET" "$fix"
+  elif [[ "$status" == "WARN" && -n "$fix" && "$VERBOSE" -eq 1 ]]; then
+    printf '       %bNote:%b %s\n' "$C_DIM" "$C_RESET" "$fix"
+  fi
+done
+
+echo
+
+if [[ "$FAIL_COUNT" -eq 0 ]]; then
+  echo "${C_OK}${C_BOLD}Verdict: READY FOR DEMO${C_RESET}"
+  echo
+  echo "${C_DIM}Next: Trigger a real send/swap from sipher chat and verify the event lands"
+  echo "in the Torque dashboard 'custom_event' stream (project cmp2as15d05pnk01hiyuf7208).${C_RESET}"
+  exit 0
+else
+  echo "${C_FAIL}${C_BOLD}Verdict: NOT READY${C_RESET} (${FAIL_COUNT} failure(s), ${WARN_COUNT} warning(s))"
+  echo
+  echo "${C_DIM}Address the failures above before recording the demo. Re-run this script"
+  echo "until you see 'READY FOR DEMO'. Run with --verbose for response bodies.${C_RESET}"
+  exit 1
+fi

--- a/scripts/torque-preflight.sh
+++ b/scripts/torque-preflight.sh
@@ -16,7 +16,8 @@
 #   NO_COLOR=1 scripts/torque-preflight.sh   # disable color
 #
 # Environment overrides (optional):
-#   SIPHER_BASE_URL       default https://sipher.sip-protocol.org
+#   SIPHER_API_URL        default https://sipher-api.sip-protocol.org  (backend host — /api/health, /admin/api/torque/status)
+#   SIPHER_FE_URL         default https://sipher.sip-protocol.org      (Vercel-served SPA host)
 #   TORQUE_INGEST_URL     default https://ingest.torque.so
 #   SIPHER_ADMIN_TOKEN    optional Bearer token. If unset, the script reads
 #                         from $SIPHER_ADMIN_TOKEN_FILE (default
@@ -56,7 +57,8 @@ set -euo pipefail
 # Config & defaults
 # ────────────────────────────────────────────────────────────────────────────
 
-SIPHER_BASE_URL="${SIPHER_BASE_URL:-https://sipher.sip-protocol.org}"
+SIPHER_API_URL="${SIPHER_API_URL:-https://sipher-api.sip-protocol.org}"
+SIPHER_FE_URL="${SIPHER_FE_URL:-https://sipher.sip-protocol.org}"
 TORQUE_INGEST_URL="${TORQUE_INGEST_URL:-https://ingest.torque.so}"
 SIPHER_ADMIN_TOKEN_FILE="${SIPHER_ADMIN_TOKEN_FILE:-$HOME/Documents/secret/sipher-admin-token}"
 
@@ -165,7 +167,7 @@ http() {
 # in the codebase, so we hit the real endpoint here.
 
 check_vps_health() {
-  local url="${SIPHER_BASE_URL}/api/health"
+  local url="${SIPHER_API_URL}/api/health"
   local body="$TMPDIR_PREFLIGHT/health.json"
   trace "GET $url"
   local code
@@ -212,7 +214,7 @@ TORQUE_STATUS_BODY=""  # populated by check 2, reused by 3 & 4
 TORQUE_STATUS_OK=0
 
 check_torque_status() {
-  local url="${SIPHER_BASE_URL}/admin/api/torque/status"
+  local url="${SIPHER_API_URL}/admin/api/torque/status"
   local body="$TMPDIR_PREFLIGHT/torque-status.json"
   TORQUE_STATUS_BODY="$body"
   trace "GET $url"
@@ -273,14 +275,21 @@ check_torque_status() {
   fi
 
   # Check 4: network correctness
+  # Hybrid mode (the canonical setup): events emit on devnet (cheap, safe),
+  # rebate pool funded on mainnet (real money). Event ingestion at
+  # ingest.torque.so is network-agnostic — the payload has no network field —
+  # so devnet events still attribute to the mainnet pool's REBATE Incentive.
+  # Either devnet or mainnet-beta is valid here; anything else is suspect.
   if [[ "$enabled" != "true" ]]; then
     record FAIL "Network correctness" "skipped (integration disabled)" \
       "Resolve check 2 first."
+  elif [[ "$network" == "devnet" ]]; then
+    record OK "Network correctness: devnet (hybrid mode — events on devnet, pool on mainnet)"
   elif [[ "$network" == "mainnet-beta" ]]; then
     record OK "Network correctness: mainnet-beta"
   else
-    record FAIL "Network correctness" "expected mainnet-beta, got ${network:-empty}" \
-      "Pool is funded on mainnet; emitting devnet events would route incentives nowhere. Set SOLANA_CLUSTER=mainnet-beta on the VPS (or whatever loadNetworkConfig() reads) and restart."
+    record FAIL "Network correctness" "expected devnet or mainnet-beta, got ${network:-empty}" \
+      "Check SIPHER_NETWORK on the VPS. Valid values: 'devnet' (hybrid mode) or 'mainnet' (full mainnet)."
   fi
 
   if [[ "$VERBOSE" -eq 1 ]]; then
@@ -420,7 +429,7 @@ check_synthetic_event() {
 # serving the bundle.
 
 check_frontend() {
-  local url="${SIPHER_BASE_URL}/"
+  local url="${SIPHER_FE_URL}/"
   local body="$TMPDIR_PREFLIGHT/frontend.html"
   trace "GET $url"
   local code
@@ -451,7 +460,7 @@ check_frontend() {
     record OK "Frontend reachable" "$url -> 200 ($size bytes, sipher SPA marker found)"
   else
     record WARN "Frontend reachable" "$url -> 200 ($size bytes) but no sipher marker in body" \
-      "Body returned by upstream is HTML but lacks identifying tokens. Inspect with: curl -s ${SIPHER_BASE_URL}/ | head -50"
+      "Body returned by upstream is HTML but lacks identifying tokens. Inspect with: curl -s ${SIPHER_FE_URL}/ | head -50"
   fi
 }
 
@@ -462,7 +471,8 @@ check_frontend() {
 if [[ "$JSON_MODE" -eq 0 ]]; then
   echo
   echo "${C_BOLD}=== Torque MCP Preflight ===${C_RESET}"
-  echo "${C_DIM}Target: ${SIPHER_BASE_URL}${C_RESET}"
+  echo "${C_DIM}API:    ${SIPHER_API_URL}${C_RESET}"
+  echo "${C_DIM}FE:     ${SIPHER_FE_URL}${C_RESET}"
   echo "${C_DIM}Ingest: ${TORQUE_INGEST_URL}${C_RESET}"
   echo
 fi
@@ -480,14 +490,16 @@ check_frontend
 if [[ "$JSON_MODE" -eq 1 ]]; then
   # Emit a single JSON object for machine consumption
   jq -n \
-    --arg target "$SIPHER_BASE_URL" \
+    --arg api "$SIPHER_API_URL" \
+    --arg fe "$SIPHER_FE_URL" \
     --arg ingest "$TORQUE_INGEST_URL" \
     --argjson fail "$FAIL_COUNT" \
     --argjson warn "$WARN_COUNT" \
     --arg verdict "$([[ $FAIL_COUNT -eq 0 ]] && echo 'READY' || echo 'NOT_READY')" \
     --argjson results "$(printf '%s\n' "${RESULTS[@]}" | jq -R 'split("|") | {status: .[0], label: .[1], detail: .[2], fix: .[3]}' | jq -s .)" \
     '{
-       target: $target,
+       api: $api,
+       fe: $fe,
        ingest: $ingest,
        fail_count: $fail,
        warn_count: $warn,


### PR DESCRIPTION
## Summary

Single-command verification step run between configuring the production VPS env vars (`TORQUE_GROWTH_ENABLED`, `TORQUE_API_TOKEN`, `TORQUE_INGESTER_URL`) and recording the Frontier Hackathon \"Build with Torque MCP\" demo video. Judges score on 2026-05-27.

- `scripts/torque-preflight.sh` — 7 read-only checks: VPS health, Torque integration enabled, ingester reachable, network correctness (devnet hybrid or mainnet-beta), local env sanity, ingester auth (synthetic event probe with deliberately-unregistered slug, expects 400 as success), frontend SPA reachable.
- `docs/integrations/torque/PREFLIGHT.md` — one-page operator guide explaining each check + interpretation of common failure modes.
- `package.json` — `pnpm run preflight:torque` invocation wired up.

## Architecture notes

- FE (`sipher.sip-protocol.org`, Vercel) and API (`sipher-api.sip-protocol.org`, VPS) live on separate hosts. Script splits into `SIPHER_FE_URL` + `SIPHER_API_URL` to avoid SPA fallback eating backend probes.
- Hybrid mode is the canonical setup: events emit on devnet (cheap, safe), pool funded on mainnet (real money). Event ingestion at `ingest.torque.so` is network-agnostic so devnet events still attribute to the mainnet pool's REBATE Incentive. Network check accepts either.
- Read-only against Torque dashboard. Only outbound POST is a synthetic event with the slug `sipher_preflight_test` (deliberately unregistered → expects 400, which simultaneously proves reachability + auth + schema validator reach).
- Never reads `~/Documents/secret/sipher-vps-secrets.env` (operator-scoped).

## Test plan

- [x] Verified live against production VPS — 6 OK + 1 WARN (synthetic probe skipped; optional)
- [x] Verdict: READY FOR DEMO
- [x] Idempotent — safe to re-run
- [x] `--verbose` dumps response bodies
- [x] `--json` emits machine-readable output (forward-compat for CI gating)
- [x] `NO_COLOR=1` disables ANSI
- [ ] Re-run after RECTOR funds the pool to confirm everything still green