### PR TITLE
fix(broadcast): normalize web3.js polling-fallback rejection

### DIFF
--- a/packages/agent/src/lib/sendWithRetry.ts
+++ b/packages/agent/src/lib/sendWithRetry.ts
@@ -99,10 +99,25 @@ export async function sendAndConfirmWithRetry(
   }
 
   const confirmInspected = async (): Promise<string> => {
-    const result = await connection.confirmTransaction(
-      { signature, blockhash, lastValidBlockHeight },
-      'confirmed',
-    )
+    let result
+    try {
+      result = await connection.confirmTransaction(
+        { signature, blockhash, lastValidBlockHeight },
+        'confirmed',
+      )
+    } catch (err) {
+      // web3.js's WS-subscription path resolves with { value: { err } }, but the
+      // getSignatureStatus polling fallback (Connection#getTransactionConfirmation
+      // Promise in node_modules/@solana/web3.js) calls `reject(value.err)` — i.e.
+      // it rejects with the bare TransactionError object (e.g.
+      // { InstructionError: [0, { Custom: 3012 }] }), not a thrown Error.
+      // Normalize so callers see a TransactionFailedOnChainError consistently
+      // regardless of which path fired. See sipher#299 follow-up.
+      if (err !== null && typeof err === 'object' && !(err instanceof Error)) {
+        throw new TransactionFailedOnChainError(signature, err)
+      }
+      throw err
+    }
     if (result?.value?.err) {
       throw new TransactionFailedOnChainError(signature, result.value.err)
     }

--- a/packages/agent/src/routes/tx-broadcast.ts
+++ b/packages/agent/src/routes/tx-broadcast.ts
@@ -127,20 +127,6 @@ txBroadcastRouter.post('/broadcast', async (req: Request, res: Response) => {
     res.status(200).json({ signature })
     return
   } catch (err) {
-    // sipher#299 follow-up: prod returns 500 INTERNAL "unknown error" instead
-    // of 502 TX_FAILED_ON_CHAIN for confirmed-with-err txs. Local repro
-    // confirms sendAndConfirmWithRetry throws TransactionFailedOnChainError
-    // correctly; the instanceof check should match. Log shape for diagnosis.
-    console.error('[tx/broadcast] caught error:', {
-      isError: err instanceof Error,
-      isTFOCE: err instanceof TransactionFailedOnChainError,
-      isSendErr: err instanceof SendTransactionError,
-      isExpired: err instanceof TransactionExpiredBlockheightExceededError,
-      constructorName: (err as { constructor?: { name?: string } })?.constructor?.name,
-      name: (err as { name?: string })?.name,
-      message: (err as { message?: string })?.message?.slice?.(0, 300),
-      stringified: String(err).slice(0, 300),
-    })
     const rawMessage = err instanceof Error ? err.message : 'unknown error'
     const message = redact(rawMessage)
 

--- a/packages/agent/tests/lib/sendWithRetry.test.ts
+++ b/packages/agent/tests/lib/sendWithRetry.test.ts
@@ -173,6 +173,47 @@ describe('sendAndConfirmWithRetry (backend)', () => {
     }
   })
 
+  it('normalizes polling-fallback rejection (bare TransactionError) into TransactionFailedOnChainError', async () => {
+    // web3.js confirmTransaction's getSignatureStatus polling fallback calls
+    // `reject(value.err)` — rejecting with a bare TransactionError object
+    // instead of resolving with { value: { err } }. confirmInspected must
+    // catch that, recognize the non-Error rejection, and wrap it consistently
+    // so the route handler can do `instanceof TransactionFailedOnChainError`.
+    const programErr = { InstructionError: [0, { Custom: 3012 }] }
+    const conn = makeConnection({
+      // Reject with the bare TransactionError object — what the polling
+      // fallback in @solana/web3.js v1.98 does.
+      confirmTransaction: vi.fn(() => Promise.reject(programErr)) as unknown as Connection['confirmTransaction'],
+    })
+
+    await expect(
+      sendAndConfirmWithRetry(conn, FAKE_BYTES, FAKE_BLOCKHASH, LAST_VALID_HEIGHT, {
+        resubmitIntervalMs: 1,
+      }),
+    ).rejects.toMatchObject({
+      name: 'TransactionFailedOnChainError',
+      signature: FAKE_SIGNATURE,
+      err: programErr,
+    })
+  })
+
+  it('preserves non-object rejection types (e.g. TransactionExpiredBlockheightExceededError) unchanged', async () => {
+    // The polling-fallback normalization must only catch plain-object
+    // rejections. Real Error instances (the WS-path's blockheight-expired
+    // throw) must propagate unchanged so the route returns 504, not 502.
+    const expired = new Error('TransactionExpiredBlockheightExceededError')
+    expired.name = 'TransactionExpiredBlockheightExceededError'
+    const conn = makeConnection({
+      confirmTransaction: vi.fn(() => Promise.reject(expired)) as unknown as Connection['confirmTransaction'],
+    })
+
+    await expect(
+      sendAndConfirmWithRetry(conn, FAKE_BYTES, FAKE_BLOCKHASH, LAST_VALID_HEIGHT, {
+        resubmitIntervalMs: 1,
+      }),
+    ).rejects.toMatchObject({ name: 'TransactionExpiredBlockheightExceededError' })
+  })
+
   it('throws TransactionFailedOnChainError when getSignatureStatuses detects err before confirmation', async () => {
     // Defense-in-depth path (sipher#299 Option 3): if confirmTransaction's
     // WebSocket subscription is slow to fire, the parallel getSignatureStatuses


### PR DESCRIPTION
## Summary

Diagnostic log from PR #303 revealed the real root cause of the prod 500 INTERNAL fallthrough that PR #302 was supposed to convert into 502 TX_FAILED_ON_CHAIN.

```
[tx/broadcast] caught error: {
  isError: false,
  isTFOCE: false,
  constructorName: 'Object',
  name: undefined,
  message: undefined,
  stringified: '[object Object]'
}
```

The thrown value is a **plain Object**, not a `TransactionFailedOnChainError` or any `Error` subclass — so every `instanceof` check in the route fails and we fall through to `500 INTERNAL "unknown error"`.

## Root cause

In `@solana/web3.js` v1.98 (`Connection#getTransactionConfirmationPromise`), two paths can settle the confirmation:

1. **WS-subscription path** (`onSignature` callback) resolves the promise with `{ __type: PROCESSED, response: { context, value: { err } } }`, so `confirmTransaction` resolves with `{ value: { err } }` and PR #302's `result.value.err` check fires correctly.
2. **`getSignatureStatus` polling fallback** (~line 6601 of `node_modules/@solana/web3.js/lib/index.cjs.js`) calls `reject(value.err)` — it **rejects with the bare `TransactionError` object** (e.g. `{ InstructionError: [0, { Custom: 3012 }] }`), not a thrown `Error`.

When the polling fallback wins the race (slow WS subscription on Helius devnet), `confirmTransaction` throws the bare plain object. PR #302 only handled the resolve path. Hence: 500 INTERNAL.

## Fix

Wrap `confirmTransaction` in `confirmInspected` with a try/catch that normalizes any non-Error object rejection into a proper `TransactionFailedOnChainError(signature, err)`. Real `Error` subclasses (`TransactionExpiredBlockheightExceededError`, `SendTransactionError`) propagate unchanged.

```typescript
const confirmInspected = async (): Promise<string> => {
  let result
  try {
    result = await connection.confirmTransaction(...)
  } catch (err) {
    if (err !== null && typeof err === 'object' && !(err instanceof Error)) {
      throw new TransactionFailedOnChainError(signature, err)
    }
    throw err
  }
  if (result?.value?.err) {
    throw new TransactionFailedOnChainError(signature, result.value.err)
  }
  return signature
}
```

Also removes the diagnostic `console.error` from #303 (it served its purpose).

## Test plan

- [x] `pnpm typecheck` clean across root + sdk + app + agent
- [x] `pnpm vitest run tests/lib/sendWithRetry.test.ts tests/routes/tx-broadcast.test.ts` — 23 passed (10 + 13)
- [x] Local diag2 against live devnet confirms `TransactionFailedOnChainError` is thrown correctly via the resolve path
- [ ] Post-merge: re-run smoke against prod, expect `502 TX_FAILED_ON_CHAIN` envelope

## New tests

- `normalizes polling-fallback rejection (bare TransactionError) into TransactionFailedOnChainError` — mocks `confirmTransaction` to `Promise.reject(programErr)` and asserts outer rejection is the wrapped class with matching signature/err.
- `preserves non-object rejection types (e.g. TransactionExpiredBlockheightExceededError) unchanged` — guards against the normalization accidentally swallowing real Error instances.