### PR TITLE
feat(signing): tool_signing_expired SSE event + greyed SignTxCard

### DIFF
--- a/app/src/components/ChatSidebar.tsx
+++ b/app/src/components/ChatSidebar.tsx
@@ -38,6 +38,7 @@ export default function ChatSidebar({ fullScreen }: Props) {
   const appendTool = useAppStore((s) => s.appendTool)
   const completeTool = useAppStore((s) => s.completeTool)
   const dismissMessage = useAppStore((s) => s.dismissMessage)
+  const markMessageExpired = useAppStore((s) => s.markMessageExpired)
   const consumePendingPrompt = useAppStore((s) => s.consumePendingPrompt)
   const unauthedRemaining = useAppStore((s) => s.unauthedRemaining)
   const setUnauthedRemaining = useAppStore((s) => s.setUnauthedRemaining)
@@ -198,6 +199,8 @@ export default function ChatSidebar({ fullScreen }: Props) {
                   display: event.display,
                 },
               })
+            } else if (event.type === 'tool_signing_expired') {
+              markMessageExpired(event.flagId)
             } else if (event.type === 'error') {
               appendToLast(`\n\nError: ${event.message}`)
             }
@@ -337,6 +340,7 @@ export default function ChatSidebar({ fullScreen }: Props) {
                     network={meta.network ?? 'devnet'}
                     walletPubkey={meta.walletPubkey ?? ''}
                     display={meta.display ?? { title: '', primaryDetail: '', secondaryDetails: [] }}
+                    expired={msg.expired === true}
                     onResolved={() => dismissMessage(msg.id)}
                   />
                 </div>

--- a/app/src/components/SignTxCard.tsx
+++ b/app/src/components/SignTxCard.tsx
@@ -18,7 +18,13 @@ interface Props {
     primaryDetail: string
     secondaryDetails: string[]
   }
-  onResolved: (decision: 'confirm' | 'reject') => void
+  /**
+   * When true, the server has already reaped this flagId (TTL fired) and the
+   * card renders in a greyed-out, dismiss-only state. Sign/Cancel are hidden;
+   * the unmount-beacon /reject is suppressed (the flag is already gone).
+   */
+  expired?: boolean
+  onResolved: (decision: 'confirm' | 'reject' | 'dismiss') => void
 }
 
 function detectClusterFromEndpoint(endpoint: string): 'mainnet-beta' | 'devnet' | 'unknown' {
@@ -34,6 +40,7 @@ export default function SignTxCard({
   network,
   walletPubkey,
   display,
+  expired = false,
   onResolved,
 }: Props) {
   const { token } = useAuthState()
@@ -129,6 +136,9 @@ export default function SignTxCard({
     return () => {
       if (beaconFiredRef.current) return
       if (statusRef.current !== 'idle') return
+      // Server has already reaped the flag — firing /reject would 404 and
+      // pollute logs. Skip the beacon entirely when expired.
+      if (expired) return
       try {
         const blob = new Blob([JSON.stringify({ reason: 'tab_closed' })], { type: 'application/json' })
         if (typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
@@ -148,14 +158,42 @@ export default function SignTxCard({
         // best-effort only — never surface to user
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- status is intentionally read via statusRef (see comment above)
-  }, [flagId, token])
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- status is intentionally read via statusRef (see comment above); expired added explicitly to suppress beacon when applicable
+  }, [flagId, token, expired])
 
   const signLabel =
     status === 'signing' ? 'Open your wallet...' :
     status === 'callback-posting' ? 'Finalizing...' :
     status === 'done' ? 'Signed' :
     'Sign with Wallet'
+
+  if (expired) {
+    return (
+      <div
+        className="bg-glass-1 border border-line rounded-lg p-4 flex flex-col gap-3 opacity-50"
+        role="region"
+        aria-label={`Expired ${toolName} signing request`}
+      >
+        <div className="text-[12px] text-text-muted uppercase tracking-wide">Sign Transaction</div>
+        <div className="text-[14px] text-text font-medium">{display.title}</div>
+        <div className="text-[12px] text-text-muted leading-relaxed">{display.primaryDetail}</div>
+        <ul className="text-[11px] text-text-muted flex flex-col gap-1">
+          {display.secondaryDetails.map((d) => (
+            <li key={d}>{d}</li>
+          ))}
+        </ul>
+        <div className="text-[12px] text-warning">Expired — request again to sign.</div>
+        <div className="flex gap-2">
+          <button
+            onClick={() => onResolved('dismiss')}
+            className="flex-1 border border-line text-text-muted py-2 rounded-lg text-[12px] hover:text-text"
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div

--- a/app/src/components/__tests__/ChatSidebar.test.tsx
+++ b/app/src/components/__tests__/ChatSidebar.test.tsx
@@ -222,6 +222,65 @@ describe('ChatSidebar', () => {
     })
   })
 
+  it('marks the matching signing message expired on tool_signing_expired SSE event', async () => {
+    useAppStore.setState({
+      token: 'test-jwt',
+      isAdmin: true,
+      messages: [
+        {
+          id: 'pre-existing',
+          role: 'system',
+          content: '',
+          kind: 'tool_signing_required',
+          meta: {
+            flagId: 'flag-exp-1',
+            toolName: 'send',
+            serializedTx: 'BASE64TX',
+            network: 'devnet',
+            walletPubkey: 'WalletABC',
+            display: { title: 'Send 1 SOL', primaryDetail: '', secondaryDetails: [] },
+          },
+        },
+      ],
+    })
+
+    const encoder = new TextEncoder()
+    const sseBody = new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            `data: ${JSON.stringify({
+              type: 'tool_signing_expired',
+              flagId: 'flag-exp-1',
+              reason: 'timeout',
+            })}\n\n`,
+          ),
+        )
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+        controller.close()
+      },
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(sseBody, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        }),
+      ),
+    )
+
+    render(<ChatSidebar />)
+    const input = screen.getByPlaceholderText('Message SIPHER...') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'noop' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() => {
+      const msg = useAppStore.getState().messages.find((m) => m.id === 'pre-existing')
+      expect(msg?.expired).toBe(true)
+    })
+  })
+
   it('sends message and appends streamed reply', async () => {
     useAppStore.setState({ token: 'test-jwt', isAdmin: true })
 

--- a/app/src/components/__tests__/SignTxCard.test.tsx
+++ b/app/src/components/__tests__/SignTxCard.test.tsx
@@ -181,4 +181,52 @@ describe('SignTxCard', () => {
     )
     expect(rejectBeacons.length).toBe(1)
   })
+
+  describe('expired state', () => {
+    it('renders only a Dismiss button (no Sign / Cancel)', () => {
+      render(<SignTxCard {...DEFAULT_PROPS} expired />)
+      expect(screen.queryByRole('button', { name: /sign with wallet/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /^cancel$/i })).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /dismiss/i })).toBeInTheDocument()
+    })
+
+    it('shows the "Expired" hint copy', () => {
+      render(<SignTxCard {...DEFAULT_PROPS} expired />)
+      expect(screen.getByText(/expired/i)).toBeInTheDocument()
+    })
+
+    it('still displays the original title / detail / secondary lines', () => {
+      render(<SignTxCard {...DEFAULT_PROPS} expired />)
+      expect(screen.getByText('Send 1 SOL to alice.sol')).toBeInTheDocument()
+      expect(screen.getByText('Protocol fee: 0.005 SOL')).toBeInTheDocument()
+    })
+
+    it('calls onResolved("dismiss") when Dismiss clicked', async () => {
+      const onResolved = vi.fn()
+      render(<SignTxCard {...DEFAULT_PROPS} expired onResolved={onResolved} />)
+      await userEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+      expect(onResolved).toHaveBeenCalledWith('dismiss')
+    })
+
+    it('does NOT fire the reject beacon on unmount when expired', () => {
+      const beaconSpy = vi.fn().mockReturnValue(true)
+      Object.defineProperty(window.navigator, 'sendBeacon', {
+        value: beaconSpy,
+        configurable: true,
+      })
+
+      const { unmount } = render(<SignTxCard {...DEFAULT_PROPS} expired />)
+      unmount()
+
+      const rejectBeacons = beaconSpy.mock.calls.filter(([url]) =>
+        typeof url === 'string' && url.includes('/reject'),
+      )
+      expect(rejectBeacons.length).toBe(0)
+    })
+
+    it('region aria-label changes to convey expiry', () => {
+      render(<SignTxCard {...DEFAULT_PROPS} expired />)
+      expect(screen.getByRole('region', { name: /expired send signing request/i })).toBeInTheDocument()
+    })
+  })
 })

