### PR TITLE
feat(herald): gate reactive mention/DM auto-reply behind HERALD_REACTIVE_ENABLED

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -164,3 +164,8 @@ HERALD_X_USER_ID=
 # Keep HERALD_AUTO_APPROVE_POSTS unset/false so content posts require manual approval
 # in the Command Center (HeraldView). Setting it 'true' auto-approves pending posts.
 HERALD_AUTO_APPROVE_POSTS=false
+# Reactive loop: poll @sipprotocol mentions + DMs and AUTO-REPLY via the LLM (no
+# approval gate). OFF by default — setting the X credentials above does NOT enable
+# auto-replies. Proactive content + publishing of approved posts run regardless.
+# Set 'true' only when ready for HERALD to auto-reply to arbitrary public mentions/DMs.
+HERALD_REACTIVE_ENABLED=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,9 @@ services:
       - HERALD_CONTENT_CRON_INTERVAL=${HERALD_CONTENT_CRON_INTERVAL:-3600000}
       - GITHUB_TOKEN=${GITHUB_TOKEN:-}
       - HERALD_AUTO_APPROVE_POSTS=${HERALD_AUTO_APPROVE_POSTS:-false}
+      # Reactive loop (mention/DM polling + LLM auto-reply) — fail-closed by default.
+      # X credentials alone do NOT enable auto-replies; opt in here when ready.
+      - HERALD_REACTIVE_ENABLED=${HERALD_REACTIVE_ENABLED:-false}
       - HERALD_MONTHLY_BUDGET=${HERALD_MONTHLY_BUDGET:-150}
       - JUPITER_API_URL=${JUPITER_API_URL:-https://lite-api.jup.ag}
       - JITO_BLOCK_ENGINE_URL=${JITO_BLOCK_ENGINE_URL:-}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -46,6 +46,7 @@ SSH access: `ssh sip` (the `sipher` container runs under the `sip` user, there i
 | `JITO_BLOCK_ENGINE_URL` | (empty) | Jito bundle relay (empty = mock mode) |
 | `AUTHORIZED_WALLETS` | (empty) | Comma-separated admin wallet pubkeys |
 | `HERALD_MONTHLY_BUDGET` | `150` | HERALD X agent USD budget cap |
+| `HERALD_REACTIVE_ENABLED` | `false` | Reactive loop: poll @sipprotocol mentions/DMs + LLM auto-reply (no approval gate). X credentials alone do **not** enable it. |
 
 ### SENTINEL Security Agent
 
@@ -78,14 +79,28 @@ SENTINEL is an LLM-backed security analyst that performs preflight risk assessme
 
 Deploy new SENTINEL features in `advisory` for at least one week before promoting to `yolo`.
 
-### HERALD content engine
+### HERALD operation modes
 
-When `HERALD_CONTENT_CRON_ENABLED=true` (and X credentials are present), HERALD drafts
-one original tweet per day from a weekly theme calendar + a live GitHub activity digest,
-and enqueues it to the approval queue. Nothing publishes until approved in the Command
-Center HeraldView — keep `HERALD_AUTO_APPROVE_POSTS` unset/false to preserve that manual
-gate. Tunables: `HERALD_CONTENT_CRON_INTERVAL` (ms, default 3600000), `GITHUB_TOKEN`
-(optional, raises the GitHub rate limit).
+HERALD starts only when X credentials (`X_BEARER_TOKEN` + `X_CONSUMER_KEY`) are present.
+It then has **two independent outward-facing paths** with different safety models:
+
+**1. Proactive content (approval-gated, recommended first).** When
+`HERALD_CONTENT_CRON_ENABLED=true`, HERALD drafts one original tweet per day from a weekly
+theme calendar + a live GitHub activity digest and enqueues it to the approval queue.
+Nothing publishes until approved in the Command Center HeraldView — keep
+`HERALD_AUTO_APPROVE_POSTS` unset/false to preserve that manual gate. Tunables:
+`HERALD_CONTENT_CRON_INTERVAL` (ms, default 3600000), `GITHUB_TOKEN` (optional, raises the
+GitHub rate limit).
+
+**2. Reactive replies (auto-post, opt-in).** When `HERALD_REACTIVE_ENABLED=true`, HERALD
+polls @sipprotocol mentions + DMs and **auto-replies via the LLM with no approval gate**
+(guarded only by the monthly budget cap, the kill switch, and the spam-intent filter).
+This is **off by default** — setting X credentials alone does *not* enable it, so you can
+run proactive content first and enable reactive replies deliberately once confident.
+
+**Recommended rollout:** launch with content only (`HERALD_CONTENT_CRON_ENABLED=true`,
+`HERALD_REACTIVE_ENABLED=false`), observe approved posts for a period, then flip
+`HERALD_REACTIVE_ENABLED=true` when ready for unattended public replies.
 
 ## Secrets Management
 

--- a/packages/agent/src/herald/poller.ts
+++ b/packages/agent/src/herald/poller.ts
@@ -191,9 +191,18 @@ export async function checkScheduledPosts(): Promise<void> {
 // ─────────────────────────────────────────────────────────────────────────────
 
 export type PollerTimers = {
-  mentionsTimer: ReturnType<typeof setTimeout>
-  dmsTimer: ReturnType<typeof setInterval>
+  mentionsTimer: ReturnType<typeof setTimeout> | null
+  dmsTimer: ReturnType<typeof setInterval> | null
   scheduledTimer: ReturnType<typeof setInterval>
+}
+
+/**
+ * Whether the reactive loop (mention/DM polling + LLM auto-reply) is enabled.
+ * Opt-in via HERALD_REACTIVE_ENABLED=true. Defaults to OFF so HERALD can run
+ * proactive content (approval-gated) without auto-replying to public mentions/DMs.
+ */
+export function reactiveEnabled(): boolean {
+  return process.env.HERALD_REACTIVE_ENABLED === 'true'
 }
 
 /**
@@ -229,28 +238,35 @@ export function startPoller(state: PollerState): PollerTimers {
   state.running = true
 
   const timers: PollerTimers = {
-    mentionsTimer: null as unknown as ReturnType<typeof setTimeout>,
-    dmsTimer: null as unknown as ReturnType<typeof setInterval>,
+    mentionsTimer: null,
+    dmsTimer: null,
     scheduledTimer: null as unknown as ReturnType<typeof setInterval>,
   }
 
-  // Mentions: recursive setTimeout for adaptive backoff
-  scheduleMentionPoll(state, timers)
+  // Reactive loop (mention + DM polling → LLM auto-reply) is opt-in via
+  // HERALD_REACTIVE_ENABLED. When disabled, HERALD never polls mentions/DMs and
+  // never auto-replies — it still publishes approved/scheduled posts below.
+  if (reactiveEnabled()) {
+    // Mentions: recursive setTimeout for adaptive backoff
+    scheduleMentionPoll(state, timers)
 
-  // DMs: fixed interval (no backoff needed)
-  timers.dmsTimer = setInterval(() => {
-    pollDMs(state).catch((err) => {
-      guardianBus.emit({
-        source: 'herald',
-        type: 'herald:poller-error',
-        level: 'important',
-        data: { poller: 'dms', error: err instanceof Error ? err.message : String(err) },
-        timestamp: new Date().toISOString(),
+    // DMs: fixed interval (no backoff needed)
+    timers.dmsTimer = setInterval(() => {
+      pollDMs(state).catch((err) => {
+        guardianBus.emit({
+          source: 'herald',
+          type: 'herald:poller-error',
+          level: 'important',
+          data: { poller: 'dms', error: err instanceof Error ? err.message : String(err) },
+          timestamp: new Date().toISOString(),
+        })
       })
-    })
-  }, state.dmInterval)
+    }, state.dmInterval)
+    timers.dmsTimer.unref()
+  }
 
-  // Scheduled posts checked every minute regardless of mention backoff
+  // Scheduled posts checked every minute — ALWAYS runs (publishes only approved
+  // posts, so it is safe regardless of the reactive gate).
   timers.scheduledTimer = setInterval(() => {
     checkScheduledPosts().catch((err) => {
       guardianBus.emit({
@@ -263,7 +279,6 @@ export function startPoller(state: PollerState): PollerTimers {
     })
   }, 60_000)
 
-  timers.dmsTimer.unref()
   timers.scheduledTimer.unref()
 
   return timers
@@ -273,8 +288,8 @@ export function startPoller(state: PollerState): PollerTimers {
  * Stop all poller timers and mark state as not running.
  */
 export function stopPoller(state: PollerState, timers: PollerTimers): void {
-  clearTimeout(timers.mentionsTimer)
-  clearInterval(timers.dmsTimer)
+  if (timers.mentionsTimer) clearTimeout(timers.mentionsTimer)
+  if (timers.dmsTimer) clearInterval(timers.dmsTimer)
   clearInterval(timers.scheduledTimer)
   state.running = false
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -374,19 +374,27 @@ const server = app.listen(PORT, () => {
       import('./herald/poller.js'),
       import('./adapters/x.js'),
       import('./herald/content/cron.js'),
-    ]).then(([{ createPollerState, startPoller }, { createXAdapter }, { startContentCron }]) => {
-      // Start X adapter first (subscribes to events before poller emits them)
-      createXAdapter()
-      console.log('  HERALD:  X adapter started (LLM brain for mentions + DMs)')
+    ]).then(([{ createPollerState, startPoller, reactiveEnabled }, { createXAdapter }, { startContentCron }]) => {
+      const reactive = reactiveEnabled()
 
-      // Then start poller (emits events the adapter handles)
+      // The LLM reply-brain (auto-replies to mentions/DMs) is wired ONLY when the
+      // reactive loop is enabled (HERALD_REACTIVE_ENABLED=true). Off by default →
+      // HERALD runs proactive content (approval-gated) without auto-replying to
+      // public mentions/DMs.
+      if (reactive) {
+        // Start X adapter first (subscribes to events before poller emits them)
+        createXAdapter()
+        console.log('  HERALD:  X adapter started (LLM brain for mentions + DMs)')
+      }
+
+      // Then start poller — emits mention/DM events only when reactive is enabled;
+      // the scheduled-publish loop (approved posts only) runs regardless.
       const heraldState = createPollerState()
       startPoller(heraldState)
       const contentTimer = startContentCron()
       console.log(
-        contentTimer
-          ? '  HERALD:  poller started (mentions + DMs + scheduled posts) + content cron'
-          : '  HERALD:  poller started (mentions + DMs + scheduled posts); content cron disabled'
+        `  HERALD:  poller started — reactive ${reactive ? 'ON (mentions + DMs auto-reply)' : 'OFF'}, ` +
+          `content cron ${contentTimer ? 'ON' : 'OFF'}, publishing approved posts`
       )
     }).catch(err => {
       console.warn('  HERALD:  not started:', (err as Error).message)

--- a/packages/agent/tests/herald/poller.test.ts
+++ b/packages/agent/tests/herald/poller.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest'
-import { createPollerState, getNextInterval } from '../../src/herald/poller.js'
+import { describe, it, expect, afterEach } from 'vitest'
+import {
+  createPollerState,
+  getNextInterval,
+  reactiveEnabled,
+  startPoller,
+  stopPoller,
+} from '../../src/herald/poller.js'
 
 describe('HERALD adaptive poller', () => {
   it('createPollerState() returns correct defaults', () => {
@@ -37,5 +43,62 @@ describe('HERALD adaptive poller', () => {
     const interval = getNextInterval(state)
 
     expect(interval).toBe(base)
+  })
+})
+
+describe('reactiveEnabled (HERALD_REACTIVE_ENABLED gate)', () => {
+  afterEach(() => {
+    delete process.env.HERALD_REACTIVE_ENABLED
+  })
+
+  it('defaults to false when the var is unset', () => {
+    delete process.env.HERALD_REACTIVE_ENABLED
+    expect(reactiveEnabled()).toBe(false)
+  })
+
+  it('is true only when set to exactly "true"', () => {
+    process.env.HERALD_REACTIVE_ENABLED = 'true'
+    expect(reactiveEnabled()).toBe(true)
+  })
+
+  it('treats any other value as disabled (fail-safe)', () => {
+    for (const v of ['', 'false', 'TRUE', '1', 'yes']) {
+      process.env.HERALD_REACTIVE_ENABLED = v
+      expect(reactiveEnabled()).toBe(false)
+    }
+  })
+})
+
+describe('startPoller reactive gate', () => {
+  afterEach(() => {
+    delete process.env.HERALD_REACTIVE_ENABLED
+  })
+
+  it('does NOT start mention/DM timers when reactive is disabled, but still publishes scheduled posts', () => {
+    delete process.env.HERALD_REACTIVE_ENABLED
+    const state = createPollerState()
+
+    const timers = startPoller(state)
+
+    expect(timers.mentionsTimer).toBeNull()
+    expect(timers.dmsTimer).toBeNull()
+    expect(timers.scheduledTimer).not.toBeNull()
+    expect(state.running).toBe(true)
+
+    stopPoller(state, timers)
+    expect(state.running).toBe(false)
+  })
+
+  it('starts all three timers when reactive is enabled', () => {
+    process.env.HERALD_REACTIVE_ENABLED = 'true'
+    const state = createPollerState()
+
+    const timers = startPoller(state)
+
+    expect(timers.mentionsTimer).not.toBeNull()
+    expect(timers.dmsTimer).not.toBeNull()
+    expect(timers.scheduledTimer).not.toBeNull()
+
+    stopPoller(state, timers)
   })
 })


### PR DESCRIPTION
## Summary

HERALD's **reactive loop** (poll @sipprotocol mentions/DMs → LLM → auto-reply) previously started **unconditionally** whenever X credentials were present (`X_BEARER_TOKEN && X_CONSUMER_KEY`), with **no approval gate**. So merely adding credentials meant HERALD would auto-reply to arbitrary public mentions/DMs immediately — before the proactive content engine was even enabled, and with the only guards being the budget cap, kill switch, and spam filter.

This PR adds an opt-in **`HERALD_REACTIVE_ENABLED`** flag (default `false`) so go-live can be phased safely.

## Behavior

| | Reactive **OFF** (new default) | Reactive **ON** (`HERALD_REACTIVE_ENABLED=true`) |
|---|---|---|
| Poll mentions/DMs | ❌ no | ✅ yes |
| LLM auto-reply brain (`createXAdapter`) | ❌ not wired | ✅ wired |
| Proactive content cron → approval queue | ✅ runs (gated by `HERALD_CONTENT_CRON_ENABLED`) | ✅ runs |
| Publish **approved** posts | ✅ runs | ✅ runs |

→ You can launch **proactive content only** (approval-gated, fully human-in-the-loop), observe it, then flip `HERALD_REACTIVE_ENABLED=true` deliberately when ready for unattended public replies.

## Changes
- **`poller.ts`**: `reactiveEnabled()` predicate; `startPoller` starts the mention/DM timers **only when enabled** (the scheduled-publish timer always runs); `PollerTimers` mention/DM handles are now nullable; `stopPoller` null-guarded.
- **`index.ts`**: `createXAdapter` (the auto-reply brain) is wired only when reactive is enabled; clearer startup log.
- **`.env.example`, `docker-compose.yml`, `docs/deployment.md`**: document the flag + the two operation modes + recommended rollout order.

## ⚠️ Intended behavior change
This is a deliberate behavior change: a deployment that sets X credentials will **no longer auto-reply** until `HERALD_REACTIVE_ENABLED=true` is also set. HERALD has never gone live (dormant — no credentials in any environment), so no running deployment is affected. Defaults are fail-closed.

## Tests
- `+5` poller tests (reactive flag default/parsing; `startPoller` gate on/off).
- Full agent suite: **1690 pass / 2 skipped**, typecheck clean.

## Related (out of scope — flagged for follow-up)
While auditing the reactive path I found `tools/send-dm.ts` emits a `herald:dm` event with shape `{ user_id, dm_id }`, but the adapter's `handleDM` expects `{ dmId, senderId, text, intent }`. When reactive is **on**, each DM HERALD sends fires a malformed incoming-DM event → the adapter mis-processes it (undefined fields), wastes one LLM call, and fails at the reply (no infinite loop — it throws before re-emitting). Pre-existing and harmless while reactive is off (this PR's default); worth a separate fix before reactive go-live.

Part of the **HERALD go-live** track (T3). An X API requirements audit (pay-per-use pricing, DM auth, setup steps) accompanies this work in the session handoff.
