### PR TITLE
feat(herald): Discord digest cross-post

### DIFF
--- a/packages/agent/src/herald/discord.ts
+++ b/packages/agent/src/herald/discord.ts
@@ -1,0 +1,75 @@
+import { guardianBus, type GuardianEvent } from '../coordination/event-bus.js'
+
+// guardianBus subscribers write to SQLite synchronously — a throwing subscriber must
+// never escape this fire-and-forget path (it would mislabel a succeeded X post as failed).
+function safeEmit(event: GuardianEvent): void {
+  try { guardianBus.emit(event) } catch { /* observability must never break publishing */ }
+}
+
+/**
+ * HERALD → Discord cross-post (sip-protocol spec 2026-06-11 Discord professional standard §5.5).
+ * Only the Friday "Week in SIP" digest crosses over — daily content stays X-only so
+ * #announcements stays high-signal. Keyed on the queue row itself (type='content'
+ * created on a UTC Friday), not on publish time, so a Saturday approval still crossposts.
+ * Convention: exactly ONE content row per Friday (the generator dedups via hasGeneratedToday) — a manually-enqueued second Friday row would also crosspost.
+ */
+export function isFridayDigest(post: { type?: unknown; created_at?: unknown }): boolean {
+  if (post.type !== 'content' || typeof post.created_at !== 'string') return false
+  const d = new Date(post.created_at)
+  return !Number.isNaN(d.getTime()) && d.getUTCDay() === 5
+}
+
+export interface DigestWebhookPayload {
+  username: string
+  avatar_url: string
+  embeds: Array<{ title: string; description: string; url: string; color: number; footer: { text: string } }>
+}
+
+export function formatDigestEmbed(content: string, tweetId: string): DigestWebhookPayload {
+  return {
+    username: 'HERALD',
+    avatar_url: 'https://github.com/sip-protocol.png',
+    embeds: [
+      {
+        title: 'This Week in SIP',
+        description: content,
+        url: `https://x.com/sipprotocol/status/${tweetId}`,
+        color: 0x6366f1,
+        footer: { text: 'SIP Protocol · weekly digest · also on x.com/sipprotocol' },
+      },
+    ],
+  }
+}
+
+/**
+ * Fire-and-forget: never throws. The X post already succeeded — a Discord failure
+ * must not break the publish loop. Failures emit a guardian event for visibility.
+ */
+export async function crosspostDigest(post: Record<string, unknown>, tweetId: string): Promise<void> {
+  const url = process.env.DISCORD_ANNOUNCE_WEBHOOK_URL
+  if (!url || !isFridayDigest(post)) return
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(formatDigestEmbed(String(post.content ?? ''), tweetId)),
+      signal: AbortSignal.timeout(8000),
+    })
+    if (!res.ok) throw new Error(`webhook → ${res.status}`)
+    safeEmit({
+      source: 'herald',
+      type: 'herald:discord-crosspost',
+      level: 'routine',
+      data: { id: post.id ?? null, tweetId },
+      timestamp: new Date().toISOString(),
+    })
+  } catch (err) {
+    safeEmit({
+      source: 'herald',
+      type: 'herald:discord-crosspost-failed',
+      level: 'important',
+      data: { id: post.id ?? null, error: err instanceof Error ? err.message : String(err) },
+      timestamp: new Date().toISOString(),
+    })
+  }
+}

--- a/packages/agent/src/herald/poller.ts
+++ b/packages/agent/src/herald/poller.ts
@@ -3,6 +3,7 @@ import { executeReadDMs } from './tools/read-dms.js'
 import { classifyIntent } from './intent.js'
 import { getReadyToPublish, markPublished } from './approval.js'
 import { publishTweet } from './tools/post-tweet.js'
+import { crosspostDigest } from './discord.js'
 import { getBudgetStatus } from './budget.js'
 import { guardianBus } from '../coordination/event-bus.js'
 import { isKillSwitchActive } from '../routes/squad-api.js'
