### PR TITLE
fix(sentinel): distinguish confirmed_with_err from not_confirmed (closes #300)

### DIFF
--- a/packages/agent/src/routes/tool-signing.ts
+++ b/packages/agent/src/routes/tool-signing.ts
@@ -81,6 +81,19 @@ toolSigningRouter.post('/:flagId/confirm', async (req: Request, res: Response) =
           )
           return
         }
+        if (verifyResult.reason === 'confirmed_with_err') {
+          // Tx landed on-chain but the program rejected it. Surface that
+          // explicitly so the LLM tells the user the program rejected the
+          // transaction, not that it was cancelled. See issue #300.
+          const detail = verifyResult.detail ?? 'unknown program error'
+          rejectPendingSigning(flagId, `program_error: ${detail}`)
+          sendSentinelError(
+            res,
+            'VALIDATION_FAILED',
+            `transaction was confirmed on-chain but the program returned an error: ${detail}`,
+          )
+          return
+        }
         rejectPendingSigning(flagId, `verification_failed: ${verifyResult.reason}`)
         sendSentinelError(
           res,

--- a/packages/agent/src/sentinel/verify-signature.ts
+++ b/packages/agent/src/sentinel/verify-signature.ts
@@ -12,7 +12,7 @@ export type VerifyResult =
   | { ok: true; slot: number }
   | {
       ok: false
-      reason: 'not_confirmed' | 'wallet_mismatch' | 'rpc_error' | 'timeout'
+      reason: 'not_confirmed' | 'confirmed_with_err' | 'wallet_mismatch' | 'rpc_error' | 'timeout'
       detail?: string
     }
 
@@ -73,9 +73,13 @@ async function runVerification(
   }
 
   if (status.err) {
+    // Tx landed on-chain AND consumed a signature/fee, but the program returned
+    // an error. Distinguish from `not_confirmed` so the caller can tell the user
+    // their tx was confirmed but rejected by the program, not that it was
+    // silently cancelled. See issue #300.
     return {
       ok: false,
-      reason: 'not_confirmed',
+      reason: 'confirmed_with_err',
       detail: typeof status.err === 'object' ? JSON.stringify(status.err) : String(status.err),
     }
   }

--- a/packages/agent/tests/routes/tool-signing-routes.test.ts
+++ b/packages/agent/tests/routes/tool-signing-routes.test.ts
@@ -248,6 +248,30 @@ describe('POST /api/tool-signing/:flagId/confirm — SIPHER_SIG_VERIFY=strict', 
     expect(res.body.error.message).toMatch(/not_confirmed/)
   })
 
+  it('rejects with program_error and returns 400 with descriptive message on confirmed_with_err', async () => {
+    verifySignatureMock.mockResolvedValue({
+      ok: false,
+      reason: 'confirmed_with_err',
+      detail: '{"InstructionError":[0,{"Custom":3012}]}',
+    })
+    const { flagId, promise } = makePending()
+    promise.catch(() => {})
+
+    const res = await supertest(createApp())
+      .post(`/api/tool-signing/${flagId}/confirm`)
+      .set('Authorization', `Bearer ${signJwt(WALLET)}`)
+      .send({ signature: 'SIG' })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_FAILED')
+    expect(res.body.error.message).toMatch(/confirmed on-chain/)
+    expect(res.body.error.message).toMatch(/program returned an error/)
+    expect(res.body.error.message).toMatch(/InstructionError/)
+    expect(res.body.error.message).not.toMatch(/not_confirmed/)
+    await expect(promise).rejects.toThrow(/program_error/)
+    expect(getPendingSigning(flagId)).toBeUndefined()
+  })
+
   it('returns 503 UNAVAILABLE + Retry-After on rpc_error and keeps pending alive', async () => {
     verifySignatureMock.mockResolvedValue({ ok: false, reason: 'rpc_error', detail: 'ETIMEDOUT' })
     const { flagId, promise } = makePending()

--- a/packages/agent/tests/sentinel/verify-signature.test.ts
+++ b/packages/agent/tests/sentinel/verify-signature.test.ts
@@ -82,7 +82,7 @@ describe('verifySignature', () => {
     if (!result.ok) expect(result.reason).toBe('not_confirmed')
   })
 
-  it('returns not_confirmed when err is set on the status', async () => {
+  it('returns confirmed_with_err when err is set on the status (tx landed on-chain but program rejected)', async () => {
     const connection = makeConnection({
       getSignatureStatuses: vi.fn().mockResolvedValue({
         value: [{ slot: 1, confirmationStatus: 'confirmed', err: { InstructionError: [0, 'Custom'] } }],
@@ -91,7 +91,7 @@ describe('verifySignature', () => {
     const result = await verifySignature(SIGNATURE, ENTRY, { connection })
     expect(result.ok).toBe(false)
     if (!result.ok) {
-      expect(result.reason).toBe('not_confirmed')
+      expect(result.reason).toBe('confirmed_with_err')
       expect(result.detail).toMatch(/InstructionError|Custom/)
     }
   })


### PR DESCRIPTION
## Summary

- `verify-signature.ts`: add `confirmed_with_err` variant to `VerifyResult.reason` and label the err-branch with it instead of `not_confirmed`
- `tool-signing.ts`: in strict mode, surface `confirmed_with_err` as a 400 envelope `transaction was confirmed on-chain but the program returned an error: <detail>` and reject the pending entry with `program_error: <detail>` so the agent layer relays the real error instead of `cancelled_by_user`
- Tests: rename + update the existing verify-signature err test, add a new tool-signing-routes test asserting the new envelope and reject reason

Closes #300. Filed alongside #299 (CF 504 follow-up, post-Frontier).

## Why this matters

Discovered during `frontier_sip_18` autonomous prod smoke test of [PR #298](https://github.com/sip-protocol/sipher/pull/298). A real signed tx that confirmed on-chain with `AnchorError 3012` was reported to the user as "tx cancelled / verify_failed: not_confirmed" — wrong on both counts. Two layers of misleading copy in front of Frontier judges scoring 2026-05-27.

Before:
```
chat: "Your transaction was cancelled (verification_failed: not_confirmed)"
```
After:
```
chat: "transaction was confirmed on-chain but the program returned an error:
       {\"InstructionError\":[0,{\"Custom\":3012}]}"
```

## Blast radius

- New `confirmed_with_err` reason is **additive** — no existing consumer switches exhaustively on `VerifyResult.reason`, verified via grep for `assertNever` usage in this codebase
- Existing `not_confirmed` consumers (`tool-signing.ts:74` Retry-After path, the FE error rendering) compile unchanged
- The fallback branch in `tool-signing.ts` still handles `not_confirmed` and `wallet_mismatch` identically to before

## Test plan

- [x] `pnpm typecheck` clean (root + sdk + app + agent)
- [x] `pnpm test -- --run` (agent: 1648, app: 577, sdk: 96, root: 555 — total 2876 green)
- [x] Manual repro plan post-merge: ask sipher chat to claim/withdraw against `S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB` from a wallet without prior deposit. Expected behaviour: agent says the program rejected the tx and surfaces the AnchorError, NOT "tx cancelled".