### PR TITLE
chore: add Dependabot config (npm, cargo, docker, github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  # npm — pnpm workspace root (covers app, packages/*, sdks/typescript, integrations/eliza)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Cargo — Rust SDK
+  - package-ecosystem: "cargo"
+    directory: "/sdks/rust"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Docker — production image (sipher.sip-protocol.org)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"


### PR DESCRIPTION
## What
Adds a Dependabot config — this repo had none, so it received zero automated dependency/security update PRs.

Ecosystems now watched (weekly, Mondays):
- **npm** `/` (pnpm workspace root — covers `app`, `packages/*`, `sdks/typescript`, `integrations/eliza`)
- **cargo** `/sdks/rust`
- **docker** `/` (production image behind sipher.sip-protocol.org)
- **github-actions** `/`

## Why
Org-wide Dependabot audit (2026-06-18) flagged `sipher` as the largest gap — a live production service with no dependency monitoring. Minor/patch grouped to keep noise down.