### PR TITLE
fix(auth): skip 401 interceptor for /v1/ REST API responses

### DIFF
--- a/app/src/api/__tests__/client.test.ts
+++ b/app/src/api/__tests__/client.test.ts
@@ -78,6 +78,27 @@ describe('apiFetch', () => {
     expect(onUnauth).not.toHaveBeenCalled()
   })
 
+  it('does not call interceptor on 401 from a /v1/ endpoint (separate API-key auth domain)', async () => {
+    // /v1/* is the REST API — it authenticates with an x-api-key header, not
+    // the agent JWT. A 401 there means "no/invalid API key", NOT "agent
+    // session expired", so it must not trigger clearAuth + the "Session
+    // expired" re-auth flow. Treating it as expiry creates an infinite
+    // sign-in loop: a valid session gets wiped the moment the dashboard's
+    // privacy-score widget fetches /v1/privacy/score.
+    const onUnauth = vi.fn()
+    registerAuthInterceptor(onUnauth)
+    ;(global.fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: { code: 'INVALID_API_KEY', message: 'Invalid API key' } }),
+    })
+
+    await expect(apiFetch('/v1/privacy/score', { method: 'POST' })).rejects.toThrow(
+      /Invalid API key/,
+    )
+    expect(onUnauth).not.toHaveBeenCalled()
+  })
+
   it('still throws on 401 even if interceptor throws', async () => {
     registerAuthInterceptor(() => {
       throw new Error('handler crashed')

--- a/app/src/api/client.ts
+++ b/app/src/api/client.ts
@@ -98,7 +98,11 @@ export async function apiFetch<T>(
   emitNetworkRecovered()
 
   if (res.status === 401) {
-    triggerAuthInterceptor()
+    // A 401 from the /v1/* REST API uses a separate x-api-key auth domain —
+    // it is NOT an agent-JWT session-expiry signal. Firing the interceptor
+    // for it would clearAuth() a still-valid session, producing an infinite
+    // re-auth loop (the dashboard refetches /v1/privacy/score on every mount).
+    if (!path.startsWith('/v1/')) triggerAuthInterceptor()
     const body = await res.json().catch(() => ({}))
     const err = (body as { error?: { message?: string } | string }).error
     if (typeof err === 'string') throw new Error(err)


### PR DESCRIPTION
## Summary

Fixes an infinite sign-in loop that prevented any user from staying logged into sipher. Sign-in succeeds, then the dashboard wipes the session ~200ms later.

## The bug

Sign-in itself works — `POST /api/auth/verify` returns `200` and the agent JWT is valid (verified: `/api/vault`, `/api/stealth/index`, `/api/activity` all return `200` with it).

But the `/v1/*` REST API uses a **separate auth domain** — an `x-api-key` header, not the agent JWT. `DashboardView` fetches `POST /v1/privacy/score` on every mount, which returns `401 INVALID_API_KEY` because the FE sends a Bearer JWT instead of an API key.

`apiFetch` fired the global auth interceptor (`triggerAuthInterceptor()`) on **every** 401 — including this one. The interceptor runs `clearAuth()`, wiping the still-valid agent session and showing a "Session expired" toast. The user re-authenticates → dashboard remounts → `/v1/privacy/score` 401 again → session cleared again → **infinite loop**.

## The fix

Scope the interceptor to non-`/v1/` paths. A 401 from a `/v1/*` endpoint is not an agent-session-expiry signal, so it must not trigger the re-auth flow.

```ts
if (res.status === 401) {
  if (!path.startsWith('/v1/')) triggerAuthInterceptor()
  ...
}
```

`apiFetch` still throws on the 401, so callers (`DashboardView.fetchPrivacyScore`) handle it locally — they already do, falling through to a null-data state.

## Diagnosis evidence

```
Same agent JWT, two endpoints:
  GET  /api/vault         -> 200   (agent API accepts the JWT)
  POST /v1/privacy/score  -> 401   {"error":{"code":"INVALID_API_KEY"}}
```

Network trace of a sign-in attempt showed the loop: `/api/auth/verify` 200 → authed `/api/*` calls 200 → `/v1/privacy/score` 401 → repeat.

## Test plan

- [x] New test in `client.test.ts`: a 401 from `/v1/privacy/score` does NOT call the interceptor (still throws to the caller)
- [x] Existing test confirms non-`/v1/` 401s still fire the interceptor
- [x] Full app suite: 572 tests pass
- [x] Typecheck clean

## Follow-ups (out of scope)

- The privacy-score widget shows no data for logged-in users — `/v1/privacy/score` needs an `/api/` equivalent (JWT auth) or the `/v1/` API should accept agent JWTs.
- `/api/stream` returns `503` (SSE stream unavailable) — separate issue, does not affect auth.