### PR TITLE
fix(herald): outgoing-DM event type + URL-aware post cost tracking

### DIFF
--- a/packages/agent/src/herald/budget.ts
+++ b/packages/agent/src/herald/budget.ts
@@ -15,11 +15,27 @@ const COST_TABLE: Record<string, number> = {
   posts_read: 0.005,
   user_read: 0.010,
   dm_read: 0.010,
-  content_create: 0.005,
+  content_create: 0.015, // X 2026 pay-per-use: post creation is $0.015/request
+  content_create_url: 0.200, // X 2026 pay-per-use: a post containing a link is $0.200/request
   dm_create: 0.015,
   user_interaction: 0.015,
   mentions_read: 0.005,
   search_read: 0.005,
+}
+
+// A post that contains a link is billed at the higher content_create_url rate.
+// Detect only unambiguous link signals (http(s):// or a www. host) — bare-domain
+// matching (e.g. `foo.io`) would false-positive on HERALD's technical content
+// such as `stealth.ts`, `v0.9.0`, or `claude-sonnet-4.6`.
+const POST_URL_PATTERN = /https?:\/\/|(?:^|\s)www\./i
+
+/**
+ * Pick the X content-creation cost key for a post body: the URL rate when the
+ * text contains a link, otherwise the base post rate. Callers track cost with
+ * this while still gating on the plain `content_create` op.
+ */
+export function postCostOperation(text: string): 'content_create' | 'content_create_url' {
+  return POST_URL_PATTERN.test(text) ? 'content_create_url' : 'content_create'
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -36,6 +52,7 @@ const BLOCKED_OPS: Record<BudgetGate, Set<string>> = {
     'search_read',
     'posts_read',
     'content_create',
+    'content_create_url',
     'user_interaction',
   ]),
   paused: new Set(Object.keys(COST_TABLE)),

--- a/packages/agent/src/herald/tools/post-tweet.ts
+++ b/packages/agent/src/herald/tools/post-tweet.ts
@@ -1,6 +1,6 @@
 import type { Tool } from '@mariozechner/pi-ai'
 import { getWriteClient } from '../x-client.js'
-import { trackXApiCost, canMakeCall } from '../budget.js'
+import { trackXApiCost, canMakeCall, postCostOperation } from '../budget.js'
 import { getDb } from '../../db.js'
 import { ulid } from 'ulid'
 import { guardianBus } from '../../coordination/event-bus.js'
@@ -84,7 +84,8 @@ export async function publishTweet(text: string): Promise<PublishTweetResult> {
   const response = await client.v2.tweet(text)
   const tweetId = response.data.id
 
-  trackXApiCost('content_create', 1)
+  // Posts containing a link bill at the higher content_create_url rate.
+  trackXApiCost(postCostOperation(text), 1)
 
   return { tweet_id: tweetId }
 }

--- a/packages/agent/src/herald/tools/reply-tweet.ts
+++ b/packages/agent/src/herald/tools/reply-tweet.ts
@@ -1,6 +1,6 @@
 import type { Tool } from '@mariozechner/pi-ai'
 import { getWriteClient } from '../x-client.js'
-import { trackXApiCost, canMakeCall } from '../budget.js'
+import { trackXApiCost, canMakeCall, postCostOperation } from '../budget.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // replyTweet — AUTO. Posts a reply to an existing tweet directly via X API.
@@ -51,7 +51,8 @@ export async function executeReplyTweet(params: ReplyTweetParams): Promise<Reply
   const response = await client.v2.reply(params.text, params.tweet_id)
   const tweetId = response.data.id
 
-  trackXApiCost('content_create', 1)
+  // Replies containing a link bill at the higher content_create_url rate.
+  trackXApiCost(postCostOperation(params.text), 1)
 
   return { tweet_id: tweetId }
 }

--- a/packages/agent/src/herald/tools/send-dm.ts
+++ b/packages/agent/src/herald/tools/send-dm.ts
@@ -56,9 +56,13 @@ export async function executeSendDM(params: SendDMParams): Promise<SendDMResult>
   trackXApiCost('dm_create', 1)
 
   const now = new Date().toISOString()
+  // Emit `herald:dm-sent` (outgoing), NOT `herald:dm` (incoming). The X adapter
+  // subscribes to `herald:dm` to auto-reply to received DMs — emitting that type
+  // here would make HERALD treat its own sent DM as an inbound one. The dashboard
+  // still surfaces this via the guardianBus onAny stream.
   guardianBus.emit({
     source: 'herald',
-    type: 'herald:dm',
+    type: 'herald:dm-sent',
     level: 'routine',
     data: { user_id: params.user_id, dm_id: dmId },
     timestamp: now,

--- a/packages/agent/tests/herald/budget.test.ts
+++ b/packages/agent/tests/herald/budget.test.ts
@@ -96,3 +96,46 @@ describe('HERALD budget tracker', () => {
     expect(canMakeCall('user_read')).toBe(true)
   })
 })
