### PR TITLE
docs(superpowers): 5 design specs from PR-E + sipher#262 follow-up list

### DIFF
--- a/docs/superpowers/specs/2026-05-15-assert-never-exhaustiveness-design.md
+++ b/docs/superpowers/specs/2026-05-15-assert-never-exhaustiveness-design.md
@@ -1,0 +1,195 @@
+# assertNever Exhaustiveness Guards — Design
+
+**Date:** 2026-05-15
+**Session:** frontier_sip_13
+**Status:** Proposed — awaiting RECTOR review
+**Predecessor:**
+  - Lesson 2 from PR-E (#269) holistic review — "Cross-file SSE plumbing drops" recorded in [[project_torque-mcp-integration-shipped]]
+  - PR #271 (sipher#262) signing callback boundary plumbing drop in `f62b308` (ResponseChunk → streamMessage switch → chunkToSSE switch needed coordinated update)
+**Scope:** Add `assertNever` default cases to the two discriminated-union switches that translate streaming events between layers: `AgentCore.streamMessage` and `chunkToSSE` in `adapters/web.ts`.
+**Out of scope:** Wholesale refactor of `ResponseChunk` into a tagged discriminated union (separate type-hygiene PR), Pi SDK internal event additions (upstream), HERALD X adapter (no SSE).
+**Estimated work-time:** 0.5 day, 1 PR.
+
+---
+
+## Why this build
+
+**The bug pattern.** Sipher's SSE pipeline has three coordination points:
+
+```
+chatStream (Pi event → SSEEvent + sipher-internal events)
+   │
+   ▼  switch (event.type)  ← agent-core.ts:156-209
+   │
+ResponseChunk yielded
+   │
+   ▼  switch (chunk.type)  ← adapters/web.ts:27-64
+   │
+SSE wire event
+```
+
+Adding a new variant to `ResponseChunk` requires updating three places in lockstep. If any one is missed, the variant is silently dropped — the SSE client never sees it, the server thinks it sent it, and debugging starts with "why isn't the frontend reacting?"
+
+**Concrete prior incident.** PR #271 (sipher#262, the signing callback) added the `tool_signing_required` ResponseChunk variant. Initial implementation extended `ResponseChunk.type` but missed the chunkToSSE branch — caught at holistic review in commit `f62b308` (`extended ResponseChunk + AgentCore.streamMessage switch + chunkToSSE switch + 1 new web-adapter test`). Three coordinated edits across three files, with no compile-time signal when one is missed.
+
+**What `assertNever` buys us.** When a switch contains `default: return assertNever(value)` where `value` is narrowed to `never` after exhausting the union, TypeScript fails to compile if a new variant is added without a case branch. The boundary plumbing drop becomes a typecheck error, not a runtime silence.
+
+---
+
+## Architecture
+
+### The helper
+
+```ts
+// packages/agent/src/core/assert-never.ts
+
+/**
+ * Compile-time exhaustiveness check for discriminated-union switches.
+ *
+ * Place at the `default` branch of a switch over a string-literal union.
+ * If the union grows and a case is added without updating the switch,
+ * `value` is no longer narrowed to `never`, and this function fails to
+ * typecheck — surfacing the missing case at build time.
+ *
+ * At runtime, throws — the type system should make this unreachable, so
+ * a thrown error indicates a real bug (cast bypassed type system, or
+ * runtime data didn't match the declared union).
+ */
+export function assertNever(value: never): never {
+  throw new Error(`Unhandled discriminant: ${String(value)}`)
+}
+```
+
+### Where it goes
+
+**Point A: `chunkToSSE` in `packages/agent/src/adapters/web.ts:27-64`**
+
+Today:
+```ts
+function chunkToSSE(chunk: ResponseChunk): Record<string, unknown> {
+  switch (chunk.type) {
+    case 'text': ...
+    case 'tool_start': ...
+    case 'tool_end': ...
+    case 'sentinel_pause': ...
+    case 'tool_signing_required': ...
+    case 'error': ...
+    case 'done': ...
+  }
+}
+```
+
+After:
+```ts
+function chunkToSSE(chunk: ResponseChunk): Record<string, unknown> {
+  switch (chunk.type) {
+    case 'text': ...
+    case 'tool_start': ...
+    case 'tool_end': ...
+    case 'sentinel_pause': ...
+    case 'tool_signing_required': ...
+    case 'error': ...
+    case 'done': ...
+    default:
+      return assertNever(chunk.type)
+  }
+}
+```
+
+Note: function return is `Record<string, unknown>`, so `assertNever` (which returns `never`) is structurally compatible with the return type. No signature change needed.
+
+**Point B: `AgentCore.streamMessage` in `packages/agent/src/core/agent-core.ts:156-209`**
+
+The switch iterates over `chatStream`'s yielded events. Today the event type is implicitly the union of `SSEEvent` (from `pi/stream-bridge.ts:25`) plus sipher-internal events injected via `externalQueue` (sentinel_pause, tool_signing_required).
+
+`chatStream`'s return type today is not a single named union — the event variants live in agent.ts. **Prerequisite for assertNever here:** declare a named `ChatStreamEvent` union in `packages/agent/src/agent.ts` that explicitly enumerates every event variant chatStream can yield:
+
+```ts
+// In agent.ts (or a new types module imported by both agent.ts and agent-core.ts)
+export type ChatStreamEvent =
+  | SSEContentDelta
+  | SSEToolUse
+  | SSEToolResult
+  | SSEMessageComplete
+  | SSEError
+  | SSESentinelPause            // sipher-internal
+  | SSEToolSigningRequired      // sipher-internal
+```
+
+Then narrow `event` to `ChatStreamEvent` inside the switch:
+
+```ts
+for await (const event of chatStream(...) as AsyncIterable<ChatStreamEvent>) {
+  switch (event.type) {
+    case 'content_block_delta': ...
+    ...
+    default:
+      return assertNever(event)  // narrowed to never if all cases handled
+  }
+}
+```
+
+Note: `assertNever(event)` (not `event.type`) — we want the variant *shape* exhausted, not just the discriminator string. If a future case adds a new field but reuses an existing `type` literal, we don't want to silently accept it.
+
+### Why two patterns
+
+| Switch | Discriminant target | Rationale |
+|---|---|---|
+| `chunkToSSE` | `assertNever(chunk.type)` | ResponseChunk is a non-discriminated interface with a string-union `type` field; only the type string narrows |
+| `streamMessage` | `assertNever(event)` | ChatStreamEvent is a proper tagged union; we want full-variant exhaustion |
+
+Both are correct uses of the pattern. The streamMessage version is stricter and preferred whenever the target type permits it.
+
+---
+
+## Implementation
+
+1. **Create helper** at `packages/agent/src/core/assert-never.ts` with the function above. Add a unit test in `packages/agent/tests/core/assert-never.test.ts` confirming the runtime throw (the typecheck behavior is verified by tsc itself; the test exists to lock the runtime branch in coverage).
+
+2. **Wire `chunkToSSE`** — add the default branch. Import `assertNever` from `../core/assert-never.js`.
+
+3. **Declare `ChatStreamEvent` union** in `packages/agent/src/agent.ts` (or a new `agent-events.ts` if cleaner). Export it. Today's `SSEEvent` from stream-bridge stays as the Pi-side union; `ChatStreamEvent = SSEEvent | SSESentinelPause | SSEToolSigningRequired`.
+
+4. **Type-annotate `event`** inside `streamMessage`'s `for await` so `event` narrows on `event.type`. Add the default branch with `assertNever(event)`.
+
+5. **Add a "missing case" compile-time test.** Two approaches:
+   - Type-only test via `expect-type` / `tsd` — assert a stripped union triggers the type error
+   - Or: comment block with a code sample showing what fails to compile (cheaper, looser)
+
+   Recommend approach 1 — there's already a vitest+tsd pattern used elsewhere in the repo (TBD: confirm during implementation).
+
+---
+
+## Test plan
+
+- [ ] **Unit test (runtime):** `assertNever('x' as never)` throws with a message containing `'x'`.
+- [ ] **Compile-time test (chunkToSSE):** delete a case from `chunkToSSE`, run `pnpm typecheck`, confirm error pinpoints the missing branch. (Done during implementation, restored before commit; not a permanent test.)
+- [ ] **Compile-time test (streamMessage):** same drill.
+- [ ] **Existing tests still pass:** `pnpm --filter @sipher/agent test` — no regression.
+- [ ] **Optional permanent type-only test:** `packages/agent/tests/core/assert-never.types.test.ts` using `expectTypeOf` from vitest to assert exhaustiveness of `ChatStreamEvent` against the switch.
+
+---
+
+## Risks
+
+**False negatives if a variant is cast.** `assertNever` only catches missing branches in the original switch. If someone introduces a new variant by casting an existing union member (e.g. `chunk as ResponseChunk` after mutating `type`), the cast bypasses the type system. Mitigation: don't cast; if a cast is necessary, prefer a `// FIXME` comment and a follow-up to broaden the union.
+
+**ChatStreamEvent drift from chatStream actual emissions.** If chatStream gets a new event variant but `ChatStreamEvent` isn't updated, the bridge code typechecks but emits something unrepresented at runtime. Mitigation: keep `ChatStreamEvent` declared next to `chatStream` (same file) so the locality forces the update.
+
+**Imports and ESM path quirks.** This repo uses `.js` import suffixes in TS source (NodeNext resolution). New helper file must follow the convention. (`import { assertNever } from '../core/assert-never.js'`).
+
+**Test-only `as never` cast surface.** Existing tests use `as never` for vi.mock implementations. `assertNever` shouldn't trigger from those paths in practice; if it does, the cast is masking a real type-flow issue worth fixing.
+
+---
+
+## Migration / rollout
+
+Single PR, single deploy. No data migration, no config change. Tests prove no behavior change. CI typecheck must pass. Roll forward — no kill-switch needed.
+
+---
+
+## Follow-ups (out of scope for this spec)
+
+- Convert `ResponseChunk` to a proper tagged discriminated union (one variant per `type`, with type-specific fields required not optional). Would tighten `chunkToSSE` further but is a larger refactor touching all yield sites.
+- Apply the same pattern to other switches in the codebase. Audit: `grep -rn "switch (.*\.type)" packages/agent/src` — should be reviewed in a follow-up.
+- Lint rule `@typescript-eslint/switch-exhaustiveness-check` — equivalent guard at lint level; consider enabling if the helper pattern proves heavy.

--- a/docs/superpowers/specs/2026-05-15-claim-phase-2-design.md
+++ b/docs/superpowers/specs/2026-05-15-claim-phase-2-design.md
@@ -1,0 +1,296 @@
+# Claim Phase 2 — ECDH Derivation + Real `claim_transfer` Instruction — Design
+
+**Date:** 2026-05-15
+**Session:** frontier_sip_13
+**Status:** Proposed — awaiting RECTOR review
+**Predecessor:**
+  - Phase 1 stub: `packages/agent/src/tools/claim.ts:64-95` (returns `serializedTx: null` + `stealthKeyDerived: true` placeholder)
+  - README emission caveat: `packages/agent/src/integrations/torque/README.md:128` ("Uses input deposit-tx-signature as the emission key. Proper fix tracked in the claim Phase 2 follow-up.")
+  - On-chain program reference: `programs/sip_privacy/src/instructions/claim_transfer.rs` (mainnet `S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at`, devnet same)
+  - SDK ECDH primitive: `@sip-protocol/sdk` — `stealth.ts` derive functions
+**Scope:** Replace the Phase 1 placeholder with a working claim flow: ECDH-derive the stealth private key from the deposit announcement + receiver's viewing/spending keys, build the `claim_transfer` instruction, serialize the unsigned tx, route through the existing tool-signing promise-gate, and emit the Torque event with the CLAIM tx signature (not the deposit tx signature).
+**Out of scope:** SPL token claim path (Phase 1 also doesn't cover this; tracked separately); Ethereum claim flow; UI changes beyond what the existing SignTxCard already handles for send/swap.
+**Estimated work-time:** 4-6 days, 1 PR (or 2 PRs if cleanly splittable into "ECDH module" + "claim wiring").
+
+---
+
+## Why this build
+
+**The current placeholder lies.** When a user runs `claim` today, `executeClaim` validates inputs, returns `{ status: 'awaiting_signature', serializedTx: null, details: { stealthKeyDerived: true } }`. No ECDH actually happens. No claim transaction is built. No on-chain claim occurs. The chat UX shows "Claim prepared..." and the user has no path forward.
+
+Yet the Torque growth-hook fires `sipher_private_claim_completed` because `executeClaim` returns a result containing a `txSignature` field (which is actually the *deposit* tx signature — not a real claim tx). Torque attribution is meaningless: a `claim_completed` event is fired when no claim occurred.
+
+**Why now.** Phase 1 was an explicit placeholder during initial sipher build. M17 Solana same-chain privacy completed. The on-chain `claim_transfer` instruction is live on mainnet (`S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at`). The SDK ECDH primitives are tested. There's no remaining blocker to making claim real.
+
+**What this fix delivers.**
+1. Real ECDH derivation: the stealth private key is recovered from the deposit's ephemeral pubkey + the recipient's viewing+spending keys.
+2. Real `claim_transfer` instruction built and serialized.
+3. Real tool-signing UX: the user gets a SignTxCard in chat with the actual claim tx, signs, and the tokens land in their destination wallet.
+4. Honest Torque telemetry: `sipher_private_claim_completed` fires only when the claim tx confirms, with the CLAIM tx signature as the attribution key.
+
+---
+
+## Architecture
+
+### Crypto background (one paragraph)
+
+The deposit transaction posts an announcement to the `sip_privacy` program with:
+- `ephemeralPubkey` — sender's per-payment fresh secp256k1 pubkey
+- `stealthPubkey` — the one-time recipient address derived as `H(ECDH(ephemeral, viewing)) * G + spending`
+- `commitment` — Pedersen commitment to the amount (binding + hiding)
+
+The recipient holds `viewingPrivateKey` + `spendingPrivateKey`. ECDH gives back the shared secret `s = ECDH(viewingPrivateKey, ephemeralPubkey)`. Hashing `s` gives the stealth derivation tweak `t = H(s)`. The stealth private key is then `stealthPrivKey = t + spendingPrivateKey (mod n)`. This corresponds to `stealthPubkey` and is the signer for the `claim_transfer` instruction.
+
+### Module structure
+
+New module: `packages/agent/src/tools/claim-helpers.ts` (or extend existing `tools/claim.ts`):
+
+```ts
+import { Connection, Transaction, PublicKey } from '@solana/web3.js'
+import { deriveStealthPrivateKey, parseAnnouncementPDA } from '@sip-protocol/sdk'
+
+export interface ClaimContext {
+  connection: Connection
+  programId: PublicKey          // S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at
+  depositTxSignature: string    // input from user
+  viewingPrivateKey: string     // hex or base58
+  spendingPrivateKey: string    // hex or base58
+  destinationWallet: PublicKey  // where to send claimed tokens
+}
+
+export interface BuiltClaimTx {
+  serializedTx: string          // base64
+  stealthPubkey: PublicKey
+  expectedAmount: bigint
+  expectedMint: PublicKey | null  // null for SOL
+}
+
+export async function buildClaimTx(ctx: ClaimContext): Promise<BuiltClaimTx>
+```
+
+### Flow
+
+```
+User: "claim payment 3QCoHcJ..."
+   │
+   ▼
+executeClaim (refactored)
+   │
+   ├─ validate inputs (existing)
+   ├─ fetch deposit tx via connection.getTransaction(depositTxSignature)
+   ├─ parse announcement PDA from tx → { ephemeralPubkey, stealthPubkey, commitment, encryptedMeta }
+   ├─ ECDH-derive stealth privkey: deriveStealthPrivateKey({ ephemeralPubkey, viewingPrivKey, spendingPrivKey })
+   ├─ assert derived pubkey === announced stealthPubkey (sanity check; catches wrong keys)
+   ├─ decrypt encryptedMeta to get amount + token mint
+   ├─ build claim_transfer instruction (sip_privacy program)
+   ├─ build transaction with recent blockhash + fee payer = destinationWallet
+   ├─ partially sign with stealth privkey (signer needed for claim_transfer)
+   ├─ serialize tx → base64
+   │
+   ▼
+return {
+  action: 'claim',
+  status: 'awaiting_signature',
+  serializedTx: <base64>,
+  ...
+}
+   │
+   ▼
+chatStream's tool-signing wrapper picks up status === 'awaiting_signature'
+   │
+   ▼
+emit `tool_signing_required` SSE → frontend SignTxCard appears
+   │
+   ▼
+User clicks Sign → wallet adds fee-payer signature → broadcasts → returns claim_tx_signature
+   │
+   ▼
+POST /api/tool-signing/:flagId/confirm { signature: claim_tx_signature }
+   │
+   ▼ (Phase 1, today)
+resolvePendingSigning → tool returns { signature: claim_tx_signature, status: 'confirmed' }
+   │
+   ▼
+growth-hook → emit sipher_private_claim_completed with data.tx_signature = claim_tx_signature
+```
+
+### Signer accounts
+
+The `claim_transfer` instruction requires TWO signers:
+1. **Stealth keypair** — proves recipient identity (server has the privkey from ECDH; signs server-side BEFORE returning to SignTxCard)
+2. **Fee payer** — the destination wallet (signs client-side via SignTxCard)
+
+Server's role is to assemble a partially-signed transaction. The stealth keypair is ephemeral — derived in memory, used to sign, then dropped. Never persisted.
+
+This is acceptable because the stealth privkey is uniquely tied to the destination wallet's spending key — leaking it doesn't compromise anything beyond this single claim. (The viewing key, however, is sensitive — see security section.)
+
+### Growth-hook update
+
+Current `extractTxSignature` reads `r.signature || r.txSignature`. For Phase 1 claim, the result's `txSignature` is the DEPOSIT tx; this is wrong.
+
+Phase 2 should return the CLAIM tx signature in the standard `signature` field (matching send/swap). Rename `txSignature` in `ClaimToolResult` → `depositTxSignature` for clarity; add `signature?: string` (the claim tx, populated after sign-and-confirm by the signing-callback path).
+
+The growth-hook will pick up `r.signature` (claim tx), not `r.txSignature` (deposit). Existing extraction priority order helps the migration.
+
+### Viewing key handling
+
+**The viewing key is sensitive.** It allows the holder to scan all of the recipient's incoming payments. Sending it to the server is a real trust delegation.
+
+Today's Phase 1 already accepts viewing key in the tool input — the threat surface exists. Phase 2 doesn't expand it but should be explicit:
+
+- The viewing key MUST be transmitted over TLS only (sipher.sip-protocol.org is HTTPS; OK).
+- The viewing key MUST NOT be logged at any verbosity.
+- The viewing key MUST NOT be persisted — kept in tool-call-scoped memory and zeroized after the claim is built (best-effort; JS GC limits guarantees).
+- A future option: a "claim co-signer" mode where the user runs the ECDH derivation locally, then sends only the resulting stealth privkey to the server (still a leak but smaller). Out of scope.
+
+**Recommend:** add a privacy warning callout in the README + the chat tool description that running claim shares the viewing key with the server, distinct from send/swap which don't.
+
+---
+
+## Implementation
+
+### Step 1 — ECDH helper (`packages/agent/src/tools/claim-helpers.ts`)
+
+Centralizes the cryptographic derivation. Uses `@sip-protocol/sdk` primitives. Pure function — no IO, easily unit-tested with known fixture vectors.
+
+### Step 2 — Announcement parser
+
+`parseAnnouncementFromTx(connection, depositTxSignature)`:
+1. `connection.getTransaction(depositTxSignature, { commitment: 'confirmed', maxSupportedTransactionVersion: 0 })`
+2. Iterate instructions, find the one targeting `sip_privacy` program
+3. Decode the instruction data per the IDL → `{ ephemeralPubkey, stealthPubkey, commitment, encryptedMeta }`
+4. Return parsed announcement
+
+### Step 3 — Claim tx builder
+
+`buildClaimTx(ctx)`:
+1. Parse announcement
+2. ECDH-derive stealth privkey
+3. Sanity check: derived pubkey === announced stealthPubkey
+4. Decrypt `encryptedMeta` (XChaCha20-Poly1305 with viewing-key-derived key per SDK convention)
+5. Construct `claim_transfer` instruction
+6. Build `Transaction`, set recent blockhash + fee payer
+7. Partially sign with stealth keypair
+8. Serialize → base64
+
+### Step 4 — Refactor `executeClaim`
+
+Replace the Phase 1 placeholder. New signature:
+```ts
+export interface ClaimToolResult {
+  action: 'claim'
+  status: 'awaiting_signature' | 'confirmed' | 'failed'
+  depositTxSignature: string
+  signature?: string            // populated after sign+confirm
+  serializedTx: string          // no longer null
+  expectedAmount: string        // human-readable
+  expectedMint: string | null   // null for SOL
+  destinationWallet: string
+  message: string
+}
+```
+
+`executeClaim` returns `awaiting_signature` with `serializedTx` populated. The tool-signing wrapper (already used by send/swap) handles the rest.
+
+### Step 5 — Wire into chatStream's tool-signing wrapper
+
+Today's wrapper (in agent.ts) detects send/swap by tool name. Extend to include claim. The wrapper emits `tool_signing_required`, awaits the promise-gate, returns `{ signature, status: 'confirmed' }` after the client posts confirm.
+
+### Step 6 — Growth-hook adjustment
+
+Add `signature` extraction priority (already present in `extractTxSignature`). Verify by inspection that the result's `signature` field is preferred over `txSignature`.
+
+### Step 7 — Tests (heavy)
+
+Discussed below.
+
+### Step 8 — README updates
+
+- `packages/agent/src/integrations/torque/README.md` table: update claim row "Partial → Yes (since #<PR>)"
+- New section in main repo README: privacy implication of sending viewing key
+
+---
+
+## Test plan
+
+### Unit tests for `claim-helpers.ts`
+
+- [ ] `parseAnnouncementFromTx` — happy path with known fixture (deposit tx from devnet)
+- [ ] `parseAnnouncementFromTx` — tx not found → throws `AnnouncementNotFoundError`
+- [ ] `parseAnnouncementFromTx` — tx exists but no sip_privacy instruction → throws `NoAnnouncementError`
+- [ ] `deriveStealthPrivateKey` round-trip: deposit fixture → derived privkey → derived pubkey matches announcement
+- [ ] `deriveStealthPrivateKey` with wrong viewing key → derived pubkey DOES NOT MATCH announcement (sanity)
+- [ ] `buildClaimTx` — happy path: builds valid tx with correct accounts, correctly signed by stealth keypair
+
+### Unit tests for `executeClaim`
+
+- [ ] Existing validation tests still pass (txSignature required, viewing/spending keys required)
+- [ ] Returns `serializedTx` (no longer null)
+- [ ] Returns `expectedAmount` matching decrypted metadata
+- [ ] Returns `destinationWallet` from input OR derived from spending pubkey
+- [ ] Wrong viewing key for the deposit → throws actionable error ("stealth address mismatch; check viewing key")
+- [ ] Already-claimed deposit (rare race) → returns useful error from chain via simulate, not server crash
+
+### Integration tests
+
+- [ ] Devnet end-to-end: scan finds payment → claim → SignTxCard → user signs → claim tx confirms → Torque event fires with CLAIM tx signature
+- [ ] Mock SignTxCard signer to avoid wallet UI in tests
+- [ ] Use `SIP_TEST_DEPOSIT_TX` env var to drive the fixture
+
+### Growth-hook tests (extend existing)
+
+- [ ] Add: claim emission uses `result.signature` (claim tx), not `result.txSignature` (deposit)
+- [ ] Add: claim emission skipped if status === 'awaiting_signature' (no signature yet)
+
+### Security tests
+
+- [ ] Viewing key never appears in any log line (grep test on captured log output)
+- [ ] Server-allocated stealth keypair zeroized after tx serialization (best-effort assertion on the keypair buffer being filled with zeros — JS-engine-specific, may be removed if unreliable)
+
+### Regression
+
+- [ ] Full agent suite: `pnpm --filter @sipher/agent test`
+- [ ] Existing claim tool tests still pass
+
+---
+
+## Risks
+
+**Viewing key exposure surface.** Today's Phase 1 already accepts it; this spec doesn't expand the threat. But Phase 2 making claim real means usage will increase, scrutiny will increase. Mitigate with README disclosure + audit-log redaction guarantees.
+
+**Stealth keypair handling in JS.** JavaScript doesn't offer guaranteed memory zeroization. Best effort with `Uint8Array.fill(0)` is acceptable but not bulletproof. Mitigation: limit the lifetime to a single function scope; never serialize to logs or persistent storage.
+
+**Announcement parse fragility.** If sip_privacy program adds new instruction variants, the parser may misclassify. Mitigation: version the IDL parsing, fail loud on unknown variants, never silent-default.
+
+**Replay protection.** Once a claim tx is built, what stops two sequential `claim` invocations from building two valid claim txs? The on-chain program rejects double claims (the announcement PDA is consumed), but the server can race: build tx A, then build tx B referencing same deposit, both fee-payer-signed; one confirms, one fails on-chain. Cosmetic issue. Mitigation: short-lived server-side "in-flight claim" cache, dedupe by `(depositTxSignature, destinationWallet)`. Out-of-scope mitigation; track as follow-up.
+
+**Recent blockhash freshness.** Building a tx with a blockhash that expires before the user signs (5-min TTL) → broadcast fails. Mitigation: refetch blockhash if the SignTxCard sits idle > 60s and the user clicks Sign late. Adds complexity; alternatively, accept that occasional expiry is recoverable via "request again" UX.
+
+**Privacy degradation if viewing key leaked from server.** Defense-in-depth measures (TLS-only, no logs, memory hygiene) reduce but don't eliminate. The honest framing: server-assisted claim is a trust delegation. Out-of-scope long-term alternative: client-side claim (no server involvement) — needs a richer frontend.
+
+**Torque attribution change.** Today's emission fires on the deposit tx signature. After Phase 2, it fires on the claim tx signature. This is the correct behavior but breaks any downstream consumer that joined on deposit-tx-sig. Verify with RECTOR before rollout that no live Incentive joins on the old key.
+
+---
+
+## Migration / rollout
+
+**Phase 1 deprecation.** Existing Phase 1 placeholder returns `serializedTx: null`. Frontend never produced a SignTxCard for claim. After Phase 2 lands, claim begins producing real SignTxCards. No data migration; the placeholder didn't persist anything.
+
+**Coordinated env config.** Ensure `SIPHER_HELIUS_API_KEY` (mainnet RPC) is configured on VPS — required for both ECDH announcement lookup and claim tx broadcast. Already configured per current send/swap path.
+
+**No flag gate.** This is a correctness fix; the prior behavior was a known stub. Roll forward.
+
+**README + chat tool description update** — surface the viewing-key-sharing disclosure prominently.
+
+**Backward compat for Torque event payload.** `data.tx_signature` field stays a string. Only the meaning shifts (deposit-tx → claim-tx). Document in the Torque integration README's "Tool emission coverage" table.
+
+---
+
+## Follow-ups (out of scope)
+
+- SPL token claim path (Phase 1 also doesn't cover this — `claim_token_transfer` instruction)
+- Client-side ECDH alternative (no viewing key sent to server)
+- In-flight claim deduplication cache
+- Replay protection in growth-hook (also tracked in [[2026-05-15-server-side-sig-verification-design]])
+- Ethereum claim path (depends on contracts/sip-ethereum claim instruction)
+- Verification of the claim tx using the same RPC verifier from [[2026-05-15-server-side-sig-verification-design]] — this should compose cleanly

--- a/docs/superpowers/specs/2026-05-15-claim-phase-2-design.md
+++ b/docs/superpowers/specs/2026-05-15-claim-phase-2-design.md
@@ -294,3 +294,127 @@ Discussed below.
 - Replay protection in growth-hook (also tracked in [[2026-05-15-server-side-sig-verification-design]])
 - Ethereum claim path (depends on contracts/sip-ethereum claim instruction)
 - Verification of the claim tx using the same RPC verifier from [[2026-05-15-server-side-sig-verification-design]] — this should compose cleanly
+
+---
+
+## Amendment — SDK reality check (2026-05-15, frontier_sip_13)
+
+**Discovered during implementation scoping:** the original spec above (Implementation Steps 1-7) assumed the server would build claim_transfer from scratch — own announcement parser, own ECDH derivation, own partial-sign + serialize for client-side fee-payer signing. **This is more work than necessary.** `@sip-protocol/sdk@^0.7.4` already exposes the complete primitive surface:
+
+```ts
+// All exported from @sip-protocol/sdk
+declare function parseAnnouncement(memo: string): SolanaAnnouncement | null
+declare function scanForPayments(params: SolanaScanParams): Promise<SolanaScanResult[]>
+declare function claimStealthPayment(params: SolanaClaimParams): Promise<SolanaClaimResult>
+declare function deriveStealthPrivateKey(...): ...
+declare function deriveSolanaStealthKeys(...): ...
+```
+
+`claimStealthPayment(params: SolanaClaimParams)` accepts the user's `viewingPrivateKey` + `spendingPrivateKey` and **internally derives the stealth privkey + builds claim_transfer + signs + broadcasts**, returning `{ txSignature, destinationAddress, ... }`. Steps 1, 2, and 3 of the original Implementation section are entirely subsumed by this single call.
+
+### What changes
+
+The original spec's flow diagram (lines 73-115) hinges on a tool-signing wrapper / SignTxCard round-trip where the user signs as the fee payer. **That UX does not match the SDK's broadcast-internal claim primitive.** Server-side, the stealth address itself signs as fee payer (using the stealth privkey derived from the user's viewing+spending keys). The destination wallet does not need to sign — it's only the recipient of the claim transfer.
+
+This collapses the "client signing UX" assumption. There are two coherent paths from here:
+
+### Path A — SDK-driven claim (recommended for first ship)
+
+**One-shot server execution. No SignTxCard. No tool-signing wrapper extension.**
+
+```
+User invokes `claim` tool with depositTxSignature + viewingKey + spendingKey + destination
+   │
+   ▼
+executeClaim
+   ├─ validate inputs (existing)
+   ├─ fetch deposit tx via getTransaction
+   ├─ extract announcement via parseAnnouncement (sip_privacy memo)
+   ├─ resolve stealthAddress (from scanForPayments OR from announcement decode)
+   ├─ resolve mint (from the deposit's token transfer instruction)
+   │
+   ▼
+claimStealthPayment({ connection, stealthAddress, ephemeralPublicKey, viewingPrivateKey, spendingPrivateKey, destinationAddress, mint })
+   │ (SDK derives stealth privkey + builds claim_transfer + signs + broadcasts)
+   │
+   ▼
+return { action: 'claim', status: 'confirmed', signature: claim_tx_sig, depositTxSignature, destinationWallet, message, ... }
+   │
+   ▼
+growth-hook → emits sipher_private_claim_completed with data.tx_signature = claim_tx_sig
+```
+
+**Trade-offs:**
+- ✅ Minimum new code — the SDK is the implementation
+- ✅ Honest Torque attribution from day one (claim-tx-sig, not deposit-tx-sig)
+- ✅ Closes the Phase 1 stub correctness gap
+- ❌ Loses explicit user consent at sign-time — calling `claim` is the consent
+- ❌ Loses the SignTxCard visual confirmation that send/swap have
+- ❌ Server can't pause-and-confirm pending claims (the SDK is one-shot)
+
+The user-consent loss is bounded: the chat-tool invocation IS the consent. Compare to how SDK CLI users invoke `claimStealthPayment` directly — they consent by calling the function. The chat-driven flow is equivalent.
+
+### Path B — Fork SDK to separate build + broadcast
+
+**Match the original spec's tool-signing UX. Replicate `claimStealthPayment`'s internals (or call lower-level SDK primitives) so build and broadcast are separable.**
+
+```
+executeClaim builds the claim tx (no broadcast) → returns serializedTx + status: awaiting_signature
+   │
+   ▼ tool-signing wrapper emits SSE → SignTxCard appears
+   │
+User confirms in SignTxCard → server broadcasts (still using SDK or raw RPC)
+```
+
+**Trade-offs:**
+- ✅ Explicit user consent moment (SignTxCard)
+- ✅ Symmetric with send/swap UX
+- ❌ Must duplicate or fork SDK internals — fragile, maintenance burden
+- ❌ The stealth keypair signing happens server-side regardless of which path; SignTxCard is cosmetic security theater (the user can't actually refuse — they already passed the keys)
+- ❌ Larger implementation surface (4-6 days remains true)
+
+The "security theater" point is real. In Path A, the user's consent is the tool invocation. In Path B, the user's consent is the SignTxCard click — but the underlying signing authority was already delegated (the viewing+spending keys are server-side). The SignTxCard doesn't gate anything cryptographically.
+
+### Revised recommendation
+
+**Ship Path A.** Defer Path B's SignTxCard surface as a follow-up if RECTOR decides the consent ceremony is worth the build cost. The Phase 1 stub is shipping incorrect Torque events today; Path A fixes that in a clean, small PR.
+
+### Revised Implementation steps (Path A)
+
+1. **Locate the announcement memo in the deposit tx** — `connection.getTransaction(depositTxSig)` → find the SPL memo instruction → call SDK's `parseAnnouncement(memoString)` → get `{ ephemeralPublicKey, viewTag, stealthAddress? }`
+2. **Resolve the stealth address** — if absent from announcement, derive from `(ephemeralPublicKey + viewingPrivateKey + spendingPublicKey)` via SDK's `generateSolanaStealthAddress` OR use `scanForPayments` to locate the matching incoming entry
+3. **Resolve the mint** — inspect the deposit tx's token transfer instruction (or sentinel-style account parse)
+4. **Call `claimStealthPayment`** — pass viewing+spending privkeys + the resolved stealth address + ephemeral pubkey + mint + destination
+5. **Return the result** — `{ status: 'confirmed', signature: result.txSignature, ... }`. The growth-hook extracts `signature` (already supported, lines 101-107 of growth-hook.ts).
+
+### Revised test plan (Path A)
+
+- Unit: executeClaim happy path with mocked SDK call (3 tests)
+- Unit: input validation (existing tests should still pass)
+- Unit: wrong viewing key → SDK throws → executeClaim re-throws as actionable error
+- Unit: deposit tx not found → throws actionable error
+- Unit: announcement parse fails → throws actionable error
+- Growth-hook: claim emission carries `signature` field (claim-tx-sig), not `txSignature` (deposit-tx-sig). One new test.
+- Skip: the entire "ECDH derive in helpers module" test set (lines 220-228 of original spec) — SDK is the implementation.
+
+### Revised viewing-key trust posture
+
+Same trust delegation as Path B (the user shares viewing+spending keys with the server). The fact that the SDK does the broadcast doesn't change the trust surface — the keys are already on the server regardless. The README disclosure section (line 146) still applies verbatim.
+
+### Revised migration / rollout
+
+Path A is a CORRECTNESS FIX (replaces stub with working flow). The chat tool's contract changes only in the return shape — `status: 'confirmed'` instead of `'awaiting_signature'`, plus a real `signature` field. No frontend changes required: today's frontend treats the claim result as plain text in the assistant message, which still works.
+
+### Risks (Path A specific)
+
+**Stealth address resolution.** If `scanForPayments` returns multiple matches or zero matches for the given deposit tx, the code must handle gracefully. Recommend: pass `fromSlot: depositTxSlot - 1, toSlot: depositTxSlot + 1` to narrow scan scope.
+
+**SDK version drift.** Current dep is `@sip-protocol/sdk@^0.7.4`. The primitives used here have been stable since at least 0.5.x but verify before assuming. Pin to a known-good version if needed.
+
+**SDK error surfaces.** `claimStealthPayment` throws on various error conditions (RPC failure, signature mismatch, insufficient lamports). Wrap with try/catch in executeClaim and map to actionable error messages.
+
+**No client consent moment.** Documented above. Acceptable for the chat-driven invocation pattern. If a future deployment requires explicit confirmation (e.g. high-value claims), revisit Path B.
+
+---
+
+This amendment supersedes the original Implementation (Step 1-3) and Test plan sections for the **default first-ship choice**. The original sections remain in this document as the Path B reference if the consent-ceremony UX is later prioritized.

--- a/docs/superpowers/specs/2026-05-15-scheduled-op-broadcasts-design.md
+++ b/docs/superpowers/specs/2026-05-15-scheduled-op-broadcasts-design.md
@@ -1,0 +1,311 @@
+# Scheduled-Op Broadcasts (drip / splitSend / sweep / consolidate / recurring / scheduleSend) — Design
+
+**Date:** 2026-05-15
+**Session:** frontier_sip_13
+**Status:** Proposed — awaiting RECTOR review
+**Predecessor:**
+  - README emission table: `packages/agent/src/integrations/torque/README.md:129` — "Scheduled-op broadcasts not yet wired. Needs wallet-delegation or pre-signed-batch design — separate follow-up."
+  - Existing crank: `packages/agent/src/crank.ts:99-113` — COURIER ticks every 60s and calls `executeTool(op.action, op.params)`
+  - Existing tools that write `scheduled_ops` rows but don't actually broadcast: `tools/drip.ts`, `tools/splitSend.ts`, `tools/sweep.ts`, `tools/consolidate.ts`, `tools/schedule-send.ts`, `tools/recurring.ts`
+  - Trust boundary anchor: server can't sign as the user; user can't be online forever
+**Scope:** Define broadcasting paths for each scheduled-op tool, classified by execution horizon (immediate batch / time-bounded / indefinite). Recommend per-tool execution strategies. Specify the on-chain delegation contract (or use of existing Squads Smart Account) for indefinite ops. Spec the durable-nonce flow for time-bounded ops. Out-of-scope: writing the on-chain delegation program; refining the UX flows for delegation approvals; mainnet rollout decisions.
+**Out of scope:** Cross-chain scheduled ops (Ethereum); fiat-denominated triggers; price-conditional sends; full Squads integration (separate sip-arcium-style spec).
+**Estimated work-time:** 3 PRs minimum across 2-3 weeks. PR-A: durable-nonce path for scheduleSend + drip + splitSend. PR-B: delegation contract + sweep + recurring. PR-C: COURIER hardening + observability.
+
+---
+
+## Why this build
+
+**The shape of the problem.** A scheduled op is a promise to broadcast a Solana transaction at a future time. Solana transactions must be signed by all required signers. The user IS one of those signers (fee payer or stealth-source). The server is NOT — and shouldn't be, by default. Yet the user is rarely online at the precise moment the op fires.
+
+This is a classic key-availability problem. Three families of solutions exist:
+
+| Family | Mechanism | Trust delegated | Horizon |
+|---|---|---|---|
+| **Immediate batch** | Sign N txs back-to-back within one user session | None new | Minutes |
+| **Pre-signed durable nonce** | User signs N future txs at create time, each anchored to a single-use durable nonce so blockhash never expires | None — txs are immutable post-sign | Hours to weeks |
+| **Wallet delegation** | User grants a scope-limited authority to a server-controlled key (PDA or Squads Smart Account); server signs within that scope | Bounded — scope, time, amount | Indefinite |
+
+The current sipher implementation persists scheduled ops to SQLite but the crank's executor (`executeTool`) routes through the tool-signing wrapper, which awaits the user to sign — and times out after 5 minutes when the user isn't there. So all scheduled ops "fail" silently after 5 min of crank ticking.
+
+**What this spec delivers.** A per-tool classification of which family applies, plus a concrete design for each family. PR-A targets the time-bounded family (durable nonce) — this unblocks 4 of the 6 scheduled tools. PR-B targets indefinite (delegation). PR-C hardens the COURIER for unattended operation (retries, observability, deduplication).
+
+---
+
+## Per-tool classification
+
+| Tool | Op intent | Horizon | Recommended family |
+|---|---|---|---|
+| `splitSend` | Split a single logical send into N small txs for privacy/obfuscation | Minutes (all within one session) | **Immediate batch** |
+| `consolidate` | Collect dust + stealth balance into main wallet | Minutes (one session) | **Immediate batch** |
+| `scheduleSend` | Send X tokens at a specific future time | Hours to days | **Pre-signed durable nonce** |
+| `drip` | DCA-style — distribute X tokens over N days in M chunks | Days | **Pre-signed durable nonce** |
+| `sweep` | Auto-shield incoming wallet funds, on each detected deposit | Indefinite | **Wallet delegation** |
+| `recurring` | Send X tokens every K days, forever | Indefinite | **Wallet delegation** |
+
+---
+
+## Family A: Immediate batch (splitSend, consolidate)
+
+### How it works
+
+User invokes splitSend. Server builds N transactions immediately (recent-blockhash-based; ~60s validity per tx). Frontend renders an "approve all" SignTxCard variant that walks the user through N consecutive signatures (or — preferred — uses a wallet adapter's `signAllTransactions(txs)` to batch-prompt). Each signed tx is broadcast in sequence (with small delay for privacy obfuscation).
+
+### Why this works for these tools
+
+splitSend's whole point is fragmenting one user-driven send. The user is online by definition. They can sign all N within minutes. Same for consolidate — it's a one-shot housekeeping action triggered manually.
+
+### What changes
+
+1. **Tool result** — splitSend returns an array of `serializedTx` strings (not a single tx). New result shape:
+   ```ts
+   {
+     action: 'splitSend',
+     status: 'awaiting_signature',
+     serializedTxs: string[],         // N base64 txs
+     batchId: string,                 // server-side correlation
+     // existing fields ...
+   }
+   ```
+
+2. **SignTxCard batch mode** — frontend gains a "sign all" UI that calls `wallet.signAllTransactions(txs)`. The card shows a single Approve button + a progress strip (3/5 signed, broadcasting...).
+
+3. **Promise gate** — extend `pending-signing.ts` to handle batches: one flagId, N signatures expected. Confirm route posts the array; reject any if any sig is missing.
+
+4. **Growth-hook emission** — emit `sipher_private_split_send_completed` ONCE per batch, with `tx_signature` = the first tx's signature (arbitrary anchor) plus a new `batch_size` field. (Schema change to Torque dashboard event definition — operator action.)
+
+### Risks
+
+- **Mid-batch failures.** If tx 3 of 5 lands but txs 4-5 expire (blockhash), the user has partially executed a split. Acceptable for splitSend's privacy intent (some chunks went through). Mitigation: server broadcasts in parallel-with-rate-limit; refetch blockhash between txs.
+- **Wallet UX.** Some wallets refuse multi-sign (Backpack supports it, Phantom historically iffy). Mitigation: feature-detect; fall back to N-prompts with a polished UI.
+
+---
+
+## Family B: Pre-signed durable nonce (scheduleSend, drip)
+
+### Background on Solana durable nonces
+
+A nonce account is a Solana account that stores a "durable" blockhash that never expires. A transaction can reference the nonce account in place of `recentBlockhash`, and the nonce program's `AdvanceNonceAccount` instruction must be the first instruction in the tx. Each nonce account is single-use — advancing consumes its current nonce; future txs need re-initialized nonces or new accounts.
+
+Rent: each nonce account ~0.0015 SOL minimum balance. For a 30-day drip with daily chunks (N=30), the user pays ~0.045 SOL up front for nonce accounts. Acceptable.
+
+### How it works
+
+```
+User invokes drip(amount=10 SOL, days=7, recipient=rector.sol)
+   │
+   ▼
+Server splits into 7 chunks, generates 7 nonce-account public keys
+   │
+   ▼
+Server builds 7 transactions, each:
+   - ix[0]: AdvanceNonceAccount(nonce_i)
+   - ix[1]: stealth send (sip_privacy program)
+   - referencing nonce_i instead of recent_blockhash
+   │
+   ▼
+Returns to client: {
+   serializedTxs: [7 base64 txs],   // unsigned
+   nonceAccounts: [7 pubkeys],
+   nonceInitInstructions: [...]     // to create+seed the 7 nonces
+}
+   │
+   ▼
+Frontend SignTxCard "schedule batch":
+   - Sign-and-broadcast the nonceInit batch FIRST (creates+seeds 7 nonce accounts on-chain)
+   - User signs all 7 drip txs WITHOUT broadcasting; signed txs returned to server
+   │
+   ▼
+POST /api/scheduled-ops/:opId/seal { signedTxs: [7 base64 signed-but-not-broadcast] }
+   │
+   ▼
+Server persists signed txs in scheduled_ops table (new column: signed_tx)
+   │
+   ▼
+COURIER tick: for each op whose next_exec ≤ now AND status === 'sealed':
+   - submit signed_tx to RPC
+   - on confirm: status='completed', emit growth-hook
+   - on transient fail: leave 'sealed', retry next tick
+   - on permanent fail (nonce already consumed): status='failed'
+```
+
+### Why this works
+
+The user's signature is captured ONCE at create time. The signed tx is bytes-immutable. The server stores and broadcasts; can't tamper without invalidating the signature. The nonce makes the tx valid indefinitely (until the nonce is advanced).
+
+### Trust analysis
+
+| Concern | Defended? |
+|---|---|
+| Server modifies tx before broadcast | No — signature breaks |
+| Server delays broadcast | Yes (cosmetic only); user can cancel any time |
+| Server reorders broadcasts | Cosmetic; each tx is independent |
+| Server replays a tx | Nonce single-use prevents on-chain |
+| Server censors a tx | Yes (out-of-band: user can broadcast manually if they have the signed tx) |
+| Server leaks signed txs | Severe — would allow front-running. Mitigation: encrypt-at-rest, viewing-key-scoped. |
+
+### What changes
+
+1. **scheduled_ops table** — add columns: `signed_tx: BLOB`, `nonce_account: TEXT`, `op_kind: 'awaiting_seal' | 'sealed' | 'pending' | ...`
+
+2. **Tool flow** — drip / scheduleSend return both `serializedTxs` (unsigned) AND `nonceInitInstructions` for the user to broadcast first. After nonce init confirms, user signs the drip txs and posts to a NEW endpoint `POST /api/scheduled-ops/:batchId/seal`.
+
+3. **Crank executor** — for `op_kind === 'sealed'` ops, the executor reads `signed_tx` and broadcasts directly via `connection.sendRawTransaction(signed_tx, { skipPreflight: true, maxRetries: 3 })`. No tool-signing wrapper involvement.
+
+4. **Cancellation** — new tool `cancelScheduledOp(opId)` builds a tx that calls Solana's `nonce.withdraw` instruction, draining the nonce account back to the user (also invalidates the pending signed_tx since the nonce is gone).
+
+### Risks
+
+- **Nonce setup complexity.** First-time user pays 0.045 SOL for 30 nonce accounts. UX friction. Mitigation: pool nonces across ops; recycle after consumption.
+- **Signed-tx storage.** SQLite blobs in the agent server. Encrypt-at-rest via OS-level disk encryption (already true on VPS). Memorialize the storage-sensitivity in CLAUDE.md / README.
+- **Recipient changes.** If recipient's stealth meta-address rotates between create and broadcast, the broadcast still targets the OLD address. Mitigation: nonce-based pre-signing pins stealth addresses; document trade-off.
+- **Recent-mainnet-rent-spike.** If Solana raises rent, future broadcasts may fail because the tx allocates a stealth ATA with insufficient lamports. Mitigation: include rent-buffer (small extra SOL) in the original tx.
+
+---
+
+## Family C: Wallet delegation (sweep, recurring)
+
+### Two options
+
+**C.1 — Custom delegation program** (clean privacy alignment, more build cost):
+
+A new on-chain program `sipher_delegation` exposes:
+- `create_delegation(scope, max_amount, valid_until, allow_list)` — user creates a delegation PDA with strict scope
+- `execute_delegated_send(amount, recipient, commitment)` — server signs as delegation PDA's "operator"; program validates scope+amount+allow_list+expiry
+- `revoke_delegation()` — user pulls back, refunds remaining
+
+Pros: scope tailored to sipher's stealth send needs (Pedersen commitment + stealth address routing). Privacy posture stays clean.
+Cons: another on-chain program to maintain + audit; 4-8 weeks of build.
+
+**C.2 — Squads Smart Account integration** (existing infra, less control):
+
+Use Squads' Smart Account Program (referenced in [[solana-defi:squads]] skill). User creates a Smart Account with sipher operator added as a "spending member" with custom spending limits. Server signs transactions as the spending member; Smart Account program enforces the limit logic.
+
+Pros: production-tested, audited. No new program. Squads UI for user to monitor and revoke.
+Cons: less alignment with sipher's privacy primitives — Smart Account is a transparent on-chain entity, defeats some privacy gains; spending limit semantics may not perfectly model sipher's needs.
+
+**Recommendation:** Start with C.2 (Squads) to ship sweep+recurring quickly. Migrate to C.1 (custom) when sipher_arcium or other in-house programs mature enough to justify the build. Tracking issue should explicitly call this out as a deliberate phasing.
+
+### What changes (assuming C.2)
+
+1. **New onboarding step for sweep/recurring** — first invocation in a user's session prompts them to:
+   - Create a Squads Smart Account (or link existing)
+   - Add sipher's operator pubkey as a spending member with caps tailored to the requested op
+   - Approve via Squads UI in a popup or redirect
+
+2. **scheduled_ops execution** — for `op_kind === 'delegated'`, crank invokes a path that:
+   - Loads the user's Smart Account + spending member config
+   - Builds the transaction (stealth send / sweep / etc.)
+   - Server signs with the sipher operator key
+   - Broadcasts; on success, growth-hook fires; on Smart Account rejection (limit exceeded, revoked), update op status accordingly
+
+3. **Operator key management** — sipher needs a per-deployment operator keypair (mainnet, devnet). Stored in VPS secrets, never committed. Rotation procedure documented.
+
+### Risks
+
+- **Operator key compromise.** If sipher's mainnet operator key leaks, ALL delegated wallets are exposed within their spending limits. Mitigation: HSM/KMS for prod; small rotating per-day operators; alert on any out-of-scope tx attempts.
+- **User trust ceiling.** Delegation = real trust. Many users won't grant it. That's fine — sweep+recurring become opt-in premium features.
+- **Smart Account UX friction.** Squads' Smart Account creation is a non-trivial flow. Some users won't complete it. Mitigation: clear UX scaffolding; show value upfront.
+
+---
+
+## COURIER hardening (PR-C)
+
+Today's crank works at a coarse level but isn't production-hardened. Issues:
+
+1. **No retries on transient failures.** A network blip during broadcast marks the op `pending` again, but the next tick will retry immediately — no backoff. Could DOS the RPC during outages.
+
+2. **No deduplication.** If crank ticks while a previous tick's executor is still mid-broadcast, duplicate broadcasts can hit the chain (Solana dedupes by signature, but it's wasteful).
+
+3. **Limited observability.** Only one line per tick. No per-op latency, no growth-hook emission correlation, no failure-rate dashboard signal.
+
+4. **Race conditions on op_status.** Two cranks in parallel (e.g. multi-process deploy) could both pick up the same op. Status update is the dedupe mechanism but isn't atomic-CAS today.
+
+### Improvements
+
+- Exponential backoff per op: `next_exec` = `now + min(max_backoff, base * 2^attempts)`
+- Single-flight per op: lock by op-id in a Map for the duration of a tick
+- Structured logging: emit per-op start/end events with latency + result
+- Atomic status CAS: SQLite `UPDATE ... WHERE status='pending'` returning rowcount, only proceed if rowcount=1
+- Metrics endpoint: `GET /admin/api/courier/stats` — last-N-tick summary
+
+---
+
+## Test plan (per PR)
+
+### PR-A (durable nonce family)
+
+- [ ] Unit: drip/scheduleSend produce N valid unsigned txs anchored to N nonce accounts
+- [ ] Unit: nonce init instructions produce txs that correctly create + seed nonce accounts
+- [ ] Unit: `POST /api/scheduled-ops/:batchId/seal` rejects mismatched batchIds, accepts valid signed batches, persists signed_tx blobs
+- [ ] Integration: full devnet flow — drip(N=3) → user signs nonce init → confirms → user signs drip txs → posts seal → crank picks up + broadcasts each at scheduled time
+- [ ] Tests for cancel: nonce withdrawal invalidates pending signed_tx
+- [ ] E2E: simulate a 3-day drip with `next_exec` set to ~1 minute apart; verify all 3 txs land
+
+### PR-B (delegation family — Squads C.2)
+
+- [ ] Onboarding integration test: invoke sweep without existing Smart Account → server returns onboarding instructions
+- [ ] Unit: sweep tool builds correct Smart Account txn (spending member with caps matching tool input)
+- [ ] Integration: sweep on devnet — user authorizes via Smart Account → crank fires on incoming deposit → stealth send confirms
+- [ ] Tests for spending-limit edge cases (over-limit attempt fails cleanly)
+- [ ] Tests for revocation — user revokes via Squads → next crank tick fails with `delegation_revoked` reason → op transitions to `cancelled`
+
+### PR-C (COURIER hardening)
+
+- [ ] Unit: exponential backoff increases between failed ticks
+- [ ] Unit: single-flight lock prevents concurrent execution of the same op
+- [ ] Integration: simulated multi-tick race; verify only one broadcast occurs
+- [ ] Stats endpoint returns sane summary
+
+### Cross-PR regression
+
+- [ ] All existing scheduled-op creation tests still pass
+- [ ] Growth-hook receives correct emission events per family (`sipher_private_send_completed` for sweep, `sipher_private_split_send_completed` for splitSend, `sipher_private_drip_completed` for drip)
+- [ ] [[2026-05-15-server-side-sig-verification-design]] verifier runs against scheduled-op confirms — different path (server-broadcast, so no client signature to verify); audit verifier compatibility
+
+---
+
+## Risks
+
+**Trust delegation is real money risk.** Family C is irreducibly a trust delegation. Even with scope+caps, a compromised sipher operator key drains delegated wallets within caps. Mitigation: HSM, rotation, alerts. Treat operator key like a vault key — minimal access, audit logs.
+
+**Signed-tx blob leakage.** Family B persists signed txs in SQLite. Server compromise = pre-signed broadcasts an attacker could publish (front-running, censorship). Mitigation: encrypt-at-rest on VPS (already standard), audit OS-level access, document the trust surface.
+
+**Privacy regression.** Family C with Squads makes the user's stealth-send linkable to their public Smart Account (the account that delegated). This partially defeats sipher's privacy goal. Mitigation: messaging — sweep / recurring are convenience features with privacy trade-offs; users should know. Long-term: Family C.1 (custom program) restores full privacy posture.
+
+**Solana protocol changes.** Durable nonces could be deprecated or reformed (unlikely but possible — see SIMD discussions). Mitigation: monitor SIMD signals; design abstractions so the "pre-signed" mechanism is swappable.
+
+**Recipient meta-address rotation.** A drip authored today pins the recipient's stealth meta-address from today. If they rotate at day 10, days 10-30 land at the old address (still reachable by them, just stale UX). Mitigation: document; offer "refresh recipient" UX.
+
+**Crank competing with main agent stream for RPC budget.** Both call Solana RPC. Heavy crank tick could starve interactive UX. Mitigation: dedicated RPC connection for crank; per-tool rate limits; observability.
+
+**Torque rebate fairness.** Crank-driven emissions fire even when the user is offline. The fresh stealth destination derived from SNS record routes the rebate correctly (the stealth meta-address points to the user's wallet). Verify that derivation works even with no live SSE — should, since [[project_torque-mcp-integration-shipped]] cache + SNS resolution is server-side.
+
+---
+
+## Migration / rollout
+
+**Phase 1 (PR-A, 2-3 weeks):** Land durable-nonce family. Wire scheduleSend, drip, splitSend, consolidate. splitSend + consolidate may not even need durable nonces if they're truly immediate batch — choose per their session-presence assumption. Feature-flag: `SIPHER_SCHEDULED_OPS_ENABLED=false` until verified on devnet.
+
+**Phase 2 (PR-B, 3-4 weeks):** Land delegation family with Squads. Wire sweep + recurring. Separate feature flag: `SIPHER_DELEGATED_OPS_ENABLED=false`.
+
+**Phase 3 (PR-C, 1-2 weeks):** COURIER hardening. Apply across both families.
+
+**Phase 4 (future):** Migrate to custom delegation program (C.1) when justified.
+
+**Coordination with other specs:**
+- [[2026-05-15-assert-never-exhaustiveness-design]] — landing first prevents plumbing drops when new event types are added (sealed-op-broadcast events, delegation events)
+- [[2026-05-15-server-side-sig-verification-design]] — server-broadcast signatures don't need verification (server holds the signed bytes) BUT a stricter check could verify the broadcast landed correctly via getSignatureStatuses post-broadcast
+- [[2026-05-15-tool-signing-expired-sse-design]] — the new `POST /api/scheduled-ops/:batchId/seal` endpoint should reuse the same TTL-driven expiry SSE event for consistency
+
+---
+
+## Follow-ups (out of scope)
+
+- Custom delegation program `sipher_delegation` (replaces Squads dependency)
+- Price-conditional triggers (send when SOL > $X)
+- Recipient meta-address auto-refresh
+- Cross-chain scheduled ops (Ethereum via Gelato)
+- Operator key rotation procedure documentation
+- Per-tool tunable rate-limit for crank execution
+- Squads spending-limit policy templates (one per sipher tool)

--- a/docs/superpowers/specs/2026-05-15-server-side-sig-verification-design.md
+++ b/docs/superpowers/specs/2026-05-15-server-side-sig-verification-design.md
@@ -1,0 +1,255 @@
+# Server-Side Signature Verification — Design
+
+**Date:** 2026-05-15
+**Session:** frontier_sip_13
+**Status:** Proposed — awaiting RECTOR review
+**Predecessor:**
+  - PR #271 (sipher#262) shipped the signing callback — `POST /api/tool-signing/:flagId/confirm` blindly trusts the client-supplied signature string
+  - [[project_torque-mcp-integration-shipped]] PR-E lesson 1 (review noted defense-in-depth gap)
+  - Today's confirm route: `packages/agent/src/routes/tool-signing.ts:17-44`
+**Scope:** Add server-side verification that the signature submitted to `/api/tool-signing/:flagId/confirm` corresponds to a real on-chain Solana transaction signed by `entry.wallet` with instructions matching what the server originally serialized. Verify BEFORE resolving the promise gate, which gates downstream Torque growth-hook emission.
+**Out of scope:** Verifying claim transactions (currently emits without on-chain proof — see [[2026-05-15-claim-phase-2-design]]); Ethereum verification path; replacing RPC dependence with a Helius webhook subscription (potential future optimization).
+**Estimated work-time:** 2-3 days, 1 PR.
+
+---
+
+## Why this build
+
+**Today's trust boundary is wrong.** When the user clicks Sign, the wallet adapter signs the serialized transaction, broadcasts to the network, and returns the resulting signature to the frontend. The frontend posts that string to `/confirm`. The server takes the client at its word — calls `resolvePendingSigning(flagId, signature)`, the promise resolves, the tool returns success, the growth-hook fires a Torque `sipher_private_send_completed` event with the signature in `data.tx_signature`.
+
+Failure modes that bypass today's guards:
+1. **Compromised client.** A malicious browser extension or XSS replaces the signature with a syntactically-valid but bogus string. Server accepts, Torque event fires with garbage. Rebate distribution attribution polluted.
+2. **Buggy client.** Frontend bug substitutes the wrong signature (e.g. from a previous tx, or a different user's tx in localStorage). Same outcome.
+3. **Replay.** Same signature is submitted twice for different flagIds. Server has no idea.
+4. **Wrong transaction.** Wallet substitutes a different transaction (e.g. malicious wallet returns the user's signature for a tx that pays the attacker, not the intended recipient). Server treats it as success.
+
+Solana RPC can answer all four. The verification cost (one RPC call) is small relative to the value of trustworthy telemetry feeding Torque.
+
+**What this fix delivers.** Three verification tiers, gated before `resolvePendingSigning` runs. If any tier fails, the confirm route returns 4xx and the pending entry is rejected, not resolved. Torque growth-hook never fires for unverified signatures.
+
+---
+
+## Architecture
+
+### Three-tier verification
+
+| Tier | Check | What it catches | RPC call |
+|---|---|---|---|
+| T1 (existence) | `getSignatureStatuses([sig])` → confirmed/finalized, no err | Fake signatures; signatures from failed txs | `getSignatureStatuses` |
+| T2 (sender binding) | tx fee payer (accountKeys[0]) === entry.wallet | Signature from a different wallet's tx | `getTransaction` (decoded) |
+| T3 (instruction match) | Decoded tx instructions structurally match `entry.serializedTx` | Wallet-substituted tx (signed wrong tx) | reuses T2's `getTransaction` |
+
+T1 alone catches most malicious scenarios. T2 closes the wrong-wallet attack. T3 is the gold standard but requires careful structural comparison.
+
+**Recommendation:** ship T1 + T2 in the initial PR. T3 in a follow-up after observing real-world false-positive rates.
+
+### Flow
+
+```
+POST /api/tool-signing/:flagId/confirm
+   │
+   ├─ existing checks (entry exists, wallet matches, signature non-empty)
+   │
+   ▼
+verifySignature(signature, entry)
+   │
+   ├─ T1: getSignatureStatuses
+   │     ├─ not-found / err / not-confirmed → return { ok: false, reason: 'not_confirmed' }
+   │     └─ confirmed →
+   │
+   ├─ T2: getTransaction → decode → check fee payer === entry.wallet
+   │     ├─ payer mismatch → return { ok: false, reason: 'wallet_mismatch' }
+   │     └─ match →
+   │
+   ├─ (T3 deferred)
+   │
+   └─ return { ok: true }
+   │
+   ├─ ok: resolvePendingSigning(flagId, signature) + 200 { status: 'accepted', verified: true }
+   └─ !ok: rejectPendingSigning(flagId, reason) + 4xx VALIDATION_FAILED envelope
+```
+
+### RPC client + network routing
+
+The verifier needs an RPC URL. Existing convention (per `loadNetworkConfig`):
+- `entry.network === 'mainnet-beta'` → `SIPHER_HELIUS_API_KEY` mainnet
+- `entry.network === 'devnet'` → devnet RPC
+
+Reuse `createConnection(loadNetworkConfig().clusterName)` (the same path the agent tools use). The verifier accepts a `Connection` injected at construction so unit tests can mock without hitting the real network.
+
+### Timing budget
+
+`getSignatureStatuses` typically responds in 50-200ms for known signatures. `getTransaction` can take 200-800ms (fetching the full tx body). With both calls in series the confirm-route latency goes from ~5ms (current) to ~250-1000ms.
+
+This is acceptable for a UX path where the user just signed a transaction; they expect a brief confirmation lag. **Hard ceiling:** if total verification > 3s, time out and return `503 UNAVAILABLE` with a `Retry-After` hint. The frontend may retry once.
+
+Confirmation level: use `'confirmed'` (~1s after submission) not `'finalized'` (~12s). Confirmed is sufficient for telemetry; finalized would block the UX too long. The signature can still later be unrolled by chain reorg, but Solana reorg risk on confirmed txs is rare enough that downstream Torque attribution is acceptable.
+
+### Failure posture
+
+| Failure | Action | Why |
+|---|---|---|
+| RPC down / network error | 503 UNAVAILABLE + auto-reject pending (configurable) | Closed posture by default — better to retry than to admit unverified. Operator may flip to open-posture via env flag for outage tolerance. |
+| Signature not yet confirmed (in-flight) | 503 UNAVAILABLE + Retry-After: 2 | Confirm may complete in seconds; retry is the right answer |
+| Signature explicitly not found (after retries with backoff) | 4xx VALIDATION_FAILED + reject pending | Likely fake |
+| Wallet mismatch | 4xx VALIDATION_FAILED + reject pending | Definitely fake |
+
+**Env flag:** `SIPHER_SIG_VERIFY=strict|advisory|off` (default `strict`).
+- `strict` — all failures reject the pending entry as designed above
+- `advisory` — verification runs but failures only LOG; promise resolves on the client's word (today's behavior). Used for soak-testing the verifier with no UX regression.
+- `off` — skip verification entirely. Emergency lever only; should never be the long-term value.
+
+Mirrors the `SENTINEL_MODE` precedent — a kill-switch posture is established practice in this codebase.
+
+---
+
+## Implementation
+
+### New module: `packages/agent/src/sentinel/verify-signature.ts`
+
+```ts
+import { Connection, PublicKey } from '@solana/web3.js'
+import type { PendingSigningFlag } from './pending-signing.js'
+
+export type VerifyResult =
+  | { ok: true; slot: number }
+  | { ok: false; reason: 'not_confirmed' | 'wallet_mismatch' | 'rpc_error' | 'timeout'; detail?: string }
+
+export interface VerifyOptions {
+  connection: Connection
+  /** ms; default 3000 */
+  timeoutMs?: number
+  /** Number of getSignatureStatuses attempts; default 3 with linear backoff */
+  retries?: number
+}
+
+export async function verifySignature(
+  signature: string,
+  entry: PendingSigningFlag,
+  opts: VerifyOptions,
+): Promise<VerifyResult> {
+  // T1: existence + confirmation
+  // T2: fee-payer match
+  // (T3 deferred)
+}
+```
+
+Return type is a discriminated union — pairs cleanly with [[2026-05-15-assert-never-exhaustiveness-design]] for downstream switches.
+
+### Confirm-route changes (`packages/agent/src/routes/tool-signing.ts`)
+
+```ts
+toolSigningRouter.post('/:flagId/confirm', async (req, res) => {
+  // ... existing checks ...
+
+  // NEW: verify
+  const mode = (process.env.SIPHER_SIG_VERIFY ?? 'strict').toLowerCase()
+  if (mode !== 'off') {
+    const result = await verifySignature(signature, entry, {
+      connection: createConnection(entry.network),
+      timeoutMs: 3000,
+    })
+    if (!result.ok) {
+      if (mode === 'strict') {
+        rejectPendingSigning(flagId, `verification_failed: ${result.reason}`)
+        sendSentinelError(res, 'VALIDATION_FAILED', `signature verification failed: ${result.reason}`)
+        return
+      }
+      // advisory mode — log and continue
+      console.warn(`[signing] verify failed (advisory mode): flagId=${flagId} reason=${result.reason}`)
+    }
+  }
+
+  resolvePendingSigning(flagId, signature)
+  res.status(200).json({ status: 'accepted', verified: mode === 'strict' })
+})
+```
+
+Note `async` — Express 5 supports async handlers natively.
+
+### Env vars
+
+```bash
+SIPHER_SIG_VERIFY=strict   # strict | advisory | off
+```
+
+Add to `.env.example`. Default `strict`.
+
+---
+
+## Test plan
+
+### Unit tests for `verifySignature` (`packages/agent/tests/sentinel/verify-signature.test.ts`)
+
+- [ ] Confirmed signature + matching wallet → `{ ok: true, slot: <n> }`
+- [ ] Signature not found via getSignatureStatuses (returns null) → `{ ok: false, reason: 'not_confirmed' }`
+- [ ] Signature found but err: not-null → `{ ok: false, reason: 'not_confirmed', detail: <err string> }`
+- [ ] Signature confirmed but fee payer != entry.wallet → `{ ok: false, reason: 'wallet_mismatch' }`
+- [ ] RPC throws → `{ ok: false, reason: 'rpc_error' }` (with detail)
+- [ ] Times out after `timeoutMs` → `{ ok: false, reason: 'timeout' }`
+- [ ] Retries on transient nulls with linear backoff (verify call count + timing via fake timers)
+
+### Route integration tests (`packages/agent/tests/routes/tool-signing.test.ts`)
+
+- [ ] `strict` mode + verifier returns ok → 200 `{ status: 'accepted', verified: true }`, pending resolved
+- [ ] `strict` mode + verifier fails → 4xx VALIDATION_FAILED envelope, pending REJECTED (not resolved)
+- [ ] `advisory` mode + verifier fails → 200 `{ status: 'accepted', verified: false }`, pending resolved, warn logged
+- [ ] `off` mode + invalid signature → 200, pending resolved (verifier never called)
+- [ ] Verifier RPC error in strict → 503 with Retry-After header
+- [ ] verified flag in response body is correct for each mode
+
+### Existing tests
+
+- [ ] No regression in `packages/agent/tests/routes/tool-signing.test.ts` (existing 4 cases)
+- [ ] Full agent suite: `pnpm --filter @sipher/agent test`
+
+### Manual smoke (post-deploy)
+
+- [ ] Submit a valid signature via sipher.sip-protocol.org chat send flow → 200 accepted
+- [ ] Submit a known-invalid signature via curl → 4xx VALIDATION_FAILED
+- [ ] Set `SIPHER_SIG_VERIFY=advisory`, repeat invalid → 200 accepted + warn in logs
+- [ ] Devnet vs mainnet routing: verify mainnet signature on devnet RPC returns not_confirmed (proves network routing)
+
+---
+
+## Risks
+
+**Increased latency on confirm.** ~250-1000ms added per request. UX-acceptable (user just signed; brief lag is normal) but logged for monitoring. If P99 > 2s, consider parallelizing T1+T2 calls (today specified sequentially for clarity).
+
+**RPC quota burn.** Each confirm adds 1-2 RPC calls. At Helius rates these are cheap (< $0.0001 per call) but at scale (1000 confirms/day) adds up. Mainnet Helius API key has known limits — verify the budget at rollout.
+
+**False positives from RPC inconsistency.** Different RPC endpoints can disagree on confirmation status briefly. Mitigation: use the same network's primary RPC (Helius for mainnet) consistently; retry with linear backoff.
+
+**T3 (instruction match) skipped — residual attack surface.** A wallet that signs a DIFFERENT transaction than the server requested (substituted via wallet UI manipulation) still passes T1+T2. The user-signed tx will land on chain. Telemetry attribution is correct (it IS the user's signature), but the user got a different outcome than intended. Mitigation: T3 in a follow-up. For now, document the known limit.
+
+**Replay (same signature for two flagIds).** Not addressed by T1+T2. Two pending flags could both confirm with the same signature, Torque double-fires. Mitigation: dedupe at growth-hook level using a `seenSignatures` LRU cache. Out of scope for this spec; tracked as follow-up.
+
+**Mode `off` risk.** Easy to leave on in production by mistake. Mitigation: admin-status endpoint surfaces the current mode, and `assertNever` on the mode union would prevent typo'd values. RECTOR-driven audit before deploys.
+
+**Webhook alternative deferred.** Helius webhook subscriptions could push confirmations to sipher rather than polling RPC, eliminating polling cost. Bigger build. Tracked as follow-up.
+
+---
+
+## Migration / rollout
+
+**Phase 1 (this PR):**
+1. Land code with `SIPHER_SIG_VERIFY=advisory` as the default on the **VPS** for one week. Verify alerts in logs match expectations (most should be `ok`, occasional `not_confirmed` from race conditions).
+2. After confidence, flip env to `strict` on VPS. No code change needed.
+
+**Phase 2 (follow-up):**
+1. Add T3 (instruction match).
+2. Add `seenSignatures` LRU to growth-hook for replay prevention.
+3. Consider migrating to Helius webhooks if quota burn is meaningful.
+
+**No data migration.** No DB schema changes. In-memory `pending` Map untouched in shape (verification is upstream of resolve/reject).
+
+**Frontend changes: none required.** The `verified` field in response body is additive and ignored by today's frontend. If the frontend wants to surface the verification result (e.g. a green checkmark on the chat message), that's a separate UI tweak.
+
+---
+
+## Follow-ups (out of scope)
+
+- T3 instruction-match: structural comparison of deserialized tx vs `entry.serializedTx`. Tricky because Solana versioned txs and lookup tables make byte-level comparison fragile; needs decoded-instruction equivalence.
+- Replay dedupe: LRU of seen signatures in growth-hook so Torque can't be tricked into double-attribution.
+- Helius webhook-based confirmation instead of polling.
+- Apply the same pattern to claim transactions — see [[2026-05-15-claim-phase-2-design]] for the broader claim rework.

--- a/docs/superpowers/specs/2026-05-15-tool-signing-expired-sse-design.md
+++ b/docs/superpowers/specs/2026-05-15-tool-signing-expired-sse-design.md
@@ -1,0 +1,224 @@
+# `tool_signing_expired` SSE Event — Design
+
+**Date:** 2026-05-15
+**Session:** frontier_sip_13
+**Status:** Proposed — awaiting RECTOR review
+**Predecessor:**
+  - PR #271 (sipher#262) shipped the signing callback flow but did not address proactive expiry — see [[project_torque-mcp-integration-shipped]] PR-E section
+  - `packages/agent/src/sentinel/pending-signing.ts:23` — 5-minute promise-gate TTL fires `rejecter(new Error('operation timed out'))`
+**Scope:** Emit a `tool_signing_expired` SSE event so the frontend `SignTxCard` greys out and disables interaction when the promise-gate TTL hits. Cleanup-only — the existing reject path stays as the authoritative state transition.
+**Out of scope:** Per-user persistent expiry log; reconnection recovery for clients that were disconnected when expiry fired (separate follow-up); server-side rebroadcast on reconnect.
+**Estimated work-time:** 1-1.5 days, 1 PR.
+
+---
+
+## Why this build
+
+**The current silent failure.** `createPendingSigning` arms a 5-minute timeout. If the user doesn't click Sign within that window, `setTimeout` fires and rejects the awaiting promise. The tool execution returns an error; the agent stream emits a `message_complete` referencing the error; the stream ends.
+
+The frontend `SignTxCard` is NEVER notified that its underlying flagId has been reaped. Three failure modes follow:
+
+1. Card stays in the visible "pending sign" state indefinitely. If the user later clicks Sign, the `/api/tool-signing/:flagId/confirm` POST returns 404 (or `INVALID` envelope per #158). No clean UX.
+2. The chat thread shows a confusing assistant turn ("transaction failed: operation timed out") next to an unmarked, still-clickable card.
+3. If the user reloads the page within the same session, the persisted card re-renders — still mid-state, still confusing.
+
+**What this fix delivers.** A first-class `tool_signing_expired` SSE event. Server emits it the instant the timeout fires (BEFORE rejecting the tool promise), so the active SSE connection forwards it to the client. The frontend transitions the SignTxCard message to an `expired` state — visually greyed out, buttons disabled, label changed to "Expired", with a tap target that lets the user dismiss it.
+
+---
+
+## Architecture
+
+### Event shape (SSE wire format)
+
+```json
+{
+  "type": "tool_signing_expired",
+  "flagId": "<uuid>",
+  "reason": "timeout"
+}
+```
+
+`reason` is reserved for future kinds — `"timeout"` is the only value emitted today. Allowing the field future-proofs the client switch (`"server_shutdown"`, `"explicit_reject"`, etc. could come later).
+
+### Server-side flow
+
+```
+createPendingSigning
+   │
+   ├─ stores entry in pending Map
+   ├─ arms setTimeout
+   ▼
+[5 minutes pass with no resolve/reject]
+   │
+   ▼
+timeout fires
+   │
+   ├─ emit `tool_signing_expired` event via externalQueue (NEW)
+   ├─ remove entry from pending Map
+   └─ rejecter(new Error('operation timed out'))
+```
+
+Today the timeout only does steps 2 and 3. This spec inserts step 1.
+
+### Where to emit
+
+The Pi stream bridge uses an `externalQueue` mechanism (`packages/agent/src/pi/stream-bridge.ts:118-122`) that lets non-Pi event sources inject events into the SSE generator. `chatStream` already uses this pattern for `sentinel_pause`. We reuse it for `tool_signing_expired`.
+
+**Coordination requirement:** the `createPendingSigning` caller (inside chatStream's tool-signing wrapper) must capture an emitter reference at creation time and bind it into the pending entry, OR a module-level event emitter must be exposed from chatStream that pending-signing.ts can call. Cleanest fit: pass an `onExpire(flagId)` callback at create time:
+
+```ts
+export interface CreatePendingSigningParams {
+  sessionId: string
+  toolName: 'send' | 'swap'
+  wallet: string
+  serializedTx: string
+  network: 'mainnet-beta' | 'devnet'
+  toolInput: unknown
+  /** Called once when the TTL fires, BEFORE the promise is rejected. */
+  onExpire?: (flagId: string) => void
+}
+```
+
+Inside the chatStream tool-signing wrapper, `onExpire` pushes `{ type: 'tool_signing_expired', flagId }` onto the externalQueue and wakes the generator.
+
+### Client-side flow
+
+`ChatSidebar.tsx` (the SSE consumer) gains a new case in the event switch:
+
+```ts
+} else if (event.type === 'tool_signing_expired') {
+  // Find the matching tool_signing_required message and mark expired
+  setMessages((msgs) =>
+    msgs.map((m) =>
+      m.role === 'system' && m.kind === 'tool_signing_required' && m.signing?.flagId === event.flagId
+        ? { ...m, expired: true }
+        : m,
+    ),
+  )
+}
+```
+
+The message store gains an `expired?: boolean` flag. `SignTxCard` reads it and renders accordingly:
+
+| State | Visual | Buttons |
+|---|---|---|
+| Active | Full opacity, neon highlights | Sign / Reject enabled |
+| Expired | `opacity-50`, neutral border | Both disabled; label "Expired — request again" |
+| Resolved | Already supported today | — |
+
+The SignTxCard exposes a `dismiss` action that removes the message from the store when the user taps it. This lets users clear stale cards without server interaction.
+
+### Why client-side instead of server-emitted "system" message
+
+We could emit a synthetic assistant message like "This transaction request expired." But that's:
+1. Lossy — the SignTxCard context is lost
+2. Inconsistent — a card-shaped state needs a card-shaped transition, not a text afterthought
+
+Keeping the expiry as a state mutation on the SAME message preserves the card and lets the UX style it appropriately.
+
+---
+
+## Implementation
+
+1. **Extend `CreatePendingSigningParams`** in `packages/agent/src/sentinel/pending-signing.ts` with optional `onExpire?: (flagId: string) => void`.
+
+2. **Invoke `onExpire` inside the timeout handler** BEFORE calling `rejecter`. Wrap in try/catch — emission failure must not block the reject path:
+   ```ts
+   const timeoutHandle = setTimeout(() => {
+     if (pending.has(flagId)) {
+       pending.delete(flagId)
+       try {
+         params.onExpire?.(flagId)
+       } catch (err) {
+         console.warn(`[signing] onExpire callback threw (suppressed): ${err}`)
+       }
+       rejecter(new Error('operation timed out'))
+     }
+   }, TIMEOUT_MS)
+   ```
+
+3. **Bind `onExpire` from chatStream** at the call site that constructs the pending entry. The callback pushes onto externalQueue and calls the bridge's `wake()`. Reuse the same pattern as the existing `sentinel_pause` injection.
+
+4. **Add `'tool_signing_expired'` to `ResponseChunk.type` union** in `packages/agent/src/core/types.ts`. Add a corresponding optional field if needed; for this event, the only payload is `flagId` and `reason`, so:
+   ```ts
+   /** Populated only when type === 'tool_signing_expired' */
+   expired?: { flagId: string; reason: 'timeout' }
+   ```
+
+5. **Add a `case 'tool_signing_expired'` branch** to both switches:
+   - `AgentCore.streamMessage` (relays from Pi/sipher event into ResponseChunk)
+   - `chunkToSSE` in `adapters/web.ts` (translates to wire format)
+
+   This depends on the [[2026-05-15-assert-never-exhaustiveness-design]] spec landing first OR concurrent — if assertNever is in place, both switches break the build until updated, surfacing the requirement.
+
+6. **Frontend store update** in `app/src/stores/app.ts`. Add `expired?: boolean` to the message type. Default `false`.
+
+7. **Frontend ChatSidebar handler** in `app/src/components/ChatSidebar.tsx` — handle the new event type.
+
+8. **Frontend SignTxCard rendering** in `app/src/components/SignTxCard.tsx`:
+   - Accept `expired` prop
+   - Branch styling: disabled buttons, `opacity-50`, label change
+   - Add `onDismiss` callback so user can remove the stale card
+
+9. **Persistence** — if SignTxCard state persists in Zustand+localStorage across reload, ensure `expired` is part of the persisted shape. (Spec assumes Zustand persistence; verify during implementation.)
+
+---
+
+## Test plan
+
+### Server tests (`packages/agent/tests/sentinel/pending-signing.test.ts`)
+
+- [ ] `createPendingSigning` with `onExpire` callback fires it once when timeout hits, BEFORE rejecter is called
+- [ ] `onExpire` is NOT called if `resolvePendingSigning` or `rejectPendingSigning` runs first
+- [ ] `onExpire` throwing does NOT prevent rejecter from being called
+- [ ] Use `_setTimeoutMsForTests(50)` + `await new Promise(r => setTimeout(r, 100))` pattern
+
+### Integration tests (`packages/agent/tests/agent-tool-signing.test.ts` or similar)
+
+- [ ] Full path: chatStream gets to tool-signing wrapper, TTL fires, SSE consumer receives `tool_signing_expired` event with matching flagId, then `error` event with `operation timed out`
+
+### Frontend tests (`app/src/components/__tests__/ChatSidebar.test.tsx`)
+
+- [ ] Receiving a `tool_signing_expired` event marks the matching signing message as `expired: true`
+- [ ] An event with an unknown flagId is a silent no-op
+- [ ] An event arriving AFTER the user already signed (race) does not regress state — match by `expired === false` precondition (defensive; the server shouldn't emit this race in practice since resolve clears the timeout)
+
+### Frontend tests (`app/src/components/__tests__/SignTxCard.test.tsx`)
+
+- [ ] `expired={true}` renders disabled buttons, `opacity-50` class, "Expired" label
+- [ ] `expired={true}` calling `onDismiss` removes the message
+- [ ] Default `expired={false}` keeps existing behavior
+
+### E2E (optional, deferred)
+
+Playwright test: trigger tool_signing_required → wait 5s (with TIMEOUT_MS overridden via test build flag, or use 5-min real wait in nightly only) → assert card greys out without manual action.
+
+---
+
+## Risks
+
+**Client-disconnected case.** If the SSE connection is closed when expiry fires (user closed tab, network drop), the event is lost. The server still cleans up. Mitigation: on reconnect, the client could query `GET /api/tool-signing/pending` (NEW endpoint, out of scope) and reconcile. For now, dismissable expired-rendering at least makes the stale-card case recoverable manually.
+
+**Race with manual signing.** If the user clicks Sign at T=4:59 and the network is slow, the server might receive the confirm POST AFTER the timeout fires. Mitigation: today's `resolvePendingSigning` returns `false` for missing entries — the route returns 404. Adding a "expired_just_now" branch is out of scope; existing 404 + frontend's expired state cover the case.
+
+**Switch fan-out.** Touching `ResponseChunk.type`, `streamMessage` switch, and `chunkToSSE` switch is exactly the cross-file plumbing-drop trap [[2026-05-15-assert-never-exhaustiveness-design]] warns about. **Recommendation:** land assertNever first (or in the same PR) so this spec's wiring fails at typecheck if a branch is missed.
+
+**Test fakes for setTimeout.** vitest fake timers can desync with `Date.now()` if not configured carefully. Recommend `vi.useFakeTimers({ shouldAdvanceTime: true })` or the `_setTimeoutMsForTests` lever which is already present.
+
+**Persistence shape changes.** If Zustand persistence already shipped the message shape without `expired`, adding the field must default safely on reload (Zustand `version` bump or `migrate` function). Verify during implementation.
+
+---
+
+## Migration / rollout
+
+- Single PR landing server + client changes together. Server emitting an event no client handles is harmless (browser logs unknown SSE event and continues). Client handling an event no server emits is dormant code. So the lockstep deploy is for clarity, not safety.
+- No data migration. The pending Map is in-memory.
+- Roll forward — no flag, no feature toggle.
+
+---
+
+## Follow-ups (out of scope)
+
+- `GET /api/tool-signing/pending` endpoint for reconnection recovery.
+- Server-side signature verification before resolving the signing flag — see [[2026-05-15-server-side-sig-verification-design]] which depends on the same pending-signing.ts surface.
+- Configurable per-tool TTL (today's 5-min applies to all signing flags).


### PR DESCRIPTION
## Summary

Five design specs bundled as follow-ups to PR-E (#269 canonical Torque ingest) and PR #271 (sipher#262 signing callback). All proposed in spec form — none are implementation; each is sized 1 PR (or 3 PRs for the largest) and can be picked off independently. Ordered smallest → largest below.

## Specs

1. **`2026-05-15-assert-never-exhaustiveness-design.md`** — Compile-time exhaustiveness guards on the `AgentCore.streamMessage` + `chunkToSSE` switches. Closes the silent-drop trap caught at PR-E holistic review (sipher#262 `f62b308`). Small (~0.5 day). Foundation for the other specs.

2. **`2026-05-15-tool-signing-expired-sse-design.md`** — `tool_signing_expired` SSE event so `SignTxCard` greys out when the 5-min promise-gate TTL hits. Removes the "ghost card" UX. Small-medium (1-1.5 days).

3. **`2026-05-15-server-side-sig-verification-design.md`** — Three-tier `getSignatureStatuses` + `getTransaction` verification before `resolvePendingSigning` runs. Adds `SIPHER_SIG_VERIFY=strict|advisory|off` env flag mirroring the `SENTINEL_MODE` precedent. Medium (2-3 days).

4. **`2026-05-15-claim-phase-2-design.md`** — Replace the Phase 1 claim stub with real ECDH derivation + `claim_transfer` instruction building. Surfaces the viewing-key-shared-with-server trust step that today's stub already implicitly accepts. Medium-large (4-6 days).

5. **`2026-05-15-scheduled-op-broadcasts-design.md`** — Per-tool execution strategy for `drip` / `splitSend` / `sweep` / `consolidate` / `recurring` / `scheduleSend`. Three families: immediate batch, pre-signed durable nonce, wallet delegation (Squads Smart Account → custom program). Largest (3 PRs across 2-3 weeks).

## Why a single bundled docs PR

The specs cross-reference each other (`[[name]]` Wiki-link syntax). Most of them are coupled to the same surface — `pending-signing.ts`, `ResponseChunk`, `chunkToSSE`, the growth-hook emission table. Reviewing together surfaces the shared concerns; merging together prevents the cross-refs from being broken Wikilink dead-ends.

If individual PRs are preferred for execution, splitting later is trivial — each spec is self-contained.

## Status of each spec

All five are **Proposed — awaiting RECTOR review**. Nothing here ships behavior; each can be approved/revised/discarded independently.

## Cross-references

Common dependencies, captured for review:
- Spec 2 (signing_expired) depends on Spec 1 (assertNever) landing first
- Spec 3 (sig verification) composes with Spec 4 (claim Phase 2)
- Spec 5 (scheduled-op) composes with all four others

## Test plan

- [x] No code change — typecheck not exercised
- [x] All five files exist at expected paths under `docs/superpowers/specs/`
- [x] Cross-references (`[[name]]`) resolve to actual filenames in this PR
- [x] No AI attribution trailers in commit messages
- [x] All commits GPG-signed
- [ ] **RECTOR review:** approve / revise / defer per spec