### PR TITLE
fix(torque): align drip + splitSend slugs with dashboard registration

### DIFF
--- a/packages/agent/src/integrations/torque/README.md
+++ b/packages/agent/src/integrations/torque/README.md
@@ -28,8 +28,8 @@ Before enabling the integration, the following must be configured at `platform.t
 | `sipher_private_send_completed` | `tx_signature` (string), `network` (string), `rebate_destination` (string) |
 | `sipher_private_swap_completed` | `tx_signature` (string), `network` (string), `rebate_destination` (string), `amount_lamports` (number), `asset` (string) |
 | `sipher_private_claim_completed` | same as send |
-| `sipher_recurring_send_tick` | same as send |
-| `sipher_batch_send_completed` | same as send |
+| `sipher_private_drip_completed` | same as send |
+| `sipher_private_split_send_completed` | same as send |
 
 4. **REBATE Incentive** configured via `CUSTOM_EVENT_PROVIDER` data source bound to those 5 slugs, with sybil/reward/epoch rules set in the Torque dashboard recipe form (NOT in this code — distribution is dashboard-driven)
 
@@ -114,8 +114,8 @@ To attribute actions and route rebates, the Torque MCP server needs the user's p
 | `sipher_private_send_completed` | yes | **no** | no |
 | `sipher_private_swap_completed` | yes | yes (already public on-chain) | no |
 | `sipher_private_claim_completed` | yes | no | no |
-| `sipher_recurring_send_tick` | yes | no | no |
-| `sipher_batch_send_completed` | yes | no | no |
+| `sipher_private_drip_completed` | yes | no | no |
+| `sipher_private_split_send_completed` | yes | no | no |
 
 Users who want zero attribution leakage should set `TORQUE_GROWTH_ENABLED=false`.
 
@@ -126,7 +126,7 @@ Users who want zero attribution leakage should set `TORQUE_GROWTH_ENABLED=false`
 | `send` (chat-driven) | `sipher_private_send_completed` | Yes (since sipher#262) | Fires after SignTxCard callback `/api/tool-signing/:flagId/confirm` |
 | `swap` (chat-driven) | `sipher_private_swap_completed` | Yes (since sipher#262) | Same flow as send; includes `amount_lamports` + `asset` |
 | `claim` (chat-driven) | `sipher_private_claim_completed` | Partial | Uses input deposit-tx-signature as the emission key. Proper fix tracked in the claim Phase 2 follow-up. |
-| `drip`, `splitSend`, `sweep`, `consolidate`, `recurring`, `scheduleSend` | `sipher_recurring_send_tick`, `sipher_batch_send_completed`, etc. | No | Scheduled-op broadcasts not yet wired. Needs wallet-delegation or pre-signed-batch design — separate follow-up. |
+| `drip`, `splitSend`, `sweep`, `consolidate`, `recurring`, `scheduleSend` | `sipher_private_drip_completed`, `sipher_private_split_send_completed`, etc. | No | Scheduled-op broadcasts not yet wired. Needs wallet-delegation or pre-signed-batch design — separate follow-up. |
 | `deposit`, `refund` | — | No | Routed through `DepositView` / `WithdrawView` dedicated UIs, not the chat path. |
 
 ## Architecture

--- a/packages/agent/src/integrations/torque/growth-hook.ts
+++ b/packages/agent/src/integrations/torque/growth-hook.ts
@@ -16,8 +16,8 @@ const TOOL_EVENT_MAP: Record<string, SipherEventName> = {
   send: 'sipher_private_send_completed',
   swap: 'sipher_private_swap_completed',
   claim: 'sipher_private_claim_completed',
-  drip: 'sipher_recurring_send_tick',
-  splitSend: 'sipher_batch_send_completed',
+  drip: 'sipher_private_drip_completed',
+  splitSend: 'sipher_private_split_send_completed',
 }
 
 /** Swap outputs are on-chain DEX events already; include lamport amount for Torque attribution. */

--- a/packages/agent/src/integrations/torque/types.ts
+++ b/packages/agent/src/integrations/torque/types.ts
@@ -29,8 +29,8 @@ export type SipherEventName =
   | 'sipher_private_send_completed'
   | 'sipher_private_swap_completed'
   | 'sipher_private_claim_completed'
-  | 'sipher_recurring_send_tick'
-  | 'sipher_batch_send_completed'
+  | 'sipher_private_drip_completed'
+  | 'sipher_private_split_send_completed'
 
 export interface TorqueMCPClientOptions {
   ingesterUrl: string

--- a/packages/agent/tests/integrations/torque/growth-hook.test.ts
+++ b/packages/agent/tests/integrations/torque/growth-hook.test.ts
@@ -131,6 +131,80 @@ describe('wrapExecutorWithGrowthHook', () => {
     })
   })
 
+  it('emits sipher_private_drip_completed for drip tool (matches dashboard slug)', async () => {
+    baseExecutor.mockResolvedValue({ action: 'drip', status: 'confirmed', signature: TX_SIG })
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)
+
+    await wrapped('drip', { wallet: WALLET, amount: 1, token: 'SOL', recipient: 'rector.sol' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(emitEventMock).toHaveBeenCalledOnce()
+    expect(emitEventMock).toHaveBeenCalledWith({
+      userPubkey: WALLET,
+      timestamp: expect.any(Number),
+      eventName: 'sipher_private_drip_completed',
+      data: {
+        tx_signature: TX_SIG,
+        network: 'devnet',
+        rebate_destination: 'RbT6X9',
+      },
+    })
+  })
+
+  it('OMITS amount_lamports for drip events (privacy)', async () => {
+    baseExecutor.mockResolvedValue({
+      action: 'drip',
+      status: 'confirmed',
+      signature: TX_SIG,
+      amountInLamports: 1_000_000,
+    })
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)
+
+    await wrapped('drip', { wallet: WALLET, amount: 1, token: 'SOL', recipient: 'rector.sol' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const call = emitEventMock.mock.calls[0]![0]
+    expect(call.data.amount_lamports).toBeUndefined()
+    expect(call.data.asset).toBeUndefined()
+  })
+
+  it('emits sipher_private_split_send_completed for splitSend tool (matches dashboard slug)', async () => {
+    baseExecutor.mockResolvedValue({ action: 'splitSend', status: 'confirmed', signature: TX_SIG })
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)
+
+    await wrapped('splitSend', { wallet: WALLET, amount: 1, token: 'SOL', recipient: 'rector.sol' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(emitEventMock).toHaveBeenCalledOnce()
+    expect(emitEventMock).toHaveBeenCalledWith({
+      userPubkey: WALLET,
+      timestamp: expect.any(Number),
+      eventName: 'sipher_private_split_send_completed',
+      data: {
+        tx_signature: TX_SIG,
+        network: 'devnet',
+        rebate_destination: 'RbT6X9',
+      },
+    })
+  })
+
+  it('OMITS amount_lamports for splitSend events (privacy)', async () => {
+    baseExecutor.mockResolvedValue({
+      action: 'splitSend',
+      status: 'confirmed',
+      signature: TX_SIG,
+      amountInLamports: 1_000_000,
+    })
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)
+
+    await wrapped('splitSend', { wallet: WALLET, amount: 1, token: 'SOL', recipient: 'rector.sol' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const call = emitEventMock.mock.calls[0]![0]
+    expect(call.data.amount_lamports).toBeUndefined()
+    expect(call.data.asset).toBeUndefined()
+  })
+
   it('does NOT emit when base executor throws', async () => {
     baseExecutor.mockRejectedValue(new Error('boom'))
     const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)


### PR DESCRIPTION
## Summary

- Code emitted `sipher_recurring_send_tick` (drip) and `sipher_batch_send_completed` (splitSend), but the Torque dashboard registered those slugs as `sipher_private_drip_completed` and `sipher_private_split_send_completed` — a silent rebate-attribution failure (ingester returns 400 "Event not found"; the integration logs warning and continues).
- Rename code constants to match dashboard. The other three slugs already follow the `sipher_private_*_completed` shape, so the new names are internally consistent.
- Adds 4 growth-hook tests locking in the new slugs + privacy parity (amount_lamports omitted for drip/splitSend, matching send).

## Why code-side rename (not dashboard-side)

Dashboard slugs are operator-managed via Torque platform UI and alter the registered Custom Event schemas. Code rename is mechanical. The dashboard side stays canonical.

## Mapping

| Tool | Before | After (matches dashboard) |
|---|---|---|
| `drip` | `sipher_recurring_send_tick` | `sipher_private_drip_completed` |
| `splitSend` | `sipher_batch_send_completed` | `sipher_private_split_send_completed` |

## Scope

- `packages/agent/src/integrations/torque/types.ts` — `SipherEventName` union members renamed
- `packages/agent/src/integrations/torque/growth-hook.ts` — `TOOL_EVENT_MAP` values renamed
- `packages/agent/src/integrations/torque/README.md` — 3 tables updated (dashboard prereqs, privacy posture, tool emission coverage)
- `packages/agent/tests/integrations/torque/growth-hook.test.ts` — 4 new tests added

## Out of scope

- `docs/superpowers/specs/2026-05-12-torque-mcp-integration-design.md` and `docs/superpowers/plans/2026-05-12-torque-canonical-ingest-rewrite.md` — dated snapshots accurately describing the slugs that PR-E (#269) landed. This PR is a separate dashboard-alignment fix; git history preserves the historical record.

## Verification

- TDD: 2 emission tests added first, watched fail (assertion diff confirmed wrong-slug emission), then GREEN after rename
- Full agent test suite: 1573 passed, 2 skipped (opt-in integration/e2e)
- `pnpm typecheck`: 0 errors
- Production impact: drip + splitSend emissions weren't actually firing in production (scheduled-op broadcasts aren't wired yet per README), so this is a pre-emptive correctness fix before those tools light up

## Test plan

- [x] `pnpm --filter @sipher/agent test -- integrations/torque/growth-hook`
- [x] `pnpm typecheck`
- [x] No remaining references to old slugs in active code paths (`grep -rn "sipher_recurring_send_tick\|sipher_batch_send_completed" --include="*.ts" --include="*.tsx"` returns empty outside `docs/superpowers/`)

Closes #274