+
+describe('content-create costs (2026 X pay-per-use rates)', () => {
+  it('content_create is $0.015 per post', async () => {
+    const { trackXApiCost, getBudgetStatus } = await getBudget()
+    trackXApiCost('content_create', 1)
+    expect(getBudgetStatus().spent).toBeCloseTo(0.015, 5)
+  })
+
+  it('content_create_url is $0.200 per post (X charges more for posts with links)', async () => {
+    const { trackXApiCost, getBudgetStatus } = await getBudget()
+    trackXApiCost('content_create_url', 1)
+    expect(getBudgetStatus().spent).toBeCloseTo(0.2, 5)
+  })
+
+  it('content_create_url is blocked when the budget gate is paused', async () => {
+    const { trackXApiCost, canMakeCall } = await getBudget()
+    trackXApiCost('user_read', 15000) // 100% → paused
+    expect(canMakeCall('content_create_url')).toBe(false)
+  })
+})
+
+describe('postCostOperation (URL-aware post cost)', () => {
+  it('returns content_create for plain text', async () => {
+    const { postCostOperation } = await getBudget()
+    expect(postCostOperation('Privacy is normal.')).toBe('content_create')
+  })
+
+  it('returns content_create_url for http(s) links', async () => {
+    const { postCostOperation } = await getBudget()
+    expect(postCostOperation('Read more: https://sip-protocol.org')).toBe('content_create_url')
+    expect(postCostOperation('http://example.com')).toBe('content_create_url')
+  })
+
+  it('returns content_create_url for www. links', async () => {
+    const { postCostOperation } = await getBudget()
+    expect(postCostOperation('visit www.sip-protocol.org today')).toBe('content_create_url')
+  })
+
+  it('does NOT false-positive on technical content (filenames, versions)', async () => {
+    const { postCostOperation } = await getBudget()
+    expect(postCostOperation('New in stealth.ts — SDK v0.9.0 with claude-sonnet-4.6')).toBe('content_create')
+  })
+})

--- a/packages/agent/tests/herald/tools/post-tweet.test.ts
+++ b/packages/agent/tests/herald/tools/post-tweet.test.ts
@@ -177,6 +177,14 @@ describe('publishTweet', () => {
     expect(row?.operation).toBe('content_create')
   })
 
