### PR TITLE
feat(claim): Phase 2 Path A — SDK-driven claim flow with claim-tx-sig attribution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build workspace SDK (consumed by agent + tests)
+        run: pnpm -r --filter @sipher/sdk run build
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/docs/superpowers/plans/2026-05-17-claim-phase-2-path-a.md
+++ b/docs/superpowers/plans/2026-05-17-claim-phase-2-path-a.md
@@ -4,9 +4,11 @@
 
 **Goal:** Replace the Phase 1 claim stub with a real, end-to-end SDK-driven claim flow so `sipher_private_claim_completed` Torque events fire with the actual claim transaction signature instead of the deposit transaction signature.
 
-**Architecture:** Delegate cryptography and broadcast to `@sip-protocol/sdk`'s `claimStealthPayment(params)` primitive, which derives the stealth private key via ECDH, builds an SPL transfer from the stealth ATA to the recipient's destination ATA, signs as the stealth keypair (paying fees from the stealth address's SOL balance), and broadcasts in one server-side call. Sipher's `executeClaim` resolves the stealth context (stealth address, ephemeral public key, mint) from the deposit transaction via `getParsedTransaction`, then hands off to the SDK. A new `signature` field on `ClaimToolResult` carries the claim transaction signature; the existing growth-hook `extractTxSignature` already prefers `signature` over `txSignature` (growth-hook.ts:104), so attribution becomes correct without touching the hook.
+**Architecture:** Delegate cryptography and broadcast to `@sip-protocol/sdk`'s `claimStealthPayment(params)` primitive, which derives the stealth private key via ECDH, builds an SPL transfer from the stealth ATA to the recipient's destination ATA, signs as the stealth keypair (paying fees from the stealth address's SOL balance), and broadcasts in one server-side call. Sipher's `executeClaim` resolves the stealth context (stealth address, ephemeral public key, mint) from the deposit transaction by parsing the Anchor `VaultWithdrawEvent` emitted by `sipher_vault`'s `withdraw_private` instruction (mirroring sipher's own `scanForPayments` at `packages/sdk/src/privacy.ts:300-454`), plus finding the SPL `transferChecked` instruction (top-level + inner — to cover Jupiter swap routes — across both `spl-token` and `spl-token-2022`). It then hands off to the SDK. A new `signature` field on `ClaimToolResult` carries the claim transaction signature; the existing growth-hook `extractTxSignature` already prefers `signature` over `txSignature` (growth-hook.ts:104), so attribution becomes correct without touching the hook.
 
-**Tech Stack:** TypeScript (strict, NodeNext ESM with .js suffixes), @sip-protocol/sdk@^0.7.4 (`claimStealthPayment`, `parseAnnouncement`, `SolanaClaimResult`), @sipher/sdk (workspace) for `createConnection` + `USDC_MINT` + `resolveTokenMint`, @solana/web3.js (`Connection`, `PublicKey`, `getParsedTransaction`), vitest 3.x with `vi.mock` for SDK isolation.
+**Tech Stack:** TypeScript (strict, NodeNext ESM with .js suffixes), @sip-protocol/sdk@^0.7.4 (`claimStealthPayment`, `SolanaClaimResult`), @sipher/sdk (workspace) for `createConnection` + `USDC_MINT`, @solana/web3.js (`Connection`, `PublicKey`, `getParsedTransaction`, `ParsedInstruction`), vitest 3.x with `vi.mock` for SDK isolation, Node `Buffer` for VaultWithdrawEvent byte parsing.
+
+**Plan revision note (2026-05-17):** Original plan assumed sipher's deposits emit an `spl-memo` instruction with `SIP:1:<eph>:<vt>` format (matching the SDK's standalone `sendStealthPayment` flow). Code review caught that sipher's actual production flow uses the vault's `withdraw_private` instruction which emits the announcement as an Anchor `VaultWithdrawEvent` in `tx.meta.logMessages` — there is no SPL memo. This revision rewrites Tasks 1 + 2 to parse the event-log format that sipher's own `scanForPayments` already uses (single source of truth for both scan AND claim event parsing). Reviewer also flagged `spl-token-2022` and inner-instruction support gaps; both are addressed in this revision.
 
 **Spec reference:** `docs/superpowers/specs/2026-05-15-claim-phase-2-design.md` — specifically the "Amendment — SDK reality check" section (lines 300–420) which documents Path A's scope and trade-offs.
 
@@ -15,7 +17,7 @@
 ## File Structure
 
 **Create:**
-- `packages/agent/src/tools/claim-helpers.ts` — pure async helpers for stealth-context resolution and destination/mint resolution. Pure functions where possible; the one IO call (`resolveStealthContext`) accepts an injected `Connection` so tests can mock it. No persistent state, no top-level side effects.
+- `packages/agent/src/tools/claim-helpers.ts` — pure async helpers for stealth-context resolution from sipher's `VaultWithdrawEvent` log + SPL `transferChecked` instruction (top-level OR inner, `spl-token` OR `spl-token-2022`). Two IO calls (`getParsedTransaction` + `getParsedAccountInfo`) accept an injected `Connection` so tests can mock them. No persistent state, no top-level side effects.
 - `packages/agent/tests/tools/claim-helpers.test.ts` — vitest suite covering the three helpers' happy + error paths.
 
 **Modify:**
@@ -53,7 +55,9 @@ Expected: typecheck clean, all 1602 agent tests pass.
 
 ## Task 1: Add `resolveStealthContext` helper (RED → GREEN)
 
-Resolves the deposit transaction into the stealth address + ephemeral public key + mint needed by the SDK's claim primitive. Pure async — accepts injected `Connection`, makes one `getParsedTransaction` call, parses the result.
+Resolves the deposit transaction into the stealth address + ephemeral public key + mint needed by the SDK's claim primitive. Reads sipher's `VaultWithdrawEvent` from the tx's `meta.logMessages` (mirroring `packages/sdk/src/privacy.ts:300-454`), then finds the SPL `transferChecked` instruction (top-level or inner, `spl-token` or `spl-token-2022`) for mint + stealth ATA. Sanity-checks the stealth ATA owner matches the event's stealth_recipient.
+
+**Why this shape:** Sipher's `withdraw_private` flow does NOT emit an SPL memo. It emits an Anchor `VaultWithdrawEvent` (layout in `parseWithdrawEvent` at `packages/sdk/src/privacy.ts:413-454`). The same parser is used here for symmetry with sipher's `scan` tool — one source of truth for event-decode logic.
 
 **Files:**
 - Create: `packages/agent/src/tools/claim-helpers.ts`
@@ -64,8 +68,9 @@ Resolves the deposit transaction into the stealth address + ephemeral public key
 Create `packages/agent/tests/tools/claim-helpers.test.ts`:
 
 ```ts
+import { Buffer } from 'node:buffer'
 import { describe, it, expect, vi } from 'vitest'
-import type { Connection } from '@solana/web3.js'
+import { PublicKey, type Connection } from '@solana/web3.js'
 import { resolveStealthContext, StealthContextError } from '../../src/tools/claim-helpers.js'
 
 const DEPOSIT_SIG =
@@ -75,39 +80,87 @@ const EPHEMERAL_PUBKEY = 'GqvBwYTWWZRyDQ4ZeNvFLgfbA8wYjBvE6cKxFQXjHvSr'
 const STEALTH_ATA = 'AfPXfQs5MNJyEnUYvxRJ6BHwQNyKqJVE9Y3CDbHwfXVc'
 const MINT_USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
 
-function mockTxWithMemoAndSplTransfer() {
+/**
+ * Build a synthetic VaultWithdrawEvent buffer matching the on-chain layout
+ * documented at packages/sdk/src/privacy.ts:401-411. Total 194 bytes (minimum).
+ */
+function buildWithdrawEventBytes(opts: {
+  stealthBs58?: string
+  ephemeralBs58?: string
+  zeroEphemeral?: boolean
+}): Buffer {
+  const buf = Buffer.alloc(194)
+  // [0, 8)  — Anchor event discriminator (arbitrary bytes; sipher doesn't validate)
+  buf.write('0011223344556677', 0, 'hex')
+  // [8, 40) — depositor (zeros, not used by resolver)
+  // [40, 72) — stealth_recipient
+  const stealth = new PublicKey(opts.stealthBs58 ?? STEALTH_PUBKEY).toBytes()
+  Buffer.from(stealth).copy(buf, 40)
+  // [72, 105) — amount_commitment (zeros)
+  // [105, 138) — ephemeral_pubkey: 0x00 prefix + 32-byte ed25519 (per privacy.ts:339-341)
+  buf[105] = 0x00
+  if (opts.zeroEphemeral) {
+    // intentionally leave [106..138] as zeros — should be skipped by resolver
+  } else {
+    const eph = new PublicKey(opts.ephemeralBs58 ?? EPHEMERAL_PUBKEY).toBytes()
+    Buffer.from(eph).copy(buf, 106)
+  }
+  // [138, 170) — viewing_key_hash (zeros)
+  // [170, 178) — transfer_amount (zeros)
+  // [178, 186) — fee_amount (zeros)
+  // [186, 194) — timestamp (zeros)
+  return buf
+}
+
+function programDataLog(eventBytes: Buffer): string {
+  return `Program data: ${eventBytes.toString('base64')}`
+}
+
+/**
+ * Synthesize a parsed-tx response shape matching @solana/web3.js's
+ * `ParsedTransactionWithMeta` for unit testing. Real responses contain
+ * many more fields; the resolver only reads the keys touched below.
+ */
+function mockTxWithEventAndSplTransfer(opts: { tokenProgram?: 'spl-token' | 'spl-token-2022'; inner?: boolean } = {}) {
+  const tokenProgram = opts.tokenProgram ?? 'spl-token'
+  const splTokenIx = {
+    program: tokenProgram,
+    programId: new PublicKey(
+      tokenProgram === 'spl-token-2022'
+        ? 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'
+        : 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    ),
+    parsed: {
+      type: 'transferChecked',
+      info: {
+        destination: STEALTH_ATA,
+        mint: MINT_USDC,
+        tokenAmount: { amount: '1000000', decimals: 6 },
+      },
+    },
+  }
   return {
     transaction: {
       message: {
-        instructions: [
-          {
-            program: 'spl-memo',
-            programId: { toString: () => 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr' },
-            parsed: `SIP:1:${EPHEMERAL_PUBKEY}:a3`,
-          },
-          {
-            program: 'spl-token',
-            programId: { toString: () => 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' },
-            parsed: {
-              type: 'transferChecked',
-              info: {
-                destination: STEALTH_ATA,
-                mint: MINT_USDC,
-                tokenAmount: { amount: '1000000', decimals: 6 },
-              },
-            },
-          },
-        ],
+        instructions: opts.inner ? [] : [splTokenIx],
       },
     },
-    meta: { err: null },
+    meta: {
+      err: null,
+      logMessages: [
+        'Program S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB invoke [1]',
+        programDataLog(buildWithdrawEventBytes({})),
+        'Program S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB success',
+      ],
+      innerInstructions: opts.inner ? [{ index: 0, instructions: [splTokenIx] }] : [],
+    },
   }
 }
 
 describe('resolveStealthContext — happy path', () => {
-  it('returns stealth address, ephemeral pubkey, and mint from a parsed deposit', async () => {
+  it('returns stealth address, ephemeral pubkey, and mint from a VaultWithdrawEvent log + top-level SPL transfer', async () => {
     const mockConnection = {
-      getParsedTransaction: vi.fn().mockResolvedValue(mockTxWithMemoAndSplTransfer()),
+      getParsedTransaction: vi.fn().mockResolvedValue(mockTxWithEventAndSplTransfer()),
       getParsedAccountInfo: vi.fn().mockResolvedValue({
         value: { data: { parsed: { info: { owner: STEALTH_PUBKEY, mint: MINT_USDC } } } },
       }),
@@ -133,17 +186,22 @@ Expected: FAIL with `Cannot find module '../../src/tools/claim-helpers.js'`.
 Create `packages/agent/src/tools/claim-helpers.ts`:
 
 ```ts
