### PR TITLE
fix(broadcast): bail on confirmed-with-err to avoid CF 504

### DIFF
--- a/packages/agent/src/lib/sendWithRetry.ts
+++ b/packages/agent/src/lib/sendWithRetry.ts
@@ -3,6 +3,27 @@ import type { Connection } from '@solana/web3.js'
 const RESUBMIT_INTERVAL_MS = 2000
 
 /**
+ * Thrown when a transaction lands on-chain but the program returns an error.
+ *
+ * Distinguishes "confirmed with program err" from "broadcast rejected" and
+ * "blockheight expired". Lets /api/tx/broadcast return a structured 502
+ * with the err payload instead of a 200 with a failed signature (or a CF 504
+ * from hanging until edge timeout). See sipher#299.
+ */
+export class TransactionFailedOnChainError extends Error {
+  readonly signature: string
+  readonly err: unknown
+
+  constructor(signature: string, err: unknown) {
+    const detail = typeof err === 'object' ? JSON.stringify(err) : String(err)
+    super(`Transaction ${signature} confirmed on-chain but the program returned an error: ${detail}`)
+    this.name = 'TransactionFailedOnChainError'
+    this.signature = signature
+    this.err = err
+  }
+}
+
+/**
  * Send a signed transaction and aggressively resubmit until confirmed or expired.
  *
  * Public Solana RPCs are rate-limited and drop transactions silently under load.
@@ -14,13 +35,18 @@ const RESUBMIT_INTERVAL_MS = 2000
  * (idempotent: Solana RPCs return the same signature for duplicate sends)
  * while polling for confirmation. First confirmation wins; the loop stops.
  *
+ * A parallel getSignatureStatuses poll runs alongside confirmTransaction so a
+ * confirmed-with-program-err tx surfaces within seconds even if the WS
+ * subscription is slow to fire. Either path throws
+ * TransactionFailedOnChainError when value.err is non-null.
+ *
  * Ported from app/src/lib/sendWithRetry.ts — see sipher#297 for why the
- * broadcast moved server-side.
+ * broadcast moved server-side, sipher#299 for the bail-on-err addition.
  *
  * Exported for testing; injected interval/sleep keeps tests deterministic.
  */
 export interface SendAndConfirmDeps {
-  /** Delay between background resubmits. Override in tests for speed. */
+  /** Delay between background resubmits and status polls. Override in tests for speed. */
   resubmitIntervalMs?: number
   /** Awaitable sleep. Override in tests with fake timers. */
   sleep?: (ms: number) => Promise<void>
@@ -51,14 +77,62 @@ export async function sendAndConfirmWithRetry(
   }
   const resubmitPromise = resubmit()
 
-  try {
-    await connection.confirmTransaction(
+  // Defense-in-depth: if confirmTransaction's WS subscription is slow to fire
+  // when value.err is non-null, this poll surfaces the err first. Resolves with
+  // null on cleanup (stopped=true) so the race below sees a definitive winner.
+  const pollForErr = async (): Promise<TransactionFailedOnChainError | null> => {
+    while (!stopped) {
+      await sleep(interval)
+      if (stopped) return null
+      try {
+        const result = await connection.getSignatureStatuses([signature])
+        const status = result?.value?.[0]
+        if (status?.err) {
+          return new TransactionFailedOnChainError(signature, status.err)
+        }
+      } catch {
+        // RPC hiccup during poll — keep going. confirmTransaction handles
+        // genuine expiry via TransactionExpiredBlockheightExceededError.
+      }
+    }
+    return null
+  }
+
+  const confirmInspected = async (): Promise<string> => {
+    const result = await connection.confirmTransaction(
       { signature, blockhash, lastValidBlockHeight },
       'confirmed',
     )
+    if (result?.value?.err) {
+      throw new TransactionFailedOnChainError(signature, result.value.err)
+    }
     return signature
+  }
+
+  const pollPromise = pollForErr()
+  // Swallow any rejection so a poll error doesn't surface as an unhandled
+  // rejection later. The race below will already have observed any err return.
+  pollPromise.catch(() => {})
+
+  try {
+    // Race: confirmInspected returns signature (or throws); pollPromise returns
+    // an err-or-null. The branch where pollPromise wins with null is structurally
+    // unreachable here — pollForErr only returns null when stopped=true, which
+    // is set in the finally block below. Treat that as an invariant violation.
+    const winner = await Promise.race([
+      confirmInspected().then((sig) => ({ kind: 'confirmed' as const, sig })),
+      pollPromise.then((errOrNull) => ({ kind: 'polled' as const, errOrNull })),
+    ])
+    if (winner.kind === 'polled') {
+      if (winner.errOrNull) throw winner.errOrNull
+      throw new Error('invariant: pollForErr resolved null before sendAndConfirmWithRetry stopped')
+    }
+    return winner.sig
   } finally {
     stopped = true
     await resubmitPromise.catch(() => {})
+    // pollPromise is left to exit on its own; it observes stopped=true on next
+    // tick and returns null. Awaiting it here would add up to one `interval`
+    // (default 2s) of cleanup latency to every successful broadcast.
   }
 }

--- a/packages/agent/src/routes/tx-broadcast.ts
+++ b/packages/agent/src/routes/tx-broadcast.ts
@@ -7,7 +7,7 @@ import {
 } from '@solana/web3.js'
 import { createConnection } from '@sipher/sdk'
 import { loadNetworkConfig } from '../config/network.js'
-import { sendAndConfirmWithRetry } from '../lib/sendWithRetry.js'
+import { sendAndConfirmWithRetry, TransactionFailedOnChainError } from '../lib/sendWithRetry.js'
 
 export const txBroadcastRouter = Router()
 
@@ -135,6 +135,20 @@ txBroadcastRouter.post('/broadcast', async (req: Request, res: Response) => {
         error: {
           code: 'CONFIRMATION_TIMEOUT',
           message: 'Transaction expired before confirmation. Retry with a fresh blockhash.',
+        },
+      })
+      return
+    }
+    if (err instanceof TransactionFailedOnChainError) {
+      // Tx landed on-chain but the program returned an error. Surface a
+      // structured 502 with the err payload so the FE can render an
+      // actionable message instead of "tx cancelled". See sipher#299.
+      res.status(502).json({
+        error: {
+          code: 'TX_FAILED_ON_CHAIN',
+          message: redact(err.message),
+          signature: err.signature,
+          err: err.err,
         },
       })
       return

--- a/packages/agent/tests/lib/sendWithRetry.test.ts
+++ b/packages/agent/tests/lib/sendWithRetry.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { Connection } from '@solana/web3.js'
-import { sendAndConfirmWithRetry } from '../../src/lib/sendWithRetry.js'
+import {
+  sendAndConfirmWithRetry,
+  TransactionFailedOnChainError,
+} from '../../src/lib/sendWithRetry.js'
 
 const FAKE_SIGNATURE = '5J7XHm...fake'
 const FAKE_BLOCKHASH = 'HF3...fake'
@@ -11,6 +14,7 @@ function makeConnection(overrides: Partial<Connection> = {}): Connection {
   return {
     sendRawTransaction: vi.fn(async () => FAKE_SIGNATURE),
     confirmTransaction: vi.fn(async () => ({ value: { err: null } })),
+    getSignatureStatuses: vi.fn(async () => ({ value: [null] })),
     ...overrides,
   } as unknown as Connection
 }
@@ -137,5 +141,96 @@ describe('sendAndConfirmWithRetry (backend)', () => {
         resubmitIntervalMs: 1,
       }),
     ).rejects.toMatchObject({ name: 'TransactionExpiredBlockheightExceededError' })
+  })
+
+  it('throws TransactionFailedOnChainError when confirmTransaction resolves with non-null err', async () => {
+    // The current bug (sipher#299): we used to discard confirmTransaction's
+    // result and return signature even when value.err was non-null. The fix
+    // is to inspect the result and throw a typed error so /api/tx/broadcast
+    // can return 502 TX_FAILED_ON_CHAIN instead of 200 with a failed signature.
+    const programErr = { InstructionError: [0, { Custom: 3012 }] }
+    const conn = makeConnection({
+      confirmTransaction: vi.fn(async () => ({ value: { err: programErr } })) as unknown as Connection['confirmTransaction'],
+    })
+
+    await expect(
+      sendAndConfirmWithRetry(conn, FAKE_BYTES, FAKE_BLOCKHASH, LAST_VALID_HEIGHT, {
+        resubmitIntervalMs: 1,
+      }),
+    ).rejects.toBeInstanceOf(TransactionFailedOnChainError)
+
+    // The thrown error must expose signature + err so the route handler can
+    // build a structured 502 envelope.
+    try {
+      await sendAndConfirmWithRetry(conn, FAKE_BYTES, FAKE_BLOCKHASH, LAST_VALID_HEIGHT, {
+        resubmitIntervalMs: 1,
+      })
+    } catch (e) {
+      expect(e).toBeInstanceOf(TransactionFailedOnChainError)
+      const failed = e as TransactionFailedOnChainError
+      expect(failed.signature).toBe(FAKE_SIGNATURE)
+      expect(failed.err).toEqual(programErr)
+    }
+  })
+
+  it('throws TransactionFailedOnChainError when getSignatureStatuses detects err before confirmation', async () => {
+    // Defense-in-depth path (sipher#299 Option 3): if confirmTransaction's
+    // WebSocket subscription is slow to fire, the parallel getSignatureStatuses
+    // poll detects the program error first and bails immediately instead of
+    // letting the request hang until CF cuts off at 100s.
+    const programErr = { InstructionError: [0, { Custom: 1 }] }
+    const conn = makeConnection({
+      // Never resolves — forces the poll to win the race.
+      confirmTransaction: vi.fn(() => new Promise(() => {})) as unknown as Connection['confirmTransaction'],
+      getSignatureStatuses: vi.fn(async () => ({
+        value: [{ slot: 100, confirmations: null, err: programErr, confirmationStatus: 'confirmed' }],
+      })) as unknown as Connection['getSignatureStatuses'],
+    })
+    const { sleep } = makeFakeSleep()
+
+    await expect(
+      sendAndConfirmWithRetry(conn, FAKE_BYTES, FAKE_BLOCKHASH, LAST_VALID_HEIGHT, {
+        sleep,
+        resubmitIntervalMs: 1,
+      }),
+    ).rejects.toMatchObject({
+      name: 'TransactionFailedOnChainError',
+      signature: FAKE_SIGNATURE,
+      err: programErr,
+    })
+  })
+
+  it('keeps polling while status is null and resolves on success', async () => {
+    // While the tx is pending (RPC has not yet seen it OR returned no err),
+    // the poll should not throw. Confirmation eventually resolves with no err
+    // and we return the signature.
+    let confirmCallCount = 0
+    let resolveConfirm: (v: { value: { err: null } }) => void = () => {}
+    const conn = makeConnection({
+      confirmTransaction: vi.fn(() => {
+        confirmCallCount += 1
+        return new Promise<{ value: { err: null } }>((r) => { resolveConfirm = r })
+      }) as unknown as Connection['confirmTransaction'],
+      // null = tx not yet seen by RPC. The poll loop must not throw in this case.
+      getSignatureStatuses: vi.fn(async () => ({ value: [null] })) as unknown as Connection['getSignatureStatuses'],
+    })
+    const { sleep, sleeps } = makeFakeSleep()
+
+    const pending = sendAndConfirmWithRetry(conn, FAKE_BYTES, FAKE_BLOCKHASH, LAST_VALID_HEIGHT, {
+      sleep,
+      resubmitIntervalMs: 1,
+    })
+
+    // Let the poll fire a few times against the null-status mock.
+    for (let i = 0; i < 10; i++) await Promise.resolve()
+    expect(confirmCallCount).toBe(1)
+
+    // Now resolve confirmation with no err — should return signature.
+    resolveConfirm({ value: { err: null } })
+    const sig = await pending
+
+    expect(sig).toBe(FAKE_SIGNATURE)
+    expect(sleeps.length).toBeGreaterThan(0)
+    expect(vi.mocked(conn.getSignatureStatuses)).toHaveBeenCalled()
   })
 })

