### PR TITLE
cleanup(env): drop dead SIPHER_OPENROUTER_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,10 @@ JWT_EXPIRY=24h
 AUTHORIZED_WALLETS=
 
 # Sipher Agent (OpenRouter)
-SIPHER_OPENROUTER_API_KEY=
+# pi-ai reads OPENROUTER_API_KEY (see @mariozechner/pi-ai/dist/env-api-keys.js).
+# Do NOT introduce a SIPHER_OPENROUTER_API_KEY — historically it caused a silent
+# prod outage when the valid key was stored under the sipher-prefixed name and
+# the invalid one was under OPENROUTER_API_KEY (issue #295).
 OPENROUTER_API_KEY=
 SIPHER_MODEL=anthropic/claude-sonnet-4.6
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -28,8 +28,7 @@ SSH access: `ssh sip` (the `sipher` container runs under the `sip` user, there i
 | `ADMIN_API_KEY` | Admin API key for `/api/admin/*` endpoints. Empty = endpoints return 503. | `openssl rand -hex 32` |
 | `API_KEYS` | Comma-separated public API keys | Generate per client |
 | `SOLANA_RPC_URL` | Primary Solana RPC endpoint | Provider dashboard |
-| `SIPHER_OPENROUTER_API_KEY` | LLM provider key (OpenRouter) | openrouter.ai dashboard |
-| `OPENROUTER_API_KEY` | Fallback for non-Sipher agents | openrouter.ai dashboard |
+| `OPENROUTER_API_KEY` | LLM provider key — read by pi-ai. Authoritative for sipher agent chat. | openrouter.ai dashboard |
 
 ### Optional
 


### PR DESCRIPTION
## Summary

Closes #295. pi-ai reads only the canonical `OPENROUTER_API_KEY` (see `@mariozechner/pi-ai/dist/env-api-keys.js:93`). `SIPHER_OPENROUTER_API_KEY` was unused but lingered in `.env.example` and `docs/deployment.md`, creating ambiguity. In `frontier_sip_17` this caused a **silent prod chat outage** when the valid key was stored under the sipher-prefixed name and the invalid one under `OPENROUTER_API_KEY` — pi-ai used the invalid key and emitted empty content with no error log.

## Changes

- `.env.example`: drops `SIPHER_OPENROUTER_API_KEY=` line; adds an inline "DO NOT reintroduce" comment so a future copy-paste doesn't regress.
- `docs/deployment.md`: collapses the two rows into a single canonical `OPENROUTER_API_KEY` row.
- `docker-compose.yml`: unchanged — repo never declared the prefixed form (VPS-side drift addressed in #294).

## Test plan

- [x] `grep -rn SIPHER_OPENROUTER_API_KEY` across the repo: only the new "DO NOT reintroduce" comment in `.env.example` remains.
- [x] `pnpm typecheck` clean across root + sdk + app + agent.
- [ ] No runtime impact; nothing to smoke.

## Follow-ups

The VPS `~/sipher/.env` still has the prefixed variable. RECTOR can remove it during the next deploy. The VPS `docker-compose.yml` drift is addressed separately by #294.