### PR TITLE
fix(tx-broadcast): log caught error shape to diagnose prod INTERNAL fallthrough

### DIFF
--- a/packages/agent/src/routes/tx-broadcast.ts
+++ b/packages/agent/src/routes/tx-broadcast.ts
@@ -127,6 +127,20 @@ txBroadcastRouter.post('/broadcast', async (req: Request, res: Response) => {
     res.status(200).json({ signature })
     return
   } catch (err) {
+    // sipher#299 follow-up: prod returns 500 INTERNAL "unknown error" instead
+    // of 502 TX_FAILED_ON_CHAIN for confirmed-with-err txs. Local repro
+    // confirms sendAndConfirmWithRetry throws TransactionFailedOnChainError
+    // correctly; the instanceof check should match. Log shape for diagnosis.
+    console.error('[tx/broadcast] caught error:', {
+      isError: err instanceof Error,
+      isTFOCE: err instanceof TransactionFailedOnChainError,
+      isSendErr: err instanceof SendTransactionError,
+      isExpired: err instanceof TransactionExpiredBlockheightExceededError,
+      constructorName: (err as { constructor?: { name?: string } })?.constructor?.name,
+      name: (err as { name?: string })?.name,
+      message: (err as { message?: string })?.message?.slice?.(0, 300),
+      stringified: String(err).slice(0, 300),
+    })
     const rawMessage = err instanceof Error ? err.message : 'unknown error'
     const message = redact(rawMessage)
 


### PR DESCRIPTION
## Summary

Follow-up to #299 / #302. Prod smoke after deploy returns either:
- `500 { code: "INTERNAL", message: "unknown error" }` — my route's fallthrough, meaning err is NOT an Error instance, OR
- Cloudflare `502 Bad gateway` HTML — meaning the origin didn't respond at all

Local repro via a standalone Node script (`diag2.mjs` against the dist build) confirms `sendAndConfirmWithRetry` throws `TransactionFailedOnChainError` correctly:

```
[diag2] THREW after 2021ms
[diag2]   name: TransactionFailedOnChainError
[diag2]   constructor: TransactionFailedOnChainError
[diag2]   isError: true
[diag2]   isTransactionFailedOnChainError: true
[diag2]   signature: 3hzQfo9YL57qNPmDKmK961LFB1b4qhexavW6zKMLtyGerSkFaDFzXTQyrFTUhdPA5kToZw2sLu3c6VTJEx2rgR3t
[diag2]   err: {"InstructionError":[0,{"Custom":1}]}
```

Yet prod's `instanceof` checks evidently don't match. Adding one `console.error` in the catch with the shape of the caught value (constructor name, instanceof flags, message, stringified). The smoke flow can be re-run after deploy to see what err actually is, then a follow-up PR fixes the root cause.

## Test plan

- [x] `pnpm typecheck` clean across root + sdk + app + agent
- [x] `pnpm vitest run tests/routes/tx-broadcast.test.ts` — 13 passed
- [ ] Post-merge: re-run smoke and read `docker logs sipher | grep "[tx/broadcast]"` to capture err shape
- [ ] Follow-up PR: actual fix based on what the log reveals