+  it('tracks the higher content_create_url cost when the post contains a link', async () => {
+    await publishTweet('Read the docs: https://sip-protocol.org')
+    const conn = getDb()
+    const row = conn.prepare("SELECT * FROM cost_log WHERE operation = 'content_create_url' LIMIT 1").get() as { operation: string } | undefined
+    expect(row).toBeDefined()
+    expect(row?.operation).toBe('content_create_url')
+  })
+
   it('re-throws X API errors', async () => {
     mockTweet.mockRejectedValue(new Error('403 Forbidden'))
     await expect(publishTweet('Will fail')).rejects.toThrow('403 Forbidden')
@@ -376,19 +384,23 @@ describe('executeSendDM', () => {
     expect(rows.length).toBeGreaterThanOrEqual(1)
   })
 
-  it('emits herald:dm event on the guardianBus', async () => {
+  it('emits herald:dm-sent (not herald:dm) so the X adapter does not treat an outgoing DM as incoming', async () => {
     const { guardianBus } = await import('../../../src/coordination/event-bus.js')
-    const handler = vi.fn()
-    guardianBus.on('herald:dm', handler)
+    const sentHandler = vi.fn()
+    const incomingHandler = vi.fn()
+    guardianBus.on('herald:dm-sent', sentHandler)
+    guardianBus.on('herald:dm', incomingHandler)
     await executeSendDM({ user_id: 'user_event', text: 'Event test' })
-    expect(handler).toHaveBeenCalledWith(
+    expect(sentHandler).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'herald:dm',
+        type: 'herald:dm-sent',
         source: 'herald',
         data: expect.objectContaining({ user_id: 'user_event' }),
       }),
     )
-    guardianBus.off('herald:dm', handler)
+    expect(incomingHandler).not.toHaveBeenCalled()
+    guardianBus.off('herald:dm-sent', sentHandler)
+    guardianBus.off('herald:dm', incomingHandler)
   })
 
   it('throws when user_id is empty', async () => {

--- a/packages/agent/tests/herald/tools/reply-tweet.test.ts
+++ b/packages/agent/tests/herald/tools/reply-tweet.test.ts
@@ -23,10 +23,16 @@ vi.mock('../../../src/herald/x-client.js', () => ({
   getWriteClient: mockGetWriteClient,
 }))
 
-vi.mock('../../../src/herald/budget.js', () => ({
-  canMakeCall: mockCanMakeCall,
-  trackXApiCost: mockTrackXApiCost,
-}))
+// Keep the real (pure) postCostOperation so the URL-aware cost path is exercised
+// end-to-end through the call site; only the gate + cost-recording are mocked.
+vi.mock('../../../src/herald/budget.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/herald/budget.js')>()
+  return {
+    ...actual,
+    canMakeCall: mockCanMakeCall,
+    trackXApiCost: mockTrackXApiCost,
+  }
+})
 
 import {
   replyTweetTool,
@@ -123,6 +129,11 @@ describe('executeReplyTweet — service interaction', () => {
   it('tracks content_create cost with resource count 1', async () => {
     await executeReplyTweet({ tweet_id: VALID_TWEET_ID, text: 'reply' })
     expect(mockTrackXApiCost).toHaveBeenCalledWith('content_create', 1)
+  })
+
+  it('tracks content_create_url when the reply contains a link', async () => {
+    await executeReplyTweet({ tweet_id: VALID_TWEET_ID, text: 'docs: https://sip-protocol.org' })
+    expect(mockTrackXApiCost).toHaveBeenCalledWith('content_create_url', 1)
   })
 
   it('propagates v2.reply throw (rate limit / network / auth)', async () => {

--- a/packages/agent/tests/herald/tools/send-dm.test.ts
+++ b/packages/agent/tests/herald/tools/send-dm.test.ts
@@ -140,14 +140,14 @@ describe('executeSendDM — service interaction', () => {
     expect(mockTrackXApiCost).toHaveBeenCalledWith('dm_create', 1)
   })
 
-  it('emits herald:dm event with user_id and dm_id in data, level routine, no wallet field', async () => {
+  it('emits herald:dm-sent (NOT herald:dm — an outgoing DM must not be re-processed as an incoming one by the X adapter)', async () => {
     await executeSendDM({ user_id: VALID_USER_ID, text: SAMPLE_DM_TEXT })
 
     expect(mockGuardianEmit).toHaveBeenCalledTimes(1)
     const [event] = mockGuardianEmit.mock.calls[0]
     expect(event).toStrictEqual({
       source: 'herald',
-      type: 'herald:dm',
+      type: 'herald:dm-sent',
       level: 'routine',
       data: { user_id: VALID_USER_ID, dm_id: VALID_DM_EVENT_ID },
       timestamp: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/),


### PR DESCRIPTION
## Summary

Two small HERALD correctness/accuracy fixes surfaced while auditing the outward-facing paths for go-live (see #316 for the reactive-gate work). Both matter before the reactive loop is enabled.

## 1. Outgoing DMs emitted the wrong event type
`executeSendDM` emitted `herald:dm` after sending a DM — but `herald:dm` is the **incoming**-DM event that the X adapter (`adapters/x.ts`) subscribes to in order to auto-reply. So with the reactive loop on, every DM HERALD *sent* re-entered `handleDM` as if it were *received*: a wasted LLM round-trip plus a failed reply (the `{user_id, dm_id}` payload lacks the `senderId`/`text` the handler needs, so it throws before re-emitting — not an infinite loop, but noise + cost).

**Fix:** emit `herald:dm-sent`, matching the existing outgoing-event convention (`herald:reply-sent`, `herald:dm-replied`, `herald:post-published`). Still surfaced to the Command Center via the `guardianBus` `onAny` stream. Added a regression guard asserting the incoming `herald:dm` handler does **not** fire on a sent DM.

## 2. Post-creation cost tracking under-counted spend
`budget.ts` charged `content_create` at **$0.005**, but X's 2026 pay-per-use rate is **$0.015/post**, and a post containing a link is **$0.200**. So the $150/mo circuit-breaker tripped ~3× later than true spend, and link posts (which HERALD content often includes) were under-counted ~40×.

**Fix:**
- `content_create` → $0.015; added `content_create_url` → $0.200.
- New URL-aware `postCostOperation(text)` helper, used by `publishTweet` + `executeReplyTweet`. The budget **gate** still keys on `content_create` (creating a post is creating a post); only the **cost** differs by URL.
- URL detection matches only `http(s)://` and `www.` — deliberately *not* bare domains, which would false-positive on HERALD's technical content (`stealth.ts` → `.ts` TLD, `v0.9.0`).

## Tests
`+9`: `content_create`/`content_create_url` rates, `content_create_url` gating, `postCostOperation` (plain / http / www / technical-content negative), URL-cost wiring through `publishTweet` + `replyTweet`, and the `herald:dm-sent` event guard. Full agent suite **1694 pass / 2 skipped**, typecheck clean.

## Context
Part of the HERALD go-live track (T3). Independent of #316 (different files) — they can merge in any order. The cost-rate source is the [X API pay-per-use pricing](https://docs.x.com/x-api/getting-started/pricing) audited this session.
