### PR TITLE
fix(scan): parse versioned SIP:1/SIP:2 announcements via SDK parseAnnouncement (#313)

### DIFF
--- a/src/routes/scan.ts
+++ b/src/routes/scan.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response, NextFunction } from 'express'
 import { z } from 'zod'
-import { checkEd25519StealthAddress } from '@sip-protocol/sdk'
+import { checkEd25519StealthAddress, parseAnnouncement } from '@sip-protocol/sdk'
 import type { StealthAddress, HexString } from '@sip-protocol/types'
 import { validateRequest } from '../middleware/validation.js'
 import { getConnection } from '../services/solana.js'
@@ -12,8 +12,14 @@ import { ErrorCode } from '../errors/codes.js'
 
 const router = Router()
 
-const SIP_MEMO_PREFIX = 'SIP:'
 const BATCH_MAX = 100
+
+// Cheap pre-filter for SIP memo logs. Mirrors the SDK's SIP_MEMO_PREFIX_ANY
+// ('SIP:'); inlined because that constant currently exists only in the SDK's CJS
+// runtime bundle — it's absent from the ESM build and from both type-declaration
+// files, so an ESM/TS consumer can't import it. The authoritative, version-aware
+// parse (SIP:1 legacy + SIP:2 canonical) is done by the SDK's parseAnnouncement.
+const SIP_MEMO_PREFIX_ANY = 'SIP:'
 
 // ─── Schemas ────────────────────────────────────────────────────────────────
 
