### PR TITLE
fix(agent): use tsup watcher for dev mode instead of tsx (fixes #253)

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsup --watch src --onSuccess 'node dist/index.js'",
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "vitest run",
@@ -33,6 +33,7 @@
     "@types/supertest": "^6.0.3",
     "@types/ws": "^8.5.0",
     "supertest": "^7.2.2",
+    "tsup": "^8.3.6",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"

--- a/packages/agent/tsup.config.ts
+++ b/packages/agent/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsup'
+
+// Dev/watch build for the agent entrypoint.
+// tsx's ESM loader cannot instantiate @bonfida/spl-name-service@3.0.21's
+// vendored borsh ESM bundle (see #253); building with tsup (esbuild) and
+// running the output with plain `node` avoids that loader entirely.
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  target: 'node22',
+  dts: false,
+  clean: true,
+  sourcemap: true,
+  splitting: false,
+  // Transpile only the agent's own source; let Node resolve node_modules at
+  // runtime. Bundling the transitive CJS chain (bs58 -> safe-buffer ->
+  // require("buffer")) into a single ESM file breaks with "Dynamic require
+  // not supported". Plain Node handles those deps (and Bonfida's ESM) fine.
+  skipNodeModulesBundle: true,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,6 +268,9 @@ importers:
       supertest:
         specifier: ^7.2.2
         version: 7.2.2
+      tsup:
+        specifier: ^8.3.6
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.19.0
         version: 4.21.0


### PR DESCRIPTION
## Summary

Resolves #253. The agent's `dev` script (`tsx watch src/index.ts`) has crashed at boot since Phase D because `@bonfida/spl-name-service@3.0.21` ships a borsh ESM bundle that tsx's ESM loader cannot instantiate (plain Node handles it fine).

## Fix

Switch `dev` to a tsup watcher matching the root pattern:
- `dev` → `tsup --watch src --onSuccess 'node dist/index.js'`
- new `packages/agent/tsup.config.ts` (esm, node22, `skipNodeModulesBundle: true`)
- add `tsup` to `devDependencies`

tsup transpiles only the agent's own source and runs the output with plain `node`, sidestepping tsx's loader. **`skipNodeModulesBundle: true` is required** — without it, tsup bundles the transitive CJS chain (`bs58` → `safe-buffer` → `require("buffer")`) into one ESM file and fails with `Dynamic require of "buffer" is not supported`.

## Verification

`pnpm exec tsup` builds clean (368 KB); `node dist/index.js` boots past **all** imports to the normal env validation (`FATAL: SIPHER_NETWORK env var required`) — confirming both the original borsh `SyntaxError` **and** the dynamic-require error are gone.

Production `build` (tsc) + `start` are unchanged — this only touches dev mode. `tsx` is retained in devDependencies (may be used for ad-hoc scripts).