-import { PublicKey, type Connection } from '@solana/web3.js'
+import { Buffer } from 'node:buffer'
+import {
+  PublicKey,
+  type Connection,
+  type ParsedInstruction,
+  type PartiallyDecodedInstruction,
+} from '@solana/web3.js'
 
 export class StealthContextError extends Error {
   constructor(
     message: string,
     public readonly code:
       | 'deposit_not_found'
-      | 'no_announcement_memo'
-      | 'invalid_announcement'
+      | 'no_withdraw_event'
       | 'no_token_transfer'
-      | 'stealth_ata_unreadable',
+      | 'stealth_ata_mismatch',
   ) {
     super(message)
     this.name = 'StealthContextError'
@@ -151,18 +209,34 @@ export class StealthContextError extends Error {
 }
 
 export interface StealthContext {
-  /** Base58-encoded stealth pubkey (owner of the stealth ATA). */
+  /** Base58-encoded stealth pubkey (must equal the stealth ATA's owner). */
   stealthAddress: string
-  /** Base58-encoded ephemeral pubkey parsed from the announcement memo. */
+  /** Base58-encoded ephemeral pubkey (32 bytes, 0x00 prefix already stripped). */
   ephemeralPublicKey: string
   /** Base58-encoded SPL token mint of the stealth ATA. */
   mint: string
 }
 
+const PROGRAM_DATA_PREFIX = 'Program data: '
+/**
+ * Minimum VaultWithdrawEvent bytes:
+ * 8 (disc) + 32 (depositor) + 32 (stealth) + 33 (commitment) + 33 (ephemeral)
+ *  + 32 (vk_hash) + 8 (amount) + 8 (fee) + 8 (ts) = 194
+ */
+const WITHDRAW_EVENT_MIN_BYTES = 194
+const SPL_TOKEN_PROGRAMS = new Set(['spl-token', 'spl-token-2022'])
+
+function isParsedInstruction(
+  ix: ParsedInstruction | PartiallyDecodedInstruction,
+): ix is ParsedInstruction {
+  return 'program' in ix && 'parsed' in ix
+}
+
 /**
  * Resolves a deposit transaction signature into the cryptographic context
- * needed by `claimStealthPayment`. One RPC call (getParsedTransaction)
- * plus optional account lookup for the stealth ATA owner.
+ * needed by `claimStealthPayment`. Two RPC calls: one `getParsedTransaction`
+ * (to read the VaultWithdrawEvent log + SPL transfer instruction) and one
+ * `getParsedAccountInfo` (to sanity-check the stealth ATA's owner).
  */
 export async function resolveStealthContext(
   connection: Connection,
@@ -180,71 +254,117 @@ export async function resolveStealthContext(
     )
   }
 
-  const instructions = tx.transaction.message.instructions
-  const memoIx = instructions.find(
-    (ix): ix is typeof ix & { parsed: string } =>
-      'program' in ix && ix.program === 'spl-memo' && typeof (ix as { parsed?: unknown }).parsed === 'string',
-  )
-  if (!memoIx) {
+  const event = parseWithdrawEventFromLogs(tx.meta?.logMessages ?? [])
+  if (!event) {
     throw new StealthContextError(
-      `No announcement memo in deposit ${depositTxSignature.slice(0, 12)}...`,
-      'no_announcement_memo',
+      `No VaultWithdrawEvent in deposit ${depositTxSignature.slice(0, 12)}... — is this a sipher private send?`,
+      'no_withdraw_event',
     )
   }
 
-  const announcement = parseAnnouncementMemo(memoIx.parsed)
-  if (!announcement) {
-    throw new StealthContextError(
-      `Announcement memo is malformed: ${memoIx.parsed.slice(0, 32)}...`,
-      'invalid_announcement',
-    )
-  }
+  const topLevel = tx.transaction.message.instructions
+  const inner = (tx.meta?.innerInstructions ?? []).flatMap((g) => g.instructions)
+  const allInstructions: ReadonlyArray<ParsedInstruction | PartiallyDecodedInstruction> = [
+    ...topLevel,
+    ...inner,
+  ]
 
-  const tokenIx = instructions.find(
-    (ix): ix is typeof ix & { parsed: { type: string; info: { destination: string; mint: string } } } =>
-      'program' in ix &&
-      ix.program === 'spl-token' &&
-      typeof (ix as { parsed?: { type?: string } }).parsed === 'object' &&
-      (ix as { parsed?: { type?: string } }).parsed?.type === 'transferChecked',
-  )
+  const tokenIx = allInstructions.filter(isParsedInstruction).find((ix) => {
+    if (!SPL_TOKEN_PROGRAMS.has(ix.program)) return false
+    const parsed = ix.parsed as { type?: string; info?: unknown } | string | null
+    if (typeof parsed !== 'object' || parsed === null) return false
+    if (parsed.type !== 'transferChecked') return false
+    if (typeof parsed.info !== 'object' || parsed.info === null) return false
+    return true
+  })
   if (!tokenIx) {
     throw new StealthContextError(
-      `No SPL token transfer instruction in deposit ${depositTxSignature.slice(0, 12)}...`,
+      `No SPL transferChecked instruction in deposit ${depositTxSignature.slice(0, 12)}...`,
       'no_token_transfer',
     )
   }
 
-  const stealthATA = tokenIx.parsed.info.destination
-  const mint = tokenIx.parsed.info.mint
+  const tokenInfo = (tokenIx.parsed as { info: { destination?: unknown; mint?: unknown } }).info
+  const stealthATA = typeof tokenInfo.destination === 'string' ? tokenInfo.destination : null
+  const mint = typeof tokenInfo.mint === 'string' ? tokenInfo.mint : null
+  if (!stealthATA || !mint) {
+    throw new StealthContextError(
+      `SPL transferChecked missing destination or mint in deposit ${depositTxSignature.slice(0, 12)}...`,
+      'no_token_transfer',
+    )
+  }
 
   const ataInfo = await connection.getParsedAccountInfo(new PublicKey(stealthATA))
-  const parsed = (ataInfo?.value?.data as { parsed?: { info?: { owner?: string } } } | undefined)?.parsed
-  const stealthAddress = parsed?.info?.owner
-  if (!stealthAddress) {
+  const ataData = ataInfo?.value?.data
+  const ataOwner =
+    ataData && typeof ataData === 'object' && 'parsed' in ataData
+      ? ((ataData.parsed as { info?: { owner?: unknown } } | undefined)?.info?.owner ?? null)
+      : null
+  if (typeof ataOwner !== 'string') {
     throw new StealthContextError(
-      `Stealth ATA ${stealthATA.slice(0, 12)}... is unreadable or not a token account`,
-      'stealth_ata_unreadable',
+      `Stealth ATA ${stealthATA.slice(0, 12)}... is unreadable or not a parsed token account`,
+      'stealth_ata_mismatch',
+    )
+  }
+  if (ataOwner !== event.stealthAddress) {
+    throw new StealthContextError(
+      `Stealth ATA owner ${ataOwner.slice(0, 12)}... does not match VaultWithdrawEvent stealth_recipient ${event.stealthAddress.slice(0, 12)}...`,
+      'stealth_ata_mismatch',
     )
   }
 
   return {
-    stealthAddress,
-    ephemeralPublicKey: announcement.ephemeralPublicKey,
+    stealthAddress: event.stealthAddress,
+    ephemeralPublicKey: event.ephemeralPublicKey,
     mint,
   }
 }
 
-function parseAnnouncementMemo(memo: string): { ephemeralPublicKey: string } | null {
-  // Format: SIP:1:<ephemeral_pubkey_base58>:<view_tag_hex>
-  const parts = memo.split(':')
-  if (parts.length !== 4) return null
-  if (parts[0] !== 'SIP' || parts[1] !== '1') return null
-  if (!parts[2] || parts[2].length < 32) return null
-  return { ephemeralPublicKey: parts[2] }
+interface WithdrawEvent {
+  stealthAddress: string
+  ephemeralPublicKey: string
+}
+
+/**
+ * Parses the first decode-able VaultWithdrawEvent out of `Program data: <b64>`
+ * log lines. Mirrors `parseWithdrawEvent` in packages/sdk/src/privacy.ts:413-454
+ * (no discriminator check — matches sipher's scan behavior; relies on the
+ * 194-byte length floor and the downstream ATA-owner equality check to
+ * filter spurious decodes).
+ */
+function parseWithdrawEventFromLogs(logs: string[]): WithdrawEvent | null {
+  for (const log of logs) {
+    if (!log.startsWith(PROGRAM_DATA_PREFIX)) continue
+    const b64 = log.slice(PROGRAM_DATA_PREFIX.length).trim()
+    if (!b64) continue
+    let data: Buffer
+    try {
+      data = Buffer.from(b64, 'base64')
+    } catch {
+      continue
+    }
+    if (data.length < WITHDRAW_EVENT_MIN_BYTES) continue
+    try {
+      // Layout (after 8-byte discriminator): depositor[32] | stealth[32]
+      //   | commitment[33] | ephemeral[33] | vk_hash[32] | amount[8] | fee[8] | ts[8]
+      const stealthBytes = data.subarray(40, 72)
+      const stealthAddress = new PublicKey(stealthBytes).toBase58()
+      // Ephemeral is 33 bytes (0x00 prefix + 32-byte ed25519); strip prefix.
+      const ephRaw = data[105] === 0x00 ? data.subarray(106, 138) : data.subarray(105, 137)
+      if (ephRaw.length !== 32) continue
+      // Skip pre-integration placeholder events with zero-filled ephemeral.
+      if (ephRaw.every((b) => b === 0)) continue
+      const ephemeralPublicKey = new PublicKey(ephRaw).toBase58()
+      return { stealthAddress, ephemeralPublicKey }
+    } catch {
+      continue // not a VaultWithdrawEvent layout; try next log
+    }
+  }
+  return null
 }
 ```
 
-Note: `getParsedAccountInfo` returns `{ value: { data: { parsed: { info: { owner } } } } }` for SPL token ATAs (the `jsonParsed` encoding is automatic for known programs). The Task 1 test fixture mock must match this shape — update the `getAccountInfo` mock to `getParsedAccountInfo` returning `{ value: { data: { parsed: { info: { owner: STEALTH_PUBKEY, mint: MINT_USDC } } } } }`.
+Note: `getParsedAccountInfo` returns `{ value: { data: { parsed: { info: { owner } } } } }` for SPL token ATAs (the `jsonParsed` encoding is automatic for known programs).
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -256,97 +376,205 @@ Expected: PASS.
 
 ```bash
 git add packages/agent/src/tools/claim-helpers.ts packages/agent/tests/tools/claim-helpers.test.ts
-git commit -m "feat(claim): add resolveStealthContext helper for deposit tx parsing"
+git commit -m "feat(claim): add resolveStealthContext helper parsing VaultWithdrawEvent"
 ```
 
 ---
 
-## Task 2: Add error path tests + handlers for `resolveStealthContext` (RED → GREEN)
+## Task 2: Add additional happy-path variants + error path tests for `resolveStealthContext` (RED → GREEN)
+
+Three additional happy-path variants (spl-token-2022 program, inner-instruction-only, heterogeneous instruction array with a PartiallyDecodedInstruction mixed in) plus four error-path tests covering the four discriminated error codes. The variants exercise the type guard's resilience to real `getParsedTransaction` shape diversity — the basic Task 1 test only covers the simplest case.
 
 **Files:**
 - Modify: `packages/agent/tests/tools/claim-helpers.test.ts`
 
-- [ ] **Step 1: Write failing tests for the four error codes**
+- [ ] **Step 1: Write failing tests for happy-path variants + error codes**
 
 Append to `packages/agent/tests/tools/claim-helpers.test.ts`:
 
 ```ts
-describe('resolveStealthContext — error paths', () => {
-  const DEPOSIT_SIG_NF = 'NotFoundTxSignaturePlaceholderXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+describe('resolveStealthContext — happy-path variants', () => {
+  it('handles spl-token-2022 transferChecked', async () => {
+    const mockConnection = {
+      getParsedTransaction: vi
+        .fn()
+        .mockResolvedValue(mockTxWithEventAndSplTransfer({ tokenProgram: 'spl-token-2022' })),
+      getParsedAccountInfo: vi.fn().mockResolvedValue({
+        value: { data: { parsed: { info: { owner: STEALTH_PUBKEY, mint: MINT_USDC } } } },
+      }),
+    } as unknown as Connection
 
+    const ctx = await resolveStealthContext(mockConnection, DEPOSIT_SIG)
+    expect(ctx.stealthAddress).toBe(STEALTH_PUBKEY)
+    expect(ctx.mint).toBe(MINT_USDC)
+  })
+
+  it('finds SPL transferChecked in inner instructions (Jupiter-routed deposit)', async () => {
+    const mockConnection = {
+      getParsedTransaction: vi
+        .fn()
+        .mockResolvedValue(mockTxWithEventAndSplTransfer({ inner: true })),
+      getParsedAccountInfo: vi.fn().mockResolvedValue({
+        value: { data: { parsed: { info: { owner: STEALTH_PUBKEY, mint: MINT_USDC } } } },
+      }),
+    } as unknown as Connection
+
+    const ctx = await resolveStealthContext(mockConnection, DEPOSIT_SIG)
+    expect(ctx.stealthAddress).toBe(STEALTH_PUBKEY)
+    expect(ctx.mint).toBe(MINT_USDC)
+  })
+
+  it('skips PartiallyDecodedInstruction entries when searching for SPL transferChecked', async () => {
+    const splTokenIx = {
+      program: 'spl-token',
+      programId: new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+      parsed: {
+        type: 'transferChecked',
+        info: {
+          destination: STEALTH_ATA,
+          mint: MINT_USDC,
+          tokenAmount: { amount: '1000000', decimals: 6 },
+        },
+      },
+    }
+    const partiallyDecoded = {
+      programId: new PublicKey('ComputeBudget111111111111111111111111111111'),
+      accounts: [],
+      data: 'AwBAQg8AAAAA',
+      // No `program` or `parsed` field — PartiallyDecodedInstruction shape
+    }
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue({
+        transaction: { message: { instructions: [partiallyDecoded, splTokenIx] } },
+        meta: {
+          err: null,
+          logMessages: [programDataLog(buildWithdrawEventBytes({}))],
+          innerInstructions: [],
+        },
+      }),
+      getParsedAccountInfo: vi.fn().mockResolvedValue({
+        value: { data: { parsed: { info: { owner: STEALTH_PUBKEY, mint: MINT_USDC } } } },
+      }),
+    } as unknown as Connection
+
+    const ctx = await resolveStealthContext(mockConnection, DEPOSIT_SIG)
+    expect(ctx.stealthAddress).toBe(STEALTH_PUBKEY)
+  })
+})
+
+describe('resolveStealthContext — error paths', () => {
   it('throws deposit_not_found when getParsedTransaction returns null', async () => {
     const mockConnection = {
       getParsedTransaction: vi.fn().mockResolvedValue(null),
       getParsedAccountInfo: vi.fn(),
     } as unknown as Connection
 
-    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG_NF))
-      .rejects.toMatchObject({ name: 'StealthContextError', code: 'deposit_not_found' })
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG)).rejects.toMatchObject({
+      name: 'StealthContextError',
+      code: 'deposit_not_found',
+    })
   })
 
-  it('throws no_announcement_memo when no memo instruction exists', async () => {
+  it('throws no_withdraw_event when logMessages has no decodable VaultWithdrawEvent', async () => {
     const mockConnection = {
       getParsedTransaction: vi.fn().mockResolvedValue({
         transaction: { message: { instructions: [] } },
-        meta: { err: null },
+        meta: {
+          err: null,
+          logMessages: [
+            'Program 11111111111111111111111111111111 invoke [1]',
+            'Program 11111111111111111111111111111111 success',
+          ],
+          innerInstructions: [],
+        },
       }),
       getParsedAccountInfo: vi.fn(),
     } as unknown as Connection
 
-    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG))
-      .rejects.toMatchObject({ code: 'no_announcement_memo' })
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG)).rejects.toMatchObject({
+      code: 'no_withdraw_event',
+    })
   })
 
-  it('throws invalid_announcement when memo does not match SIP:1:... format', async () => {
+  it('also throws no_withdraw_event when Program data log is present but too short', async () => {
+    const shortBuf = Buffer.alloc(64) // < 194-byte floor
     const mockConnection = {
       getParsedTransaction: vi.fn().mockResolvedValue({
-        transaction: {
-          message: {
-            instructions: [
-              { program: 'spl-memo', programId: { toString: () => 'memo' }, parsed: 'garbage' },
-            ],
-          },
+        transaction: { message: { instructions: [] } },
+        meta: {
+          err: null,
+          logMessages: [programDataLog(shortBuf)],
+          innerInstructions: [],
         },
-        meta: { err: null },
       }),
       getParsedAccountInfo: vi.fn(),
     } as unknown as Connection
 
-    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG))
-      .rejects.toMatchObject({ code: 'invalid_announcement' })
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG)).rejects.toMatchObject({
+      code: 'no_withdraw_event',
+    })
   })
 
-  it('throws no_token_transfer when memo exists but no SPL transferChecked', async () => {
+  it('skips zero-filled placeholder events and throws no_withdraw_event if none decodable', async () => {
+    const zeroEphBuf = buildWithdrawEventBytes({ zeroEphemeral: true })
     const mockConnection = {
       getParsedTransaction: vi.fn().mockResolvedValue({
-        transaction: {
-          message: {
-            instructions: [
-              {
-                program: 'spl-memo',
-                programId: { toString: () => 'memo' },
-                parsed: `SIP:1:${EPHEMERAL_PUBKEY}:a3`,
-              },
-            ],
-          },
+        transaction: { message: { instructions: [] } },
+        meta: {
+          err: null,
+          logMessages: [programDataLog(zeroEphBuf)],
+          innerInstructions: [],
         },
-        meta: { err: null },
       }),
       getParsedAccountInfo: vi.fn(),
     } as unknown as Connection
 
-    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG))
-      .rejects.toMatchObject({ code: 'no_token_transfer' })
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG)).rejects.toMatchObject({
+      code: 'no_withdraw_event',
+    })
   })
 
-  it('throws stealth_ata_unreadable when ATA account info has no owner', async () => {
+  it('throws no_token_transfer when event exists but no SPL transferChecked', async () => {
     const mockConnection = {
-      getParsedTransaction: vi.fn().mockResolvedValue(mockTxWithMemoAndSplTransfer()),
+      getParsedTransaction: vi.fn().mockResolvedValue({
+        transaction: { message: { instructions: [] } },
+        meta: {
+          err: null,
+          logMessages: [programDataLog(buildWithdrawEventBytes({}))],
+          innerInstructions: [],
+        },
+      }),
+      getParsedAccountInfo: vi.fn(),
+    } as unknown as Connection
+
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG)).rejects.toMatchObject({
+      code: 'no_token_transfer',
+    })
+  })
+
+  it('throws stealth_ata_mismatch when ATA account info has no owner', async () => {
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue(mockTxWithEventAndSplTransfer()),
       getParsedAccountInfo: vi.fn().mockResolvedValue({ value: null }),
     } as unknown as Connection
 
-    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG))
-      .rejects.toMatchObject({ code: 'stealth_ata_unreadable' })
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG)).rejects.toMatchObject({
+      code: 'stealth_ata_mismatch',
+    })
+  })
+
+  it('throws stealth_ata_mismatch when ATA owner differs from event stealth_recipient', async () => {
+    const DIFFERENT_OWNER = 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr'
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue(mockTxWithEventAndSplTransfer()),
+      getParsedAccountInfo: vi.fn().mockResolvedValue({
+        value: { data: { parsed: { info: { owner: DIFFERENT_OWNER, mint: MINT_USDC } } } },
+      }),
+    } as unknown as Connection
+
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG)).rejects.toMatchObject({
+      code: 'stealth_ata_mismatch',
+    })
   })
 })
 ```
@@ -355,13 +583,13 @@ describe('resolveStealthContext — error paths', () => {
 
 Run: `cd packages/agent && pnpm exec vitest run tests/tools/claim-helpers.test.ts`
 
-Expected: ALL 6 tests pass (1 happy path from Task 1 + 5 error paths). If any fail, the Task 1 implementation needs tightening — fix the implementation rather than weakening the test.
+Expected: ALL 11 tests pass (1 happy path from Task 1 + 3 happy-path variants + 7 error paths = 11). If any fail, the Task 1 implementation needs tightening — fix the implementation rather than weakening the test.
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add packages/agent/tests/tools/claim-helpers.test.ts
-git commit -m "test(claim): add error path coverage for resolveStealthContext"
+git commit -m "test(claim): add variant + error path coverage for resolveStealthContext"
 ```
 
 ---
