### PR TITLE
chore(deploy): reconcile repo docker-compose with VPS — add SIPHER_MODEL + TORQUE_*

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,15 @@ services:
       - SENTINEL_MODE=${SENTINEL_MODE:-advisory}
       - SENTINEL_AUTHORITY_KEYPAIR=${SENTINEL_AUTHORITY_KEYPAIR:-}
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      # Sipher chat model — MUST use dot-form (e.g. claude-sonnet-4.6, NOT
+      # claude-sonnet-4-6). Hyphen-form silently fails the getSipherModel
+      # lookup and emits empty content with no error (issue #294/#293).
+      - SIPHER_MODEL=${SIPHER_MODEL:-anthropic/claude-sonnet-4.6}
+      # Torque growth integration — fail-closed by default; opt in with
+      # TORQUE_GROWTH_ENABLED=true + TORQUE_API_TOKEN set.
+      - TORQUE_GROWTH_ENABLED=${TORQUE_GROWTH_ENABLED:-false}
+      - TORQUE_API_TOKEN=${TORQUE_API_TOKEN:-}
+      - TORQUE_INGESTER_URL=${TORQUE_INGESTER_URL:-https://ingest.torque.so}
       - X_BEARER_TOKEN=${X_BEARER_TOKEN:-}
       - X_CONSUMER_KEY=${X_CONSUMER_KEY:-}
       - X_CONSUMER_SECRET=${X_CONSUMER_SECRET:-}


### PR DESCRIPTION
## Summary

Closes #294. The VPS-hosted `docker-compose.yml` had drifted from the repo's. This PR brings the repo file forward (canonical) so future deploys start from a consistent base.

## What's added

| Variable | Default | Why |
|---|---|---|
| `SIPHER_MODEL` | `anthropic/claude-sonnet-4.6` (dot-form) | VPS compose had a HYPHEN-form default (`claude-sonnet-4-6`) that silently failed `getSipherModel()` and emitted empty content — the outage that frontier_sip_17 caught. Dot-form here means even if `.env` unsets the var, the agent boots with a working model. |
| `TORQUE_GROWTH_ENABLED` | `false` | Fail-closed: integration only opts in when explicitly `true`. |
| `TORQUE_API_TOKEN` | `` (empty) | Required when `TORQUE_GROWTH_ENABLED=true`. |
| `TORQUE_INGESTER_URL` | `https://ingest.torque.so` | Canonical Torque ingest endpoint. |

`frontier_sip_12` added the Torque vars to the VPS compose but never landed them in the repo. This closes that gap.

## What's NOT added

- `SIPHER_OPENROUTER_API_KEY` — dropped in #295. pi-ai only reads `OPENROUTER_API_KEY`. The VPS should drop its declaration next deploy.

## Out of scope (follow-ups)

These are noted in #294's drift table but aren't repo source-of-truth fixes — they need separate deploy-side action:

- `SENTINEL_MODE` default discrepancy (repo `:-advisory` / VPS `:-yolo`). Repo's fail-safe default is correct; VPS can override via `.env` if it wants yolo.
- `SENTINEL_AUTHORITY_KEYPAIR` + `JWT_EXPIRY` declarations missing on VPS — VPS should add these to match repo.
- CI lint of VPS compose vs repo HEAD on deploy. Would catch future drift automatically. Would need workflow edit + safe-handling for legitimate VPS-only additions.

## Test plan

- [x] `docker compose config` validates syntax + interpolates defaults correctly.
- [x] Diff is additive only — no existing line changed, no behavior change for environments that already set these vars in `.env`.
- [x] Fail-closed defaults (TORQUE_GROWTH_ENABLED=false) mean zero impact on prod where Torque isn't enabled.