### PR TITLE
fix(tx-broadcast): use 422 over 502 to bypass CF error-page interception

### DIFF
--- a/packages/agent/src/routes/tx-broadcast.ts
+++ b/packages/agent/src/routes/tx-broadcast.ts
@@ -141,9 +141,18 @@ txBroadcastRouter.post('/broadcast', async (req: Request, res: Response) => {
     }
     if (err instanceof TransactionFailedOnChainError) {
       // Tx landed on-chain but the program returned an error. Surface a
-      // structured 502 with the err payload so the FE can render an
+      // structured 422 with the err payload so the FE can render an
       // actionable message instead of "tx cancelled". See sipher#299.
-      res.status(502).json({
+      //
+      // 422 (Unprocessable Entity) chosen over 502 (Bad Gateway) because
+      // Cloudflare's default behavior for 5xx status codes is to replace
+      // the origin's JSON body with a CF-branded HTML error page —
+      // confirmed empirically: an in-VPS curl sees the JSON envelope,
+      // but the same request via sipher-api.sip-protocol.org gets the
+      // CF 502 page. 422 passes through unchanged. The semantics also
+      // fit better here: the request itself was syntactically valid;
+      // the on-chain program could not process it.
+      res.status(422).json({
         error: {
           code: 'TX_FAILED_ON_CHAIN',
           message: redact(err.message),

--- a/packages/agent/tests/routes/tx-broadcast.test.ts
+++ b/packages/agent/tests/routes/tx-broadcast.test.ts
@@ -190,17 +190,18 @@ describe('POST /api/tx/broadcast', () => {
     expect(JSON.stringify(res.body)).not.toContain('api-key=')
   })
 
-  it('returns 502 TX_FAILED_ON_CHAIN when sendAndConfirmWithRetry detects program error', async () => {
+  it('returns 422 TX_FAILED_ON_CHAIN when sendAndConfirmWithRetry detects program error', async () => {
     // sipher#299: when a tx confirms on-chain with meta.err (e.g.
     // AccountNotInitialized, slippage exceeded), the broadcast route must
-    // surface that as a structured 502 — not a 200 with the failed signature,
-    // and not a generic CF 504 from the request hanging until edge timeout.
+    // surface that as a structured 422 envelope — not a 200 with the failed
+    // signature, and not a CF-mangled 5xx page. 422 (vs 502) chosen so
+    // Cloudflare passes the JSON body through unchanged.
     const programErr = { InstructionError: [0, { Custom: 3012 }] }
     const failure = new TransactionFailedOnChainError(FAKE_SIGNATURE, programErr)
     vi.mocked(sendAndConfirmWithRetry).mockRejectedValueOnce(failure)
     const app = createApp()
     const res = await supertest(app).post('/api/tx/broadcast').send(validBody())
-    expect(res.status).toBe(502)
+    expect(res.status).toBe(422)
     expect(res.body.error.code).toBe('TX_FAILED_ON_CHAIN')
     expect(res.body.error.signature).toBe(FAKE_SIGNATURE)
     expect(res.body.error.err).toEqual(programErr)


### PR DESCRIPTION
## Summary

Final follow-up to #299. PR #304 normalized the polling-fallback rejection so the route catches `TransactionFailedOnChainError` and emits a structured envelope — verified working via in-VPS curl:

```
status: 502
content-type: application/json; charset=utf-8
body: {"error":{"code":"TX_FAILED_ON_CHAIN","message":"...","signature":"...","err":{"InstructionError":[0,{"Custom":1}]}}}
```

But the same request via `https://sipher-api.sip-protocol.org/api/tx/broadcast` returns a Cloudflare-branded `502 Bad gateway` HTML page — CF's default behavior is to replace origin's body for 5xx codes. The FE never sees our JSON envelope.

This PR switches the status to **422 Unprocessable Entity**, which CF passes through unchanged. The semantics also fit: the request was syntactically valid; the on-chain program could not process it.

## Test plan

- [x] `pnpm typecheck` clean across root + sdk + app + agent
- [x] `pnpm vitest run tests/routes/tx-broadcast.test.ts` — 13 passed
- [ ] Post-merge: re-run smoke against prod; expect `422 TX_FAILED_ON_CHAIN` envelope visible end-to-end through Cloudflare.

## Notes

- Origin headers (vary, content-type, content-length) were all correct on 502; this is CF's hard-coded error page substitution, not an origin issue.
- Body shape unchanged — only the status code changed. FE consumers branching on `error.code` continue to work; consumers branching on numeric status need to add 422 to their "tx failed at program level" bucket.
- All other status codes (200, 400, 401, 504 for blockheight expired) remain unchanged.