--- a/app/src/stores/__tests__/app.test.ts
+++ b/app/src/stores/__tests__/app.test.ts
@@ -48,3 +48,72 @@ describe('useAppStore.clearAuth', () => {
     expect(observedToken).toBeNull()
   })
 })
+
+describe('useAppStore.markMessageExpired', () => {
+  beforeEach(() => {
+    useAppStore.setState({ messages: [] }, false)
+  })
+
+  const baseSigningMsg = {
+    id: 'msg-1',
+    role: 'system' as const,
+    content: '',
+    kind: 'tool_signing_required' as const,
+    meta: { flagId: 'flag-abc', toolName: 'send' as const },
+  }
+
+  it('marks the matching tool_signing_required message expired by flagId', () => {
+    useAppStore.setState({ messages: [baseSigningMsg] })
+    useAppStore.getState().markMessageExpired('flag-abc')
+    const msg = useAppStore.getState().messages[0]
+    expect(msg.expired).toBe(true)
+  })
+
+  it('is a no-op when no message matches the flagId', () => {
+    useAppStore.setState({ messages: [baseSigningMsg] })
+    useAppStore.getState().markMessageExpired('flag-OTHER')
+    const msg = useAppStore.getState().messages[0]
+    expect(msg.expired).toBeUndefined()
+  })
+
+  it('skips non-signing messages even when meta.flagId happens to match', () => {
+    const sentinelMsg = {
+      id: 'msg-2',
+      role: 'system' as const,
+      content: '',
+      kind: 'sentinel_pause' as const,
+      meta: { flagId: 'flag-abc' },
+    }
+    useAppStore.setState({ messages: [sentinelMsg] })
+    useAppStore.getState().markMessageExpired('flag-abc')
+    const msg = useAppStore.getState().messages[0]
+    expect(msg.expired).toBeUndefined()
+  })
+
+  it('skips already-dismissed messages (race protection)', () => {
+    useAppStore.setState({ messages: [{ ...baseSigningMsg, dismissed: true }] })
+    useAppStore.getState().markMessageExpired('flag-abc')
+    const msg = useAppStore.getState().messages[0]
+    expect(msg.expired).toBeUndefined()
+  })
+
+  it('skips already-expired messages (idempotent)', () => {
+    useAppStore.setState({ messages: [{ ...baseSigningMsg, expired: true }] })
+    // Snapshot the array reference; idempotent should leave entries untouched
+    const before = useAppStore.getState().messages
+    useAppStore.getState().markMessageExpired('flag-abc')
+    const after = useAppStore.getState().messages
+    // The message itself remains expired; we just confirm no double-mutation
+    expect(after[0].expired).toBe(true)
+    expect(after[0]).toBe(before[0])
+  })
+
+  it('only updates the matched message; leaves siblings alone', () => {
+    const other = { ...baseSigningMsg, id: 'msg-other', meta: { flagId: 'flag-XYZ' } }
+    useAppStore.setState({ messages: [baseSigningMsg, other] })
+    useAppStore.getState().markMessageExpired('flag-abc')
+    const msgs = useAppStore.getState().messages
+    expect(msgs[0].expired).toBe(true)
+    expect(msgs[1].expired).toBeUndefined()
+  })
+})

