### PR TITLE
feat(signing): server-side signature verification via Solana RPC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,22 @@ SENTINEL_MODE=advisory
 SENTINEL_AUTHORITY_KEYPAIR=
 
 # ───────────────────────────────────────────
+# Server-side signature verification (Spec 3)
+# ───────────────────────────────────────────
+# Controls how POST /api/tool-signing/:flagId/confirm verifies client-supplied
+# signatures via Solana RPC (getSignatureStatuses + getTransaction fee-payer).
+# strict   (default) — reject pending + 4xx VALIDATION_FAILED on verify failure;
+#                      503 + Retry-After on RPC unavailability
+# advisory          — verify and log on failure, but still resolve pending
+#                      (used for soak-testing the verifier without UX impact)
+# off               — skip verification entirely (legacy behavior)
+#
+# Code defaults to 'strict' when unset. Ship 'advisory' here as the safe first-
+# deploy default so operators can promote to 'strict' after >= 1 week of
+# observation (mirrors the SENTINEL_MODE rollout posture).
+SIPHER_SIG_VERIFY=advisory
+
+# ───────────────────────────────────────────
 # Phase 4 — Network configuration
 # ───────────────────────────────────────────
 

--- a/packages/agent/src/routes/tool-signing.ts
+++ b/packages/agent/src/routes/tool-signing.ts
@@ -1,20 +1,38 @@
 import { Router, type Request, type Response } from 'express'
+import { createConnection } from '@sipher/sdk'
 import {
   getPendingSigning,
   resolvePendingSigning,
   rejectPendingSigning,
 } from '../sentinel/pending-signing.js'
+import { verifySignature, type VerifyResult } from '../sentinel/verify-signature.js'
+import { loadNetworkConfig } from '../config/network.js'
 import { sendSentinelError } from './sentinel-errors.js'
 
 export const toolSigningRouter = Router()
+
+type VerifyMode = 'strict' | 'advisory' | 'off'
+
+function loadVerifyMode(): VerifyMode {
+  const raw = (process.env.SIPHER_SIG_VERIFY ?? 'strict').toLowerCase()
+  if (raw === 'strict' || raw === 'advisory' || raw === 'off') return raw
+  return 'strict'
+}
 
 /**
  * POST /api/tool-signing/:flagId/confirm
  * Body: { signature: string }
  * Resolves the pending signing promise with the on-chain tx signature.
  * Wallet binding: JWT wallet must equal the pending entry's wallet.
+ *
+ * Server-side verification (Spec 3 — PR #279):
+ *   SIPHER_SIG_VERIFY=strict (default) — verify via Solana RPC; reject pending
+ *     on failure and return 4xx VALIDATION_FAILED. RPC unavailable → 503.
+ *   SIPHER_SIG_VERIFY=advisory — verify and log on failure, but still resolve.
+ *     Used for soak-testing the verifier without blocking the UX.
+ *   SIPHER_SIG_VERIFY=off — skip verification entirely (legacy behavior).
  */