@@ -1011,7 +1239,7 @@ Expected: clean across all packages (recursive `pnpm -r --filter='!sipher' run t
 
 Run: `cd /Users/rector/local-dev/sipher/packages/agent && pnpm test -- --run 2>&1 | tail -5`
 
-Expected: all previously-passing tests (1602 baseline) still pass, plus the new tests added in Tasks 1, 2, 4, 5, 6 (~15 net new). Approximate target: 1617+ passing.
+Expected: all previously-passing tests (1602 baseline) still pass, plus the new tests added in Tasks 1, 2, 4, 5, 6 (~20 net new: 1 helper happy + 10 helper variants/errors + 3 executeClaim happy + 4 executeClaim error + 1 attribution + 1 input-validation regression delta = ~20). Approximate target: 1622+ passing.
 
 - [ ] **Step 4: Push branch**
 
@@ -1047,7 +1275,7 @@ Replaces the Phase 1 claim stub with an end-to-end SDK-driven claim flow per Spe
 - [x] `executeClaim` input validation (regression): 4 tests
 - [x] `executeClaim` error paths: 4 tests (StealthContextError wrap, SDK broadcast error wrap, missing destination, malformed key)
 - [x] Growth-hook attribution: 1 test asserting `data.tx_signature === signature` (not `depositTxSignature`)
-- [x] Full agent suite green: ~1617 passing
+- [x] Full agent suite green: ~1622 passing
 - [x] Recursive typecheck clean
 
 ## Verification
@@ -1088,7 +1316,7 @@ After completing all tasks, before requesting RECTOR review:
 - [ ] All 8 tasks committed with conventional prefixes (feat/refactor/test/docs/chore)
 - [ ] No commit on the branch contains `Co-Authored-By`, `🤖`, or any AI attribution
 - [ ] `pnpm typecheck` clean at repo root
-- [ ] `cd packages/agent && pnpm test -- --run` passes (~1617 tests, +15 net)
+- [ ] `cd packages/agent && pnpm test -- --run` passes (~1622 tests, +20 net)
 - [ ] PR description accurately summarizes the Path A scope + trade-offs
 - [ ] Follow-up issues filed and linked from PR body
 - [ ] Spec 4 amendment recommendation honored: SDK-driven, no SignTxCard, honest claim-tx-sig attribution

--- a/docs/superpowers/plans/2026-05-17-claim-phase-2-path-a.md
+++ b/docs/superpowers/plans/2026-05-17-claim-phase-2-path-a.md
@@ -1,0 +1,1095 @@
+# Claim Phase 2 Path A Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Phase 1 claim stub with a real, end-to-end SDK-driven claim flow so `sipher_private_claim_completed` Torque events fire with the actual claim transaction signature instead of the deposit transaction signature.
+
+**Architecture:** Delegate cryptography and broadcast to `@sip-protocol/sdk`'s `claimStealthPayment(params)` primitive, which derives the stealth private key via ECDH, builds an SPL transfer from the stealth ATA to the recipient's destination ATA, signs as the stealth keypair (paying fees from the stealth address's SOL balance), and broadcasts in one server-side call. Sipher's `executeClaim` resolves the stealth context (stealth address, ephemeral public key, mint) from the deposit transaction via `getParsedTransaction`, then hands off to the SDK. A new `signature` field on `ClaimToolResult` carries the claim transaction signature; the existing growth-hook `extractTxSignature` already prefers `signature` over `txSignature` (growth-hook.ts:104), so attribution becomes correct without touching the hook.
+
+**Tech Stack:** TypeScript (strict, NodeNext ESM with .js suffixes), @sip-protocol/sdk@^0.7.4 (`claimStealthPayment`, `parseAnnouncement`, `SolanaClaimResult`), @sipher/sdk (workspace) for `createConnection` + `USDC_MINT` + `resolveTokenMint`, @solana/web3.js (`Connection`, `PublicKey`, `getParsedTransaction`), vitest 3.x with `vi.mock` for SDK isolation.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-15-claim-phase-2-design.md` — specifically the "Amendment — SDK reality check" section (lines 300–420) which documents Path A's scope and trade-offs.
+
+---
+
+## File Structure
+
+**Create:**
+- `packages/agent/src/tools/claim-helpers.ts` — pure async helpers for stealth-context resolution and destination/mint resolution. Pure functions where possible; the one IO call (`resolveStealthContext`) accepts an injected `Connection` so tests can mock it. No persistent state, no top-level side effects.
+- `packages/agent/tests/tools/claim-helpers.test.ts` — vitest suite covering the three helpers' happy + error paths.
+
+**Modify:**
+- `packages/agent/src/tools/claim.ts` — replace Phase 1 stub: new `ClaimParams` (adds optional `mint`), new `ClaimToolResult` (status always `'confirmed'`, drops `details` placeholder, renames `txSignature` → `depositTxSignature`, adds `signature` + `amount` + `mint` + `explorerUrl`), refactor `executeClaim` to: validate → resolve stealth context → resolve destination + mint → call SDK → map result. Updates `claimTool.description` + `input_schema` to document the new optional `mint` field.
+- `packages/agent/tests/claim.test.ts` — keep the input-validation tests (still valid), replace the Phase 1 happy-path expectations with the new SDK-mocked happy path + error paths.
+- `packages/agent/tests/integrations/torque/growth-hook.test.ts` — add one test asserting that when `executeClaim`-shaped result has both `signature` and `depositTxSignature`, the growth-hook emits with `data.tx_signature === signature` (the claim tx), not the deposit tx.
+- `packages/agent/src/integrations/torque/README.md` — update line 128 "Tool emission coverage" table claim row from `Partial` to `Yes`, drop the "Proper fix tracked in claim Phase 2 follow-up" caveat, point at this PR for context.
+
+**Out of scope (track as GH issues post-merge):**
+- Stealth keypair memory zeroization
+- Replay deduplication for the growth-hook (covered separately by Spec 3 follow-up)
+- Frontend SignTxCard for claim (Path B — separate GH issue, post-judges)
+- T3 instruction-match verification of broadcast tx
+- Manual mint-extraction from deposit tx (if user omits mint AND default USDC doesn't apply)
+
+---
+
+## Pre-flight check (do this once before Task 1)
+
+Verify the workspace is clean and the baseline tests pass on `main`:
+
+```bash
+cd /Users/rector/local-dev/sipher
+git fetch origin
+git checkout main
+git pull --ff-only
+git checkout -b feat/spec-4-path-a-claim-phase-2
+cd packages/agent && pnpm exec tsc --noEmit
+cd packages/agent && pnpm test -- --run 2>&1 | tail -10
+```
+
+Expected: typecheck clean, all 1602 agent tests pass.
+
+---
+
+## Task 1: Add `resolveStealthContext` helper (RED → GREEN)
+
+Resolves the deposit transaction into the stealth address + ephemeral public key + mint needed by the SDK's claim primitive. Pure async — accepts injected `Connection`, makes one `getParsedTransaction` call, parses the result.
+
+**Files:**
+- Create: `packages/agent/src/tools/claim-helpers.ts`
+- Create: `packages/agent/tests/tools/claim-helpers.test.ts`
+
+- [ ] **Step 1: Write the failing test for happy path**
+
+Create `packages/agent/tests/tools/claim-helpers.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest'
+import type { Connection } from '@solana/web3.js'
+import { resolveStealthContext, StealthContextError } from '../../src/tools/claim-helpers.js'
+
+const DEPOSIT_SIG =
+  '4Hc3vQBhYzS5xQZK1RtwvkLqxg1JhWf5pSr6vKQYVbTtFNxRr5jJp2k4QvJqwn3aB6XzMpYsLqHv2QwRcVbN8mY5s5c'
+const STEALTH_PUBKEY = 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N'
+const EPHEMERAL_PUBKEY = 'GqvBwYTWWZRyDQ4ZeNvFLgfbA8wYjBvE6cKxFQXjHvSr'
+const STEALTH_ATA = 'AfPXfQs5MNJyEnUYvxRJ6BHwQNyKqJVE9Y3CDbHwfXVc'
+const MINT_USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+
+function mockTxWithMemoAndSplTransfer() {
+  return {
+    transaction: {
+      message: {
+        instructions: [
+          {
+            program: 'spl-memo',
+            programId: { toString: () => 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr' },
+            parsed: `SIP:1:${EPHEMERAL_PUBKEY}:a3`,
+          },
+          {
+            program: 'spl-token',
+            programId: { toString: () => 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' },
+            parsed: {
+              type: 'transferChecked',
+              info: {
+                destination: STEALTH_ATA,
+                mint: MINT_USDC,
+                tokenAmount: { amount: '1000000', decimals: 6 },
+              },
+            },
+          },
+        ],
+      },
+    },
+    meta: { err: null },
+  }
+}
+
+describe('resolveStealthContext — happy path', () => {
+  it('returns stealth address, ephemeral pubkey, and mint from a parsed deposit', async () => {
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue(mockTxWithMemoAndSplTransfer()),
+      getParsedAccountInfo: vi.fn().mockResolvedValue({
+        value: { data: { parsed: { info: { owner: STEALTH_PUBKEY, mint: MINT_USDC } } } },
+      }),
+    } as unknown as Connection
+
+    const ctx = await resolveStealthContext(mockConnection, DEPOSIT_SIG)
+
+    expect(ctx.stealthAddress).toBe(STEALTH_PUBKEY)
+    expect(ctx.ephemeralPublicKey).toBe(EPHEMERAL_PUBKEY)
+    expect(ctx.mint).toBe(MINT_USDC)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/agent && pnpm exec vitest run tests/tools/claim-helpers.test.ts`
+
+Expected: FAIL with `Cannot find module '../../src/tools/claim-helpers.js'`.
+
+- [ ] **Step 3: Write minimal implementation for happy path**
+
+Create `packages/agent/src/tools/claim-helpers.ts`:
+
+```ts
+import { PublicKey, type Connection } from '@solana/web3.js'
+
+export class StealthContextError extends Error {
+  constructor(
+    message: string,
+    public readonly code:
+      | 'deposit_not_found'
+      | 'no_announcement_memo'
+      | 'invalid_announcement'
+      | 'no_token_transfer'
+      | 'stealth_ata_unreadable',
+  ) {
+    super(message)
+    this.name = 'StealthContextError'
+  }
+}
+
+export interface StealthContext {
+  /** Base58-encoded stealth pubkey (owner of the stealth ATA). */
+  stealthAddress: string
+  /** Base58-encoded ephemeral pubkey parsed from the announcement memo. */
+  ephemeralPublicKey: string
+  /** Base58-encoded SPL token mint of the stealth ATA. */
+  mint: string
+}
+
+/**
+ * Resolves a deposit transaction signature into the cryptographic context
+ * needed by `claimStealthPayment`. One RPC call (getParsedTransaction)
+ * plus optional account lookup for the stealth ATA owner.
+ */
+export async function resolveStealthContext(
+  connection: Connection,
+  depositTxSignature: string,
+): Promise<StealthContext> {
+  const tx = await connection.getParsedTransaction(depositTxSignature, {
+    commitment: 'confirmed',
+    maxSupportedTransactionVersion: 0,
+  })
+
+  if (!tx) {
+    throw new StealthContextError(
+      `Deposit transaction ${depositTxSignature.slice(0, 12)}... not found on chain`,
+      'deposit_not_found',
+    )
+  }
+
+  const instructions = tx.transaction.message.instructions
+  const memoIx = instructions.find(
+    (ix): ix is typeof ix & { parsed: string } =>
+      'program' in ix && ix.program === 'spl-memo' && typeof (ix as { parsed?: unknown }).parsed === 'string',
+  )
+  if (!memoIx) {
+    throw new StealthContextError(
+      `No announcement memo in deposit ${depositTxSignature.slice(0, 12)}...`,
+      'no_announcement_memo',
+    )
+  }
+
+  const announcement = parseAnnouncementMemo(memoIx.parsed)
+  if (!announcement) {
+    throw new StealthContextError(
+      `Announcement memo is malformed: ${memoIx.parsed.slice(0, 32)}...`,
+      'invalid_announcement',
+    )
+  }
+
+  const tokenIx = instructions.find(
+    (ix): ix is typeof ix & { parsed: { type: string; info: { destination: string; mint: string } } } =>
+      'program' in ix &&
+      ix.program === 'spl-token' &&
+      typeof (ix as { parsed?: { type?: string } }).parsed === 'object' &&
+      (ix as { parsed?: { type?: string } }).parsed?.type === 'transferChecked',
+  )
+  if (!tokenIx) {
+    throw new StealthContextError(
+      `No SPL token transfer instruction in deposit ${depositTxSignature.slice(0, 12)}...`,
+      'no_token_transfer',
+    )
+  }
+
+  const stealthATA = tokenIx.parsed.info.destination
+  const mint = tokenIx.parsed.info.mint
+
+  const ataInfo = await connection.getParsedAccountInfo(new PublicKey(stealthATA))
+  const parsed = (ataInfo?.value?.data as { parsed?: { info?: { owner?: string } } } | undefined)?.parsed
+  const stealthAddress = parsed?.info?.owner
+  if (!stealthAddress) {
+    throw new StealthContextError(
+      `Stealth ATA ${stealthATA.slice(0, 12)}... is unreadable or not a token account`,
+      'stealth_ata_unreadable',
+    )
+  }
+
+  return {
+    stealthAddress,
+    ephemeralPublicKey: announcement.ephemeralPublicKey,
+    mint,
+  }
+}
+
+function parseAnnouncementMemo(memo: string): { ephemeralPublicKey: string } | null {
+  // Format: SIP:1:<ephemeral_pubkey_base58>:<view_tag_hex>
+  const parts = memo.split(':')
+  if (parts.length !== 4) return null
+  if (parts[0] !== 'SIP' || parts[1] !== '1') return null
+  if (!parts[2] || parts[2].length < 32) return null
+  return { ephemeralPublicKey: parts[2] }
+}
+```
+
+Note: `getParsedAccountInfo` returns `{ value: { data: { parsed: { info: { owner } } } } }` for SPL token ATAs (the `jsonParsed` encoding is automatic for known programs). The Task 1 test fixture mock must match this shape — update the `getAccountInfo` mock to `getParsedAccountInfo` returning `{ value: { data: { parsed: { info: { owner: STEALTH_PUBKEY, mint: MINT_USDC } } } } }`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/agent && pnpm exec vitest run tests/tools/claim-helpers.test.ts -t "happy path"`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/agent/src/tools/claim-helpers.ts packages/agent/tests/tools/claim-helpers.test.ts
+git commit -m "feat(claim): add resolveStealthContext helper for deposit tx parsing"
+```
+
+---
+
+## Task 2: Add error path tests + handlers for `resolveStealthContext` (RED → GREEN)
+
+**Files:**
+- Modify: `packages/agent/tests/tools/claim-helpers.test.ts`
+
+- [ ] **Step 1: Write failing tests for the four error codes**
+
+Append to `packages/agent/tests/tools/claim-helpers.test.ts`:
+
+```ts
+describe('resolveStealthContext — error paths', () => {
+  const DEPOSIT_SIG_NF = 'NotFoundTxSignaturePlaceholderXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+
+  it('throws deposit_not_found when getParsedTransaction returns null', async () => {
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue(null),
+      getParsedAccountInfo: vi.fn(),
+    } as unknown as Connection
+
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG_NF))
+      .rejects.toMatchObject({ name: 'StealthContextError', code: 'deposit_not_found' })
+  })
+
+  it('throws no_announcement_memo when no memo instruction exists', async () => {
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue({
+        transaction: { message: { instructions: [] } },
+        meta: { err: null },
+      }),
+      getParsedAccountInfo: vi.fn(),
+    } as unknown as Connection
+
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG))
+      .rejects.toMatchObject({ code: 'no_announcement_memo' })
+  })
+
+  it('throws invalid_announcement when memo does not match SIP:1:... format', async () => {
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue({
+        transaction: {
+          message: {
+            instructions: [
+              { program: 'spl-memo', programId: { toString: () => 'memo' }, parsed: 'garbage' },
+            ],
+          },
+        },
+        meta: { err: null },
+      }),
+      getParsedAccountInfo: vi.fn(),
+    } as unknown as Connection
+
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG))
+      .rejects.toMatchObject({ code: 'invalid_announcement' })
+  })
+
+  it('throws no_token_transfer when memo exists but no SPL transferChecked', async () => {
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue({
+        transaction: {
+          message: {
+            instructions: [
+              {
+                program: 'spl-memo',
+                programId: { toString: () => 'memo' },
+                parsed: `SIP:1:${EPHEMERAL_PUBKEY}:a3`,
+              },
+            ],
+          },
+        },
+        meta: { err: null },
+      }),
+      getParsedAccountInfo: vi.fn(),
+    } as unknown as Connection
+
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG))
+      .rejects.toMatchObject({ code: 'no_token_transfer' })
+  })
+
+  it('throws stealth_ata_unreadable when ATA account info has no owner', async () => {
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue(mockTxWithMemoAndSplTransfer()),
+      getParsedAccountInfo: vi.fn().mockResolvedValue({ value: null }),
+    } as unknown as Connection
+
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG))
+      .rejects.toMatchObject({ code: 'stealth_ata_unreadable' })
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they pass against the Task 1 implementation**
+
+Run: `cd packages/agent && pnpm exec vitest run tests/tools/claim-helpers.test.ts`
+
+Expected: ALL 6 tests pass (1 happy path from Task 1 + 5 error paths). If any fail, the Task 1 implementation needs tightening — fix the implementation rather than weakening the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/agent/tests/tools/claim-helpers.test.ts
+git commit -m "test(claim): add error path coverage for resolveStealthContext"
+```
+
+---
+
+## Task 3: Replace `ClaimParams` + `ClaimToolResult` with Path A shape (typecheck-driven)
+
+This is a contract change. No runtime test yet — the type change will surface every consumer of `ClaimToolResult` at `tsc --noEmit`. Update each surfaced consumer in the same task.
+
+**Files:**
+- Modify: `packages/agent/src/tools/claim.ts`
+
+- [ ] **Step 1: Replace ClaimParams + ClaimToolResult + claimTool description**
+
+In `packages/agent/src/tools/claim.ts`, replace lines 13–62 (the interfaces and tool definition) with:
+
+```ts
+export interface ClaimParams {
+  txSignature: string
+  viewingKey: string
+  spendingKey: string
+  /** Optional destination wallet (base58). Defaults to the spending pubkey. */
+  destinationWallet?: string
+  /**
+   * Optional SPL token mint (base58). If omitted, the mint is resolved from
+   * the deposit transaction. Provide explicitly when you already know it
+   * (e.g. from a prior scan result) to skip the on-chain lookup.
+   */
+  mint?: string
+}
+
+export interface ClaimToolResult {
+  action: 'claim'
+  status: 'confirmed'
+  /** The input deposit-tx signature (for traceability). */
+  depositTxSignature: string
+  /** The CLAIM tx signature — growth-hook reads this as the Torque attribution key. */
+  signature: string
+  /** Base58 destination wallet that received the funds. */
+  destinationWallet: string
+  /** Claimed amount in the token's smallest unit, stringified to avoid BigInt JSON issues. */
+  amount: string
+  /** Base58 SPL token mint. */
+  mint: string
+  /** Explorer URL for the claim transaction. */
+  explorerUrl: string
+  /** Human-readable summary for the chat UX. */
+  message: string
+}
+
+export const claimTool: AnthropicTool = {
+  name: 'claim',
+  description:
+    'Claim a received stealth payment found by the scan tool. ' +
+    'Derives the stealth private key from your viewing+spending keys, ' +
+    'transfers the tokens to your destination wallet, and returns the claim tx signature.',
+  input_schema: {
+    type: 'object' as const,
+    properties: {
+      txSignature: {
+        type: 'string',
+        description: 'Transaction signature of the stealth payment to claim (from scan results)',
+      },
+      viewingKey: {
+        type: 'string',
+        description: 'Your viewing private key (hex or base58)',
+      },
+      spendingKey: {
+        type: 'string',
+        description: 'Your spending private key (hex or base58). Used to derive the stealth key.',
+      },
+      destinationWallet: {
+        type: 'string',
+        description: 'Wallet address (base58) to receive claimed tokens. Defaults to the spending pubkey.',
+      },
+      mint: {
+        type: 'string',
+        description:
+          'Optional SPL token mint (base58). If omitted, the mint is resolved from the deposit transaction.',
+      },
+    },
+    required: ['txSignature', 'viewingKey', 'spendingKey'],
+  },
+}
+```
+
+- [ ] **Step 2: Replace `executeClaim` body with a typed stub that returns the new shape**
+
+Replace lines 64–95 of `packages/agent/src/tools/claim.ts` with:
+
+```ts
+export async function executeClaim(params: ClaimParams): Promise<ClaimToolResult> {
+  if (!params.txSignature || params.txSignature.trim().length === 0) {
+    throw new Error('Transaction signature is required')
+  }
+  if (!params.viewingKey || params.viewingKey.trim().length === 0) {
+    throw new Error('Viewing key is required to derive stealth key')
+  }
+  if (!params.spendingKey || params.spendingKey.trim().length === 0) {
+    throw new Error('Spending key is required to derive stealth key')
+  }
+
+  // Task 4 will replace this stub with the real SDK call.
+  throw new Error('executeClaim Phase 2 not yet wired — Task 4 placeholder')
+}
+```
+
+- [ ] **Step 3: Run typecheck to find broken consumers**
+
+Run: `cd packages/agent && pnpm exec tsc --noEmit`
+
+Expected: typecheck errors in `tests/claim.test.ts` (it asserts on `result.serializedTx`, `result.details.*`, `result.status === 'awaiting_signature'` — all of which were removed). Note the errors; Task 5 rewrites the test.
+
+- [ ] **Step 4: Commit (the type change with stub body, before behavior wiring)**
+
+```bash
+git add packages/agent/src/tools/claim.ts
+git commit -m "refactor(claim): switch ClaimToolResult to Path A shape (stub body)"
+```
+
+---
+
+## Task 4: Wire `executeClaim` to SDK (RED → GREEN)
+
+**Files:**
+- Modify: `packages/agent/src/tools/claim.ts`
+- Modify: `packages/agent/tests/claim.test.ts`
+
+- [ ] **Step 1: Write failing happy-path test for executeClaim**
+
+Replace the entire content of `packages/agent/tests/claim.test.ts` with:
+
+```ts
+// packages/agent/tests/claim.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the SDK BEFORE importing claim.ts
+vi.mock('@sip-protocol/sdk', async () => {
+  const actual = await vi.importActual<typeof import('@sip-protocol/sdk')>('@sip-protocol/sdk')
+  return {
+    ...actual,
+    claimStealthPayment: vi.fn(),
+  }
+})
+
+// Mock helpers + sipher connection helper
+vi.mock('../src/tools/claim-helpers.js', () => ({
+  resolveStealthContext: vi.fn(),
+  StealthContextError: class StealthContextError extends Error {
+    constructor(message: string, public code: string) {
+      super(message)
+      this.name = 'StealthContextError'
+    }
+  },
+}))
+
+vi.mock('@sipher/sdk', async () => {
+  const actual = await vi.importActual<typeof import('@sipher/sdk')>('@sipher/sdk')
+  return {
+    ...actual,
+    createConnection: vi.fn(() => ({
+      // Minimal Connection mock surface — methods called by claim flow indirectly
+    })),
+  }
+})
+
+import { claimTool, executeClaim } from '../src/tools/claim.js'
+import { claimStealthPayment } from '@sip-protocol/sdk'
+import { resolveStealthContext } from '../src/tools/claim-helpers.js'
+
+const VALID_TX_SIG = '5' + 'a'.repeat(87)
+const VALID_VIEWING_KEY = 'ab'.repeat(32)
+const VALID_SPENDING_KEY = 'cd'.repeat(32)
+const VALID_DESTINATION = 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr'
+const STEALTH_ADDR = 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N'
+const EPHEMERAL_PUBKEY = 'GqvBwYTWWZRyDQ4ZeNvFLgfbA8wYjBvE6cKxFQXjHvSr'
+const MINT_USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+const CLAIM_TX_SIG = '4Hc' + 'b'.repeat(85)
+
+describe('claimTool definition', () => {
+  it('has correct name', () => {
+    expect(claimTool.name).toBe('claim')
+  })
+
+  it('declares required input fields', () => {
+    expect(claimTool.input_schema.required).toEqual([
+      'txSignature',
+      'viewingKey',
+      'spendingKey',
+    ])
+  })
+
+  it('declares optional destinationWallet and mint fields', () => {
+    expect(claimTool.input_schema.properties).toHaveProperty('destinationWallet')
+    expect(claimTool.input_schema.properties).toHaveProperty('mint')
+  })
+})
+
+describe('executeClaim — happy path', () => {
+  beforeEach(() => {
+    vi.mocked(resolveStealthContext).mockResolvedValue({
+      stealthAddress: STEALTH_ADDR,
+      ephemeralPublicKey: EPHEMERAL_PUBKEY,
+      mint: MINT_USDC,
+    })
+    vi.mocked(claimStealthPayment).mockResolvedValue({
+      txSignature: CLAIM_TX_SIG,
+      destinationAddress: VALID_DESTINATION,
+      amount: 1000000n,
+      explorerUrl: `https://solscan.io/tx/${CLAIM_TX_SIG}`,
+    })
+  })
+
+  it('returns confirmed status with claim signature', async () => {
+    const result = await executeClaim({
+      txSignature: VALID_TX_SIG,
+      viewingKey: VALID_VIEWING_KEY,
+      spendingKey: VALID_SPENDING_KEY,
+      destinationWallet: VALID_DESTINATION,
+    })
+
+    expect(result.action).toBe('claim')
+    expect(result.status).toBe('confirmed')
+    expect(result.signature).toBe(CLAIM_TX_SIG)
+    expect(result.depositTxSignature).toBe(VALID_TX_SIG)
+    expect(result.destinationWallet).toBe(VALID_DESTINATION)
+    expect(result.amount).toBe('1000000')
+    expect(result.mint).toBe(MINT_USDC)
+    expect(result.explorerUrl).toContain(CLAIM_TX_SIG)
+  })
+
+  it('passes resolved stealth context to claimStealthPayment', async () => {
+    await executeClaim({
+      txSignature: VALID_TX_SIG,
+      viewingKey: VALID_VIEWING_KEY,
+      spendingKey: VALID_SPENDING_KEY,
+      destinationWallet: VALID_DESTINATION,
+    })
+
+    expect(claimStealthPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stealthAddress: STEALTH_ADDR,
+        ephemeralPublicKey: EPHEMERAL_PUBKEY,
+        destinationAddress: VALID_DESTINATION,
+      }),
+    )
+  })
+
+  it('truncates deposit signature in message', async () => {
+    const result = await executeClaim({
+      txSignature: VALID_TX_SIG,
+      viewingKey: VALID_VIEWING_KEY,
+      spendingKey: VALID_SPENDING_KEY,
+      destinationWallet: VALID_DESTINATION,
+    })
+
+    expect(result.message).toContain(VALID_TX_SIG.slice(0, 12))
+    expect(result.message).toContain(CLAIM_TX_SIG.slice(0, 12))
+  })
+})
+
+describe('executeClaim — input validation (regression)', () => {
+  it('rejects empty txSignature', async () => {
+    await expect(
+      executeClaim({
+        txSignature: '',
+        viewingKey: VALID_VIEWING_KEY,
+        spendingKey: VALID_SPENDING_KEY,
+      })
+    ).rejects.toThrow(/transaction signature is required/i)
+  })
+
+  it('rejects whitespace-only txSignature', async () => {
+    await expect(
+      executeClaim({
+        txSignature: '   ',
+        viewingKey: VALID_VIEWING_KEY,
+        spendingKey: VALID_SPENDING_KEY,
+      })
+    ).rejects.toThrow(/transaction signature is required/i)
+  })
+
+  it('rejects empty viewingKey', async () => {
+    await expect(
+      executeClaim({
+        txSignature: VALID_TX_SIG,
+        viewingKey: '',
+        spendingKey: VALID_SPENDING_KEY,
+      })
+    ).rejects.toThrow(/viewing key is required/i)
+  })
+
+  it('rejects empty spendingKey', async () => {
+    await expect(
+      executeClaim({
+        txSignature: VALID_TX_SIG,
+        viewingKey: VALID_VIEWING_KEY,
+        spendingKey: '',
+      })
+    ).rejects.toThrow(/spending key is required/i)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify happy path fails (stub still throws)**
+
+Run: `cd packages/agent && pnpm exec vitest run tests/claim.test.ts`
+
+Expected: Input validation tests PASS (4), happy-path tests FAIL with the "Phase 2 not yet wired" error from Task 3's stub.
+
+- [ ] **Step 3: Implement executeClaim using the SDK**
+
+Replace `executeClaim` in `packages/agent/src/tools/claim.ts` with:
+
+```ts
+import { claimStealthPayment, type SolanaClaimResult } from '@sip-protocol/sdk'
+import { PublicKey } from '@solana/web3.js'
+import { createConnection, USDC_MINT } from '@sipher/sdk'
+import { loadNetworkConfig } from '../config/network.js'
+import { resolveStealthContext, StealthContextError } from './claim-helpers.js'
+
+// Keep imports for type tooling
+import type { AnthropicTool } from '../pi/tool-adapter.js'
+
+// ... ClaimParams + ClaimToolResult + claimTool stay as in Task 3 ...
+
+export async function executeClaim(params: ClaimParams): Promise<ClaimToolResult> {
+  if (!params.txSignature || params.txSignature.trim().length === 0) {
+    throw new Error('Transaction signature is required')
+  }
+  if (!params.viewingKey || params.viewingKey.trim().length === 0) {
+    throw new Error('Viewing key is required to derive stealth key')
+  }
+  if (!params.spendingKey || params.spendingKey.trim().length === 0) {
+    throw new Error('Spending key is required to derive stealth key')
+  }
+
+  const network = loadNetworkConfig().clusterName
+  const connection = createConnection(network)
+
+  let ctx
+  try {
+    ctx = await resolveStealthContext(connection, params.txSignature)
+  } catch (err) {
+    if (err instanceof StealthContextError) {
+      throw new Error(`Cannot resolve stealth payment: ${err.message}`)
+    }
+    throw err
+  }
+
+  const mintBase58 = params.mint ?? ctx.mint ?? USDC_MINT.toBase58()
+  const destinationAddress = params.destinationWallet ?? deriveDestinationFromSpending(params.spendingKey)
+  const viewingPrivateKey = normalizeKey(params.viewingKey)
+  const spendingPrivateKey = normalizeKey(params.spendingKey)
+
+  let sdkResult: SolanaClaimResult
+  try {
+    sdkResult = await claimStealthPayment({
+      connection,
+      stealthAddress: ctx.stealthAddress,
+      ephemeralPublicKey: ctx.ephemeralPublicKey,
+      viewingPrivateKey,
+      spendingPrivateKey,
+      destinationAddress,
+      mint: new PublicKey(mintBase58),
+    })
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err)
+    throw new Error(`Claim broadcast failed: ${detail}`)
+  }
+
+  return {
+    action: 'claim',
+    status: 'confirmed',
+    depositTxSignature: params.txSignature,
+    signature: sdkResult.txSignature,
+    destinationWallet: sdkResult.destinationAddress,
+    amount: sdkResult.amount.toString(),
+    mint: mintBase58,
+    explorerUrl: sdkResult.explorerUrl,
+    message:
+      `Claimed payment ${params.txSignature.slice(0, 12)}... → claim tx ${sdkResult.txSignature.slice(0, 12)}... ` +
+      `(${sdkResult.amount.toString()} units to ${sdkResult.destinationAddress.slice(0, 8)}...)`,
+  }
+}
+
+/** @internal — placeholder until SDK exposes spending pubkey derivation */
+function deriveDestinationFromSpending(spendingKey: string): string {
+  // For Path A initial scope: if user does not provide destinationWallet, throw —
+  // mirroring the existing send tool's pattern. A follow-up PR can derive the
+  // pubkey from the spending privkey, but for the initial ship the destination
+  // is always supplied via the agent's tool input.
+  void spendingKey
+  throw new Error('destinationWallet is required (Path A initial scope — auto-derive in follow-up)')
+}
+
+/** Strip 0x prefix and validate hex shape for SDK consumption. */
+function normalizeKey(key: string): `0x${string}` {
+  const stripped = key.startsWith('0x') ? key.slice(2) : key
+  if (!/^[0-9a-fA-F]+$/.test(stripped)) {
+    throw new Error('Key must be hex (with or without 0x prefix)')
+  }
+  return `0x${stripped.toLowerCase()}` as `0x${string}`
+}
+```
+
+Note: `deriveDestinationFromSpending` throws to force the caller to supply `destinationWallet`. This keeps Path A scope tight. Tests pass `destinationWallet` so they don't hit this path. A follow-up issue will add real derivation.
+
+- [ ] **Step 4: Run tests to verify happy path passes**
+
+Run: `cd packages/agent && pnpm exec vitest run tests/claim.test.ts`
+
+Expected: ALL tests pass (4 tool-definition + 3 happy-path + 4 input-validation = 11 tests).
+
+- [ ] **Step 5: Run agent typecheck to confirm no cross-file regression**
+
+Run: `cd packages/agent && pnpm exec tsc --noEmit`
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/agent/src/tools/claim.ts packages/agent/tests/claim.test.ts
+git commit -m "feat(claim): wire executeClaim to SDK claimStealthPayment (Path A)"
+```
+
+---
+
+## Task 5: Add error path tests for SDK failure modes (RED → GREEN)
+
+**Files:**
+- Modify: `packages/agent/tests/claim.test.ts`
+
+- [ ] **Step 1: Write failing tests for two error paths**
+
+Append to `packages/agent/tests/claim.test.ts`:
+
+```ts
+describe('executeClaim — error paths', () => {
+  it('wraps StealthContextError in actionable error', async () => {
+    vi.mocked(resolveStealthContext).mockRejectedValue(
+      Object.assign(new Error('Deposit transaction 5aaaaaa... not found on chain'), {
+        name: 'StealthContextError',
+        code: 'deposit_not_found',
+      }),
+    )
+
+    await expect(
+      executeClaim({
+        txSignature: VALID_TX_SIG,
+        viewingKey: VALID_VIEWING_KEY,
+        spendingKey: VALID_SPENDING_KEY,
+        destinationWallet: VALID_DESTINATION,
+      }),
+    ).rejects.toThrow(/Cannot resolve stealth payment/i)
+  })
+
+  it('wraps SDK broadcast errors in actionable error', async () => {
+    vi.mocked(resolveStealthContext).mockResolvedValue({
+      stealthAddress: STEALTH_ADDR,
+      ephemeralPublicKey: EPHEMERAL_PUBKEY,
+      mint: MINT_USDC,
+    })
+    vi.mocked(claimStealthPayment).mockRejectedValue(
+      new Error('Stealth key derivation failed: derived private key does not produce expected public key'),
+    )
+
+    await expect(
+      executeClaim({
+        txSignature: VALID_TX_SIG,
+        viewingKey: VALID_VIEWING_KEY,
+        spendingKey: VALID_SPENDING_KEY,
+        destinationWallet: VALID_DESTINATION,
+      }),
+    ).rejects.toThrow(/Claim broadcast failed:.*Stealth key derivation failed/i)
+  })
+
+  it('throws when destinationWallet is omitted (Path A scope)', async () => {
+    vi.mocked(resolveStealthContext).mockResolvedValue({
+      stealthAddress: STEALTH_ADDR,
+      ephemeralPublicKey: EPHEMERAL_PUBKEY,
+      mint: MINT_USDC,
+    })
+
+    await expect(
+      executeClaim({
+        txSignature: VALID_TX_SIG,
+        viewingKey: VALID_VIEWING_KEY,
+        spendingKey: VALID_SPENDING_KEY,
+      }),
+    ).rejects.toThrow(/destinationWallet is required/i)
+  })
+
+  it('rejects non-hex viewing key', async () => {
+    vi.mocked(resolveStealthContext).mockResolvedValue({
+      stealthAddress: STEALTH_ADDR,
+      ephemeralPublicKey: EPHEMERAL_PUBKEY,
+      mint: MINT_USDC,
+    })
+
+    await expect(
+      executeClaim({
+        txSignature: VALID_TX_SIG,
+        viewingKey: 'this-is-not-hex',
+        spendingKey: VALID_SPENDING_KEY,
+        destinationWallet: VALID_DESTINATION,
+      }),
+    ).rejects.toThrow(/key must be hex/i)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `cd packages/agent && pnpm exec vitest run tests/claim.test.ts`
+
+Expected: ALL 15 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/agent/tests/claim.test.ts
+git commit -m "test(claim): cover SDK + helper error paths in executeClaim"
+```
+
+---
+
+## Task 6: Growth-hook test — claim emission uses `signature` not `txSignature` (RED → GREEN)
+
+**Files:**
+- Modify: `packages/agent/tests/integrations/torque/growth-hook.test.ts`
+
+- [ ] **Step 1: Read the existing growth-hook test setup to match its conventions**
+
+Run: `cd packages/agent && head -80 tests/integrations/torque/growth-hook.test.ts`
+
+Note the imports, mock pattern, and how `wrapExecutorWithGrowthHook` is exercised. The new test must follow the same pattern (likely uses an in-memory MCP client mock and asserts on `client.emitEvent` calls).
+
+- [ ] **Step 2: Add a failing test for claim attribution**
+
+Append to `packages/agent/tests/integrations/torque/growth-hook.test.ts` (adjust import paths + mock setup to match existing patterns observed in Step 1):
+
+```ts
+describe('growth-hook — claim emission attribution', () => {
+  it('uses result.signature (claim tx) as data.tx_signature, not result.depositTxSignature', async () => {
+    // Mirror the existing test's setup pattern. The key assertion: when the
+    // wrapped executor returns a claim-shaped result with BOTH signature and
+    // depositTxSignature populated, the emitted event's data.tx_signature
+    // equals signature.
+
+    const claimResult = {
+      action: 'claim',
+      status: 'confirmed',
+      depositTxSignature: '5' + 'a'.repeat(87), // deposit
+      signature: '4' + 'b'.repeat(87),           // CLAIM tx — what should be attributed
+      destinationWallet: 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr',
+      amount: '1000000',
+      mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+      explorerUrl: 'https://solscan.io/tx/...',
+      message: '...',
+    }
+
+    // ... wire up the test harness following existing pattern ...
+    // ... call wrapped executor with 'claim' tool name and a wallet input ...
+    // ... assert emit was called with data.tx_signature === claimResult.signature ...
+
+    // Specifically: emitEvent receives { data: { tx_signature: <claim_sig>, ... } }
+    // NOT depositTxSignature.
+  })
+})
+```
+
+The implementer should fill in the harness-wiring portion using whatever fixtures + mocks the existing growth-hook.test.ts already uses (TorqueMCPClient stub, deriveRebateDestination stub returning `{ kind: 'stealth', address: 'X...' }`).
+
+- [ ] **Step 3: Run test to verify it passes (growth-hook already prefers `signature` per line 104)**
+
+Run: `cd packages/agent && pnpm exec vitest run tests/integrations/torque/growth-hook.test.ts -t "claim emission attribution"`
+
+Expected: PASS — `extractTxSignature` (growth-hook.ts:101-107) already prefers `signature` over `txSignature`, and the new ClaimToolResult uses `signature` for the claim tx. No production code change needed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/agent/tests/integrations/torque/growth-hook.test.ts
+git commit -m "test(torque): assert claim emission attributes to claim-tx-sig"
+```
+
+---
+
+## Task 7: README update — Tool emission coverage table
+
+**Files:**
+- Modify: `packages/agent/src/integrations/torque/README.md`
+
+- [ ] **Step 1: Read the existing emission table to find line 128**
+
+Run: `cd packages/agent && sed -n '120,135p' src/integrations/torque/README.md`
+
+Confirm the row format and the existing `Partial` value for `claim`.
+
+- [ ] **Step 2: Update the claim row**
+
+Edit `packages/agent/src/integrations/torque/README.md` line 128. Replace the existing claim row with:
+
+```
+| `claim` (chat-driven) | `sipher_private_claim_completed` | Yes | Uses the CLAIM tx signature as the emission key (Path A SDK-driven, since PR-<number>). |
+```
+
+If the table uses different column counts/separators, match the surrounding rows verbatim.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/agent/src/integrations/torque/README.md
+git commit -m "docs(torque): mark claim emission Yes with claim-tx-sig attribution"
+```
+
+---
+
+## Task 8: Full regression + PR
+
+**Files:**
+- (none — verification + PR creation)
+
+- [ ] **Step 1: Strip any AI attribution from commit messages on this branch**
+
+Run:
+
+```bash
+git log main..HEAD --format=%B | grep -iE "co-authored|🤖|generated with|claude" || echo "CLEAN"
+```
+
+Expected: `CLEAN`. If any commit has AI attribution, interactive-rebase to strip (or amend the offending commit). NEVER use `--no-verify` to bypass hooks.
+
+- [ ] **Step 2: Run full per-package typechecks**
+
+Run:
+
+```bash
+cd /Users/rector/local-dev/sipher
+pnpm typecheck 2>&1 | tail -20
+```
+
+Expected: clean across all packages (recursive `pnpm -r --filter='!sipher' run typecheck` per PR #280).
+
+- [ ] **Step 3: Run full agent test suite**
+
+Run: `cd /Users/rector/local-dev/sipher/packages/agent && pnpm test -- --run 2>&1 | tail -5`
+
+Expected: all previously-passing tests (1602 baseline) still pass, plus the new tests added in Tasks 1, 2, 4, 5, 6 (~15 net new). Approximate target: 1617+ passing.
+
+- [ ] **Step 4: Push branch**
+
+```bash
+git push -u origin feat/spec-4-path-a-claim-phase-2
+```
+
+- [ ] **Step 5: Open PR**
+
+```bash
+gh pr create \
+  --base main \
+  --title "feat(claim): Phase 2 Path A — SDK-driven claim flow with claim-tx-sig attribution" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Replaces the Phase 1 claim stub with an end-to-end SDK-driven claim flow per Spec 4 Path A (`docs/superpowers/specs/2026-05-15-claim-phase-2-design.md`, "Amendment — SDK reality check" section).
+
+**Before:** `executeClaim` returned `serializedTx: null` and the growth-hook emitted `sipher_private_claim_completed` with the DEPOSIT tx signature as the attribution key (incorrect).
+
+**After:** `executeClaim` resolves the stealth context from the deposit transaction, delegates ECDH derivation + tx build + broadcast to `@sip-protocol/sdk`'s `claimStealthPayment`, and returns `{ status: 'confirmed', signature: <claim-tx-sig>, depositTxSignature: <input>, ... }`. The growth-hook's existing `extractTxSignature` (line 104) prefers `signature` over `txSignature`, so Torque attribution now points at the actual claim transaction.
+
+## Scope notes
+
+- Path A trade-offs documented in the spec amendment. Path B (SignTxCard UX via SDK extension) tracked separately as a post-judges follow-up.
+- `destinationWallet` is required in Path A initial scope (agent supplies it from prior scan context). Auto-derivation from spending pubkey is a fast-follow.
+- SOL claims work via WSOL ATA (sipher's deposit model wraps SOL to WSOL on send).
+
+## Test plan
+
+- [x] `resolveStealthContext` helper: 6 unit tests (1 happy, 5 error codes)
+- [x] `executeClaim` happy path: 3 tests (shape, SDK call args, message format)
+- [x] `executeClaim` input validation (regression): 4 tests
+- [x] `executeClaim` error paths: 4 tests (StealthContextError wrap, SDK broadcast error wrap, missing destination, malformed key)
+- [x] Growth-hook attribution: 1 test asserting `data.tx_signature === signature` (not `depositTxSignature`)
+- [x] Full agent suite green: ~1617 passing
+- [x] Recursive typecheck clean
+
+## Verification
+
+Before deploy: `https://sipher-api.sip-protocol.org/admin/api/torque/status` still reports `enabled: true, network: devnet, ingesterReachable: true`. After deploy: trigger a claim from sipher chat with a known recent deposit; confirm the Torque event in the dashboard attributes to the claim tx signature (not the deposit signature).
+
+## Follow-ups (separate issues, post-merge)
+
+- Spec 4 Path B: SDK extension + SignTxCard claim UX
+- Auto-derive `destinationWallet` from spending pubkey
+- Replay deduplication in growth-hook (also tracked under Spec 3)
+- Stealth keypair memory zeroization (best-effort)
+EOF
+)"
+```
+
+- [ ] **Step 6: Open the Path B + Spec 5 follow-up issues**
+
+After the PR is opened (so they can cite its URL):
+
+```bash
+gh issue create --title "feat(sdk): add buildClaimTx + broadcastClaimTx split for SignTxCard claim UX (Spec 4 Path B)" --body "Post-judges follow-up. Extend @sip-protocol/sdk with split build/broadcast primitives so sipher can intercept between the two and present a SignTxCard for claim. Spec: docs/superpowers/specs/2026-05-15-claim-phase-2-design.md (Path B section). Predecessor: PR <Path A>." --label "enhancement" --label "post-hackathon"
+
+# Spec 5 follow-ups (one per PR in the spec)
+gh issue create --title "feat(scheduled-ops): durable-nonce family (scheduleSend + drip)" --body "Spec 5 PR-A. Implement pre-signed durable-nonce flow for time-bounded scheduled operations. Spec: docs/superpowers/specs/2026-05-15-scheduled-op-broadcasts-design.md (Family B section)." --label "enhancement" --label "post-hackathon"
+
+gh issue create --title "feat(scheduled-ops): Squads delegation family (sweep + recurring)" --body "Spec 5 PR-B. Wallet-delegation via Squads Smart Account for indefinite scheduled operations. Spec: docs/superpowers/specs/2026-05-15-scheduled-op-broadcasts-design.md (Family C.2 section)." --label "enhancement" --label "post-hackathon"
+
+gh issue create --title "chore(scheduled-ops): COURIER hardening (retries, observability, single-flight)" --body "Spec 5 PR-C. Make the crank production-ready under load. Spec: docs/superpowers/specs/2026-05-15-scheduled-op-broadcasts-design.md (COURIER hardening section)." --label "enhancement" --label "post-hackathon"
+```
+
+---
+
+## Self-review checklist
+
+After completing all tasks, before requesting RECTOR review:
+
+- [ ] All 8 tasks committed with conventional prefixes (feat/refactor/test/docs/chore)
+- [ ] No commit on the branch contains `Co-Authored-By`, `🤖`, or any AI attribution
+- [ ] `pnpm typecheck` clean at repo root
+- [ ] `cd packages/agent && pnpm test -- --run` passes (~1617 tests, +15 net)
+- [ ] PR description accurately summarizes the Path A scope + trade-offs
+- [ ] Follow-up issues filed and linked from PR body
+- [ ] Spec 4 amendment recommendation honored: SDK-driven, no SignTxCard, honest claim-tx-sig attribution
+- [ ] `.env.example` unchanged (no new env vars introduced by Path A)

--- a/packages/agent/src/integrations/torque/README.md
+++ b/packages/agent/src/integrations/torque/README.md
@@ -125,7 +125,7 @@ Users who want zero attribution leakage should set `TORQUE_GROWTH_ENABLED=false`
 |---|---|---|---|
 | `send` (chat-driven) | `sipher_private_send_completed` | Yes (since sipher#262) | Fires after SignTxCard callback `/api/tool-signing/:flagId/confirm` |
 | `swap` (chat-driven) | `sipher_private_swap_completed` | Yes (since sipher#262) | Same flow as send; includes `amount_lamports` + `asset` |
-| `claim` (chat-driven) | `sipher_private_claim_completed` | Partial | Uses input deposit-tx-signature as the emission key. Proper fix tracked in the claim Phase 2 follow-up. |
+| `claim` (chat-driven) | `sipher_private_claim_completed` | Yes (Path A) | Uses the CLAIM tx signature (`result.signature`) as the emission key, distinct from the input deposit-tx-signature (`result.depositTxSignature`). |
 | `drip`, `splitSend`, `sweep`, `consolidate`, `recurring`, `scheduleSend` | `sipher_private_drip_completed`, `sipher_private_split_send_completed`, etc. | No | Scheduled-op broadcasts not yet wired. Needs wallet-delegation or pre-signed-batch design — separate follow-up. |
 | `deposit`, `refund` | — | No | Routed through `DepositView` / `WithdrawView` dedicated UIs, not the chat path. |
 

--- a/packages/agent/src/tools/claim-helpers.ts
+++ b/packages/agent/src/tools/claim-helpers.ts
@@ -1,0 +1,176 @@
+import { Buffer } from 'node:buffer'
+import {
+  PublicKey,
+  type Connection,
+  type ParsedInstruction,
+  type PartiallyDecodedInstruction,
+} from '@solana/web3.js'
+
+export class StealthContextError extends Error {
+  constructor(
+    message: string,
+    public readonly code:
+      | 'deposit_not_found'
+      | 'no_withdraw_event'
+      | 'no_token_transfer'
+      | 'stealth_ata_mismatch',
+  ) {
+    super(message)
+    this.name = 'StealthContextError'
+  }
+}
+
+export interface StealthContext {
+  /** Base58-encoded stealth pubkey (must equal the stealth ATA's owner). */
+  stealthAddress: string
+  /** Base58-encoded ephemeral pubkey (32 bytes, 0x00 prefix already stripped). */
+  ephemeralPublicKey: string
+  /** Base58-encoded SPL token mint of the stealth ATA. */
+  mint: string
+}
+
+const PROGRAM_DATA_PREFIX = 'Program data: '
+/**
+ * Minimum VaultWithdrawEvent bytes:
+ * 8 (disc) + 32 (depositor) + 32 (stealth) + 33 (commitment) + 33 (ephemeral)
+ *  + 32 (vk_hash) + 8 (amount) + 8 (fee) + 8 (ts) = 194
+ */
+const WITHDRAW_EVENT_MIN_BYTES = 194
+const SPL_TOKEN_PROGRAMS = new Set(['spl-token', 'spl-token-2022'])
+
+function isParsedInstruction(
+  ix: ParsedInstruction | PartiallyDecodedInstruction,
+): ix is ParsedInstruction {
+  return 'program' in ix && 'parsed' in ix
+}
+
+/**
+ * Resolves a deposit transaction signature into the cryptographic context
+ * needed by `claimStealthPayment`. Two RPC calls: one `getParsedTransaction`
+ * (to read the VaultWithdrawEvent log + SPL transfer instruction) and one
+ * `getParsedAccountInfo` (to sanity-check the stealth ATA's owner).
+ */
+export async function resolveStealthContext(
+  connection: Connection,
+  depositTxSignature: string,
+): Promise<StealthContext> {
+  const tx = await connection.getParsedTransaction(depositTxSignature, {
+    commitment: 'confirmed',
+    maxSupportedTransactionVersion: 0,
+  })
+
+  if (!tx) {
+    throw new StealthContextError(
+      `Deposit transaction ${depositTxSignature.slice(0, 12)}... not found on chain`,
+      'deposit_not_found',
+    )
+  }
+
+  const event = parseWithdrawEventFromLogs(tx.meta?.logMessages ?? [])
+  if (!event) {
+    throw new StealthContextError(
+      `No VaultWithdrawEvent in deposit ${depositTxSignature.slice(0, 12)}... — is this a sipher private send?`,
+      'no_withdraw_event',
+    )
+  }
+
+  const topLevel = tx.transaction.message.instructions
+  const inner = (tx.meta?.innerInstructions ?? []).flatMap((g) => g.instructions)
+  const allInstructions: ReadonlyArray<ParsedInstruction | PartiallyDecodedInstruction> = [
+    ...topLevel,
+    ...inner,
+  ]
+
+  const tokenIx = allInstructions.filter(isParsedInstruction).find((ix) => {
+    if (!SPL_TOKEN_PROGRAMS.has(ix.program)) return false
+    const parsed = ix.parsed as { type?: string; info?: unknown } | string | null
+    if (typeof parsed !== 'object' || parsed === null) return false
+    if (parsed.type !== 'transferChecked') return false
+    if (typeof parsed.info !== 'object' || parsed.info === null) return false
+    return true
+  })
+  if (!tokenIx) {
+    throw new StealthContextError(
+      `No SPL transferChecked instruction in deposit ${depositTxSignature.slice(0, 12)}...`,
+      'no_token_transfer',
+    )
+  }
+
+  const tokenInfo = (tokenIx.parsed as { info: { destination?: unknown; mint?: unknown } }).info
+  const stealthATA = typeof tokenInfo.destination === 'string' ? tokenInfo.destination : null
+  const mint = typeof tokenInfo.mint === 'string' ? tokenInfo.mint : null
+  if (!stealthATA || !mint) {
+    throw new StealthContextError(
+      `SPL transferChecked missing destination or mint in deposit ${depositTxSignature.slice(0, 12)}...`,
+      'no_token_transfer',
+    )
+  }
+
+  const ataInfo = await connection.getParsedAccountInfo(new PublicKey(stealthATA))
+  const ataData = ataInfo?.value?.data
+  const ataOwner =
+    ataData && typeof ataData === 'object' && 'parsed' in ataData
+      ? ((ataData.parsed as { info?: { owner?: unknown } } | undefined)?.info?.owner ?? null)
+      : null
+  if (typeof ataOwner !== 'string') {
+    throw new StealthContextError(
+      `Stealth ATA ${stealthATA.slice(0, 12)}... is unreadable or not a parsed token account`,
+      'stealth_ata_mismatch',
+    )
+  }
+  if (ataOwner !== event.stealthAddress) {
+    throw new StealthContextError(
+      `Stealth ATA owner ${ataOwner.slice(0, 12)}... does not match VaultWithdrawEvent stealth_recipient ${event.stealthAddress.slice(0, 12)}...`,
+      'stealth_ata_mismatch',
+    )
+  }
+
+  return {
+    stealthAddress: event.stealthAddress,
+    ephemeralPublicKey: event.ephemeralPublicKey,
+    mint,
+  }
+}
+
+interface WithdrawEvent {
+  stealthAddress: string
+  ephemeralPublicKey: string
+}
+
+/**
+ * Parses the first decode-able VaultWithdrawEvent out of `Program data: <b64>`
+ * log lines. Mirrors `parseWithdrawEvent` in packages/sdk/src/privacy.ts:413-454
+ * (no discriminator check — matches sipher's scan behavior; relies on the
+ * 194-byte length floor and the downstream ATA-owner equality check to
+ * filter spurious decodes).
+ */
+function parseWithdrawEventFromLogs(logs: string[]): WithdrawEvent | null {
+  for (const log of logs) {
+    if (!log.startsWith(PROGRAM_DATA_PREFIX)) continue
+    const b64 = log.slice(PROGRAM_DATA_PREFIX.length).trim()
+    if (!b64) continue
+    let data: Buffer
+    try {
+      data = Buffer.from(b64, 'base64')
+    } catch {
+      continue
+    }
+    if (data.length < WITHDRAW_EVENT_MIN_BYTES) continue
+    try {
+      // Layout (after 8-byte discriminator): depositor[32] | stealth[32]
+      //   | commitment[33] | ephemeral[33] | vk_hash[32] | amount[8] | fee[8] | ts[8]
+      const stealthBytes = data.subarray(40, 72)
+      const stealthAddress = new PublicKey(stealthBytes).toBase58()
+      // Ephemeral is 33 bytes (0x00 prefix + 32-byte ed25519); strip prefix.
+      const ephRaw = data[105] === 0x00 ? data.subarray(106, 138) : data.subarray(105, 137)
+      if (ephRaw.length !== 32) continue
+      // Skip pre-integration placeholder events with zero-filled ephemeral.
+      if (ephRaw.every((b) => b === 0)) continue
+      const ephemeralPublicKey = new PublicKey(ephRaw).toBase58()
+      return { stealthAddress, ephemeralPublicKey }
+    } catch {
+      continue // not a VaultWithdrawEvent layout; try next log
+    }
+  }
+  return null
+}

--- a/packages/agent/src/tools/claim.ts
+++ b/packages/agent/src/tools/claim.ts
@@ -1,6 +1,6 @@
 import { PublicKey } from '@solana/web3.js'
 import { claimStealthPayment, type SolanaClaimResult } from '@sip-protocol/sdk'
-import { createConnection, USDC_MINT } from '@sipher/sdk'
+import { createConnection } from '@sipher/sdk'
 import { loadNetworkConfig } from '../config/network.js'
 import { resolveStealthContext, StealthContextError } from './claim-helpers.js'
 import type { AnthropicTool } from '../pi/tool-adapter.js'
@@ -18,8 +18,8 @@ export interface ClaimParams {
   txSignature: string
   viewingKey: string
   spendingKey: string
-  /** Optional destination wallet (base58). Defaults to the spending pubkey. */
-  destinationWallet?: string
+  /** Destination wallet (base58) to receive claimed tokens. */
+  destinationWallet: string
   /**
    * Optional SPL token mint (base58). If omitted, the mint is resolved from
    * the deposit transaction. Provide explicitly when you already know it
@@ -62,15 +62,15 @@ export const claimTool: AnthropicTool = {
       },
       viewingKey: {
         type: 'string',
-        description: 'Your viewing private key (hex or base58)',
+        description: 'Your viewing private key (hex, with or without 0x prefix)',
       },
       spendingKey: {
         type: 'string',
-        description: 'Your spending private key (hex or base58). Used to derive the stealth key.',
+        description: 'Your spending private key (hex, with or without 0x prefix). Used to derive the stealth key.',
       },
       destinationWallet: {
         type: 'string',
-        description: 'Wallet address (base58) to receive claimed tokens. Defaults to the spending pubkey.',
+        description: 'Wallet address (base58) to receive claimed tokens. Required (auto-derive from spending pubkey is a planned follow-up).',
       },
       mint: {
         type: 'string',
@@ -78,7 +78,7 @@ export const claimTool: AnthropicTool = {
           'Optional SPL token mint (base58). If omitted, the mint is resolved from the deposit transaction.',
       },
     },
-    required: ['txSignature', 'viewingKey', 'spendingKey'],
+    required: ['txSignature', 'viewingKey', 'spendingKey', 'destinationWallet'],
   },
 }
 
@@ -106,8 +106,11 @@ export async function executeClaim(params: ClaimParams): Promise<ClaimToolResult
     throw err
   }
 
-  const mintBase58 = params.mint ?? ctx.mint ?? USDC_MINT.toBase58()
-  const destinationAddress = params.destinationWallet ?? deriveDestinationFromSpending(params.spendingKey)
+  const mintBase58 = params.mint ?? ctx.mint
+  if (!mintBase58) {
+    throw new Error('Internal: resolveStealthContext returned no mint and no override was provided')
+  }
+  const destinationAddress = params.destinationWallet
   const viewingPrivateKey = normalizeKey(params.viewingKey)
   const spendingPrivateKey = normalizeKey(params.spendingKey)
 
@@ -140,16 +143,6 @@ export async function executeClaim(params: ClaimParams): Promise<ClaimToolResult
       `Claimed payment ${params.txSignature.slice(0, 12)}... → claim tx ${sdkResult.txSignature.slice(0, 12)}... ` +
       `(${sdkResult.amount.toString()} units to ${sdkResult.destinationAddress.slice(0, 8)}...)`,
   }
-}
-
-/** @internal — placeholder until SDK exposes spending pubkey derivation */
-function deriveDestinationFromSpending(spendingKey: string): string {
-  // For Path A initial scope: if user does not provide destinationWallet, throw —
-  // mirroring the existing send tool's pattern. A follow-up PR can derive the
-  // pubkey from the spending privkey, but for the initial ship the destination
-  // is always supplied via the agent's tool input.
-  void spendingKey
-  throw new Error('destinationWallet is required (Path A initial scope — auto-derive in follow-up)')
 }
 
 /** Strip 0x prefix and validate hex shape for SDK consumption. */

--- a/packages/agent/src/tools/claim.ts
+++ b/packages/agent/src/tools/claim.ts
@@ -1,13 +1,17 @@
+import { PublicKey } from '@solana/web3.js'
+import { claimStealthPayment, type SolanaClaimResult } from '@sip-protocol/sdk'
+import { createConnection, USDC_MINT } from '@sipher/sdk'
+import { loadNetworkConfig } from '../config/network.js'
+import { resolveStealthContext, StealthContextError } from './claim-helpers.js'
 import type { AnthropicTool } from '../pi/tool-adapter.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Claim tool — Claim a received stealth payment
 //
-// NOTE: Claim uses sip_privacy program's claim_transfer instruction, not
-// sipher_vault. The stealth private key derivation requires the full
-// @sip-protocol/sdk ECDH flow. This is scaffolded for Phase 1 — the tool
-// validates inputs, derives the stealth key concept, and returns the
-// prepared shape. Phase 2 will wire to the real claim_transfer instruction.
+// Delegates ECDH derivation + SPL transfer + broadcast to @sip-protocol/sdk's
+// claimStealthPayment. Stealth context (stealth address, ephemeral pubkey,
+// mint) is resolved from the deposit tx via resolveStealthContext (helper).
+// Returns the claim tx signature for honest Torque attribution.
 // ─────────────────────────────────────────────────────────────────────────────
 
 export interface ClaimParams {
@@ -89,6 +93,70 @@ export async function executeClaim(params: ClaimParams): Promise<ClaimToolResult
     throw new Error('Spending key is required to derive stealth key')
   }
 
-  // Task 4 will replace this stub with the real SDK call.
-  throw new Error('executeClaim Phase 2 not yet wired — Task 4 placeholder')
+  const network = loadNetworkConfig().clusterName
+  const connection = createConnection(network)
+
+  let ctx
+  try {
+    ctx = await resolveStealthContext(connection, params.txSignature)
+  } catch (err) {
+    if (err instanceof StealthContextError) {
+      throw new Error(`Cannot resolve stealth payment: ${err.message}`)
+    }
+    throw err
+  }
+
+  const mintBase58 = params.mint ?? ctx.mint ?? USDC_MINT.toBase58()
+  const destinationAddress = params.destinationWallet ?? deriveDestinationFromSpending(params.spendingKey)
+  const viewingPrivateKey = normalizeKey(params.viewingKey)
+  const spendingPrivateKey = normalizeKey(params.spendingKey)
+
+  let sdkResult: SolanaClaimResult
+  try {
+    sdkResult = await claimStealthPayment({
+      connection,
+      stealthAddress: ctx.stealthAddress,
+      ephemeralPublicKey: ctx.ephemeralPublicKey,
+      viewingPrivateKey,
+      spendingPrivateKey,
+      destinationAddress,
+      mint: new PublicKey(mintBase58),
+    })
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err)
+    throw new Error(`Claim broadcast failed: ${detail}`)
+  }
+
+  return {
+    action: 'claim',
+    status: 'confirmed',
+    depositTxSignature: params.txSignature,
+    signature: sdkResult.txSignature,
+    destinationWallet: sdkResult.destinationAddress,
+    amount: sdkResult.amount.toString(),
+    mint: mintBase58,
+    explorerUrl: sdkResult.explorerUrl,
+    message:
+      `Claimed payment ${params.txSignature.slice(0, 12)}... → claim tx ${sdkResult.txSignature.slice(0, 12)}... ` +
+      `(${sdkResult.amount.toString()} units to ${sdkResult.destinationAddress.slice(0, 8)}...)`,
+  }
+}
+
+/** @internal — placeholder until SDK exposes spending pubkey derivation */
+function deriveDestinationFromSpending(spendingKey: string): string {
+  // For Path A initial scope: if user does not provide destinationWallet, throw —
+  // mirroring the existing send tool's pattern. A follow-up PR can derive the
+  // pubkey from the spending privkey, but for the initial ship the destination
+  // is always supplied via the agent's tool input.
+  void spendingKey
+  throw new Error('destinationWallet is required (Path A initial scope — auto-derive in follow-up)')
+}
+
+/** Strip 0x prefix and validate hex shape for SDK consumption. */
+function normalizeKey(key: string): `0x${string}` {
+  const stripped = key.startsWith('0x') ? key.slice(2) : key
+  if (!/^[0-9a-fA-F]+$/.test(stripped)) {
+    throw new Error('Key must be hex (with or without 0x prefix)')
+  }
+  return `0x${stripped.toLowerCase()}` as `0x${string}`
 }

--- a/packages/agent/src/tools/claim.ts
+++ b/packages/agent/src/tools/claim.ts
@@ -14,29 +14,41 @@ export interface ClaimParams {
   txSignature: string
   viewingKey: string
   spendingKey: string
+  /** Optional destination wallet (base58). Defaults to the spending pubkey. */
   destinationWallet?: string
+  /**
+   * Optional SPL token mint (base58). If omitted, the mint is resolved from
+   * the deposit transaction. Provide explicitly when you already know it
+   * (e.g. from a prior scan result) to skip the on-chain lookup.
+   */
+  mint?: string
 }
 
 export interface ClaimToolResult {
   action: 'claim'
-  txSignature: string
-  status: 'awaiting_signature'
+  status: 'confirmed'
+  /** The input deposit-tx signature (for traceability). */
+  depositTxSignature: string
+  /** The CLAIM tx signature — growth-hook reads this as the Torque attribution key. */
+  signature: string
+  /** Base58 destination wallet that received the funds. */
+  destinationWallet: string
+  /** Claimed amount in the token's smallest unit, stringified to avoid BigInt JSON issues. */
+  amount: string
+  /** Base58 SPL token mint. */
+  mint: string
+  /** Explorer URL for the claim transaction. */
+  explorerUrl: string
+  /** Human-readable summary for the chat UX. */
   message: string
-  /** Base64-serialized unsigned transaction (null until Phase 2 integration) */
-  serializedTx: string | null
-  details: {
-    stealthKeyDerived: boolean
-    destinationWallet: string | null
-    note: string
-  }
 }
 
 export const claimTool: AnthropicTool = {
   name: 'claim',
   description:
     'Claim a received stealth payment found by the scan tool. ' +
-    'Derives the stealth private key from your viewing+spending keys and builds a claim transaction. ' +
-    'The claimed tokens are sent to your destination wallet.',
+    'Derives the stealth private key from your viewing+spending keys, ' +
+    'transfers the tokens to your destination wallet, and returns the claim tx signature.',
   input_schema: {
     type: 'object' as const,
     properties: {
@@ -56,6 +68,11 @@ export const claimTool: AnthropicTool = {
         type: 'string',
         description: 'Wallet address (base58) to receive claimed tokens. Defaults to the spending pubkey.',
       },
+      mint: {
+        type: 'string',
+        description:
+          'Optional SPL token mint (base58). If omitted, the mint is resolved from the deposit transaction.',
+      },
     },
     required: ['txSignature', 'viewingKey', 'spendingKey'],
   },
@@ -65,31 +82,13 @@ export async function executeClaim(params: ClaimParams): Promise<ClaimToolResult
   if (!params.txSignature || params.txSignature.trim().length === 0) {
     throw new Error('Transaction signature is required')
   }
-
   if (!params.viewingKey || params.viewingKey.trim().length === 0) {
     throw new Error('Viewing key is required to derive stealth key')
   }
-
   if (!params.spendingKey || params.spendingKey.trim().length === 0) {
     throw new Error('Spending key is required to derive stealth key')
   }
 
-  // Phase 1: Return the prepared shape. The actual claim_transfer instruction
-  // building requires @sip-protocol/sdk's ECDH derivation to compute the
-  // stealth private key from ephemeralPubkey + viewingKey + spendingKey.
-  // That wiring happens in Phase 2 when the full claim flow is implemented.
-  return {
-    action: 'claim',
-    txSignature: params.txSignature,
-    status: 'awaiting_signature',
-    message:
-      `Claim prepared for payment ${params.txSignature.slice(0, 12)}... ` +
-      `Stealth key derived. Awaiting signature to transfer tokens to your wallet.`,
-    serializedTx: null,
-    details: {
-      stealthKeyDerived: true,
-      destinationWallet: params.destinationWallet ?? null,
-      note: 'The stealth private key is ephemeral — it exists only for this claim and is never stored.',
-    },
-  }
+  // Task 4 will replace this stub with the real SDK call.
+  throw new Error('executeClaim Phase 2 not yet wired — Task 4 placeholder')
 }

--- a/packages/agent/src/tools/consolidate.ts
+++ b/packages/agent/src/tools/consolidate.ts
@@ -113,6 +113,7 @@ export async function executeConsolidate(
         stealthAddress: payment.stealthAddress.toBase58(),
         viewingKey: params.viewingKey,
         spendingKey: params.spendingKey,
+        destinationWallet: params.wallet,
       },
       wallet_signature: params.walletSignature ?? 'pending',
       next_exec: executesAt,

--- a/packages/agent/tests/claim.test.ts
+++ b/packages/agent/tests/claim.test.ts
@@ -1,11 +1,48 @@
 // packages/agent/tests/claim.test.ts
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the SDK BEFORE importing claim.ts
+vi.mock('@sip-protocol/sdk', async () => {
+  const actual = await vi.importActual<typeof import('@sip-protocol/sdk')>('@sip-protocol/sdk')
+  return {
+    ...actual,
+    claimStealthPayment: vi.fn(),
+  }
+})
+
+// Mock helpers + sipher connection helper
+vi.mock('../src/tools/claim-helpers.js', () => ({
+  resolveStealthContext: vi.fn(),
+  StealthContextError: class StealthContextError extends Error {
+    constructor(message: string, public code: string) {
+      super(message)
+      this.name = 'StealthContextError'
+    }
+  },
+}))
+
+vi.mock('@sipher/sdk', async () => {
+  const actual = await vi.importActual<typeof import('@sipher/sdk')>('@sipher/sdk')
+  return {
+    ...actual,
+    createConnection: vi.fn(() => ({
+      // Minimal Connection mock surface — methods called by claim flow indirectly
+    })),
+  }
+})
+
 import { claimTool, executeClaim } from '../src/tools/claim.js'
+import { claimStealthPayment } from '@sip-protocol/sdk'
+import { resolveStealthContext } from '../src/tools/claim-helpers.js'
 
 const VALID_TX_SIG = '5' + 'a'.repeat(87)
 const VALID_VIEWING_KEY = 'ab'.repeat(32)
 const VALID_SPENDING_KEY = 'cd'.repeat(32)
 const VALID_DESTINATION = 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr'
+const STEALTH_ADDR = 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N'
+const EPHEMERAL_PUBKEY = 'GqvBwYTWWZRyDQ4ZeNvFLgfbA8wYjBvE6cKxFQXjHvSr'
+const MINT_USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+const CLAIM_TX_SIG = '4Hc' + 'b'.repeat(85)
 
 describe('claimTool definition', () => {
   it('has correct name', () => {
@@ -20,29 +57,28 @@ describe('claimTool definition', () => {
     ])
   })
 
-  it('declares optional destinationWallet field', () => {
+  it('declares optional destinationWallet and mint fields', () => {
     expect(claimTool.input_schema.properties).toHaveProperty('destinationWallet')
+    expect(claimTool.input_schema.properties).toHaveProperty('mint')
   })
 })
 
 describe('executeClaim — happy path', () => {
-  it('returns awaiting_signature shape with stealth key derived', async () => {
-    const result = await executeClaim({
-      txSignature: VALID_TX_SIG,
-      viewingKey: VALID_VIEWING_KEY,
-      spendingKey: VALID_SPENDING_KEY,
+  beforeEach(() => {
+    vi.mocked(resolveStealthContext).mockResolvedValue({
+      stealthAddress: STEALTH_ADDR,
+      ephemeralPublicKey: EPHEMERAL_PUBKEY,
+      mint: MINT_USDC,
     })
-
-    expect(result.action).toBe('claim')
-    expect(result.txSignature).toBe(VALID_TX_SIG)
-    expect(result.status).toBe('awaiting_signature')
-    expect(result.serializedTx).toBeNull()
-    expect(result.details.stealthKeyDerived).toBe(true)
-    expect(result.details.destinationWallet).toBeNull()
-    expect(result.details.note).toContain('ephemeral')
+    vi.mocked(claimStealthPayment).mockResolvedValue({
+      txSignature: CLAIM_TX_SIG,
+      destinationAddress: VALID_DESTINATION,
+      amount: 1000000n,
+      explorerUrl: `https://solscan.io/tx/${CLAIM_TX_SIG}`,
+    })
   })
 
-  it('reflects destinationWallet when provided', async () => {
+  it('returns confirmed status with claim signature', async () => {
     const result = await executeClaim({
       txSignature: VALID_TX_SIG,
       viewingKey: VALID_VIEWING_KEY,
@@ -50,22 +86,47 @@ describe('executeClaim — happy path', () => {
       destinationWallet: VALID_DESTINATION,
     })
 
-    expect(result.details.destinationWallet).toBe(VALID_DESTINATION)
+    expect(result.action).toBe('claim')
+    expect(result.status).toBe('confirmed')
+    expect(result.signature).toBe(CLAIM_TX_SIG)
+    expect(result.depositTxSignature).toBe(VALID_TX_SIG)
+    expect(result.destinationWallet).toBe(VALID_DESTINATION)
+    expect(result.amount).toBe('1000000')
+    expect(result.mint).toBe(MINT_USDC)
+    expect(result.explorerUrl).toContain(CLAIM_TX_SIG)
   })
 
-  it('truncates signature in message', async () => {
+  it('passes resolved stealth context to claimStealthPayment', async () => {
+    await executeClaim({
+      txSignature: VALID_TX_SIG,
+      viewingKey: VALID_VIEWING_KEY,
+      spendingKey: VALID_SPENDING_KEY,
+      destinationWallet: VALID_DESTINATION,
+    })
+
+    expect(claimStealthPayment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stealthAddress: STEALTH_ADDR,
+        ephemeralPublicKey: EPHEMERAL_PUBKEY,
+        destinationAddress: VALID_DESTINATION,
+      }),
+    )
+  })
+
+  it('truncates deposit signature in message', async () => {
     const result = await executeClaim({
       txSignature: VALID_TX_SIG,
       viewingKey: VALID_VIEWING_KEY,
       spendingKey: VALID_SPENDING_KEY,
+      destinationWallet: VALID_DESTINATION,
     })
 
     expect(result.message).toContain(VALID_TX_SIG.slice(0, 12))
-    expect(result.message).not.toContain(VALID_TX_SIG.slice(13))
+    expect(result.message).toContain(CLAIM_TX_SIG.slice(0, 12))
   })
 })
 
-describe('executeClaim — input validation', () => {
+describe('executeClaim — input validation (regression)', () => {
   it('rejects empty txSignature', async () => {
     await expect(
       executeClaim({

--- a/packages/agent/tests/claim.test.ts
+++ b/packages/agent/tests/claim.test.ts
@@ -33,7 +33,7 @@ vi.mock('@sipher/sdk', async () => {
 
 import { claimTool, executeClaim } from '../src/tools/claim.js'
 import { claimStealthPayment } from '@sip-protocol/sdk'
-import { resolveStealthContext } from '../src/tools/claim-helpers.js'
+import { resolveStealthContext, StealthContextError } from '../src/tools/claim-helpers.js'
 
 const VALID_TX_SIG = '5' + 'a'.repeat(87)
 const VALID_VIEWING_KEY = 'ab'.repeat(32)
@@ -170,5 +170,59 @@ describe('executeClaim — input validation (regression)', () => {
         destinationWallet: VALID_DESTINATION,
       })
     ).rejects.toThrow(/spending key is required/i)
+  })
+})
+
+describe('executeClaim — error paths', () => {
+  it('wraps StealthContextError in actionable error', async () => {
+    vi.mocked(resolveStealthContext).mockRejectedValue(
+      new StealthContextError('Deposit transaction 5aaaaaa... not found on chain', 'deposit_not_found'),
+    )
+
+    await expect(
+      executeClaim({
+        txSignature: VALID_TX_SIG,
+        viewingKey: VALID_VIEWING_KEY,
+        spendingKey: VALID_SPENDING_KEY,
+        destinationWallet: VALID_DESTINATION,
+      }),
+    ).rejects.toThrow(/Cannot resolve stealth payment/i)
+  })
+
+  it('wraps SDK broadcast errors in actionable error', async () => {
+    vi.mocked(resolveStealthContext).mockResolvedValue({
+      stealthAddress: STEALTH_ADDR,
+      ephemeralPublicKey: EPHEMERAL_PUBKEY,
+      mint: MINT_USDC,
+    })
+    vi.mocked(claimStealthPayment).mockRejectedValue(
+      new Error('Stealth key derivation failed: derived private key does not produce expected public key'),
+    )
+
+    await expect(
+      executeClaim({
+        txSignature: VALID_TX_SIG,
+        viewingKey: VALID_VIEWING_KEY,
+        spendingKey: VALID_SPENDING_KEY,
+        destinationWallet: VALID_DESTINATION,
+      }),
+    ).rejects.toThrow(/Claim broadcast failed:.*Stealth key derivation failed/i)
+  })
+
+  it('rejects non-hex viewing key', async () => {
+    vi.mocked(resolveStealthContext).mockResolvedValue({
+      stealthAddress: STEALTH_ADDR,
+      ephemeralPublicKey: EPHEMERAL_PUBKEY,
+      mint: MINT_USDC,
+    })
+
+    await expect(
+      executeClaim({
+        txSignature: VALID_TX_SIG,
+        viewingKey: 'this-is-not-hex',
+        spendingKey: VALID_SPENDING_KEY,
+        destinationWallet: VALID_DESTINATION,
+      }),
+    ).rejects.toThrow(/key must be hex/i)
   })
 })

--- a/packages/agent/tests/claim.test.ts
+++ b/packages/agent/tests/claim.test.ts
@@ -54,10 +54,11 @@ describe('claimTool definition', () => {
       'txSignature',
       'viewingKey',
       'spendingKey',
+      'destinationWallet',
     ])
   })
 
-  it('declares optional destinationWallet and mint fields', () => {
+  it('declares destinationWallet and mint properties', () => {
     expect(claimTool.input_schema.properties).toHaveProperty('destinationWallet')
     expect(claimTool.input_schema.properties).toHaveProperty('mint')
   })
@@ -133,6 +134,7 @@ describe('executeClaim — input validation (regression)', () => {
         txSignature: '',
         viewingKey: VALID_VIEWING_KEY,
         spendingKey: VALID_SPENDING_KEY,
+        destinationWallet: VALID_DESTINATION,
       })
     ).rejects.toThrow(/transaction signature is required/i)
   })
@@ -143,6 +145,7 @@ describe('executeClaim — input validation (regression)', () => {
         txSignature: '   ',
         viewingKey: VALID_VIEWING_KEY,
         spendingKey: VALID_SPENDING_KEY,
+        destinationWallet: VALID_DESTINATION,
       })
     ).rejects.toThrow(/transaction signature is required/i)
   })
@@ -153,6 +156,7 @@ describe('executeClaim — input validation (regression)', () => {
         txSignature: VALID_TX_SIG,
         viewingKey: '',
         spendingKey: VALID_SPENDING_KEY,
+        destinationWallet: VALID_DESTINATION,
       })
     ).rejects.toThrow(/viewing key is required/i)
   })
@@ -163,6 +167,7 @@ describe('executeClaim — input validation (regression)', () => {
         txSignature: VALID_TX_SIG,
         viewingKey: VALID_VIEWING_KEY,
         spendingKey: '',
+        destinationWallet: VALID_DESTINATION,
       })
     ).rejects.toThrow(/spending key is required/i)
   })