@@ -161,6 +162,7 @@ export async function checkScheduledPosts(): Promise<void> {
     try {
       const result = await publishTweet(post.content as string)
       markPublished(post.id as string, result.tweet_id)
+      await crosspostDigest(post, result.tweet_id)
 
       guardianBus.emit({
         source: 'herald',

--- a/packages/agent/tests/herald/discord.test.ts
+++ b/packages/agent/tests/herald/discord.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { isFridayDigest, formatDigestEmbed, crosspostDigest } from '../../src/herald/discord.js'
+
+describe('isFridayDigest', () => {
+  it('true only for content rows created on a UTC Friday', () => {
+    // 2026-06-12 is a Friday
+    expect(isFridayDigest({ type: 'content', created_at: '2026-06-12T08:00:00.000Z' })).toBe(true)
+    expect(isFridayDigest({ type: 'content', created_at: '2026-06-11T08:00:00.000Z' })).toBe(false) // Thursday
+    expect(isFridayDigest({ type: 'post', created_at: '2026-06-12T08:00:00.000Z' })).toBe(false)
+    expect(isFridayDigest({ type: 'content', created_at: undefined })).toBe(false)
+    expect(isFridayDigest({ type: 'content', created_at: 'not-a-date' })).toBe(false)
+  })
+})
+
+describe('formatDigestEmbed', () => {
+  it('builds the indigo HERALD webhook payload linking the X post', () => {
+    const p = formatDigestEmbed('This week in SIP: shipped things.', '123456789')
+    expect(p.username).toBe('HERALD')
+    expect(p.avatar_url).toBe('https://github.com/sip-protocol.png')
+    expect(p.embeds).toHaveLength(1)
+    expect(p.embeds[0].title).toBe('This Week in SIP')
+    expect(p.embeds[0].description).toBe('This week in SIP: shipped things.')
+    expect(p.embeds[0].url).toBe('https://x.com/sipprotocol/status/123456789')
+    expect(p.embeds[0].color).toBe(0x6366f1)
+  })
+})
+
+describe('crosspostDigest', () => {
+  beforeEach(() => { vi.unstubAllEnvs(); vi.unstubAllGlobals() })
+  afterEach(() => { vi.unstubAllEnvs(); vi.unstubAllGlobals() })
+
+  it('no-ops when DISCORD_ANNOUNCE_WEBHOOK_URL is unset', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    await crosspostDigest({ type: 'content', created_at: '2026-06-12T08:00:00.000Z' }, '1')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('no-ops for non-digest rows', async () => {
+    vi.stubEnv('DISCORD_ANNOUNCE_WEBHOOK_URL', 'https://discord.com/api/webhooks/x/y')
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    await crosspostDigest({ type: 'content', created_at: '2026-06-10T08:00:00.000Z' }, '1')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('POSTs the webhook for a Friday digest', async () => {
+    vi.stubEnv('DISCORD_ANNOUNCE_WEBHOOK_URL', 'https://discord.com/api/webhooks/x/y')
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 204 })
+    vi.stubGlobal('fetch', fetchMock)
+    await crosspostDigest({ type: 'content', created_at: '2026-06-12T08:00:00.000Z', content: 'recap' }, '42')
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('https://discord.com/api/webhooks/x/y')
+    expect(JSON.parse(init.body).embeds[0].url).toContain('/status/42')
+  })
+
+  it('swallows fetch failures (X post already succeeded — never throw)', async () => {
+    vi.stubEnv('DISCORD_ANNOUNCE_WEBHOOK_URL', 'https://discord.com/api/webhooks/x/y')
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')))
+    await expect(
+      crosspostDigest({ type: 'content', created_at: '2026-06-12T08:00:00.000Z', content: 'recap' }, '42')
+    ).resolves.toBeUndefined()
+  })
+
+  it('swallows non-ok webhook responses', async () => {
+    vi.stubEnv('DISCORD_ANNOUNCE_WEBHOOK_URL', 'https://discord.com/api/webhooks/x/y')
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }))
+    await expect(
+      crosspostDigest({ type: 'content', created_at: '2026-06-12T08:00:00.000Z', content: 'recap' }, '42')
+    ).resolves.toBeUndefined()
+  })
+
+  it('never rejects even when guardianBus.emit throws (sync subscriber failure)', async () => {
+    vi.stubEnv('DISCORD_ANNOUNCE_WEBHOOK_URL', 'https://discord.com/api/webhooks/x/y')
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 204 }))
+    const { guardianBus } = await import('../../src/coordination/event-bus.js')
+    const spy = vi.spyOn(guardianBus, 'emit').mockImplementation(() => { throw new Error('sqlite busy') })
+    try {
+      await expect(
+        crosspostDigest({ type: 'content', created_at: '2026-06-12T08:00:00.000Z', content: 'recap' }, '42')
+      ).resolves.toBeUndefined()
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('bounds the webhook call with an 8s abort signal', async () => {
+    vi.stubEnv('DISCORD_ANNOUNCE_WEBHOOK_URL', 'https://discord.com/api/webhooks/x/y')
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 204 })
+    vi.stubGlobal('fetch', fetchMock)
+    await crosspostDigest({ type: 'content', created_at: '2026-06-12T08:00:00.000Z', content: 'recap' }, '42')
+    expect(fetchMock.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal)
+  })
+})