--- a/app/src/stores/app.ts
+++ b/app/src/stores/app.ts
@@ -23,6 +23,12 @@ export interface ChatMessage {
   kind?: 'sentinel_pause' | 'tool_signing_required'
   meta?: Record<string, unknown>
   dismissed?: boolean
+  /**
+   * Set true when a tool_signing_expired SSE event arrives matching this
+   * message's flagId. The SignTxCard renders a greyed-out, dismiss-only
+   * state when this is true. Defaults to false / absent.
+   */
+  expired?: boolean
 }
 
 interface AppState {
@@ -41,6 +47,12 @@ interface AppState {
   appendTool: (name: string, args?: string) => void
   completeTool: (name: string, status: ToolStatus) => void
   dismissMessage: (id: string) => void
+  /**
+   * Mark a tool_signing_required message as expired by its server-issued
+   * flagId. No-op if no matching message is found (silent — late events
+   * after a sign/reject/dismiss should not regress UI).
+   */
+  markMessageExpired: (flagId: string) => void
   seedChat: (prompt: string) => void
 
   chatOpen: boolean
@@ -125,6 +137,17 @@ export const useAppStore = create<AppState>()(
       dismissMessage: (id) =>
         set((s) => ({
           messages: s.messages.map((m) => (m.id === id ? { ...m, dismissed: true } : m)),
+        })),
+      markMessageExpired: (flagId) =>
+        set((s) => ({
+          messages: s.messages.map((m) =>
+            m.kind === 'tool_signing_required' &&
+            !m.expired &&
+            !m.dismissed &&
+            (m.meta as { flagId?: string } | undefined)?.flagId === flagId
+              ? { ...m, expired: true }
+              : m,
+          ),
         })),
       seedChat: (prompt) => set({ chatOpen: true, pendingPrompt: prompt }),
 

--- a/packages/agent/src/adapters/web.ts
+++ b/packages/agent/src/adapters/web.ts
@@ -57,6 +57,12 @@ function chunkToSSE(chunk: ResponseChunk): Record<string, unknown> {
         walletPubkey: chunk.signing?.walletPubkey ?? '',
         display: chunk.signing?.display ?? { title: '', primaryDetail: '', secondaryDetails: [] },
       }
+    case 'tool_signing_expired':
+      return {
+        type: 'tool_signing_expired',
+        flagId: chunk.expired?.flagId ?? '',
+        reason: chunk.expired?.reason ?? 'timeout',
+      }
     case 'error':
       return { type: 'error', message: chunk.text }
     case 'done':

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -282,6 +282,14 @@ export interface SSEToolSigningRequired {
   }
 }
 
+export interface SSEToolSigningExpired {
+  type: 'tool_signing_expired'
+  /** Matches the flagId of a previously emitted tool_signing_required event */
+  flagId: string
+  /** Reason kind — reserved for future variants (server_shutdown, etc.) */
+  reason: 'timeout'
+}
+
 export type SSEEvent =
   | SSEContentDelta
   | SSEToolUse
@@ -290,6 +298,7 @@ export type SSEEvent =
   | SSEError
   | SSESentinelPause
   | SSEToolSigningRequired
+  | SSEToolSigningExpired
 
 // ─── Local helpers — humanize advisory metadata for the UI ──────────────────
 
@@ -413,7 +422,7 @@ type ToolExecutorAsync = (name: string, input: Record<string, unknown>) => Promi
 interface SigningWrapperOptions {
   sessionId: string
   network: 'mainnet-beta' | 'devnet'
-  externalQueue: Array<SSESentinelPause | SSEToolSigningRequired>
+  externalQueue: Array<SSESentinelPause | SSEToolSigningRequired | SSEToolSigningExpired>
   externalWake: () => void
 }
 
@@ -474,6 +483,14 @@ export function wrapWithSigning(
       serializedTx,
       network: opts.network,
       toolInput: input,
+      onExpire: (expiredFlagId) => {
+        opts.externalQueue.push({
+          type: 'tool_signing_expired',
+          flagId: expiredFlagId,
+          reason: 'timeout',
+        })
+        opts.externalWake()
+      },
     })
 
     opts.externalQueue.push({
@@ -607,7 +624,7 @@ export async function* chatStream(
   // don't collide under a shared key. Production callers (AgentCore) always
   // pass a real session id derived from the wallet.
   const sessionId = opts.sessionId ?? randomUUID()
-  const externalQueue: Array<SSESentinelPause | SSEToolSigningRequired> = []
+  const externalQueue: Array<SSESentinelPause | SSEToolSigningRequired | SSEToolSigningExpired> = []
   let externalWake: (() => void) | null = null
   const baseExecutor = opts.toolExecutor ?? executeTool
 
@@ -681,7 +698,7 @@ export async function* chatStream(
     sessionId: opts.sessionId,
   })
 
-  for await (const event of streamPiAgent<SSESentinelPause | SSEToolSigningRequired>(agent, userMessage, {
+  for await (const event of streamPiAgent<SSESentinelPause | SSEToolSigningRequired | SSEToolSigningExpired>(agent, userMessage, {
     externalQueue,
     attachWake: (wake) => {
       externalWake = wake

--- a/packages/agent/src/core/agent-core.ts
+++ b/packages/agent/src/core/agent-core.ts
@@ -200,6 +200,16 @@ export class AgentCore {
           }
           break
 
+        case 'tool_signing_expired':
+          yield {
+            type: 'tool_signing_expired',
+            expired: {
+              flagId: event.flagId,
+              reason: event.reason,
+            },
+          }
+          break
+
         case 'error':
           yield { type: 'error', text: event.message }
           break

--- a/packages/agent/src/core/types.ts
+++ b/packages/agent/src/core/types.ts
@@ -30,7 +30,15 @@ export interface MsgContext {
 
 /** A single response chunk for streaming */
 export interface ResponseChunk {
-  type: 'text' | 'tool_start' | 'tool_end' | 'error' | 'done' | 'sentinel_pause' | 'tool_signing_required'
+  type:
+    | 'text'
+    | 'tool_start'
+    | 'tool_end'
+    | 'error'
+    | 'done'
+    | 'sentinel_pause'
+    | 'tool_signing_required'
+    | 'tool_signing_expired'
   text?: string
   toolName?: string
   toolId?: string
@@ -55,6 +63,11 @@ export interface ResponseChunk {
       primaryDetail: string
       secondaryDetails: string[]
     }
+  }
+  /** Populated only when type === 'tool_signing_expired' */
+  expired?: {
+    flagId: string
+    reason: 'timeout'
   }
 }
 

--- a/packages/agent/src/sentinel/pending-signing.ts
+++ b/packages/agent/src/sentinel/pending-signing.ts
@@ -34,6 +34,14 @@ export interface CreatePendingSigningParams {
   serializedTx: string
   network: 'mainnet-beta' | 'devnet'
   toolInput: unknown
+  /**
+   * Optional callback invoked once when the TTL fires, BEFORE the awaiting
+   * promise is rejected. Used to emit a `tool_signing_expired` SSE event
+   * so the active client SSE stream can transition its SignTxCard to an
+   * expired state. Throws are suppressed — emission failure must not block
+   * the reject path.
+   */
+  onExpire?: (flagId: string) => void
 }
 
 export function createPendingSigning(
@@ -49,6 +57,15 @@ export function createPendingSigning(
   const timeoutHandle = setTimeout(() => {
     if (pending.has(flagId)) {
       pending.delete(flagId)
+      if (params.onExpire) {
+        try {
+          params.onExpire(flagId)
+        } catch (err) {
+          console.warn(
+            `[signing] onExpire callback threw (suppressed): ${err instanceof Error ? err.message : String(err)}`,
+          )
+        }
+      }
       rejecter(new Error('operation timed out'))
     }
   }, TIMEOUT_MS)

--- a/packages/agent/tests/sentinel/pending-signing.test.ts
+++ b/packages/agent/tests/sentinel/pending-signing.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import {
   createPendingSigning,
   resolvePendingSigning,
@@ -90,5 +90,42 @@ describe('pending-signing registry', () => {
     promise.catch(() => {})
     rejectPendingSigning(flagId, 'cancelled')
     expect(getPendingSigning(flagId)).toBeUndefined()
+  })
+
+  it('onExpire callback fires with flagId when timeout hits', async () => {
+    _setTimeoutMsForTests(20)
+    const onExpire = vi.fn()
+    const { flagId, promise } = createPendingSigning({ ...SAMPLE, onExpire })
+    promise.catch(() => {})
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(onExpire).toHaveBeenCalledTimes(1)
+    expect(onExpire).toHaveBeenCalledWith(flagId)
+  })
+
+  it('onExpire is NOT called when resolvePendingSigning runs first', async () => {
+    const onExpire = vi.fn()
+    const { flagId, promise } = createPendingSigning({ ...SAMPLE, onExpire })
+    resolvePendingSigning(flagId, 'SIG')
+    await expect(promise).resolves.toBe('SIG')
+    expect(onExpire).not.toHaveBeenCalled()
+  })
+
+  it('onExpire is NOT called when rejectPendingSigning runs first', async () => {
+    const onExpire = vi.fn()
+    const { flagId, promise } = createPendingSigning({ ...SAMPLE, onExpire })
+    promise.catch(() => {})
+    rejectPendingSigning(flagId, 'cancelled_by_user')
+    await expect(promise).rejects.toThrow('cancelled_by_user')
+    expect(onExpire).not.toHaveBeenCalled()
+  })
+
+  it('rejection still fires even when onExpire throws (suppressed)', async () => {
+    _setTimeoutMsForTests(20)
+    const onExpire = vi.fn(() => {
+      throw new Error('boom')
+    })
+    const { promise } = createPendingSigning({ ...SAMPLE, onExpire })
+    await expect(promise).rejects.toThrow('operation timed out')
+    expect(onExpire).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary

Implements [Spec 2](https://github.com/sip-protocol/sipher/blob/main/docs/superpowers/specs/2026-05-15-tool-signing-expired-sse-design.md) from PR #276. Closes the silent-expiration "ghost card" UX — today's 5-min promise-gate TTL silently rejects the awaiting promise without notifying the active SSE stream, so SignTxCards stay in "pending sign" state indefinitely and late signs hit 404 confirm routes.

Server now emits a new `SSEToolSigningExpired` event the instant the TTL fires (via the same `externalQueue` path that `sentinel_pause` uses), BEFORE the rejecter runs. The frontend marks the matching message expired and `SignTxCard` renders a greyed-out, dismiss-only state.

## assertNever working as designed

Adding `SSEToolSigningExpired` to the `SSEEvent` union immediately surfaced two compile errors at the `streamMessage` and `chunkToSSE` switches — before any test ran, the typecheck told me exactly where the cross-file plumbing fanout needed to land. This is the first real follow-up PR proving the Spec 1 guard.

```
src/core/agent-core.ts(212,23): error TS2345: Argument of type 'SSEToolSigningExpired' is not assignable to parameter of type 'never'.
src/adapters/web.ts(65,26): error TS2345: Argument of type '"tool_signing_expired"' is not assignable to parameter of type 'never'.
```

## Changes

**Backend** (5 source + 1 test file)
- `packages/agent/src/sentinel/pending-signing.ts` — new optional `onExpire(flagId)` callback, invoked before rejecter, with throws suppressed
- `packages/agent/src/agent.ts` — new `SSEToolSigningExpired` interface, added to `SSEEvent` union + both `externalQueue` widths. `wrapWithSigning` passes `onExpire` callback at `createPendingSigning` call site
- `packages/agent/src/core/types.ts` — `tool_signing_expired` added to `ResponseChunk.type` + new `expired?` field
- `packages/agent/src/core/agent-core.ts` — new case in `streamMessage` switch
- `packages/agent/src/adapters/web.ts` — new case in `chunkToSSE` switch

**Frontend** (3 source + 3 test files)
- `app/src/stores/app.ts` — new `expired?` field on `ChatMessage` + `markMessageExpired(flagId)` action with idempotency + race guards
- `app/src/components/ChatSidebar.tsx` — SSE handler case for `tool_signing_expired`, passes `expired` prop down
- `app/src/components/SignTxCard.tsx` — new `expired` prop (default false). When true: skips unmount `/reject` beacon (server already reaped the flag), renders `opacity-50` region with just a Dismiss button. `onResolved` union widened to `'confirm' | 'reject' | 'dismiss'`

## Test plan

- [x] Backend: 1576 → 1580 agent tests (+4 onExpire tests)
- [x] Frontend: 558 → 571 app tests (+13: store 6, SignTxCard 6, ChatSidebar 1)
- [x] `cd packages/agent && pnpm exec tsc --noEmit` clean
- [x] `cd app && pnpm exec tsc --noEmit` clean
- [x] GPG-signed commit
- [x] No AI-attribution trailers

## Test coverage detail

**`pending-signing.test.ts` (+4):**
- `onExpire` fires with `flagId` when timeout hits
- `onExpire` NOT called when `resolvePendingSigning` runs first
- `onExpire` NOT called when `rejectPendingSigning` runs first
- Rejection still fires when `onExpire` throws (suppressed)

**`SignTxCard.test.tsx` (+6, in new `describe('expired state')` block):**
- Renders only Dismiss button (no Sign / Cancel)
- "Expired" hint copy visible
- Original title / detail / secondary lines preserved
- `onResolved("dismiss")` fires on Dismiss click
- Reject beacon suppressed on unmount when expired
- Region aria-label changes

**`app.test.ts` (+6, in new `describe('markMessageExpired')` block):**
- Marks matching message by flagId
- No-op on missing flagId
- Skips non-signing kinds even with matching meta.flagId
- Skips already-dismissed (race protection)
- Idempotent (no-op on already-expired)
- Siblings unchanged

**`ChatSidebar.test.tsx` (+1):**
- SSE `tool_signing_expired` event triggers store update for matching message

## Out of scope (deferred per spec)

- **Reconnection recovery:** a client disconnected when the TTL fired won't discover the expiry on reconnect. Tracked as a follow-up needing a new `GET /api/tool-signing/pending` route
- **Configurable per-tool TTL:** today's 5-min applies uniformly

## Spec reference + dependency chain

Stacked atop **PR #277** (Spec 1 assertNever — merged). The compile-time guard proved its value during this build: it caught the missing switch cases before tests ran.

Spec: `docs/superpowers/specs/2026-05-15-tool-signing-expired-sse-design.md`

## Demo-day relevance

This PR has visible UX polish — if a recording demonstrates a SignTxCard sitting beyond the 5-min TTL, the greyed-out + Dismiss state is a polished detail judges may notice. Even without that scenario, the integration-soundness signal (proper cross-layer SSE event propagation + typed exhaustiveness guards firing in CI) is judge-positive.