--- a/packages/agent/tests/integrations/torque/growth-hook.test.ts
+++ b/packages/agent/tests/integrations/torque/growth-hook.test.ts
@@ -205,6 +205,40 @@ describe('wrapExecutorWithGrowthHook', () => {
     expect(call.data.asset).toBeUndefined()
   })
 
+  it('claim emission uses result.signature (claim tx) as data.tx_signature, NOT depositTxSignature', async () => {
+    const DEPOSIT_TX = TX_SIG // existing constant — what we WOULDN'T want as the attribution key
+    const CLAIM_TX = '4HcClaimTxSignaturePlaceholderXXXXXXXXXXXXXXX' // distinct sig — should be the attribution key
+
+    baseExecutor.mockResolvedValue({
+      action: 'claim',
+      status: 'confirmed',
+      depositTxSignature: DEPOSIT_TX,
+      signature: CLAIM_TX,
+      destinationWallet: 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr',
+      amount: '1000000',
+      mint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+      explorerUrl: `https://solscan.io/tx/${CLAIM_TX}`,
+      message: '...',
+    })
+
+    const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)
+    await wrapped('claim', {
+      wallet: WALLET,
+      txSignature: DEPOSIT_TX,
+      viewingKey: 'vk',
+      spendingKey: 'sk',
+      destinationWallet: 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr',
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(emitEventMock).toHaveBeenCalledOnce()
+    const emittedEvent = emitEventMock.mock.calls[0]![0]
+    expect(emittedEvent.eventName).toBe('sipher_private_claim_completed')
+    expect(emittedEvent.data.tx_signature).toBe(CLAIM_TX)
+    // Negative assertion: the deposit-tx-sig must NOT be the attribution key
+    expect(emittedEvent.data.tx_signature).not.toBe(DEPOSIT_TX)
+  })
+
   it('does NOT emit when base executor throws', async () => {
     baseExecutor.mockRejectedValue(new Error('boom'))
     const wrapped = wrapExecutorWithGrowthHook(baseExecutor, opts)

--- a/packages/agent/tests/tools.test.ts
+++ b/packages/agent/tests/tools.test.ts
@@ -11,7 +11,6 @@ import {
   scanTool,
   executeScan,
   claimTool,
-  executeClaim,
   swapTool,
   executeSwap,
   viewingKeyTool,
@@ -263,13 +262,19 @@ describe('executeTool', () => {
     expect(result).toHaveProperty('action', 'scan')
   })
 
-  it('dispatches to claim', async () => {
-    const result = await executeTool('claim', {
-      txSignature: 'sig123',
-      viewingKey: 'abc',
-      spendingKey: 'def',
-    })
-    expect(result).toHaveProperty('action', 'claim')
+  it('dispatches to claim (routes through executeClaim and resolveStealthContext)', async () => {
+    // executeClaim now delegates to the SDK via resolveStealthContext, which
+    // calls connection.getParsedTransaction. The mocked connection returns
+    // null → StealthContextError('deposit_not_found') → wrapped error here.
+    // The throw confirms the dispatcher routed to executeClaim correctly.
+    await expect(
+      executeTool('claim', {
+        txSignature: 'sig123',
+        viewingKey: 'ab'.repeat(32),
+        spendingKey: 'cd'.repeat(32),
+        destinationWallet: VALID_WALLET,
+      })
+    ).rejects.toThrow(/Cannot resolve stealth payment/i)
   })
 
   it('dispatches to swap', async () => {
@@ -526,57 +531,10 @@ describe('executeScan', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Claim tool
+// Claim tool — unit coverage lives in tests/claim.test.ts (full SDK + helper
+// mock setup). Dispatch routing is exercised by the executeTool dispatcher
+// block above.
 // ─────────────────────────────────────────────────────────────────────────────
-
-describe('executeClaim', () => {
-  const validParams = {
-    txSignature: 'sig123abc456def',
-    viewingKey: 'vk999',
-    spendingKey: 'sk888',
-  }
-
-  it('returns correct result shape', async () => {
-    const result = await executeClaim(validParams)
-    expect(result.action).toBe('claim')
-    expect(result.txSignature).toBe('sig123abc456def')
-    expect(result.status).toBe('awaiting_signature')
-    expect(result.details.stealthKeyDerived).toBe(true)
-    expect(result.details.destinationWallet).toBeNull()
-    expect(result.serializedTx).toBeNull()
-  })
-
-  it('includes destination wallet when provided', async () => {
-    const result = await executeClaim({
-      ...validParams,
-      destinationWallet: VALID_WALLET,
-    })
-    expect(result.details.destinationWallet).toBe(VALID_WALLET)
-  })
-
-  it('message contains truncated signature', async () => {
-    const result = await executeClaim(validParams)
-    expect(result.message).toContain('sig123abc456')
-  })
-
-  it('rejects empty tx signature', async () => {
-    await expect(
-      executeClaim({ ...validParams, txSignature: '' })
-    ).rejects.toThrow('Transaction signature is required')
-  })
-
-  it('rejects empty viewing key', async () => {
-    await expect(
-      executeClaim({ ...validParams, viewingKey: '' })
-    ).rejects.toThrow('Viewing key is required')
-  })
-
-  it('rejects empty spending key', async () => {
-    await expect(
-      executeClaim({ ...validParams, spendingKey: '' })
-    ).rejects.toThrow('Spending key is required')
-  })
-})
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Swap tool

--- a/packages/agent/tests/tools/claim-helpers.test.ts
+++ b/packages/agent/tests/tools/claim-helpers.test.ts
@@ -1,0 +1,105 @@
+import { Buffer } from 'node:buffer'
+import { describe, it, expect, vi } from 'vitest'
+import { PublicKey, type Connection } from '@solana/web3.js'
+import { resolveStealthContext, StealthContextError } from '../../src/tools/claim-helpers.js'
+
+const DEPOSIT_SIG =
+  '4Hc3vQBhYzS5xQZK1RtwvkLqxg1JhWf5pSr6vKQYVbTtFNxRr5jJp2k4QvJqwn3aB6XzMpYsLqHv2QwRcVbN8mY5s5c'
+const STEALTH_PUBKEY = 'C1phrE76Wrkmt1GP6Aa9RjCeLDKHZ7p4MPVRuPa8x85N'
+const EPHEMERAL_PUBKEY = 'GqvBwYTWWZRyDQ4ZeNvFLgfbA8wYjBvE6cKxFQXjHvSr'
+const STEALTH_ATA = 'AfPXfQs5MNJyEnUYvxRJ6BHwQNyKqJVE9Y3CDbHwfXVc'
+const MINT_USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+
+/**
+ * Build a synthetic VaultWithdrawEvent buffer matching the on-chain layout
+ * documented at packages/sdk/src/privacy.ts:401-411. Total 194 bytes (minimum).
+ */
+function buildWithdrawEventBytes(opts: {
+  stealthBs58?: string
+  ephemeralBs58?: string
+  zeroEphemeral?: boolean
+}): Buffer {
+  const buf = Buffer.alloc(194)
+  // [0, 8)  — Anchor event discriminator (arbitrary bytes; sipher doesn't validate)
+  buf.write('0011223344556677', 0, 'hex')
+  // [8, 40) — depositor (zeros, not used by resolver)
+  // [40, 72) — stealth_recipient
+  const stealth = new PublicKey(opts.stealthBs58 ?? STEALTH_PUBKEY).toBytes()
+  Buffer.from(stealth).copy(buf, 40)
+  // [72, 105) — amount_commitment (zeros)
+  // [105, 138) — ephemeral_pubkey: 0x00 prefix + 32-byte ed25519 (per privacy.ts:339-341)
+  buf[105] = 0x00
+  if (opts.zeroEphemeral) {
+    // intentionally leave [106..138] as zeros — should be skipped by resolver
+  } else {
+    const eph = new PublicKey(opts.ephemeralBs58 ?? EPHEMERAL_PUBKEY).toBytes()
+    Buffer.from(eph).copy(buf, 106)
+  }
+  // [138, 170) — viewing_key_hash (zeros)
+  // [170, 178) — transfer_amount (zeros)
+  // [178, 186) — fee_amount (zeros)
+  // [186, 194) — timestamp (zeros)
+  return buf
+}
+
+function programDataLog(eventBytes: Buffer): string {
+  return `Program data: ${eventBytes.toString('base64')}`
+}
+
+/**
+ * Synthesize a parsed-tx response shape matching @solana/web3.js's
+ * `ParsedTransactionWithMeta` for unit testing. Real responses contain
+ * many more fields; the resolver only reads the keys touched below.
+ */
+function mockTxWithEventAndSplTransfer(opts: { tokenProgram?: 'spl-token' | 'spl-token-2022'; inner?: boolean } = {}) {
+  const tokenProgram = opts.tokenProgram ?? 'spl-token'
+  const splTokenIx = {
+    program: tokenProgram,
+    programId: new PublicKey(
+      tokenProgram === 'spl-token-2022'
+        ? 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'
+        : 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+    ),
+    parsed: {
+      type: 'transferChecked',
+      info: {
+        destination: STEALTH_ATA,
+        mint: MINT_USDC,
+        tokenAmount: { amount: '1000000', decimals: 6 },
+      },
+    },
+  }
+  return {
+    transaction: {
+      message: {
+        instructions: opts.inner ? [] : [splTokenIx],
+      },
+    },
+    meta: {
+      err: null,
+      logMessages: [
+        'Program S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB invoke [1]',
+        programDataLog(buildWithdrawEventBytes({})),
+        'Program S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB success',
+      ],
+      innerInstructions: opts.inner ? [{ index: 0, instructions: [splTokenIx] }] : [],
+    },
+  }
+}
+
+describe('resolveStealthContext — happy path', () => {
+  it('returns stealth address, ephemeral pubkey, and mint from a VaultWithdrawEvent log + top-level SPL transfer', async () => {
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue(mockTxWithEventAndSplTransfer()),
+      getParsedAccountInfo: vi.fn().mockResolvedValue({
+        value: { data: { parsed: { info: { owner: STEALTH_PUBKEY, mint: MINT_USDC } } } },
+      }),
+    } as unknown as Connection
+
+    const ctx = await resolveStealthContext(mockConnection, DEPOSIT_SIG)
+
+    expect(ctx.stealthAddress).toBe(STEALTH_PUBKEY)
+    expect(ctx.ephemeralPublicKey).toBe(EPHEMERAL_PUBKEY)
+    expect(ctx.mint).toBe(MINT_USDC)
+  })
+})

--- a/packages/agent/tests/tools/claim-helpers.test.ts
+++ b/packages/agent/tests/tools/claim-helpers.test.ts
@@ -170,6 +170,8 @@ describe('resolveStealthContext — happy-path variants', () => {
 
     const ctx = await resolveStealthContext(mockConnection, DEPOSIT_SIG)
     expect(ctx.stealthAddress).toBe(STEALTH_PUBKEY)
+    expect(ctx.mint).toBe(MINT_USDC)
+    expect(ctx.ephemeralPublicKey).toBe(EPHEMERAL_PUBKEY)
   })
 })
 
@@ -280,6 +282,19 @@ describe('resolveStealthContext — error paths', () => {
       getParsedTransaction: vi.fn().mockResolvedValue(mockTxWithEventAndSplTransfer()),
       getParsedAccountInfo: vi.fn().mockResolvedValue({
         value: { data: { parsed: { info: { owner: DIFFERENT_OWNER, mint: MINT_USDC } } } },
+      }),
+    } as unknown as Connection
+
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG)).rejects.toMatchObject({
+      code: 'stealth_ata_mismatch',
+    })
+  })
+
+  it('throws stealth_ata_mismatch when ATA data is raw bytes (not a parsed token account)', async () => {
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue(mockTxWithEventAndSplTransfer()),
+      getParsedAccountInfo: vi.fn().mockResolvedValue({
+        value: { data: Buffer.from([1, 2, 3, 4]) },
       }),
     } as unknown as Connection
 

--- a/packages/agent/tests/tools/claim-helpers.test.ts
+++ b/packages/agent/tests/tools/claim-helpers.test.ts
@@ -103,3 +103,188 @@ describe('resolveStealthContext — happy path', () => {
     expect(ctx.mint).toBe(MINT_USDC)
   })
 })
+
+describe('resolveStealthContext — happy-path variants', () => {
+  it('handles spl-token-2022 transferChecked', async () => {
+    const mockConnection = {
+      getParsedTransaction: vi
+        .fn()
+        .mockResolvedValue(mockTxWithEventAndSplTransfer({ tokenProgram: 'spl-token-2022' })),
+      getParsedAccountInfo: vi.fn().mockResolvedValue({
+        value: { data: { parsed: { info: { owner: STEALTH_PUBKEY, mint: MINT_USDC } } } },
+      }),
+    } as unknown as Connection
+
+    const ctx = await resolveStealthContext(mockConnection, DEPOSIT_SIG)
+    expect(ctx.stealthAddress).toBe(STEALTH_PUBKEY)
+    expect(ctx.mint).toBe(MINT_USDC)
+  })
+
+  it('finds SPL transferChecked in inner instructions (Jupiter-routed deposit)', async () => {
+    const mockConnection = {
+      getParsedTransaction: vi
+        .fn()
+        .mockResolvedValue(mockTxWithEventAndSplTransfer({ inner: true })),
+      getParsedAccountInfo: vi.fn().mockResolvedValue({
+        value: { data: { parsed: { info: { owner: STEALTH_PUBKEY, mint: MINT_USDC } } } },
+      }),
+    } as unknown as Connection
+
+    const ctx = await resolveStealthContext(mockConnection, DEPOSIT_SIG)
+    expect(ctx.stealthAddress).toBe(STEALTH_PUBKEY)
+    expect(ctx.mint).toBe(MINT_USDC)
+  })
+
+  it('skips PartiallyDecodedInstruction entries when searching for SPL transferChecked', async () => {
+    const splTokenIx = {
+      program: 'spl-token',
+      programId: new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+      parsed: {
+        type: 'transferChecked',
+        info: {
+          destination: STEALTH_ATA,
+          mint: MINT_USDC,
+          tokenAmount: { amount: '1000000', decimals: 6 },
+        },
+      },
+    }
+    const partiallyDecoded = {
+      programId: new PublicKey('ComputeBudget111111111111111111111111111111'),
+      accounts: [],
+      data: 'AwBAQg8AAAAA',
+      // No `program` or `parsed` field — PartiallyDecodedInstruction shape
+    }
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue({
+        transaction: { message: { instructions: [partiallyDecoded, splTokenIx] } },
+        meta: {
+          err: null,
+          logMessages: [programDataLog(buildWithdrawEventBytes({}))],
+          innerInstructions: [],
+        },
+      }),
+      getParsedAccountInfo: vi.fn().mockResolvedValue({
+        value: { data: { parsed: { info: { owner: STEALTH_PUBKEY, mint: MINT_USDC } } } },
+      }),
+    } as unknown as Connection
+
+    const ctx = await resolveStealthContext(mockConnection, DEPOSIT_SIG)
+    expect(ctx.stealthAddress).toBe(STEALTH_PUBKEY)
+  })
+})
+
+describe('resolveStealthContext — error paths', () => {
+  it('throws deposit_not_found when getParsedTransaction returns null', async () => {
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue(null),
+      getParsedAccountInfo: vi.fn(),
+    } as unknown as Connection
+
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG)).rejects.toMatchObject({
+      name: 'StealthContextError',
+      code: 'deposit_not_found',
+    })
+  })
+
+  it('throws no_withdraw_event when logMessages has no decodable VaultWithdrawEvent', async () => {
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue({
+        transaction: { message: { instructions: [] } },
+        meta: {
+          err: null,
+          logMessages: [
+            'Program 11111111111111111111111111111111 invoke [1]',
+            'Program 11111111111111111111111111111111 success',
+          ],
+          innerInstructions: [],
+        },
+      }),
+      getParsedAccountInfo: vi.fn(),
+    } as unknown as Connection
+
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG)).rejects.toMatchObject({
+      code: 'no_withdraw_event',
+    })
+  })
+
+  it('also throws no_withdraw_event when Program data log is present but too short', async () => {
+    const shortBuf = Buffer.alloc(64) // < 194-byte floor
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue({
+        transaction: { message: { instructions: [] } },
+        meta: {
+          err: null,
+          logMessages: [programDataLog(shortBuf)],
+          innerInstructions: [],
+        },
+      }),
+      getParsedAccountInfo: vi.fn(),
+    } as unknown as Connection
+
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG)).rejects.toMatchObject({
+      code: 'no_withdraw_event',
+    })
+  })
+
+  it('skips zero-filled placeholder events and throws no_withdraw_event if none decodable', async () => {
+    const zeroEphBuf = buildWithdrawEventBytes({ zeroEphemeral: true })
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue({
+        transaction: { message: { instructions: [] } },
+        meta: {
+          err: null,
+          logMessages: [programDataLog(zeroEphBuf)],
+          innerInstructions: [],
+        },
+      }),
+      getParsedAccountInfo: vi.fn(),
+    } as unknown as Connection
+
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG)).rejects.toMatchObject({
+      code: 'no_withdraw_event',
+    })
+  })
+
+  it('throws no_token_transfer when event exists but no SPL transferChecked', async () => {
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue({
+        transaction: { message: { instructions: [] } },
+        meta: {
+          err: null,
+          logMessages: [programDataLog(buildWithdrawEventBytes({}))],
+          innerInstructions: [],
+        },
+      }),
+      getParsedAccountInfo: vi.fn(),
+    } as unknown as Connection
+
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG)).rejects.toMatchObject({
+      code: 'no_token_transfer',
+    })
+  })
+
+  it('throws stealth_ata_mismatch when ATA account info has no owner', async () => {
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue(mockTxWithEventAndSplTransfer()),
+      getParsedAccountInfo: vi.fn().mockResolvedValue({ value: null }),
+    } as unknown as Connection
+
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG)).rejects.toMatchObject({
+      code: 'stealth_ata_mismatch',
+    })
+  })
+
+  it('throws stealth_ata_mismatch when ATA owner differs from event stealth_recipient', async () => {
+    const DIFFERENT_OWNER = 'FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr'
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue(mockTxWithEventAndSplTransfer()),
+      getParsedAccountInfo: vi.fn().mockResolvedValue({
+        value: { data: { parsed: { info: { owner: DIFFERENT_OWNER, mint: MINT_USDC } } } },
+      }),
+    } as unknown as Connection
+
+    await expect(resolveStealthContext(mockConnection, DEPOSIT_SIG)).rejects.toMatchObject({
+      code: 'stealth_ata_mismatch',
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Replaces Phase 1 claim stub with an end-to-end SDK-driven claim flow per Spec 4 Path A. `executeClaim` now resolves the stealth context from sipher's `VaultWithdrawEvent` (mirroring `scanForPayments`), delegates ECDH derivation + SPL transfer + broadcast to `@sip-protocol/sdk`'s `claimStealthPayment`, and returns the real claim tx signature.
- Torque attribution becomes honest from day one — `sipher_private_claim_completed` now carries `data.tx_signature = <claim_tx_sig>` instead of the input deposit-tx-sig.
- 11 commits, +10 net tests, no breaking API changes for external consumers. All commits GPG-signed.

## Test plan

- [x] `tests/tools/claim-helpers.test.ts` — 12 tests (1 happy + 3 happy-path variants + 8 error paths covering all 4 discriminated codes incl. the Buffer-data ATA branch)
- [x] `tests/claim.test.ts` — 13 tests (3 tool-definition + 3 happy-path + 4 input-validation regression + 3 SDK/helper error wraps)
- [x] `tests/integrations/torque/growth-hook.test.ts` — +1 test locking in claim-tx-sig attribution priority
- [x] `tests/tools.test.ts` — duplicate `executeClaim` describe block removed; dispatch test updated to verify the new resolveStealthContext code path
- [x] Full agent suite: 1612 passed + 2 pre-existing skipped (was 1602 baseline, net +10)
- [x] Workspace typecheck: clean (4 packages)
- [x] All 11 commits GPG-signed (`BF47B9DC1FA320FA`)
- [x] No AI attribution in any commit body

## Scope notes

**Path A trade-offs** are documented in `docs/superpowers/specs/2026-05-15-claim-phase-2-design.md` (Amendment — SDK reality check). Summary:
- ✅ One-shot server execution. No SignTxCard round-trip.
- ✅ Honest Torque attribution. Minimum new code.
- ❌ Loses explicit consent moment at sign-time — the chat tool invocation IS the consent.

**Path B** (SDK extension + SignTxCard UX) is tracked as a post-judges follow-up.

**Other deliberate scope choices:**
- `destinationWallet` is now **required** in `ClaimParams` + Anthropic schema (was optional with runtime throw — schema-vs-runtime gap closed). Auto-derive from spending pubkey is a follow-up.
- SOL claims work transparently — sipher's deposit model wraps SOL to WSOL on send, so the stealth ATA always holds an SPL token. Claim then uses SDK's SPL transfer primitive.
- `spl-token-2022` (Token Extensions) supported alongside `spl-token` in the SPL transfer finder.
- Inner-instruction search included for Jupiter-routed deposits (private swap → stealth output → claim).

## Mid-PR revision

A first attempt at Task 1 assumed sipher's deposits emit `spl-memo` instructions with `SIP:1:` format (the SDK's standalone send flow). Code review caught that sipher's actual production flow uses the vault's `withdraw_private` instruction which emits an Anchor `VaultWithdrawEvent` in `tx.meta.logMessages` — **no SPL memo**. The plan was revised (commit `7621df6`) to parse the event-log format that sipher's own `scanForPayments` already uses (single source of truth for both scan AND claim event parsing). The first Task 1 attempt was reset before any wrong tests landed.

## Verification

- Pre-deploy: `https://sipher-api.sip-protocol.org/admin/api/torque/status` should remain `{ enabled: true, network: 'devnet', ingesterReachable: true }` after deploy.
- Post-deploy: trigger a claim from sipher chat with a known recent deposit signature; confirm the Torque event in the dashboard attributes to the claim tx signature (not the deposit signature).

## Follow-ups (separate issues, post-merge)

Will be filed against this PR's merge:
- Spec 4 Path B — SDK extension + SignTxCard claim UX
- Spec 5 PR-A — durable-nonce family (scheduleSend + drip)
- Spec 5 PR-B — Squads delegation family (sweep + recurring)
- Spec 5 PR-C — COURIER hardening (retries, observability, single-flight)
- Claim Path A polish — auto-derive `destinationWallet` from spending pubkey, human-readable `amount` display in chat message
- PR review polish — add `tests/**` to `packages/agent/tsconfig.json`, extract `normalizeKey` to shared utility, add `beforeEach` mock reset in claim.test.ts error-paths describe

## Plan + spec references

- Implementation plan: `docs/superpowers/plans/2026-05-17-claim-phase-2-path-a.md` (this PR adds the plan as commit `037cffa`, revised as `7621df6`)
- Design spec: `docs/superpowers/specs/2026-05-15-claim-phase-2-design.md` (on the design-specs PR #276 — read the "Amendment — SDK reality check" section for Path A vs Path B trade-off)