### PR TITLE
chore(agent): claim PR-review follow-ups — typecheck tests + normalizeKey util + test isolation

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc -p tsconfig.test.json"
   },
   "dependencies": {
     "@mariozechner/pi-agent-core": "^0.66.1",

--- a/packages/agent/src/tools/claim.ts
+++ b/packages/agent/src/tools/claim.ts
@@ -8,6 +8,7 @@ import {
   deriveDestinationFromSpending,
   formatClaimAmount,
 } from './claim-helpers.js'
+import { normalizeKey } from '../utils/key-normalize.js'
 import type { AnthropicTool } from '../pi/tool-adapter.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -148,13 +149,4 @@ export async function executeClaim(params: ClaimParams): Promise<ClaimToolResult
       `Claimed payment ${params.txSignature.slice(0, 12)}... → claim tx ${sdkResult.txSignature.slice(0, 12)}... ` +
       `(${formatClaimAmount(sdkResult.amount, mintBase58)} to ${sdkResult.destinationAddress.slice(0, 8)}...)`,
   }
-}
-
-/** Strip 0x prefix and validate hex shape for SDK consumption. */
-function normalizeKey(key: string): `0x${string}` {
-  const stripped = key.startsWith('0x') ? key.slice(2) : key
-  if (!/^[0-9a-fA-F]+$/.test(stripped)) {
-    throw new Error('Key must be hex (with or without 0x prefix)')
-  }
-  return `0x${stripped.toLowerCase()}` as `0x${string}`
 }

--- a/packages/agent/src/utils/key-normalize.ts
+++ b/packages/agent/src/utils/key-normalize.ts
@@ -1,0 +1,22 @@
+// packages/agent/src/utils/key-normalize.ts
+
+/**
+ * Normalize a hex-encoded key to the `0x`-prefixed lowercase form expected by
+ * `@sip-protocol/sdk` (its `HexString` brand).
+ *
+ * Accepts input with or without a leading `0x`, in any letter case, and
+ * validates the hex body — non-hex input is rejected rather than silently
+ * handed to the SDK. Shared by the stealth/ECDH tools (claim today, send/swap
+ * as they adopt it) that pass raw user-supplied keys into the SDK.
+ *
+ * @param key - hex string, with or without a `0x` prefix
+ * @returns the key as `0x<lowercase-hex>`
+ * @throws if the key (after stripping any `0x` prefix) is not non-empty hex
+ */
+export function normalizeKey(key: string): `0x${string}` {
+  const stripped = key.startsWith('0x') ? key.slice(2) : key
+  if (!/^[0-9a-fA-F]+$/.test(stripped)) {
+    throw new Error('Key must be hex (with or without 0x prefix)')
+  }
+  return `0x${stripped.toLowerCase()}` as `0x${string}`
+}

--- a/packages/agent/tests/adapters/web.test.ts
+++ b/packages/agent/tests/adapters/web.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Response } from 'express'
 import type { AgentResponse, ResponseChunk } from '../../src/core/types.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -44,7 +45,7 @@ function mockRes() {
     _writes: writes,
     _headers: headers,
   }
-  return res as typeof res & { _writes: string[]; _headers: Record<string, string> }
+  return res as unknown as Response & { _writes: string[]; _headers: Record<string, string> }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/agent/tests/agent-signing-wrapper.test.ts
+++ b/packages/agent/tests/agent-signing-wrapper.test.ts
@@ -1,4 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type {
+  SSESentinelPause,
+  SSEToolSigningRequired,
+  SSEToolSigningExpired,
+} from '../src/agent.js'
+
+type SigningQueueEvent = SSESentinelPause | SSEToolSigningRequired | SSEToolSigningExpired
 
 // Mock the Pi agent so we don't make LLM calls; we drive the executor manually
 vi.mock('../src/pi/sipher-agent.js', () => ({
@@ -69,7 +76,7 @@ describe('chatStream signing-wait wrapper (wrapWithSigning)', () => {
       },
     }))
 
-    const queue: unknown[] = []
+    const queue: SigningQueueEvent[] = []
     let wakeCalled = false
     const wake = () => { wakeCalled = true }
 
@@ -108,7 +115,7 @@ describe('chatStream signing-wait wrapper (wrapWithSigning)', () => {
       privacy: { stealthRouted: true, stealthAddress: 'S' },
     }))
 