-toolSigningRouter.post('/:flagId/confirm', (req: Request, res: Response) => {
+toolSigningRouter.post('/:flagId/confirm', async (req: Request, res: Response) => {
   const flagId = req.params.flagId as string
   const entry = getPendingSigning(flagId)
   if (!entry) {
@@ -39,8 +57,49 @@ toolSigningRouter.post('/:flagId/confirm', (req: Request, res: Response) => {
     return
   }
 
+  const mode = loadVerifyMode()
+  let verifyResult: VerifyResult | null = null
+  if (mode !== 'off') {
+    try {
+      const net = loadNetworkConfig()
+      const connection = createConnection(net.clusterName, net.rpcUrl)
+      verifyResult = await verifySignature(signature, entry, { connection })
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err)
+      verifyResult = { ok: false, reason: 'rpc_error', detail }
+    }
+
+    if (!verifyResult.ok) {
+      if (mode === 'strict') {
+        if (verifyResult.reason === 'rpc_error' || verifyResult.reason === 'timeout') {
+          // RPC blip — let the client retry rather than killing the pending entry.
+          res.setHeader('Retry-After', '2')
+          sendSentinelError(
+            res,
+            'UNAVAILABLE',
+            `signature verification unavailable (${verifyResult.reason})`,
+          )
+          return
+        }
+        rejectPendingSigning(flagId, `verification_failed: ${verifyResult.reason}`)
+        sendSentinelError(
+          res,
+          'VALIDATION_FAILED',
+          `signature verification failed: ${verifyResult.reason}${verifyResult.detail ? ` (${verifyResult.detail})` : ''}`,
+        )
+        return
+      }
+      console.warn(
+        `[signing] verify failed (advisory mode): flagId=${flagId} reason=${verifyResult.reason}${verifyResult.detail ? ` detail=${verifyResult.detail}` : ''}`,
+      )
+    }
+  }
+
   resolvePendingSigning(flagId, signature)
-  res.status(200).json({ status: 'accepted' })
+  res.status(200).json({
+    status: 'accepted',
+    verified: mode === 'strict' && verifyResult?.ok === true,
+  })
 })
 
 /**

--- a/packages/agent/src/sentinel/verify-signature.ts
+++ b/packages/agent/src/sentinel/verify-signature.ts
@@ -1,0 +1,136 @@
+import type { Connection } from '@solana/web3.js'
+import type { PendingSigningFlag } from './pending-signing.js'
+
+/**
+ * Result of server-side signature verification.
+ *
+ * Discriminated union so the consumer (confirm route) can switch on `reason`
+ * without losing type narrowing. The `assertNever` exhaustiveness guard added
+ * in PR #277 applies here when the consumer dispatches on this union.
+ */
+export type VerifyResult =
+  | { ok: true; slot: number }
+  | {
+      ok: false
+      reason: 'not_confirmed' | 'wallet_mismatch' | 'rpc_error' | 'timeout'
+      detail?: string
+    }
+
+export interface VerifyOptions {
+  connection: Connection
+  /** Total budget for verification. Default 3000ms. */
+  timeoutMs?: number
+}
+
+/**
+ * Verify that a signature submitted to /api/tool-signing/:flagId/confirm
+ * corresponds to a real on-chain Solana transaction signed by the wallet
+ * recorded in the pending entry.
+ *
+ * Two tiers:
+ *  - T1: getSignatureStatuses — confirmed/finalized AND no err
+ *  - T2: getTransaction — fee payer (accountKeys[0]) === entry.wallet
+ *
+ * T3 (instruction-match against entry.serializedTx) is deferred per spec.
+ *
+ * Returns a discriminated VerifyResult — caller decides how to act based on
+ * the SIPHER_SIG_VERIFY mode.
+ */
+export async function verifySignature(
+  signature: string,
+  entry: PendingSigningFlag,
+  opts: VerifyOptions,
+): Promise<VerifyResult> {
+  const timeoutMs = opts.timeoutMs ?? 3000
+  return Promise.race([
+    runVerification(signature, entry, opts.connection),
+    new Promise<VerifyResult>((resolve) =>
+      setTimeout(() => resolve({ ok: false, reason: 'timeout' }), timeoutMs),
+    ),
+  ])
+}
+
+async function runVerification(
+  signature: string,
+  entry: PendingSigningFlag,
+  connection: Connection,
+): Promise<VerifyResult> {
+  // ── T1: existence + confirmation status ────────────────────────────────
+  let statuses
+  try {
+    statuses = await connection.getSignatureStatuses([signature])
+  } catch (err) {
+    return {
+      ok: false,
+      reason: 'rpc_error',
+      detail: err instanceof Error ? err.message : String(err),
+    }
+  }
+
+  const status = statuses?.value?.[0]
+  if (!status) {
+    return { ok: false, reason: 'not_confirmed' }
+  }
+
+  if (status.err) {
+    return {
+      ok: false,
+      reason: 'not_confirmed',
+      detail: typeof status.err === 'object' ? JSON.stringify(status.err) : String(status.err),
+    }
+  }
+
+  if (status.confirmationStatus !== 'confirmed' && status.confirmationStatus !== 'finalized') {
+    return {
+      ok: false,
+      reason: 'not_confirmed',
+      detail: `confirmationStatus=${status.confirmationStatus ?? 'unknown'}`,
+    }
+  }
+
+  // ── T2: fee payer must match entry.wallet ──────────────────────────────
+  let tx
+  try {
+    tx = await connection.getTransaction(signature, {
+      commitment: 'confirmed',
+      maxSupportedTransactionVersion: 0,
+    })
+  } catch (err) {
+    return {
+      ok: false,
+      reason: 'rpc_error',
+      detail: err instanceof Error ? err.message : String(err),
+    }
+  }
+
+  if (!tx) {
+    return { ok: false, reason: 'not_confirmed', detail: 'tx body not available after confirmation' }
+  }
+
+  // Versioned messages expose `staticAccountKeys`; legacy messages use
+  // `accountKeys`. Mocks provide whichever path the test cares about.
+  // Index 0 is the fee payer in both shapes.
+  const feePayer = extractFeePayer(tx.transaction?.message as unknown)
+  if (feePayer !== entry.wallet) {
+    return {
+      ok: false,
+      reason: 'wallet_mismatch',
+      detail: `expected ${entry.wallet}, got ${feePayer ?? '(no fee payer)'}`,
+    }
+  }
+
+  return { ok: true, slot: status.slot }
+}
+
+function extractFeePayer(message: unknown): string | null {
+  if (message === null || typeof message !== 'object') return null
+  const m = message as {
+    staticAccountKeys?: Array<{ toBase58?: () => string } | string>
+    accountKeys?: Array<{ toBase58?: () => string } | string>
+  }
+  const candidate = m.staticAccountKeys?.[0] ?? m.accountKeys?.[0]
+  if (!candidate) return null
+  if (typeof candidate === 'string') return candidate
+  if (typeof candidate.toBase58 === 'function') return candidate.toBase58()
+  return null
+}

--- a/packages/agent/tests/routes/tool-signing-routes.test.ts
+++ b/packages/agent/tests/routes/tool-signing-routes.test.ts
@@ -1,17 +1,25 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import express from 'express'
 import supertest from 'supertest'
 import jwt from 'jsonwebtoken'
-import {
-  createPendingSigning,
-  getPendingSigning,
-  clearAllSigning,
-  _setTimeoutMsForTests,
-} from '../../src/sentinel/pending-signing.js'
 
 const TEST_JWT_SECRET = 'test-secret-for-tool-signing-tests'
 const WALLET = 'WalletABC'
 const OTHER_WALLET = 'WalletDEF'
+
+// Verifier is mocked across the file so route tests stay deterministic without
+// hitting Solana RPC. Each `describe` block configures the mock per its needs.
+const verifySignatureMock = vi.fn()
+vi.mock('../../src/sentinel/verify-signature.js', () => ({
+  verifySignature: (...args: unknown[]) => verifySignatureMock(...args),
+}))
+vi.mock('@sipher/sdk', async () => {
+  const actual = await vi.importActual<typeof import('@sipher/sdk')>('@sipher/sdk')
+  return {
+    ...actual,
+    createConnection: () => ({}) as unknown,
+  }
+})
 
 function signJwt(wallet: string): string {
   return jwt.sign({ wallet }, TEST_JWT_SECRET, { expiresIn: '1h', algorithm: 'HS256' })
@@ -19,16 +27,32 @@ function signJwt(wallet: string): string {
 
 const { toolSigningRouter } = await import('../../src/routes/tool-signing.js')
 const { verifyJwt } = await import('../../src/routes/auth.js')
+const {
+  createPendingSigning,
+  getPendingSigning,
+  clearAllSigning,
+  _setTimeoutMsForTests,
+} = await import('../../src/sentinel/pending-signing.js')
 
 beforeEach(() => {
   process.env.NODE_ENV = 'test'
   process.env.JWT_SECRET = TEST_JWT_SECRET
+  process.env.SIPHER_NETWORK = 'devnet'
+  process.env.SIPHER_HELIUS_API_KEY = 'test-helius-key'
+  // Default: verifier off — keeps the original base-behavior tests focused on
+  // the auth/validation surface. Per-describe blocks below override to test
+  // strict/advisory behavior with the verifier mock.
+  process.env.SIPHER_SIG_VERIFY = 'off'
   _setTimeoutMsForTests(60_000)
   for (const s of ['test-session', 's1']) clearAllSigning(s)
+  verifySignatureMock.mockReset()
 })
 
 afterEach(() => {
   delete process.env.JWT_SECRET
+  delete process.env.SIPHER_NETWORK
+  delete process.env.SIPHER_HELIUS_API_KEY
+  delete process.env.SIPHER_SIG_VERIFY
   for (const s of ['test-session', 's1']) clearAllSigning(s)
 })
 
@@ -54,15 +78,16 @@ function makePending(overrides: Partial<{ wallet: string; sessionId: string }> =
 }
 
 describe('POST /api/tool-signing/:flagId/confirm', () => {
-  it('resolves the pending promise with the signature on valid request (200)', async () => {
+  it('resolves the pending promise with the signature on valid request (200, verify=off)', async () => {
     const { flagId, promise } = makePending()
     const res = await supertest(createApp())
       .post(`/api/tool-signing/${flagId}/confirm`)
       .set('Authorization', `Bearer ${signJwt(WALLET)}`)
       .send({ signature: 'SIG_VALID_BASE58_SIGNATURE_VALUE' })
     expect(res.status).toBe(200)
-    expect(res.body).toEqual({ status: 'accepted' })
+    expect(res.body).toEqual({ status: 'accepted', verified: false })
     await expect(promise).resolves.toBe('SIG_VALID_BASE58_SIGNATURE_VALUE')
+    expect(verifySignatureMock).not.toHaveBeenCalled()
   })
 
   it('returns 404 NOT_FOUND when flagId does not exist', async () => {
@@ -163,5 +188,204 @@ describe('POST /api/tool-signing/:flagId/reject', () => {
       .send({ reason: 'user_closed_tab' })
     expect(res.status).toBe(200)
     await expect(promise).rejects.toThrow('user_closed_tab')
+  })
+})
+
+describe('POST /api/tool-signing/:flagId/confirm — SIPHER_SIG_VERIFY=strict', () => {
+  beforeEach(() => {
+    process.env.SIPHER_SIG_VERIFY = 'strict'
+  })
+
+  it('returns 200 verified=true and resolves pending on verifier ok', async () => {
+    verifySignatureMock.mockResolvedValue({ ok: true, slot: 42 })
+    const { flagId, promise } = makePending()
+
+    const res = await supertest(createApp())
+      .post(`/api/tool-signing/${flagId}/confirm`)
+      .set('Authorization', `Bearer ${signJwt(WALLET)}`)
+      .send({ signature: 'SIG_OK' })
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ status: 'accepted', verified: true })
+    await expect(promise).resolves.toBe('SIG_OK')
+    expect(getPendingSigning(flagId)).toBeUndefined()
+    expect(verifySignatureMock).toHaveBeenCalledOnce()
+  })
+
+  it('rejects pending and returns 400 VALIDATION_FAILED on wallet_mismatch', async () => {
+    verifySignatureMock.mockResolvedValue({ ok: false, reason: 'wallet_mismatch' })
+    const { flagId, promise } = makePending()
+    promise.catch(() => {})
+
+    const res = await supertest(createApp())
+      .post(`/api/tool-signing/${flagId}/confirm`)
+      .set('Authorization', `Bearer ${signJwt(WALLET)}`)
+      .send({ signature: 'SIG' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_FAILED')
+    expect(res.body.error.message).toMatch(/wallet_mismatch/)
+    await expect(promise).rejects.toThrow(/verification_failed: wallet_mismatch/)
+    expect(getPendingSigning(flagId)).toBeUndefined()
+  })
+
+  it('rejects pending and returns 400 on not_confirmed', async () => {
+    verifySignatureMock.mockResolvedValue({
+      ok: false,
+      reason: 'not_confirmed',
+      detail: 'tx not found',
+    })
+    const { flagId, promise } = makePending()
+    promise.catch(() => {})
+
+    const res = await supertest(createApp())
+      .post(`/api/tool-signing/${flagId}/confirm`)
+      .set('Authorization', `Bearer ${signJwt(WALLET)}`)
+      .send({ signature: 'SIG' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_FAILED')
+    expect(res.body.error.message).toMatch(/not_confirmed/)
+  })
+
+  it('returns 503 UNAVAILABLE + Retry-After on rpc_error and keeps pending alive', async () => {
+    verifySignatureMock.mockResolvedValue({ ok: false, reason: 'rpc_error', detail: 'ETIMEDOUT' })
+    const { flagId, promise } = makePending()
+    promise.catch(() => {})
+
+    const res = await supertest(createApp())
+      .post(`/api/tool-signing/${flagId}/confirm`)
+      .set('Authorization', `Bearer ${signJwt(WALLET)}`)
+      .send({ signature: 'SIG' })
+
+    expect(res.status).toBe(503)
+    expect(res.body.error.code).toBe('UNAVAILABLE')
+    expect(res.headers['retry-after']).toBe('2')
+    expect(getPendingSigning(flagId)).toBeDefined()
+  })
+
+  it('returns 503 UNAVAILABLE + Retry-After on verifier timeout and keeps pending alive', async () => {
+    verifySignatureMock.mockResolvedValue({ ok: false, reason: 'timeout' })
+    const { flagId, promise } = makePending()
+    promise.catch(() => {})
+
+    const res = await supertest(createApp())
+      .post(`/api/tool-signing/${flagId}/confirm`)
+      .set('Authorization', `Bearer ${signJwt(WALLET)}`)
+      .send({ signature: 'SIG' })
+
+    expect(res.status).toBe(503)
+    expect(res.headers['retry-after']).toBe('2')
+    expect(getPendingSigning(flagId)).toBeDefined()
+  })
+
+  it('returns 503 when verifier itself throws (config or createConnection failure)', async () => {
+    verifySignatureMock.mockRejectedValue(new Error('config blew up'))
+    const { flagId, promise } = makePending()
+    promise.catch(() => {})
+
+    const res = await supertest(createApp())
+      .post(`/api/tool-signing/${flagId}/confirm`)
+      .set('Authorization', `Bearer ${signJwt(WALLET)}`)
+      .send({ signature: 'SIG' })
+
+    expect(res.status).toBe(503)
+    expect(res.headers['retry-after']).toBe('2')
+    expect(getPendingSigning(flagId)).toBeDefined()
+  })
+})
+
+describe('POST /api/tool-signing/:flagId/confirm — SIPHER_SIG_VERIFY=advisory', () => {
+  beforeEach(() => {
+    process.env.SIPHER_SIG_VERIFY = 'advisory'
+  })
+
+  it('resolves pending and returns 200 verified=false even when verifier fails', async () => {
+    verifySignatureMock.mockResolvedValue({ ok: false, reason: 'wallet_mismatch' })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { flagId, promise } = makePending()
+
+    const res = await supertest(createApp())
+      .post(`/api/tool-signing/${flagId}/confirm`)
+      .set('Authorization', `Bearer ${signJwt(WALLET)}`)
+      .send({ signature: 'SIG' })
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ status: 'accepted', verified: false })
+    await expect(promise).resolves.toBe('SIG')
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/advisory mode.*wallet_mismatch/))
+    warnSpy.mockRestore()
+  })
+
+  it('resolves and returns verified=false even on rpc_error (does NOT 503)', async () => {
+    verifySignatureMock.mockResolvedValue({ ok: false, reason: 'rpc_error' })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { flagId, promise } = makePending()
+
+    const res = await supertest(createApp())
+      .post(`/api/tool-signing/${flagId}/confirm`)
+      .set('Authorization', `Bearer ${signJwt(WALLET)}`)
+      .send({ signature: 'SIG' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.verified).toBe(false)
+    await expect(promise).resolves.toBe('SIG')
+    warnSpy.mockRestore()
+  })
+
+  it('reports verified=false even when verifier returns ok (advisory never marks verified=true)', async () => {
+    verifySignatureMock.mockResolvedValue({ ok: true, slot: 1 })
+    const { flagId, promise } = makePending()
+
+    const res = await supertest(createApp())
+      .post(`/api/tool-signing/${flagId}/confirm`)
+      .set('Authorization', `Bearer ${signJwt(WALLET)}`)
+      .send({ signature: 'SIG' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.verified).toBe(false)
+    await expect(promise).resolves.toBe('SIG')
+  })
+})
+
+describe('POST /api/tool-signing/:flagId/confirm — pre-verifier guards skip verifier', () => {
+  it('returns 404 NOT_FOUND without calling verifier when flagId is missing (strict mode)', async () => {
+    process.env.SIPHER_SIG_VERIFY = 'strict'
+
+    const res = await supertest(createApp())
+      .post('/api/tool-signing/unknown-id/confirm')
+      .set('Authorization', `Bearer ${signJwt(WALLET)}`)
+      .send({ signature: 'SIG' })
+
+    expect(res.status).toBe(404)
+    expect(verifySignatureMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 FORBIDDEN without calling verifier on JWT mismatch (strict mode)', async () => {
+    process.env.SIPHER_SIG_VERIFY = 'strict'
+    const { flagId, promise } = makePending()
+    promise.catch(() => {})
+
+    const res = await supertest(createApp())
+      .post(`/api/tool-signing/${flagId}/confirm`)
+      .set('Authorization', `Bearer ${signJwt(OTHER_WALLET)}`)
+      .send({ signature: 'SIG' })
+
+    expect(res.status).toBe(403)
+    expect(verifySignatureMock).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 VALIDATION_FAILED without calling verifier on empty signature (strict mode)', async () => {
+    process.env.SIPHER_SIG_VERIFY = 'strict'
+    const { flagId, promise } = makePending()
+    promise.catch(() => {})
+
+    const res = await supertest(createApp())
+      .post(`/api/tool-signing/${flagId}/confirm`)
+      .set('Authorization', `Bearer ${signJwt(WALLET)}`)
+      .send({ signature: '' })
+
+    expect(res.status).toBe(400)
+    expect(verifySignatureMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/agent/tests/sentinel/verify-signature.test.ts
+++ b/packages/agent/tests/sentinel/verify-signature.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { Connection } from '@solana/web3.js'
+import { verifySignature } from '../../src/sentinel/verify-signature.js'
+import type { PendingSigningFlag } from '../../src/sentinel/pending-signing.js'
+
+const ENTRY: PendingSigningFlag = {
+  sessionId: 's1',
+  toolName: 'send',
+  wallet: 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N',
+  serializedTx: 'BASE64TX',
+  network: 'devnet',
+  toolInput: {},
+  createdAt: 0,
+  resolver: () => {},
+  rejecter: () => {},
+  timeoutHandle: setTimeout(() => {}, 0) as unknown as NodeJS.Timeout,
+}
+clearTimeout(ENTRY.timeoutHandle)
+
+const SIGNATURE = '3QCoHcJ1NNg_fake_for_tests'
+
+function makeConnection(overrides: Partial<{
+  getSignatureStatuses: typeof Connection.prototype.getSignatureStatuses
+  getTransaction: typeof Connection.prototype.getTransaction
+}>): Connection {
+  const conn = {
+    getSignatureStatuses:
+      overrides.getSignatureStatuses ??
+      vi.fn().mockResolvedValue({ value: [null] }),
+    getTransaction:
+      overrides.getTransaction ?? vi.fn().mockResolvedValue(null),
+  } as unknown as Connection
+  return conn
+}
+
+describe('verifySignature', () => {
+  it('returns ok when signature is confirmed and fee payer matches entry.wallet', async () => {
+    const connection = makeConnection({
+      getSignatureStatuses: vi.fn().mockResolvedValue({
+        value: [{ slot: 42, confirmationStatus: 'confirmed', err: null }],
+      }),
+      getTransaction: vi.fn().mockResolvedValue({
+        transaction: {
+          message: {
+            accountKeys: [
+              { toBase58: () => ENTRY.wallet },
+              { toBase58: () => 'Other11111111111111111111111111111111111111' },
+            ],
+          },
+        },
+      }),
+    })
+
+    const result = await verifySignature(SIGNATURE, ENTRY, { connection })
+    expect(result).toEqual({ ok: true, slot: 42 })
+  })
+
+  it('accepts finalized confirmationStatus', async () => {
+    const connection = makeConnection({
+      getSignatureStatuses: vi.fn().mockResolvedValue({
+        value: [{ slot: 99, confirmationStatus: 'finalized', err: null }],
+      }),
+      getTransaction: vi.fn().mockResolvedValue({
+        transaction: {
+          message: {
+            accountKeys: [{ toBase58: () => ENTRY.wallet }],
+          },
+        },
+      }),
+    })
+
+    const result = await verifySignature(SIGNATURE, ENTRY, { connection })
+    expect(result.ok).toBe(true)
+  })
+
+  it('returns not_confirmed when getSignatureStatuses returns null', async () => {
+    const connection = makeConnection({
+      getSignatureStatuses: vi.fn().mockResolvedValue({ value: [null] }),
+    })
+    const result = await verifySignature(SIGNATURE, ENTRY, { connection })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('not_confirmed')
+  })
+
+  it('returns not_confirmed when err is set on the status', async () => {
+    const connection = makeConnection({
+      getSignatureStatuses: vi.fn().mockResolvedValue({
+        value: [{ slot: 1, confirmationStatus: 'confirmed', err: { InstructionError: [0, 'Custom'] } }],
+      }),
+    })
+    const result = await verifySignature(SIGNATURE, ENTRY, { connection })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.reason).toBe('not_confirmed')
+      expect(result.detail).toMatch(/InstructionError|Custom/)
+    }
+  })
+
+  it('returns not_confirmed when confirmationStatus is "processed"', async () => {
+    const connection = makeConnection({
+      getSignatureStatuses: vi.fn().mockResolvedValue({
+        value: [{ slot: 1, confirmationStatus: 'processed', err: null }],
+      }),
+    })
+    const result = await verifySignature(SIGNATURE, ENTRY, { connection })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('not_confirmed')
+  })
+
+  it('returns wallet_mismatch when fee payer differs from entry.wallet', async () => {
+    const connection = makeConnection({
+      getSignatureStatuses: vi.fn().mockResolvedValue({
+        value: [{ slot: 7, confirmationStatus: 'confirmed', err: null }],
+      }),
+      getTransaction: vi.fn().mockResolvedValue({
+        transaction: {
+          message: {
+            accountKeys: [
+              { toBase58: () => 'SomeOtherWallet11111111111111111111111111111' },
+            ],
+          },
+        },
+      }),
+    })
+    const result = await verifySignature(SIGNATURE, ENTRY, { connection })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('wallet_mismatch')
+  })
+
+  it('returns not_confirmed when getTransaction returns null after confirmed status', async () => {
+    const connection = makeConnection({
+      getSignatureStatuses: vi.fn().mockResolvedValue({
+        value: [{ slot: 7, confirmationStatus: 'confirmed', err: null }],
+      }),
+      getTransaction: vi.fn().mockResolvedValue(null),
+    })
+    const result = await verifySignature(SIGNATURE, ENTRY, { connection })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('not_confirmed')
+  })
+
+  it('returns rpc_error when getSignatureStatuses throws', async () => {
+    const connection = makeConnection({
+      getSignatureStatuses: vi.fn().mockRejectedValue(new Error('connect ETIMEDOUT')),
+    })
+    const result = await verifySignature(SIGNATURE, ENTRY, { connection })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.reason).toBe('rpc_error')
+      expect(result.detail).toMatch(/ETIMEDOUT/)
+    }
+  })
+
+  it('returns rpc_error when getTransaction throws', async () => {
+    const connection = makeConnection({
+      getSignatureStatuses: vi.fn().mockResolvedValue({
+        value: [{ slot: 5, confirmationStatus: 'confirmed', err: null }],
+      }),
+      getTransaction: vi.fn().mockRejectedValue(new Error('rpc 500')),
+    })
+    const result = await verifySignature(SIGNATURE, ENTRY, { connection })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('rpc_error')
+  })
+
+  it('returns timeout when verification exceeds timeoutMs', async () => {
+    const connection = makeConnection({
+      getSignatureStatuses: vi.fn().mockImplementation(
+        () => new Promise(() => {}), // never resolves
+      ),
+    })
+    const result = await verifySignature(SIGNATURE, ENTRY, { connection, timeoutMs: 30 })
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.reason).toBe('timeout')
+  })
+})


### PR DESCRIPTION
## Summary

Implements [Spec 3](https://github.com/sip-protocol/sipher/blob/main/docs/superpowers/specs/2026-05-15-server-side-sig-verification-design.md) from PR #276. Closes the trust gap in `POST /api/tool-signing/:flagId/confirm` — today the route accepts whatever signature the client posts at face value. A compromised browser, buggy client, or replay attack can submit syntactically-valid garbage and Torque attribution fires for a non-existent transaction.

## Three-tier design (T1 + T2 shipped, T3 deferred)

| Tier | Check | Catches | RPC |
|---|---|---|---|
| **T1** | `getSignatureStatuses` → `confirmed`/`finalized` AND no err | Fake signatures, failed txs, in-flight | 1 call |
| **T2** | `getTransaction` → fee payer (accountKeys[0]) === entry.wallet | Signature from a different wallet's tx | 1 call |
| ~~T3~~ | Decoded instructions match entry.serializedTx | Wallet-substituted tx | Deferred (spec) |

`'processed'` confirmation rejected — too early for telemetry to trust. `'confirmed'` is used for the commitment level (not `'finalized'`) to keep UX latency bounded.

## SIPHER_SIG_VERIFY rollout posture

Three modes mirroring the `SENTINEL_MODE` precedent:

- **strict** (code default) — verify; reject pending + 4xx on failure; 503 + Retry-After on RPC unavailability
- **advisory** — verify, log on failure, still resolve. Used for soak-testing the verifier without UX impact
- **off** — skip entirely (legacy behavior)

`.env.example` ships **`SIPHER_SIG_VERIFY=advisory`** as the safe first-deploy default so operators can promote to `strict` after observation — matching the SENTINEL_MODE rollout pattern.

## Third PR exercising assertNever

`VerifyResult` is a discriminated union; the confirm route's switch on `result.reason` composes with the [PR #277](https://github.com/sip-protocol/sipher/pull/277) assertNever guard. Adding a new reason (e.g. `'tx_invalid_signature'`) in the future will surface as a typecheck error at every consumer switch. Spec 1's pattern in continued use across the spec chain.

## Test plan

- [x] Verifier unit tests: **10** (`tests/sentinel/verify-signature.test.ts`)
  - confirmed + matching fee payer → ok
  - finalized status accepted
  - status null / err set / `'processed'` → not_confirmed
  - fee payer mismatch → wallet_mismatch
  - getTransaction null → not_confirmed
  - throws on either RPC call → rpc_error
  - never resolves → timeout (via Promise.race)
- [x] Route tests: **12** new + **9** existing preserved (`tests/routes/tool-signing-routes.test.ts`)
  - strict mode: ok / wallet_mismatch / not_confirmed / rpc_error 503 / timeout 503 / verifier throws 503
  - advisory mode: failure → 200 verified=false + warn / rpc_error stays 200 / verifier ok → still verified=false
  - off mode: never calls verifier
  - pre-verifier guards (404 / 403 / 400) never invoke verifier
- [x] Backend: 1580 → 1602 (+22)
- [x] `cd packages/agent && pnpm exec tsc --noEmit` clean
- [x] App tests unaffected (route is backend-only; frontend ignores the additive `verified` field)
- [x] GPG-signed commit
- [x] No AI-attribution trailers

## Spec deviations

**Test file consolidation.** Spec proposed a fresh `tests/routes/tool-signing.test.ts`. Existing repo file is `tool-signing-routes.test.ts`. Created the duplicate first, hit module-level state races on `pending-signing.ts`'s Map, then consolidated into the existing file. Adds `SIPHER_SIG_VERIFY=off` to beforeEach so the original 9 base tests preserve their semantics; the one strict-equality assertion (`toEqual({ status: 'accepted' })`) was tightened to include the new `verified: false` field.

**`extractFeePayer` helper.** Versioned messages expose `staticAccountKeys`; legacy messages use `accountKeys`. Real Solana RPC with `maxSupportedTransactionVersion: 0` returns versioned. Mocks in tests still use the simpler `accountKeys` shape. Helper handles both — and a string-vs-object form of the key for paranoia.

## Out of scope (per spec)

- **T3 (instruction-match):** residual surface where a wallet signs a different tx than what the server serialized. Tracked as follow-up.
- **Replay dedupe:** same signature used for two flagIds slips through T1+T2. LRU in growth-hook is the suggested mitigation.
- **Helius webhook alternative:** push-based confirmations instead of RPC polling. Bigger build.

## Stacked atop

- PR #275 (slug fix — merged)
- PR #277 (assertNever — merged)
- PR #278 (tool_signing_expired SSE — merged)

This is PR 3-of-5 in the spec implementation chain. Specs 4 (claim Phase 2) and 5 (scheduled-op broadcasts) both reference this verifier in their compose sections — landing this enables their cleaner implementation.

## Spec reference

`docs/superpowers/specs/2026-05-15-server-side-sig-verification-design.md`