### PR TITLE
feat(core): assertNever exhaustiveness guards on streaming switches

### DIFF
--- a/packages/agent/src/adapters/web.ts
+++ b/packages/agent/src/adapters/web.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from 'express'
+import { assertNever } from '../core/assert-never.js'
 import type { ResponseChunk } from '../core/types.js'
 import { AgentCore } from '../core/agent-core.js'
 import { resolveSession } from '../session.js'
@@ -60,6 +61,8 @@ function chunkToSSE(chunk: ResponseChunk): Record<string, unknown> {
       return { type: 'error', message: chunk.text }
     case 'done':
       return { type: 'message_complete', content: chunk.text }
+    default:
+      return assertNever(chunk.type)
   }
 }
 

--- a/packages/agent/src/core/agent-core.ts
+++ b/packages/agent/src/core/agent-core.ts
@@ -1,4 +1,5 @@
 import type { MsgContext, ResponseChunk, AgentResponse, AgentConfig } from './types.js'
+import { assertNever } from './assert-never.js'
 import { chat, chatStream } from '../agent.js'
 import {
   resolveSession,
@@ -206,6 +207,9 @@ export class AgentCore {
         case 'message_complete':
           fullText = event.content
           break
+
+        default:
+          assertNever(event)
       }
     }
 

--- a/packages/agent/src/core/assert-never.ts
+++ b/packages/agent/src/core/assert-never.ts
@@ -1,0 +1,15 @@
+/**
+ * Compile-time exhaustiveness check for discriminated-union switches.
+ *
+ * Place at the `default` branch of a switch over a string-literal union.
+ * If the union grows and a case is added without updating the switch,
+ * `value` is no longer narrowed to `never`, and this function fails to
+ * typecheck — surfacing the missing case at build time.
+ *
+ * At runtime, throws — the type system should make this unreachable, so
+ * a thrown error indicates a real bug (cast bypassed type system, or
+ * runtime data didn't match the declared union).
+ */
+export function assertNever(value: never): never {
+  throw new Error(`Unhandled discriminant: ${String(value)}`)
+}

--- a/packages/agent/tests/core/assert-never.test.ts
+++ b/packages/agent/tests/core/assert-never.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { assertNever } from '../../src/core/assert-never.js'
+
+describe('assertNever', () => {
+  it('throws with a message containing the unexpected value', () => {
+    expect(() => assertNever('unexpected_variant' as never)).toThrow(/unexpected_variant/)
+  })
+
+  it('throws even for non-string runtime values (defensive)', () => {
+    expect(() => assertNever({ shape: 'object' } as never)).toThrow(/Unhandled discriminant/)
+  })
+
+  it('throws for numeric runtime values', () => {
+    expect(() => assertNever(42 as never)).toThrow(/42/)
+  })
+})


### PR DESCRIPTION
## Summary

Implements [Spec 1](https://github.com/sip-protocol/sipher/blob/main/docs/superpowers/specs/2026-05-15-assert-never-exhaustiveness-design.md) from PR #276. Closes the silent-case-drop trap caught at PR-E holistic review (commit `f62b308` in sipher#262, where extending `ResponseChunk` required coordinated edits across three files with no compile-time signal when one was missed).

## Changes

- New helper `packages/agent/src/core/assert-never.ts` — 3-line runtime-throw whose value is the type signature: `value: never` means the call only typechecks when the surrounding switch has exhausted its discriminator
- `chunkToSSE` (`packages/agent/src/adapters/web.ts:27`) — added `default: return assertNever(chunk.type)`
- `AgentCore.streamMessage` (`packages/agent/src/core/agent-core.ts:156`) — added `default: assertNever(event)` using the full-variant pattern (event is a proper discriminated union from agent.ts:285)

## Manual verification of the guard

Temporarily removed `case 'message_complete'` from `streamMessage` and ran `cd packages/agent && pnpm exec tsc --noEmit`:

```
src/core/agent-core.ts(208,23): error TS2345: Argument of type 'SSEMessageComplete' is not assignable to parameter of type 'never'.
```

The trap is now closed.

## Test plan

- [x] `cd packages/agent && pnpm test -- --run tests/core/assert-never.test.ts` — 3 new tests pass (string / object / number values)
- [x] `cd packages/agent && pnpm test -- --run` — 1573 → 1576 passing, 2 skipped (no regressions)
- [x] `cd app && pnpm test -- --run` — 558 passing (no regressions)
- [x] `cd packages/agent && pnpm exec tsc --noEmit` — clean
- [x] All commits GPG-signed
- [x] No AI-attribution trailers

## Discoveries during implementation

**Root `pnpm typecheck` is misleading.** The root script runs `tsc --noEmit` against the root tsconfig, which silently skips the agent package's actual source. The real check is `cd packages/agent && pnpm exec tsc --noEmit`. Worth a separate CI hygiene PR but out of scope here.

**Spec's `ChatStreamEvent` prerequisite already met.** `agent.ts:285` already exports `SSEEvent` as the full 7-variant union. No rename in this PR.

## Out of scope (follow-ups)

- `ResponseChunk` → tagged discriminated union conversion (current shape is string-union with optional fields; works for assertNever but weaker than a proper tagged union)
- Rename `SSEEvent` in agent.ts → `ChatStreamEvent` to disambiguate from the narrower `SSEEvent` in `pi/stream-bridge.ts`
- Codebase-wide audit of other discriminated-union switches that could adopt the same guard
- Fix root `pnpm typecheck` to actually validate sub-packages

## Spec reference

`docs/superpowers/specs/2026-05-15-assert-never-exhaustiveness-design.md` — full design rationale. This PR implements the spec's recommendations 1-5; the optional permanent type-only test (recommendation 5 final paragraph) is deferred — runtime test + per-package tsc give equivalent coverage with less ceremony.

Stacked atop: PR #275 (merged), PR #276 (still open — but this PR doesn't strictly depend on it; the spec is the published design doc whether #276 lands or not).