@@ -66,16 +72,19 @@ router.post(
           if (!tx?.meta?.logMessages) continue
 
           for (const log of tx.meta.logMessages) {
-            if (!log.includes(SIP_MEMO_PREFIX)) continue
+            if (!log.includes(SIP_MEMO_PREFIX_ANY)) continue
 
             const memoMatch = log.match(/Program log: (.+)/)
             if (!memoMatch) continue
 
-            // Parse announcement: SIP:<ephemeralPubKey>:<viewTag>:<stealthAddress>
-            const parts = memoMatch[1].replace(SIP_MEMO_PREFIX, '').split(':')
-            if (parts.length < 3) continue
+            // Version-aware parse of SIP:1 (legacy) + SIP:2 (canonical) announcements
+            // via the SDK. Format: SIP:<version>:<ephemeral>:<viewTag>[:<stealth>].
+            const announcement = parseAnnouncement(memoMatch[1].trim())
+            if (!announcement || !announcement.stealthAddress) continue
 
-            const [ephemeralB58, viewTagHex, stealthB58] = parts
+            const ephemeralB58 = announcement.ephemeralPublicKey
+            const viewTagHex = announcement.viewTag
+            const stealthB58 = announcement.stealthAddress
 
             let ephemeralHex: HexString
             let stealthHex: HexString
@@ -198,15 +207,19 @@ router.post(
               if (!tx?.meta?.logMessages) continue
 
               for (const log of tx.meta.logMessages) {
-                if (!log.includes(SIP_MEMO_PREFIX)) continue
+                if (!log.includes(SIP_MEMO_PREFIX_ANY)) continue
 
                 const memoMatch = log.match(/Program log: (.+)/)
                 if (!memoMatch) continue
 
-                const parts = memoMatch[1].replace(SIP_MEMO_PREFIX, '').split(':')
-                if (parts.length < 3) continue
+                // Version-aware parse of SIP:1 (legacy) + SIP:2 (canonical) announcements
+                // via the SDK. Format: SIP:<version>:<ephemeral>:<viewTag>[:<stealth>].
+                const announcement = parseAnnouncement(memoMatch[1].trim())
+                if (!announcement || !announcement.stealthAddress) continue
 
-                const [ephemeralB58, viewTagHex, stealthB58] = parts
+                const ephemeralB58 = announcement.ephemeralPublicKey
+                const viewTagHex = announcement.viewTag
+                const stealthB58 = announcement.stealthAddress
 
                 let ephemeralHex: HexString
                 let stealthHex: HexString

--- a/tests/scan.test.ts
+++ b/tests/scan.test.ts
@@ -4,6 +4,7 @@ import {
   generateEd25519StealthMetaAddress,
   generateEd25519StealthAddress,
   ed25519PublicKeyToSolanaAddress,
+  createAnnouncementMemo,
 } from '@sip-protocol/sdk'
 
 const { mockGetSignaturesForAddress, mockGetTransaction } = vi.hoisted(() => ({
@@ -180,19 +181,21 @@ describe('POST /v1/scan/payments', () => {
     expect(res.status).toBe(400)
   })
 
-  it('finds a matching announcement (canonical view-only round-trip)', async () => {
+  it('finds a SIP:2 versioned announcement (canonical view-only round-trip)', async () => {
     // A sender derived this stealth address + announcement for our meta-address.
     const meta = generateEd25519StealthMetaAddress('solana')
     const stealth = generateEd25519StealthAddress(meta.metaAddress)
     const ephB58 = ed25519PublicKeyToSolanaAddress(stealth.stealthAddress.ephemeralPublicKey)
     const stealthB58 = ed25519PublicKeyToSolanaAddress(stealth.stealthAddress.address)
     const viewTagHex = stealth.stealthAddress.viewTag.toString(16)
+    // Canonical on-chain format emitted by the SDK: `SIP:2:<eph>:<viewTag>:<stealth>`.
+    const memo = createAnnouncementMemo(ephB58, viewTagHex, stealthB58)
 
     mockGetSignaturesForAddress.mockResolvedValueOnce([
       { signature: 'pos-sig', slot: 300000001, blockTime: 1_700_000_000 },
     ])
     mockGetTransaction.mockResolvedValueOnce({
-      meta: { logMessages: [`Program log: SIP:${ephB58}:${viewTagHex}:${stealthB58}`] },
+      meta: { logMessages: [`Program log: ${memo}`] },
     })
 
     // Scan with ONLY the viewing private key + spending PUBLIC key (view-only).
@@ -209,5 +212,75 @@ describe('POST /v1/scan/payments', () => {
     expect(res.body.data.payments[0].stealthAddress).toBe(stealthB58)
     expect(res.body.data.payments[0].ephemeralPublicKey).toBe(ephB58)
     expect(res.body.data.payments[0].txSignature).toBe('pos-sig')
+  })
+
+  it('ignores legacy unversioned SIP: memos (never a real on-chain format)', async () => {
+    // The SDK has always versioned announcements (`SIP:1:` / `SIP:2:`); an
+    // unversioned `SIP:<eph>:<viewTag>:<stealth>` memo is not a canonical format
+    // and must not be matched.
+    const meta = generateEd25519StealthMetaAddress('solana')
+    const stealth = generateEd25519StealthAddress(meta.metaAddress)
+    const ephB58 = ed25519PublicKeyToSolanaAddress(stealth.stealthAddress.ephemeralPublicKey)
+    const stealthB58 = ed25519PublicKeyToSolanaAddress(stealth.stealthAddress.address)
+    const viewTagHex = stealth.stealthAddress.viewTag.toString(16)
+
+    mockGetSignaturesForAddress.mockResolvedValueOnce([
+      { signature: 'unversioned-sig', slot: 300000003, blockTime: 1_700_000_002 },
+    ])
+    mockGetTransaction.mockResolvedValueOnce({
+      meta: { logMessages: [`Program log: SIP:${ephB58}:${viewTagHex}:${stealthB58}`] },
+    })
+
+    const res = await request(app)
+      .post('/v1/scan/payments')
+      .send({
+        viewingPrivateKey: meta.viewingPrivateKey,
+        spendingPublicKey: meta.metaAddress.spendingKey,
+      })
+
+    expect(res.status).toBe(200)
+    expect(res.body.success).toBe(true)
+    expect(res.body.data.payments).toEqual([])
+  })
+})
+
+describe('POST /v1/scan/payments/batch', () => {
+  it('finds a SIP:2 versioned announcement for a keypair (view-only round-trip)', async () => {
+    const meta = generateEd25519StealthMetaAddress('solana')
+    const stealth = generateEd25519StealthAddress(meta.metaAddress)
+    const ephB58 = ed25519PublicKeyToSolanaAddress(stealth.stealthAddress.ephemeralPublicKey)
+    const stealthB58 = ed25519PublicKeyToSolanaAddress(stealth.stealthAddress.address)
+    const viewTagHex = stealth.stealthAddress.viewTag.toString(16)
+    const memo = createAnnouncementMemo(ephB58, viewTagHex, stealthB58)
+
+    mockGetSignaturesForAddress.mockResolvedValueOnce([
+      { signature: 'batch-sig', slot: 300000002, blockTime: 1_700_000_001 },
+    ])
+    mockGetTransaction.mockResolvedValueOnce({
+      meta: { logMessages: [`Program log: ${memo}`] },
+    })
+
+    const res = await request(app)
+      .post('/v1/scan/payments/batch')
+      .send({
+        keyPairs: [
+          {
+            viewingPrivateKey: meta.viewingPrivateKey,
+            spendingPublicKey: meta.metaAddress.spendingKey,
+            label: 'alice',
+          },
+        ],
+      })
+
+    expect(res.status).toBe(200)
+    expect(res.body.success).toBe(true)
+    expect(res.body.data.summary.totalPaymentsFound).toBe(1)
+    const found = res.body.data.results[0]
+    expect(found.success).toBe(true)
+    expect(found.label).toBe('alice')
+    expect(found.data.payments).toHaveLength(1)
+    expect(found.data.payments[0].stealthAddress).toBe(stealthB58)
+    expect(found.data.payments[0].ephemeralPublicKey).toBe(ephB58)
+    expect(found.data.payments[0].txSignature).toBe('batch-sig')
   })
 })


### PR DESCRIPTION
Closes #313.

## The bug (broader than the issue framed)

Both `/v1/scan/payments` and `/v1/scan/payments/batch` parsed stealth announcements with:

```ts
const parts = memoMatch[1].replace('SIP:', '').split(':')
const [ephemeralB58, viewTagHex, stealthB58] = parts
```

This assumes an **unversioned** `SIP:<eph>:<viewTag>:<stealth>` memo. But git history shows the SIP SDK has **always** emitted *versioned* announcements:

- pre-flip: `createAnnouncementMemo` → `SIP:1:<eph>:<viewTag>`, `parseAnnouncement` required `startsWith('SIP:1:')`
- post EIP-5564 canonical flip (sdk 0.10/0.11): `SIP:2:<eph>:<viewTag>[:<stealth>]`

For a real memo, `.replace('SIP:', '')` leaves the **version digit** as `parts[0]` → `new PublicKey('1'|'2')` throws → the announcement is silently skipped. So the route missed **every** real on-chain announcement (SIP:1 *and* SIP:2), not just SIP:2 as the issue estimated. The unversioned form the code parsed is fictional — nothing in the SIP ecosystem emits it (verified: sipher writes no `SIP:` memos; the SDK always versions).

## The fix

Adopt the SDK's canonical, version-aware `parseAnnouncement` at both parse sites. It resolves `SIP:1:` + `SIP:2:` and validates the ephemeral/viewTag/stealth components. The fictional unversioned form is intentionally no longer matched (a test documents this). Downstream logic (PublicKey→hex, viewTag range, `checkEd25519StealthAddress`, response shape) is unchanged — **no API contract change**.

## SDK ESM-export gap (found en route — filed separately)

`parseAnnouncement`/`createAnnouncementMemo` are exported from the SDK's ESM build, but the constants `SIP_MEMO_PREFIX_ANY` / `SIP_MEMO_PREFIX_V2` exist **only in the SDK's CJS runtime bundle (`dist/index.js`)** — they're absent from the ESM bundle (`dist/index.mjs`) **and from both type-declaration files** (`dist/index.d.ts`, `dist/index.d.mts`). So no ESM/TS consumer can import them: tsc errors ("no exported member"), and a bundler that tolerates missing named ESM imports yields `undefined` at runtime (caught here during TDD). The `SIP:` pre-filter therefore uses a local constant; `parseAnnouncement` does the authoritative parsing. Filed upstream: sip-protocol/sip-protocol#1123.

## Tests (TDD — red first)

- `POST /v1/scan/payments` — SIP:2 view-only round-trip (built via the SDK's `createAnnouncementMemo`)
- `POST /v1/scan/payments/batch` — SIP:2 view-only round-trip (the batch route has the same bug)
- guard: legacy unversioned `SIP:` memo is ignored

## Verification

- `pnpm exec vitest run tests/scan.test.ts` → 15/15
- `pnpm exec vitest run` (root) → **558/558** (+2 net new)
- `pnpm typecheck` → clean (app + packages/sdk + packages/agent)

## Notes

- Devnet/testnet only; no fund loss. Pre-flip devnet announcements (`SIP:1:`) parse but won't match the canonical view-only check — the accepted data-compat behavior from the #1099 flip.
- `src/routes/scan.ts` was untouched by #312, so this is pre-existing.