-    const queue: unknown[] = []
+    const queue: SigningQueueEvent[] = []
     const wrapped = wrapWithSigning(baseExecutor, {
       sessionId: 's1', network: 'devnet', externalQueue: queue, externalWake: () => {},
     })
@@ -135,7 +142,7 @@ describe('chatStream signing-wait wrapper (wrapWithSigning)', () => {
       privacy: { stealthAddress: '', commitmentGenerated: false, viewingKeyHashIncluded: false, feeBps: 50, estimatedFee: '0.005 SOL', netAmount: null },
     }))
 
-    const queue: unknown[] = []
+    const queue: SigningQueueEvent[] = []
     const wrapped = wrapWithSigning(baseExecutor, {
       sessionId: 's1', network: 'devnet', externalQueue: queue, externalWake: () => {},
     })
@@ -151,7 +158,7 @@ describe('chatStream signing-wait wrapper (wrapWithSigning)', () => {
     const baseExecutor = vi.fn(async () => ({
       action: 'claim', status: 'awaiting_signature' as const, txSignature: 'INPUT_SIG',
     }))
-    const queue: unknown[] = []
+    const queue: SigningQueueEvent[] = []
     const wrapped = wrapWithSigning(baseExecutor, {
       sessionId: 's1', network: 'devnet', externalQueue: queue, externalWake: () => {},
     })
@@ -164,7 +171,7 @@ describe('chatStream signing-wait wrapper (wrapWithSigning)', () => {
       action: 'send', status: 'awaiting_signature' as const, serializedTx: 'TX',
       privacy: { stealthAddress: 'X', commitmentGenerated: true, viewingKeyHashIncluded: true, feeBps: 50, estimatedFee: '0', netAmount: '1' },
     }))
-    const queue: unknown[] = []
+    const queue: SigningQueueEvent[] = []
     const wrapped = wrapWithSigning(baseExecutor, {
       sessionId: 's1', network: 'devnet', externalQueue: queue, externalWake: () => {},
     })
@@ -176,7 +183,7 @@ describe('chatStream signing-wait wrapper (wrapWithSigning)', () => {
     const baseExecutor = vi.fn(async () => ({
       action: 'send', status: 'cancelled_by_user' as const, reason: 'sentinel blocked',
     }))
-    const queue: unknown[] = []
+    const queue: SigningQueueEvent[] = []
     const wrapped = wrapWithSigning(baseExecutor, {
       sessionId: 's1', network: 'devnet', externalQueue: queue, externalWake: () => {},
     })

--- a/packages/agent/tests/claim.test.ts
+++ b/packages/agent/tests/claim.test.ts
@@ -198,6 +198,13 @@ describe('executeClaim — input validation (regression)', () => {
 })
 
 describe('executeClaim — error paths', () => {
+  // resetAllMocks (not clearAllMocks) between tests: each test re-stubs only
+  // the mocks on its own code path, so stale implementations from an earlier
+  // test must be cleared, not just call history.
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
   it('wraps StealthContextError in actionable error', async () => {
     vi.mocked(resolveStealthContext).mockRejectedValue(
       new StealthContextError('Deposit transaction 5aaaaaa... not found on chain', 'deposit_not_found'),

--- a/packages/agent/tests/coordination/activity-logger.test.ts
+++ b/packages/agent/tests/coordination/activity-logger.test.ts
@@ -230,7 +230,7 @@ describe('ActivityLogger', () => {
     })
     const rows = getActivity(null)
     expect(rows).toHaveLength(1)
-    expect(rows[0].title.toLowerCase()).toContain('refund')
+    expect((rows[0].title as string).toLowerCase()).toContain('refund')
   })
 
   it('formats sentinel:pending-action + sentinel:action-cancelled + sentinel:veto + sentinel:risk-report', () => {

--- a/packages/agent/tests/herald/herald.test.ts
+++ b/packages/agent/tests/herald/herald.test.ts
@@ -5,7 +5,7 @@ const {
   HERALD_TOOLS,
   HERALD_TOOL_EXECUTORS,
   HERALD_IDENTITY,
-} = await import('../../packages/agent/src/herald/herald.js')
+} = await import('../../src/herald/herald.js')
 
 describe('HERALD agent factory', () => {
   it('exports HERALD_SYSTEM_PROMPT with HERALD and cypherpunk keywords', () => {

--- a/packages/agent/tests/integration/pi-smoke.test.ts
+++ b/packages/agent/tests/integration/pi-smoke.test.ts
@@ -217,7 +217,7 @@ describe('chatStream() end-to-end with stubbed Pi agent', () => {
     const chunks: Array<Record<string, unknown>> = []
 
     for await (const chunk of chatStream('hi', {})) {
-      chunks.push(chunk as Record<string, unknown>)
+      chunks.push(chunk as unknown as Record<string, unknown>)
     }
 
     const toolUse = chunks.find((c) => c.type === 'tool_use')
@@ -231,7 +231,7 @@ describe('chatStream() end-to-end with stubbed Pi agent', () => {
     const chunks: Array<Record<string, unknown>> = []
 
     for await (const chunk of chatStream('hi', {})) {
-      chunks.push(chunk as Record<string, unknown>)
+      chunks.push(chunk as unknown as Record<string, unknown>)
     }
 
     const toolResult = chunks.find((c) => c.type === 'tool_result')
@@ -245,7 +245,7 @@ describe('chatStream() end-to-end with stubbed Pi agent', () => {
     const chunks: Array<Record<string, unknown>> = []
 
     for await (const chunk of chatStream('hi', {})) {
-      chunks.push(chunk as Record<string, unknown>)
+      chunks.push(chunk as unknown as Record<string, unknown>)
     }
 
     const done = chunks.find((c) => c.type === 'message_complete')

--- a/packages/agent/tests/integration/sentinel-core-smoke.test.ts
+++ b/packages/agent/tests/integration/sentinel-core-smoke.test.ts
@@ -15,7 +15,7 @@ vi.mock('../../src/pi/sipher-agent.js', async (orig) => {
       const subs: Array<(e: AgentEvent, s: AbortSignal) => unknown> = []
       const messages: AgentMessage[] = []
       const fake: Agent = {
-        subscribe: (cb) => { subs.push(cb); return () => subs.splice(subs.indexOf(cb), 1) },
+        subscribe: (cb: (e: AgentEvent, s: AbortSignal) => unknown) => { subs.push(cb); return () => subs.splice(subs.indexOf(cb), 1) },
         prompt: async () => {
           const signal = new AbortController().signal
           for (const cb of [...subs]) await cb({ type: 'tool_execution_start', toolCallId: 't1', toolName: stub.toolName, args: stub.toolArgs }, signal)

--- a/packages/agent/tests/pi/tool-adapter.test.ts
+++ b/packages/agent/tests/pi/tool-adapter.test.ts
@@ -178,7 +178,7 @@ describe('round-trip safety', () => {
     expect(roundTripped.description).toBe(original.description ?? '')
     expect(roundTripped.parameters).toMatchObject({
       type: 'object',
-      properties: (original.parameters as { properties: Record<string, unknown> }).properties,
+      properties: (original.parameters as unknown as { properties: Record<string, unknown> }).properties,
     })
   })
 

--- a/packages/agent/tests/sentinel/tools/cancel-pending.test.ts
+++ b/packages/agent/tests/sentinel/tools/cancel-pending.test.ts
@@ -29,7 +29,7 @@ describe('cancelPendingTool definition', () => {
   })
 
   it('has a non-empty description', () => {
-    expect(cancelPendingTool.description.length).toBeGreaterThan(0)
+    expect(cancelPendingTool.description).toBeTruthy()
   })
 })
 

--- a/packages/agent/tests/sentinel/tools/check-reputation.test.ts
+++ b/packages/agent/tests/sentinel/tools/check-reputation.test.ts
@@ -32,7 +32,7 @@ describe('checkReputationTool definition', () => {
   })
 
   it('has a non-empty description', () => {
-    expect(checkReputationTool.description.length).toBeGreaterThan(0)
+    expect(checkReputationTool.description).toBeTruthy()
   })
 })
 

--- a/packages/agent/tests/sentinel/tools/get-deposit-status.test.ts
+++ b/packages/agent/tests/sentinel/tools/get-deposit-status.test.ts
@@ -45,7 +45,7 @@ describe('getDepositStatusTool definition', () => {
   })
 
   it('has a non-empty description', () => {
-    expect(getDepositStatusTool.description.length).toBeGreaterThan(0)
+    expect(getDepositStatusTool.description).toBeTruthy()
   })
 })
 

--- a/packages/agent/tests/sentinel/tools/get-pending-claims.test.ts
+++ b/packages/agent/tests/sentinel/tools/get-pending-claims.test.ts
@@ -42,7 +42,7 @@ describe('getPendingClaimsTool definition', () => {
   })
 
   it('has a non-empty description', () => {
-    expect(getPendingClaimsTool.description.length).toBeGreaterThan(0)
+    expect(getPendingClaimsTool.description).toBeTruthy()
   })
 })
 

--- a/packages/agent/tests/sentinel/tools/get-recent-activity.test.ts
+++ b/packages/agent/tests/sentinel/tools/get-recent-activity.test.ts
@@ -43,7 +43,7 @@ describe('getRecentActivityTool definition', () => {
   })
 
   it('has a non-empty description', () => {
-    expect(getRecentActivityTool.description.length).toBeGreaterThan(0)
+    expect(getRecentActivityTool.description).toBeTruthy()
   })
 })
 

--- a/packages/agent/tests/sentinel/tools/get-risk-history.test.ts
+++ b/packages/agent/tests/sentinel/tools/get-risk-history.test.ts
@@ -34,7 +34,7 @@ describe('getRiskHistoryTool definition', () => {
   })
 
   it('has a non-empty description', () => {
-    expect(getRiskHistoryTool.description.length).toBeGreaterThan(0)
+    expect(getRiskHistoryTool.description).toBeTruthy()
   })
 })
 

--- a/packages/agent/tests/sentinel/tools/get-vault-balance.test.ts
+++ b/packages/agent/tests/sentinel/tools/get-vault-balance.test.ts
@@ -52,7 +52,7 @@ describe('getVaultBalanceTool definition', () => {
   })
 
   it('has a non-empty description', () => {
-    expect(getVaultBalanceTool.description.length).toBeGreaterThan(0)
+    expect(getVaultBalanceTool.description).toBeTruthy()
   })
 })
 

--- a/packages/agent/tests/sentinel/tools/remove-from-blacklist.test.ts
+++ b/packages/agent/tests/sentinel/tools/remove-from-blacklist.test.ts
@@ -37,7 +37,7 @@ describe('removeFromBlacklistTool definition', () => {
   })
 
   it('has a non-empty description', () => {
-    expect(removeFromBlacklistTool.description.length).toBeGreaterThan(0)
+    expect(removeFromBlacklistTool.description).toBeTruthy()
   })
 })
 

--- a/packages/agent/tests/sentinel/tools/veto-sipher-action.test.ts
+++ b/packages/agent/tests/sentinel/tools/veto-sipher-action.test.ts
@@ -33,7 +33,7 @@ describe('vetoSipherTool definition', () => {
   })
 
   it('has a non-empty description', () => {
-    expect(vetoSipherTool.description.length).toBeGreaterThan(0)
+    expect(vetoSipherTool.description).toBeTruthy()
   })
 })
 

--- a/packages/agent/tests/utils/key-normalize.test.ts
+++ b/packages/agent/tests/utils/key-normalize.test.ts
@@ -1,0 +1,37 @@
+// packages/agent/tests/utils/key-normalize.test.ts
+import { describe, it, expect } from 'vitest'
+import { normalizeKey } from '../../src/utils/key-normalize.js'
+
+describe('normalizeKey', () => {
+  it('adds a 0x prefix to a bare hex string', () => {
+    expect(normalizeKey('abcdef')).toBe('0xabcdef')
+  })
+
+  it('keeps a single 0x prefix when one is already present', () => {
+    expect(normalizeKey('0xabcdef')).toBe('0xabcdef')
+  })
+
+  it('lowercases uppercase hex digits', () => {
+    expect(normalizeKey('0xDEADBEEF')).toBe('0xdeadbeef')
+  })
+
+  it('normalizes a full 32-byte key (prefix + lowercase)', () => {
+    expect(normalizeKey('AB'.repeat(32))).toBe(`0x${'ab'.repeat(32)}`)
+  })
+
+  it('throws on non-hex characters', () => {
+    expect(() => normalizeKey('not-hex')).toThrow(/key must be hex/i)
+  })
+
+  it('throws on an empty string', () => {
+    expect(() => normalizeKey('')).toThrow(/key must be hex/i)
+  })
+
+  it('throws on a bare 0x prefix with no body', () => {
+    expect(() => normalizeKey('0x')).toThrow(/key must be hex/i)
+  })
+
+  it('validates hex only after stripping the 0x prefix', () => {
+    expect(() => normalizeKey('0xZZ')).toThrow(/key must be hex/i)
+  })
+})

--- a/packages/agent/tsconfig.test.json
+++ b/packages/agent/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+  // Typecheck-only config: extends the build tsconfig but widens scope to
+  // include test files. The build config (tsconfig.json) keeps its narrow
+  // "include": ["src"] so `tsc` (the build) does not emit test files into
+  // dist/. `pnpm typecheck` runs against this config so test-file type
+  // drift — e.g. assertions referencing removed interface members — is
+  // caught at typecheck time instead of only by `vitest run`.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    // rootDir is the repo root, not packages/agent: a few agent tests import
+    // root-package modules (e.g. tests/routes/) via ../../../src, so those
+    // files must be allowed inside the program without a TS6059 rootDir error.
+    // noEmit makes rootDir advisory-only — it affects no output.
+    "rootDir": "../.."
+  },
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
Resolves the three follow-up items from #287, surfaced during the #281 (Claim Phase 2 Path A) review.

## Item 2 — extract `normalizeKey` (`refactor`)

`normalizeKey` (strip `0x`, validate the hex body, return the `0x`-prefixed lowercase form the SDK `HexString` brand expects) was a private helper in `claim.ts`. Moved to `src/utils/key-normalize.ts` as a shared, directly-tested util — it is not claim-specific, other tools that hand raw keys to the SDK need the same normalization. Behaviour and the `Key must be hex` error message are unchanged; 8 new unit tests.

## Item 3 — claim test isolation (`test`)

The `executeClaim — error paths` describe had no per-test mock reset; it passed only because the non-hex-key test throws before reaching `claimStealthPayment`. Added `beforeEach(vi.resetAllMocks())`.

> The issue suggested `clearAllMocks`, but that only clears call history. The leak being guarded against is a stale `mockResolvedValue`/`mockRejectedValue` *implementation* — only `resetAllMocks` clears those. Used `resetAllMocks` (explained in the commit + an inline comment).

## Item 1 — typecheck test files (`build`)

`packages/agent/tsconfig.json` drives the `tsc` build, so its `include` stays `src`-only — listing `tests` there would emit test files into `dist/`. Added `tsconfig.test.json` (extends the build config, includes `src` + `tests`); `pnpm typecheck` now runs against it, so test-file type drift is caught at typecheck time rather than only by `vitest run`.

**Scope note:** widening typecheck to `tests/` surfaced **40 pre-existing errors** across ~14 files — the original issue assumed a one-line change. Per the agreed call, all 40 are fixed here. None were behaviour bugs:

- **12** — `web.test.ts` `mockRes()` casts to the express `Response` type, not its own partial-mock shape
- **9** — sentinel tool tests assert `tool.description` is truthy instead of reading `.length` off the optional field
- **6** — `agent-signing-wrapper.test.ts` `externalQueue` arrays typed as the SSE event union, not `unknown[]`
- **6** — `rootDir` widened to the repo root (a few tests import root-package modules)
- **4** — `SSEEvent` / `TSchema` casts routed through `unknown`
- **3** — a corrected import path, an implicit-`any` callback, a narrowed `unknown` row field

Full per-file breakdown is in the `build(agent):` commit message.

## Verification

- `pnpm typecheck` (now via `tsconfig.test.json`) — clean
- `pnpm test` — **1630 passed**, 2 skipped (8 new vs the 1622 baseline)
- `pnpm build` — clean (`tsc` build still emits `src` only)

Closes #287