--- a/packages/agent/tests/routes/tx-broadcast.test.ts
+++ b/packages/agent/tests/routes/tx-broadcast.test.ts
@@ -30,12 +30,19 @@ vi.mock('@sipher/sdk', async () => {
   }
 })
 
-vi.mock('../../src/lib/sendWithRetry.js', () => ({
-  sendAndConfirmWithRetry: vi.fn(),
-}))
+vi.mock('../../src/lib/sendWithRetry.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/lib/sendWithRetry.js')>()
+  return {
+    ...actual,
+    sendAndConfirmWithRetry: vi.fn(),
+  }
+})
 
 import { createConnection } from '@sipher/sdk'
-import { sendAndConfirmWithRetry } from '../../src/lib/sendWithRetry.js'
+import {
+  sendAndConfirmWithRetry,
+  TransactionFailedOnChainError,
+} from '../../src/lib/sendWithRetry.js'
 import { txBroadcastRouter } from '../../src/routes/tx-broadcast.js'
 
 function mockAuth(wallet: string | null) {
@@ -181,6 +188,26 @@ describe('POST /api/tx/broadcast', () => {
     expect(res.body.error.code).toBe('INTERNAL')
     // body must not contain key fragments
     expect(JSON.stringify(res.body)).not.toContain('api-key=')
+  })
+
+  it('returns 502 TX_FAILED_ON_CHAIN when sendAndConfirmWithRetry detects program error', async () => {
+    // sipher#299: when a tx confirms on-chain with meta.err (e.g.
+    // AccountNotInitialized, slippage exceeded), the broadcast route must
+    // surface that as a structured 502 — not a 200 with the failed signature,
+    // and not a generic CF 504 from the request hanging until edge timeout.
+    const programErr = { InstructionError: [0, { Custom: 3012 }] }
+    const failure = new TransactionFailedOnChainError(FAKE_SIGNATURE, programErr)
+    vi.mocked(sendAndConfirmWithRetry).mockRejectedValueOnce(failure)
+    const app = createApp()
+    const res = await supertest(app).post('/api/tx/broadcast').send(validBody())
+    expect(res.status).toBe(502)
+    expect(res.body.error.code).toBe('TX_FAILED_ON_CHAIN')
+    expect(res.body.error.signature).toBe(FAKE_SIGNATURE)
+    expect(res.body.error.err).toEqual(programErr)
+    // Message should be human-readable and reference the program error so the
+    // FE can render it without parsing the err object itself.
+    expect(typeof res.body.error.message).toBe('string')
+    expect(res.body.error.message.length).toBeGreaterThan(0)
   })
 
   it('redacts Helius API key fragments from error messages', async () => {


### PR DESCRIPTION
## Summary

Closes #299. When a transaction is confirmed on-chain but the program returns an error (e.g. `AccountNotInitialized`, slippage exceeded), `sendAndConfirmWithRetry` used to discard `value.err` from `confirmTransaction` and return the signature as a success. If the WS subscription was slow to fire, `confirmTransaction` polled until blockhash expiry (~90s), exceeding the 100s Cloudflare edge timeout — the user saw a generic CF 504 HTML page instead of a structured error envelope.

This PR implements Option 3 from the issue:

1. **`confirmInspected`** — wraps `connection.confirmTransaction` and throws a new `TransactionFailedOnChainError` when `value.err` is non-null, capturing both the signature and the err detail.
2. **`pollForErr`** — runs in parallel, calling `getSignatureStatuses` every interval and returning the same typed error the moment the RPC reports confirmed-with-err. Either path wins the race; `/api/tx/broadcast` catches the typed error and returns a structured `502 TX_FAILED_ON_CHAIN` with the err payload so the FE can render an actionable message.

The poll loop is fire-and-forget on cleanup so successful broadcasts do **not** pay an extra interval (2s in prod) of latency waiting for the poll to observe `stopped=true`.

### Response envelope on a confirmed-with-err tx

Before:
- Best case: `200 { signature }` with a signature whose tx errored — FE proceeded as if success.
- Worst case: CF 504 HTML page after 100s.

After:
```json
{
  "error": {
    "code": "TX_FAILED_ON_CHAIN",
    "message": "Transaction <sig> confirmed on-chain but the program returned an error: {\"InstructionError\":[0,{\"Custom\":3012}]}",
    "signature": "<sig>",
    "err": { "InstructionError": [0, { "Custom": 3012 }] }
  }
}
```

## Test plan

- [x] `pnpm test -- --run` in `packages/agent` — 1652 passed (was 1648, +4 new tests: 3 in `sendWithRetry`, 1 in `tx-broadcast`)
- [x] `pnpm typecheck` clean across root + sdk + app + agent
- [x] New tests cover three paths: (a) `confirmTransaction` returns `{ value: { err } }` → throws; (b) `getSignatureStatuses` detects err first while `confirmTransaction` hangs → throws; (c) poll stays quiet on `null` (tx-not-yet-seen) status while confirmation resolves cleanly.
- [x] `routes/tx-broadcast` test asserts the structured `502 TX_FAILED_ON_CHAIN` envelope shape (code, message, signature, err).
- [ ] Post-merge: re-run `/tmp/sipher-smoke/smoke5.mjs` once VPS deploys — expect `/api/tx/broadcast` to return the new 502 envelope instead of 200 for the confirmed-with-3012 signature.

## Notes

- The `winner.kind === 'polled' && !winner.errOrNull` branch is structurally unreachable (poll only returns null when `stopped=true`, set in finally); the code throws an invariant error if it ever fires.
- `redact()` is reused on `err.message` to ensure Helius API-key fragments don't escape if a future code path attaches them.
- Smoke evidence from frontier_sip_18 + 19: `confirmTransaction` typically resolves in ~3s for confirmed-with-err txs, so this is primarily a correctness fix; the parallel poll adds defense-in-depth for the slow-subscription edge case the issue called out.