--- a/packages/agent/tests/herald/poller.test.ts
+++ b/packages/agent/tests/herald/poller.test.ts
@@ -1,11 +1,31 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import {
   createPollerState,
   getNextInterval,
   reactiveEnabled,
   startPoller,
   stopPoller,
+  checkScheduledPosts,
 } from '../../src/herald/poller.js'
+
+// ─── Module mocks (hoisted by vitest) ────────────────────────────────────────
+
+vi.mock('../../src/herald/approval.js', () => ({
+  getReadyToPublish: vi.fn(),
+  markPublished: vi.fn(),
+}))
+
+vi.mock('../../src/herald/tools/post-tweet.js', () => ({
+  publishTweet: vi.fn(),
+}))
+
+vi.mock('../../src/herald/discord.js', () => ({
+  crosspostDigest: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { getReadyToPublish, markPublished } from '../../src/herald/approval.js'
+import { publishTweet } from '../../src/herald/tools/post-tweet.js'
+import { crosspostDigest } from '../../src/herald/discord.js'
 
 describe('HERALD adaptive poller', () => {
   it('createPollerState() returns correct defaults', () => {
@@ -100,5 +120,32 @@ describe('startPoller reactive gate', () => {
     expect(timers.scheduledTimer).not.toBeNull()
 
     stopPoller(state, timers)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// checkScheduledPosts — Discord cross-post regression
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('checkScheduledPosts', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('calls crosspostDigest with the post row and tweet_id after a successful publish', async () => {
+    const post = { id: 'row-1', type: 'content', content: 'recap', created_at: '2026-06-12T08:00:00.000Z' }
+    const mockedGetReady = vi.mocked(getReadyToPublish)
+    const mockedPublish = vi.mocked(publishTweet)
+    const mockedCrosspost = vi.mocked(crosspostDigest)
+
+    mockedGetReady.mockReturnValue([post])
+    mockedPublish.mockResolvedValue({ tweet_id: 'tw_99' })
+
+    await checkScheduledPosts()
+
+    expect(mockedPublish).toHaveBeenCalledOnce()
+    expect(vi.mocked(markPublished)).toHaveBeenCalledWith('row-1', 'tw_99')
+    expect(mockedCrosspost).toHaveBeenCalledOnce()
+    expect(mockedCrosspost).toHaveBeenCalledWith(post, 'tw_99')
   })
 })


### PR DESCRIPTION
After a successful X publish of the Friday 'Week in SIP' content row, HERALD now also posts an indigo embed to the Discord #announcements webhook (DISCORD_ANNOUNCE_WEBHOOK_URL — no-op when unset; never throws into the publish loop: safeEmit guards subscriber failures, AbortSignal.timeout(8000) bounds a hung webhook). Keyed on the queue row (type='content' + UTC-Friday created_at), so Saturday approvals still crosspost. 300 herald tests green + typecheck. Part of the Discord professional standard (sip-protocol spec 2026-06-11).