### PR TITLE
fix(sdk): sync vault account layout to merged program (B6 + universal-asset)

### DIFF
--- a/app/src/components/vault/StealthAddressList.tsx
+++ b/app/src/components/vault/StealthAddressList.tsx
@@ -7,7 +7,6 @@ export interface Position {
   symbol: string
   balance: string
   balanceUiAmount: number
-  lockedAmount: string
   decimals: number
   lastDepositAt: number
   refundableAt: number

--- a/app/src/components/vault/__tests__/RefundList.test.tsx
+++ b/app/src/components/vault/__tests__/RefundList.test.tsx
@@ -16,7 +16,6 @@ const fakePosition = {
   symbol: 'SOL',
   balance: '2500000000',
   balanceUiAmount: 2.5,
-  lockedAmount: '0',
   decimals: 9,
   lastDepositAt: 1715000000,
   refundableAt: 1715086400,

--- a/app/src/components/vault/__tests__/StealthAddressList.test.tsx
+++ b/app/src/components/vault/__tests__/StealthAddressList.test.tsx
@@ -7,7 +7,6 @@ const fakePosition = {
   symbol: 'SOL',
   balance: '2500000000',
   balanceUiAmount: 2.5,
-  lockedAmount: '0',
   decimals: 9,
   lastDepositAt: 1715000000,
   refundableAt: 1715086400,

--- a/app/src/views/DepositView.tsx
+++ b/app/src/views/DepositView.tsx
@@ -29,7 +29,6 @@ interface VaultPosition {
   symbol: string
   balance: string
   balanceUiAmount: number
-  lockedAmount: string
   decimals: number
   lastDepositAt: number
   refundableAt: number

--- a/app/src/views/__tests__/VaultView.test.tsx
+++ b/app/src/views/__tests__/VaultView.test.tsx
@@ -41,7 +41,6 @@ interface PositionsResponse {
     symbol: string
     balance: string
     balanceUiAmount: number
-    lockedAmount: string
     decimals: number
     lastDepositAt: number
     refundableAt: number
@@ -73,7 +72,6 @@ const populatedPositions: PositionsResponse = {
       symbol: 'SOL',
       balance: '1000000000',
       balanceUiAmount: 1,
-      lockedAmount: '0',
       decimals: 9,
       lastDepositAt: 0,
       refundableAt: 0,

--- a/app/src/views/__tests__/WithdrawView.test.tsx
+++ b/app/src/views/__tests__/WithdrawView.test.tsx
@@ -60,7 +60,6 @@ const fakePosition = {
   symbol: 'SOL',
   balance: '2500000000',
   balanceUiAmount: 2.5,
-  lockedAmount: '0',
   decimals: 9,
   lastDepositAt: 1715000000,
   refundableAt: 1715086400,

--- a/packages/agent/src/routes/vault-positions.ts
+++ b/packages/agent/src/routes/vault-positions.ts
@@ -23,7 +23,6 @@ interface Position {
   symbol: string
   balance: string
   balanceUiAmount: number
-  lockedAmount: string
   decimals: number
   lastDepositAt: number
   refundableAt: number
@@ -81,7 +80,6 @@ vaultPositionsRouter.get('/positions', async (req: Request, res: Response) => {
         symbol,
         balance: balance.balance.toString(),
         balanceUiAmount: Number(balance.balance) / 10 ** decimals,
-        lockedAmount: balance.lockedAmount.toString(),
         decimals,
         lastDepositAt: balance.lastDepositAt,
         refundableAt,

--- a/packages/agent/src/tools/balance.ts
+++ b/packages/agent/src/tools/balance.ts
@@ -26,7 +26,6 @@ export interface BalanceToolResult {
   balance: {
     total: string
     available: string
-    locked: string
     cumulativeVolume: string
     lastDepositAt: string | null
     exists: boolean
@@ -38,7 +37,7 @@ export const balanceTool: AnthropicTool = {
   name: 'balance',
   description:
     'Check the vault balance for a wallet address and token. ' +
-    'Returns total balance, available (unlocked) balance, and locked amount. ' +
+    'Returns total balance and available (withdrawable) balance. ' +
     'No wallet signature required — this is a read-only operation.',
   input_schema: {
     type: 'object' as const,
@@ -82,7 +81,6 @@ export async function executeBalance(params: BalanceParams): Promise<BalanceTool
 
   const total = fromBaseUnits(vaultBalance.balance, decimals)
   const available = fromBaseUnits(vaultBalance.available, decimals)
-  const locked = fromBaseUnits(vaultBalance.lockedAmount, decimals)
   const volume = fromBaseUnits(vaultBalance.cumulativeVolume, decimals)
 
   const lastDeposit = vaultBalance.lastDepositAt > 0
@@ -90,7 +88,7 @@ export async function executeBalance(params: BalanceParams): Promise<BalanceTool
     : null
 
   const message = vaultBalance.exists
-    ? `Vault balance for ${params.wallet}: ${total} ${token} (${available} available, ${locked} locked).`
+    ? `Vault balance for ${params.wallet}: ${total} ${token} (${available} available).`
     : `Vault balance for ${params.wallet}: 0 ${token} (no deposit record found). ` +
       `Deposit first to start using privacy features.`
 
@@ -102,7 +100,6 @@ export async function executeBalance(params: BalanceParams): Promise<BalanceTool
     balance: {
       total,
       available,
-      locked,
       cumulativeVolume: volume,
       lastDepositAt: lastDeposit,
       exists: vaultBalance.exists,

--- a/packages/agent/tests/balance.test.ts
+++ b/packages/agent/tests/balance.test.ts
@@ -97,7 +97,6 @@ describe('executeBalance — happy path', () => {
     expect(result.balance.exists).toBe(true)
     expect(result.balance.total).toBe('1') // 1_000_000_000 base / 1e9
     expect(result.balance.available).toBe('0.8')
-    expect(result.balance.locked).toBe('0.2')
     expect(result.balance.cumulativeVolume).toBe('5')
     expect(result.balance.lastDepositAt).toBe(
       new Date(1_700_000_000 * 1000).toISOString()
@@ -130,7 +129,6 @@ describe('executeBalance — branches', () => {
         exists: false,
         balance: 0n,
         available: 0n,
-        lockedAmount: 0n,
         cumulativeVolume: 0n,
         lastDepositAt: 0,
       })

--- a/packages/agent/tests/fixtures/user-tool-mocks.ts
+++ b/packages/agent/tests/fixtures/user-tool-mocks.ts
@@ -41,7 +41,6 @@ export const VAULT_PROGRAM_ID_BASE58 = 'S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4
 export interface VaultBalanceShape {
   balance: bigint
   available: bigint
-  lockedAmount: bigint
   cumulativeVolume: bigint
   lastDepositAt: number
   exists: boolean
@@ -53,7 +52,6 @@ export function makeVaultBalance(
   return {
     balance: 1_000_000_000n,
     available: 800_000_000n,
-    lockedAmount: 200_000_000n,
     cumulativeVolume: 5_000_000_000n,
     lastDepositAt: 1_700_000_000,
     exists: true,

--- a/packages/agent/tests/routes/vault-positions.test.ts
+++ b/packages/agent/tests/routes/vault-positions.test.ts
@@ -55,9 +55,7 @@ function emptyBalance(mint: PublicKey) {
   return {
     depositor: new PublicKey(TEST_WALLET),
     tokenMint: mint,
-    balance: 0n,
-    lockedAmount: 0n,
-    available: 0n,
+    balance: 0n,    available: 0n,
     cumulativeVolume: 0n,
     lastDepositAt: 0,
     exists: false,
@@ -96,9 +94,7 @@ describe('GET /api/vault/positions', () => {
         return {
           depositor,
           tokenMint: mint,
-          balance: 2_500_000_000n,
-          lockedAmount: 0n,
-          available: 2_500_000_000n,
+          balance: 2_500_000_000n,          available: 2_500_000_000n,
           cumulativeVolume: 2_500_000_000n,
           lastDepositAt: 1715000000,
           exists: true,
@@ -116,7 +112,6 @@ describe('GET /api/vault/positions', () => {
       symbol: 'SOL',
       balance: '2500000000',
       balanceUiAmount: 2.5,
-      lockedAmount: '0',
       decimals: 9,
       lastDepositAt: 1715000000,
       cooldownActive: expect.any(Boolean),
@@ -132,9 +127,7 @@ describe('GET /api/vault/positions', () => {
     vi.mocked(getVaultBalance).mockImplementation(async (_conn, depositor, mint) => ({
       depositor,
       tokenMint: mint,
-      balance: 0n,
-      lockedAmount: 0n,
-      available: 0n,
+      balance: 0n,      available: 0n,
       cumulativeVolume: 0n,
       lastDepositAt: 0,
       exists: true,
@@ -211,9 +204,7 @@ describe('GET /api/vault/positions', () => {
         return {
           depositor,
           tokenMint: mint,
-          balance: 1_000_000_000n,
-          lockedAmount: 0n,
-          available: 1_000_000_000n,
+          balance: 1_000_000_000n,          available: 1_000_000_000n,
           cumulativeVolume: 1_000_000_000n,
           lastDepositAt: fixedNowSeconds - 100, // 100s ago — well inside cooldown
           exists: true,
@@ -240,9 +231,7 @@ describe('GET /api/vault/positions', () => {
         return {
           depositor,
           tokenMint: mint,
-          balance: 1_000_000_000n,
-          lockedAmount: 0n,
-          available: 1_000_000_000n,
+          balance: 1_000_000_000n,          available: 1_000_000_000n,
           cumulativeVolume: 1_000_000_000n,
           lastDepositAt: fixedNowSeconds - DEFAULT_REFUND_TIMEOUT - 1, // just past cooldown
           exists: true,

--- a/packages/agent/tests/routes/vault-positions.test.ts
+++ b/packages/agent/tests/routes/vault-positions.test.ts
@@ -55,7 +55,8 @@ function emptyBalance(mint: PublicKey) {
   return {
     depositor: new PublicKey(TEST_WALLET),
     tokenMint: mint,
-    balance: 0n,    available: 0n,
+    balance: 0n,
+    available: 0n,
     cumulativeVolume: 0n,
     lastDepositAt: 0,
     exists: false,
@@ -94,7 +95,8 @@ describe('GET /api/vault/positions', () => {
         return {
           depositor,
           tokenMint: mint,
-          balance: 2_500_000_000n,          available: 2_500_000_000n,
+          balance: 2_500_000_000n,
+          available: 2_500_000_000n,
           cumulativeVolume: 2_500_000_000n,
           lastDepositAt: 1715000000,
           exists: true,
@@ -127,7 +129,8 @@ describe('GET /api/vault/positions', () => {
     vi.mocked(getVaultBalance).mockImplementation(async (_conn, depositor, mint) => ({
       depositor,
       tokenMint: mint,
-      balance: 0n,      available: 0n,
+      balance: 0n,
+      available: 0n,
       cumulativeVolume: 0n,
       lastDepositAt: 0,
       exists: true,
@@ -204,7 +207,8 @@ describe('GET /api/vault/positions', () => {
         return {
           depositor,
           tokenMint: mint,
-          balance: 1_000_000_000n,          available: 1_000_000_000n,
+          balance: 1_000_000_000n,
+          available: 1_000_000_000n,
           cumulativeVolume: 1_000_000_000n,
           lastDepositAt: fixedNowSeconds - 100, // 100s ago — well inside cooldown
           exists: true,
@@ -231,7 +235,8 @@ describe('GET /api/vault/positions', () => {
         return {
           depositor,
           tokenMint: mint,
-          balance: 1_000_000_000n,          available: 1_000_000_000n,
+          balance: 1_000_000_000n,
+          available: 1_000_000_000n,
           cumulativeVolume: 1_000_000_000n,
           lastDepositAt: fixedNowSeconds - DEFAULT_REFUND_TIMEOUT - 1, // just past cooldown
           exists: true,

--- a/packages/agent/tests/routes/vault-refund-tx.test.ts
+++ b/packages/agent/tests/routes/vault-refund-tx.test.ts
@@ -50,9 +50,7 @@ function emptyBalance(mint: PublicKey) {
   return {
     depositor: new PublicKey(TEST_WALLET),
     tokenMint: mint,
-    balance: 0n,
-    lockedAmount: 0n,
-    available: 0n,
+    balance: 0n,    available: 0n,
     cumulativeVolume: 0n,
     lastDepositAt: 0,
     exists: false,
@@ -64,9 +62,7 @@ function cooledBalance(mint: PublicKey, balance: bigint = 1_500_000_000n) {
   return {
     depositor: new PublicKey(TEST_WALLET),
     tokenMint: mint,
-    balance,
-    lockedAmount: 0n,
-    available: balance,
+    balance,    available: balance,
     cumulativeVolume: balance,
     lastDepositAt: NOW_SECONDS - DEFAULT_REFUND_TIMEOUT - 10, // 10s past cooldown
     exists: true,
@@ -139,9 +135,7 @@ describe('POST /api/vault/refund-tx', () => {
     vi.mocked(getVaultBalance).mockImplementation(async (_conn, depositor, mint) => ({
       depositor,
       tokenMint: mint,
-      balance: 0n,
-      lockedAmount: 0n,
-      available: 0n,
+      balance: 0n,      available: 0n,
       cumulativeVolume: 0n,
       lastDepositAt: NOW_SECONDS - DEFAULT_REFUND_TIMEOUT - 10,
       exists: true,
@@ -161,9 +155,7 @@ describe('POST /api/vault/refund-tx', () => {
     vi.mocked(getVaultBalance).mockImplementation(async (_conn, depositor, mint) => ({
       depositor,
       tokenMint: mint,
-      balance: 1_000_000_000n,
-      lockedAmount: 0n,
-      available: 1_000_000_000n,
+      balance: 1_000_000_000n,      available: 1_000_000_000n,
       cumulativeVolume: 1_000_000_000n,
       lastDepositAt,
       exists: true,

--- a/packages/agent/tests/routes/vault-refund-tx.test.ts
+++ b/packages/agent/tests/routes/vault-refund-tx.test.ts
@@ -50,7 +50,8 @@ function emptyBalance(mint: PublicKey) {
   return {
     depositor: new PublicKey(TEST_WALLET),
     tokenMint: mint,
-    balance: 0n,    available: 0n,
+    balance: 0n,
+    available: 0n,
     cumulativeVolume: 0n,
     lastDepositAt: 0,
     exists: false,
@@ -62,7 +63,8 @@ function cooledBalance(mint: PublicKey, balance: bigint = 1_500_000_000n) {
   return {
     depositor: new PublicKey(TEST_WALLET),
     tokenMint: mint,
-    balance,    available: balance,
+    balance,
+    available: balance,
     cumulativeVolume: balance,
     lastDepositAt: NOW_SECONDS - DEFAULT_REFUND_TIMEOUT - 10, // 10s past cooldown
     exists: true,
@@ -135,7 +137,8 @@ describe('POST /api/vault/refund-tx', () => {
     vi.mocked(getVaultBalance).mockImplementation(async (_conn, depositor, mint) => ({
       depositor,
       tokenMint: mint,
-      balance: 0n,      available: 0n,
+      balance: 0n,
+      available: 0n,
       cumulativeVolume: 0n,
       lastDepositAt: NOW_SECONDS - DEFAULT_REFUND_TIMEOUT - 10,
       exists: true,
@@ -155,7 +158,8 @@ describe('POST /api/vault/refund-tx', () => {
     vi.mocked(getVaultBalance).mockImplementation(async (_conn, depositor, mint) => ({
       depositor,
       tokenMint: mint,
-      balance: 1_000_000_000n,      available: 1_000_000_000n,
+      balance: 1_000_000_000n,
+      available: 1_000_000_000n,
       cumulativeVolume: 1_000_000_000n,
       lastDepositAt,
       exists: true,

--- a/packages/agent/tests/sentinel/scanner.test.ts
+++ b/packages/agent/tests/sentinel/scanner.test.ts
@@ -46,7 +46,6 @@ function makeVaultBalance(lamports = 5_000_000_000n) {
     depositor: DEPOSITOR,
     tokenMint: WSOL,
     balance: lamports,
-    lockedAmount: 0n,
     available: lamports,
     cumulativeVolume: 10_000_000_000n,
     lastDepositAt: 1712600000,

--- a/packages/agent/tests/tools.test.ts
+++ b/packages/agent/tests/tools.test.ts
@@ -459,7 +459,6 @@ describe('executeBalance', () => {
     expect(result.status).toBe('success')
     expect(result.balance.total).toBe('0')
     expect(result.balance.available).toBe('0')
-    expect(result.balance.locked).toBe('0')
     expect(result.balance.exists).toBe(false)
   })
 

--- a/packages/sdk/scripts/devnet-check.ts
+++ b/packages/sdk/scripts/devnet-check.ts
@@ -57,7 +57,6 @@ async function main() {
   if (balance.exists) {
     console.log(`  Balance: ${balance.balance} lamports`)
     console.log(`  Available: ${balance.available} lamports`)
-    console.log(`  Locked: ${balance.lockedAmount} lamports`)
     console.log(`  Cumulative volume: ${balance.cumulativeVolume} lamports`)
     console.log(`  Last deposit: ${new Date(balance.lastDepositAt * 1000).toISOString()}`)
   } else {

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -43,15 +43,16 @@ export const MAX_FEE_BPS = 100
 // Account data offsets (after 8-byte Anchor discriminator)
 //
 // VaultConfig:  authority(32) + fee_bps(2) + refund_timeout(8) + paused(1)
-//             + total_deposits(8) + total_depositors(8) + bump(1) = 60
+//             + total_deposits(8) + total_depositors(8) + bump(1)
+//             + pending_authority(1+32) = 93
 //
-// DepositRecord: depositor(32) + token_mint(32) + balance(8) + locked_amount(8)
-//              + cumulative_volume(8) + last_deposit_at(8) + bump(1) = 97
+// DepositRecord: depositor(32) + token_mint(32) + balance(8)
+//              + cumulative_volume(8) + last_deposit_at(8) + bump(1) = 89
 // ─────────────────────────────────────────────────────────────────────────────
 
 export const ANCHOR_DISCRIMINATOR_SIZE = 8
-export const VAULT_CONFIG_SIZE = ANCHOR_DISCRIMINATOR_SIZE + 60
-export const DEPOSIT_RECORD_SIZE = ANCHOR_DISCRIMINATOR_SIZE + 97
+export const VAULT_CONFIG_SIZE = ANCHOR_DISCRIMINATOR_SIZE + 93
+export const DEPOSIT_RECORD_SIZE = ANCHOR_DISCRIMINATOR_SIZE + 89
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Cluster configs

--- a/packages/sdk/src/idl/sipher_vault.json
+++ b/packages/sdk/src/idl/sipher_vault.json
@@ -8,6 +8,357 @@
   },
   "instructions": [
     {
+      "name": "accept_authority",
+      "docs": [
+        "Accept a pending authority transfer (step 2). The proposed authority must",
+        "sign \u2014 proving control of the key \u2014 before `config.authority` changes, so",
+        "the authority can never be handed to a key nobody controls. Clears the",
+        "pending slot on success."
+      ],
+      "discriminator": [
+        107,
+        86,
+        198,
+        91,
+        33,
+        12,
+        107,
+        160
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "new_authority",
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "authority_refund",
+      "docs": [
+        "Authority-signed refund: return available balance to depositor.",
+        "Mirrors `refund` exactly except the authority signs instead of the depositor.",
+        "Used by SENTINEL for autonomous refunds of expired deposits.",
+        "Timeout is still enforced on-chain \u2014 authority does NOT bypass the cooldown."
+      ],
+      "discriminator": [
+        90,
+        239,
+        78,
+        209,
+        125,
+        15,
+        125,
+        28
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "deposit_record",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  101,
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  95,
+                  114,
+                  101,
+                  99,
+                  111,
+                  114,
+                  100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "depositor"
+              },
+              {
+                "kind": "account",
+                "path": "deposit_record.token_mint",
+                "account": "DepositRecord"
+              }
+            ]
+          }
+        },
+        {
+          "name": "vault_token",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  116,
+                  111,
+                  107,
+                  101,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "deposit_record.token_mint",
+                "account": "DepositRecord"
+              }
+            ]
+          }
+        },
+        {
+          "name": "depositor_token",
+          "writable": true
+        },
+        {
+          "name": "token_mint",
+          "docs": [
+            "Mint account required by transfer_checked (must match deposit_record.token_mint)"
+          ]
+        },
+        {
+          "name": "depositor",
+          "docs": [
+            "derivation and token account ownership check. The authority (not depositor)",
+            "is the signer for this instruction."
+          ],
+          "relations": [
+            "deposit_record"
+          ]
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "token_program"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "authority_refund_sol",
+      "docs": [
+        "Authority-signed refund of available native SOL to the original depositor.",
+        "Mirrors `refund_sol` exactly except:",
+        "- the authority signs instead of the depositor,",
+        "- `config` carries `has_one = authority` (so wrong authority \u2192 Unauthorized),",
+        "- the vault MUST NOT be paused (authority cannot bypass the emergency gate),",
+        "- `depositor` is a non-signer SystemAccount (lamport destination + seed source).",
+        "Timeout is still enforced on-chain \u2014 authority does NOT bypass the cooldown."
+      ],
+      "discriminator": [
+        47,
+        152,
+        199,
+        158,
+        147,
+        185,
+        21,
+        218
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "deposit_record",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  101,
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  95,
+                  114,
+                  101,
+                  99,
+                  111,
+                  114,
+                  100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "depositor"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "sol_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  115,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "depositor",
+          "docs": [
+            "Non-signer lamport destination + seed source for the deposit_record PDA.",
+            "Validated by the deposit_record.has_one constraint above."
+          ],
+          "writable": true,
+          "relations": [
+            "deposit_record"
+          ]
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "config"
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "collect_fee",
       "docs": [
         "Authority-only: collect accumulated fees from the fee token account.",
@@ -90,8 +441,90 @@
           ]
         },
         {
-          "name": "token_program",
-          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+          "name": "token_program"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "collect_fee_sol",
+      "docs": [
+        "Authority-only: drain lamports above the rent-exempt minimum from the native",
+        "SOL fee PDA (`sol_fee`). Fees accrue during `withdraw_private_sol` (fee_bps",
+        "per withdrawal). Pass `amount = 0` to collect ALL collectable lamports.",
+        "",
+        "Safety: Uses the Task-7 checked lamport mutation pattern \u2014 every new balance",
+        "is computed with `checked_sub`/`checked_add` before any assignment. The rent",
+        "floor of `sol_fee` is preserved; the instruction reverts with `NoFeesToCollect`",
+        "if there is nothing above the floor."
+      ],
+      "discriminator": [
+        124,
+        173,
+        32,
+        197,
+        117,
+        102,
+        189,
+        253
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "sol_fee",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  115,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "config"
+          ]
         }
       ],
       "args": [
@@ -177,8 +610,103 @@
           "signer": true
         },
         {
-          "name": "token_program",
-          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "create_sol_vault",
+      "docs": [
+        "Create the singleton native-SOL vault + fee PDAs.",
+        "Called once per deployment before any native-SOL deposits.",
+        "Payer funds the rent-exempt reserve for both PDAs."
+      ],
+      "discriminator": [
+        199,
+        85,
+        223,
+        31,
+        210,
+        142,
+        93,
+        76
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "sol_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  115,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "sol_fee",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  115,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
         },
         {
           "name": "system_program",
@@ -191,7 +719,13 @@
       "name": "create_vault_token",
       "docs": [
         "Create the vault token PDA for a given mint.",
-        "Anyone can call this (first depositor pays rent). Must be called before deposit."
+        "Anyone can call this (first depositor pays rent). Must be called before deposit.",
+        "",
+        "For Token-2022 mints, a fail-closed extension allowlist is enforced.",
+        "Only MetadataPointer, TokenMetadata, and InterestBearingConfig are allowed.",
+        "Any other extension (TransferFeeConfig, PermanentDelegate, TransferHook,",
+        "NonTransferable, DefaultAccountState, MintCloseAuthority, etc.) is rejected",
+        "with UnsupportedMintExtension to protect the vault's transfer invariants."
       ],
       "discriminator": [
         49,
@@ -265,8 +799,7 @@
           "signer": true
         },
         {
-          "name": "token_program",
-          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+          "name": "token_program"
         },
         {
           "name": "system_program",
@@ -392,8 +925,156 @@
           "signer": true
         },
         {
-          "name": "token_program",
-          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+          "name": "token_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "deposit_sol",
+      "docs": [
+        "Deposit native SOL into the vault. Creates DepositRecord keyed by",
+        "(depositor, NATIVE_SOL_MINT) on first deposit; accumulates on repeat calls."
+      ],
+      "discriminator": [
+        108,
+        81,
+        78,
+        117,
+        125,
+        155,
+        56,
+        200
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "deposit_record",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  101,
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  95,
+                  114,
+                  101,
+                  99,
+                  111,
+                  114,
+                  100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "depositor"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "sol_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  115,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "depositor",
+          "writable": true,
+          "signer": true
         },
         {
           "name": "system_program",
@@ -470,9 +1151,78 @@
       ]
     },
     {
+      "name": "migrate_config",
+      "docs": [
+        "Grow a legacy (pre-M1, 68-byte) VaultConfig to the current 101-byte layout",
+        "by appending `pending_authority = None`. Authority-gated on every path,",
+        "idempotent. Scoped to this one-time 68\u2192101 migration: the accepted legacy",
+        "size is pinned to `LEGACY_VAULT_CONFIG_LEN`. The mechanism (raw realloc +",
+        "zero-fill of the appended region) would generalize to a future",
+        "trailing-field migration, but that would require bumping that constant to",
+        "the then-current size.",
+        "",
+        "The legacy account cannot be deserialized into `VaultConfig` (the trailing",
+        "Option is absent \u2192 AccountDidNotDeserialize) and a renamed struct would fail",
+        "the discriminator check, so `config` is a raw UncheckedAccount: the PDA is",
+        "verified by seeds+bump and the authority is read manually from bytes [8..40]",
+        "(the authority sits at the same offset in the legacy and current layout)."
+      ],
+      "discriminator": [
+        92,
+        131,
+        58,
+        105,
+        210,
+        154,
+        224,
+        193
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "docs": [
+            "is verified by seeds+bump and the authority is verified manually in the",
+            "handler (bytes [8..40]). Owned by this program, so realloc is permitted."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "refund",
       "docs": [
-        "Refund available (unlocked) balance back to depositor."
+        "Refund available balance back to depositor."
       ],
       "discriminator": [
         2,
@@ -579,6 +1329,12 @@
           "writable": true
         },
         {
+          "name": "token_mint",
+          "docs": [
+            "Mint account required by transfer_checked (must match deposit_record.token_mint)"
+          ]
+        },
+        {
           "name": "depositor",
           "writable": true,
           "signer": true,
@@ -587,11 +1343,341 @@
           ]
         },
         {
-          "name": "token_program",
-          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+          "name": "token_program"
         }
       ],
       "args": []
+    },
+    {
+      "name": "refund_sol",
+      "docs": [
+        "Refund available native SOL balance back to the depositor.",
+        "Depositor is the signer and the lamport destination.",
+        "Timeout is enforced on-chain \u2014 the depositor must wait `refund_timeout` seconds",
+        "since their last deposit before reclaiming funds."
+      ],
+      "discriminator": [
+        158,
+        68,
+        131,
+        114,
+        106,
+        77,
+        56,
+        13
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "deposit_record",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  101,
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  95,
+                  114,
+                  101,
+                  99,
+                  111,
+                  114,
+                  100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "depositor"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "sol_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  115,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "depositor",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "deposit_record"
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "set_paused",
+      "docs": [
+        "Pause or unpause the vault. Authority-only.",
+        "",
+        "While paused (`config.paused == true`), `deposit`, `withdraw_private`,",
+        "`authority_refund`, `deposit_sol`, `withdraw_private_sol`, and",
+        "`authority_refund_sol` revert with `VaultError::ProgramPaused`. The",
+        "`refund`, `collect_fee`, `refund_sol`, and `collect_fee_sol` paths",
+        "intentionally remain available so depositors can always self-recover funds",
+        "and the authority can still drain accumulated fees during an emergency.",
+        "",
+        "Idempotent \u2014 calling with the current state is a no-op success.",
+        "",
+        "Emits `VaultPausedEvent` so off-chain monitoring (SENTINEL, audit",
+        "log indexers, dashboards) can subscribe to state changes without",
+        "log-parsing."
+      ],
+      "discriminator": [
+        91,
+        60,
+        125,
+        192,
+        176,
+        225,
+        166,
+        218
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": [
+            "config"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "paused",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "update_authority",
+      "docs": [
+        "Propose a new authority (step 1 of a two-step transfer). The current",
+        "authority signs; the proposed key is recorded in `pending_authority` but",
+        "does not take effect until it calls `accept_authority`. This lets the",
+        "program hand control to e.g. a multisig without a redeploy, and lets a",
+        "fat-fingered or compromised proposal be overwritten by another",
+        "`update_authority` before it is ever accepted."
+      ],
+      "discriminator": [
+        32,
+        46,
+        64,
+        28,
+        149,
+        75,
+        243,
+        88
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": [
+            "config"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "new_authority",
+          "type": "pubkey"
+        }
+      ]
+    },
+    {
+      "name": "update_fee",
+      "docs": [
+        "Update the protocol fee (basis points). Authority-only, capped at",
+        "MAX_FEE_BPS. Lets the authority adjust the fee without a redeploy."
+      ],
+      "discriminator": [
+        232,
+        253,
+        195,
+        247,
+        148,
+        212,
+        73,
+        222
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": [
+            "config"
+          ]
+        }
+      ],
+      "args": [
+        {
+          "name": "new_fee_bps",
+          "type": "u16"
+        }
+      ]
     },
     {
       "name": "withdraw_private",
@@ -747,8 +1833,394 @@
           ]
         },
         {
-          "name": "token_program",
-          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+          "name": "token_program"
+        },
+        {
+          "name": "sip_config",
+          "docs": [
+            "SIP Privacy program config PDA"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                6,
+                103,
+                244,
+                183,
+                95,
+                66,
+                85,
+                178,
+                94,
+                77,
+                35,
+                31,
+                200,
+                4,
+                171,
+                142,
+                239,
+                75,
+                239,
+                31,
+                200,
+                233,
+                194,
+                236,
+                6,
+                172,
+                102,
+                172,
+                187,
+                213,
+                122,
+                133
+              ]
+            }
+          }
+        },
+        {
+          "name": "sip_transfer_record",
+          "docs": [
+            "Transfer record PDA \u2014 will be initialized by CPI to sip_privacy"
+          ],
+          "writable": true
+        },
+        {
+          "name": "sip_privacy_program",
+          "docs": [
+            "SIP Privacy program for CPI"
+          ],
+          "address": "S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program (needed by sip_privacy to init the transfer record)"
+          ],
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        },
+        {
+          "name": "amount_commitment",
+          "type": {
+            "array": [
+              "u8",
+              33
+            ]
+          }
+        },
+        {
+          "name": "stealth_pubkey",
+          "type": "pubkey"
+        },
+        {
+          "name": "ephemeral_pubkey",
+          "type": {
+            "array": [
+              "u8",
+              33
+            ]
+          }
+        },
+        {
+          "name": "viewing_key_hash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "_encrypted_amount",
+          "type": "bytes"
+        },
+        {
+          "name": "_proof",
+          "type": "bytes"
+        }
+      ]
+    },
+    {
+      "name": "withdraw_private_sol",
+      "docs": [
+        "Withdraw native SOL privately to a stealth address. The native-track analog",
+        "of `withdraw_private`. Debit-first pattern, then a **checked lamport mutation**",
+        "of the program-owned `SolVault` PDA (no system CPI \u2014 the source is PDA-owned):",
+        "1. Guards: not paused, amount > 0.",
+        "2. Debit-first: reduce `DepositRecord.balance` before moving any lamports.",
+        "3. Fee split: `fee = amount \u00b7 fee_bps / 10_000`, `net = amount \u2212 fee`.",
+        "4. Checked lamport mutation: compute every new balance with checked ops",
+        "(BPF release WRAPS on `+=`/`-=`, which would be a vault drain), enforce",
+        "the rent-reserve guard on the vault debit, THEN assign.",
+        "5. CPI `create_transfer_announcement` (shared helper, mint = NATIVE_SOL_MINT).",
+        "6. Emit `VaultWithdrawEvent` (mint = NATIVE_SOL_MINT).",
+        "",
+        "`encrypted_amount` / `proof` mirror the token signature \u2014 carried for",
+        "announcement parity + off-chain verification; format-checked, unused on-chain."
+      ],
+      "discriminator": [
+        231,
+        25,
+        127,
+        244,
+        146,
+        146,
+        119,
+        213
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "deposit_record",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  101,
+                  112,
+                  111,
+                  115,
+                  105,
+                  116,
+                  95,
+                  114,
+                  101,
+                  99,
+                  111,
+                  114,
+                  100
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "depositor"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0,
+                  0
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "sol_vault",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  97,
+                  117,
+                  108,
+                  116,
+                  95,
+                  115,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "sol_fee",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  102,
+                  101,
+                  101,
+                  95,
+                  115,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "stealth",
+          "docs": [
+            "The stealth recipient \u2014 a plain writable system account that receives the",
+            "net lamports. No mint check (native SOL); may be below the rent-exempt",
+            "minimum after a small payout (documented in the design \u2014 no fund loss)."
+          ],
+          "writable": true
+        },
+        {
+          "name": "depositor",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "deposit_record"
+          ]
+        },
+        {
+          "name": "sip_config",
+          "docs": [
+            "SIP Privacy program config PDA"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                6,
+                103,
+                244,
+                183,
+                95,
+                66,
+                85,
+                178,
+                94,
+                77,
+                35,
+                31,
+                200,
+                4,
+                171,
+                142,
+                239,
+                75,
+                239,
+                31,
+                200,
+                233,
+                194,
+                236,
+                6,
+                172,
+                102,
+                172,
+                187,
+                213,
+                122,
+                133
+              ]
+            }
+          }
+        },
+        {
+          "name": "sip_transfer_record",
+          "docs": [
+            "Transfer record PDA \u2014 will be initialized by CPI to sip_privacy"
+          ],
+          "writable": true
+        },
+        {
+          "name": "sip_privacy_program",
+          "docs": [
+            "SIP Privacy program for CPI"
+          ],
+          "address": "S1PMFspo4W6BYKHWkHNF7kZ3fnqibEXg3LQjxepS9at"
+        },
+        {
+          "name": "system_program",
+          "docs": [
+            "System program (needed by sip_privacy to init the transfer record)"
+          ],
+          "address": "11111111111111111111111111111111"
         }
       ],
       "args": [
@@ -813,6 +2285,32 @@
       ]
     },
     {
+      "name": "SolFee",
+      "discriminator": [
+        39,
+        220,
+        57,
+        50,
+        228,
+        181,
+        159,
+        180
+      ]
+    },
+    {
+      "name": "SolVault",
+      "discriminator": [
+        21,
+        132,
+        230,
+        103,
+        19,
+        209,
+        129,
+        248
+      ]
+    },
+    {
       "name": "VaultConfig",
       "discriminator": [
         99,
@@ -827,6 +2325,71 @@
     }
   ],
   "events": [
+    {
+      "name": "AuthorityTransferProposedEvent",
+      "discriminator": [
+        219,
+        219,
+        120,
+        196,
+        117,
+        157,
+        182,
+        254
+      ]
+    },
+    {
+      "name": "AuthorityUpdatedEvent",
+      "discriminator": [
+        44,
+        40,
+        20,
+        115,
+        145,
+        198,
+        95,
+        200
+      ]
+    },
+    {
+      "name": "FeeUpdatedEvent",
+      "discriminator": [
+        124,
+        0,
+        33,
+        112,
+        38,
+        152,
+        178,
+        195
+      ]
+    },
+    {
+      "name": "VaultConfigMigratedEvent",
+      "discriminator": [
+        30,
+        126,
+        44,
+        151,
+        86,
+        252,
+        101,
+        239
+      ]
+    },
+    {
+      "name": "VaultPausedEvent",
+      "discriminator": [
+        75,
+        189,
+        120,
+        167,
+        117,
+        229,
+        155,
+        60
+      ]
+    },
     {
       "name": "VaultWithdrawEvent",
       "discriminator": [
@@ -894,11 +2457,81 @@
     },
     {
       "code": 6010,
-      "name": "BalanceLocked",
-      "msg": "Balance locked by scheduled operations"
+      "name": "AnnouncementCpiFailed",
+      "msg": "CPI to SIP Privacy program failed"
+    },
+    {
+      "code": 6011,
+      "name": "UnsupportedMintExtension",
+      "msg": "Mint carries an unsupported Token-2022 extension"
+    },
+    {
+      "code": 6012,
+      "name": "RentReserveViolation",
+      "msg": "Operation would drain a SOL PDA below its rent-exempt minimum"
+    },
+    {
+      "code": 6013,
+      "name": "EncryptedAmountTooLong",
+      "msg": "Encrypted amount exceeds the 64-byte maximum"
+    },
+    {
+      "code": 6014,
+      "name": "InvalidConfigAccount",
+      "msg": "Config account is not a migratable legacy layout"
     }
   ],
   "types": [
+    {
+      "name": "AuthorityTransferProposedEvent",
+      "docs": [
+        "Emitted when the current authority proposes a transfer (step 1). Lets",
+        "off-chain monitoring (SENTINEL, indexers) react to a pending authority",
+        "change without log-parsing \u2014 the same rationale as `VaultPausedEvent`."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "current_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "pending_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AuthorityUpdatedEvent",
+      "docs": [
+        "Emitted when a pending authority transfer is accepted (step 2) and",
+        "`config.authority` actually changes \u2014 the single most alarm-worthy custody",
+        "event, especially once the authority is a mainnet multisig."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "old_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
     {
       "name": "DepositRecord",
       "type": {
@@ -917,10 +2550,6 @@
             "type": "u64"
           },
           {
-            "name": "locked_amount",
-            "type": "u64"
-          },
-          {
             "name": "cumulative_volume",
             "type": "u64"
           },
@@ -928,6 +2557,57 @@
             "name": "last_deposit_at",
             "type": "i64"
           },
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeeUpdatedEvent",
+      "docs": [
+        "Emitted when the authority updates the protocol fee."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "old_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "new_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SolFee",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SolVault",
+      "type": {
+        "kind": "struct",
+        "fields": [
           {
             "name": "bump",
             "type": "u8"
@@ -967,6 +2647,61 @@
           {
             "name": "bump",
             "type": "u8"
+          },
+          {
+            "name": "pending_authority",
+            "docs": [
+              "Pending authority for the two-step authority transfer (None = no transfer",
+              "in flight). Set by `update_authority`, promoted/cleared by `accept_authority`.",
+              "Trailing field so the fixed-offset fields above keep their byte positions."
+            ],
+            "type": {
+              "option": "pubkey"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "VaultConfigMigratedEvent",
+      "docs": [
+        "Emitted when `migrate_config` grows a legacy VaultConfig to the current",
+        "layout. Lets off-chain tooling confirm the one-time migration on-chain."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_len",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "VaultPausedEvent",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "paused",
+            "type": "bool"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }
@@ -978,6 +2713,10 @@
         "fields": [
           {
             "name": "depositor",
+            "type": "pubkey"
+          },
+          {
+            "name": "mint",
             "type": "pubkey"
           },
           {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -18,7 +18,6 @@ export interface DepositRecord {
   depositor: PublicKey
   tokenMint: PublicKey
   balance: bigint
-  lockedAmount: bigint
   cumulativeVolume: bigint
   lastDepositAt: number
   bump: number
@@ -33,9 +32,7 @@ export interface VaultBalance {
   tokenMint: PublicKey
   /** Total balance in the vault (lamports / token base units) */
   balance: bigint
-  /** Amount locked by pending private sends */
-  lockedAmount: bigint
-  /** balance - lockedAmount */
+  /** Withdrawable balance — equals `balance` (the on-chain vault has no lock field) */
   available: bigint
   /** Lifetime deposit volume */
   cumulativeVolume: bigint

--- a/packages/sdk/src/vault.ts
+++ b/packages/sdk/src/vault.ts
@@ -112,6 +112,8 @@ export function anchorDiscriminator(instructionName: string): Buffer {
  *   total_deposits:    u64    (8 bytes, LE)
  *   total_depositors:  u64    (8 bytes, LE)
  *   bump:              u8     (1 byte)
+ *   pending_authority: Option<Pubkey>  (trailing, present on-chain since B6;
+ *                      not decoded here — we read only the 60-byte fixed prefix)
  */
 export function deserializeVaultConfig(data: Buffer): VaultConfig {
   if (data.length < ANCHOR_DISCRIMINATOR_SIZE + 60) {
@@ -159,15 +161,14 @@ export function deserializeVaultConfig(data: Buffer): VaultConfig {
  *   depositor:          Pubkey  (32 bytes)
  *   token_mint:         Pubkey  (32 bytes)
  *   balance:            u64    (8 bytes, LE)
- *   locked_amount:      u64    (8 bytes, LE)
  *   cumulative_volume:  u64    (8 bytes, LE)
  *   last_deposit_at:    i64    (8 bytes, LE)
  *   bump:               u8     (1 byte)
  */
 export function deserializeDepositRecord(data: Buffer): DepositRecord {
-  if (data.length < ANCHOR_DISCRIMINATOR_SIZE + 97) {
+  if (data.length < ANCHOR_DISCRIMINATOR_SIZE + 89) {
     throw new Error(
-      `DepositRecord data too short: expected ${ANCHOR_DISCRIMINATOR_SIZE + 97} bytes, got ${data.length}`
+      `DepositRecord data too short: expected ${ANCHOR_DISCRIMINATOR_SIZE + 89} bytes, got ${data.length}`
     )
   }
 
@@ -182,9 +183,6 @@ export function deserializeDepositRecord(data: Buffer): DepositRecord {
   const balance = data.readBigUInt64LE(offset)
   offset += 8
 
-  const lockedAmount = data.readBigUInt64LE(offset)
-  offset += 8
-
   const cumulativeVolume = data.readBigUInt64LE(offset)
   offset += 8
 
@@ -197,7 +195,6 @@ export function deserializeDepositRecord(data: Buffer): DepositRecord {
     depositor,
     tokenMint,
     balance,
-    lockedAmount,
     cumulativeVolume,
     lastDepositAt,
     bump,
@@ -240,7 +237,6 @@ export async function getVaultBalance(
       depositor,
       tokenMint,
       balance: 0n,
-      lockedAmount: 0n,
       available: 0n,
       cumulativeVolume: 0n,
       lastDepositAt: 0,
@@ -253,8 +249,7 @@ export async function getVaultBalance(
     depositor: record.depositor,
     tokenMint: record.tokenMint,
     balance: record.balance,
-    lockedAmount: record.lockedAmount,
-    available: record.balance - record.lockedAmount,
+    available: record.balance,
     cumulativeVolume: record.cumulativeVolume,
     lastDepositAt: record.lastDepositAt,
     exists: true,
@@ -358,9 +353,9 @@ export async function buildRefundTx(
     throw new Error('No deposit record found — nothing to refund')
   }
   const record = deserializeDepositRecord(Buffer.from(recordInfo.data))
-  const refundAmount = record.balance - record.lockedAmount
+  const refundAmount = record.balance
   if (refundAmount <= 0n) {
-    throw new Error('No available balance to refund (all funds locked or zero)')
+    throw new Error('No balance to refund')
   }
 
   // Encode: discriminator(8) only — refund has no params
@@ -442,9 +437,9 @@ export async function buildAuthorityRefundTx(
     throw new Error('No deposit record found — nothing to refund')
   }
   const record = deserializeDepositRecord(Buffer.from(recordInfo.data))
-  const refundAmount = record.balance - record.lockedAmount
+  const refundAmount = record.balance
   if (refundAmount <= 0n) {
-    throw new Error('No available balance to refund (all funds locked or zero)')
+    throw new Error('No balance to refund')
   }
 
   // Encode: discriminator(8) only — authority_refund has no params

--- a/packages/sdk/tests/vault.test.ts
+++ b/packages/sdk/tests/vault.test.ts
@@ -70,10 +70,10 @@ describe('Config', () => {
   })
 
   it('has correct account sizes', () => {
-    // VaultConfig: 8 (disc) + 32 + 2 + 8 + 1 + 8 + 8 + 1 = 68
-    expect(VAULT_CONFIG_SIZE).toBe(68)
-    // DepositRecord: 8 (disc) + 32 + 32 + 8 + 8 + 8 + 8 + 1 = 105
-    expect(DEPOSIT_RECORD_SIZE).toBe(105)
+    // VaultConfig: 8 (disc) + 32 + 2 + 8 + 1 + 8 + 8 + 1 + pending_authority(1+32) = 101
+    expect(VAULT_CONFIG_SIZE).toBe(101)
+    // DepositRecord: 8 (disc) + 32 + 32 + 8 + 8 + 8 + 1 = 97
+    expect(DEPOSIT_RECORD_SIZE).toBe(97)
     expect(ANCHOR_DISCRIMINATOR_SIZE).toBe(8)
   })
 
@@ -359,7 +359,6 @@ describe('deserializeDepositRecord', () => {
     depositor?: PublicKey
     tokenMint?: PublicKey
     balance?: bigint
-    lockedAmount?: bigint
     cumulativeVolume?: bigint
     lastDepositAt?: number
     bump?: number
@@ -368,14 +367,13 @@ describe('deserializeDepositRecord', () => {
       depositor = DEPOSITOR_A,
       tokenMint = MINT_USDC,
       balance = 1_000_000n,
-      lockedAmount = 100_000n,
       cumulativeVolume = 5_000_000n,
       lastDepositAt = 1711900800,
       bump = 253,
     } = overrides
 
-    // 8 (discriminator) + 32 + 32 + 8 + 8 + 8 + 8 + 1 = 105
-    const buf = Buffer.alloc(105)
+    // 8 (discriminator) + 32 + 32 + 8 + 8 + 8 + 1 = 97
+    const buf = Buffer.alloc(97)
     let offset = 0
 
     // Discriminator
@@ -392,10 +390,6 @@ describe('deserializeDepositRecord', () => {
 
     // balance: u64 LE
     buf.writeBigUInt64LE(balance, offset)
-    offset += 8
-
-    // locked_amount: u64 LE
-    buf.writeBigUInt64LE(lockedAmount, offset)
     offset += 8
 
     // cumulative_volume: u64 LE
@@ -419,17 +413,15 @@ describe('deserializeDepositRecord', () => {
     expect(record.depositor.equals(DEPOSITOR_A)).toBe(true)
     expect(record.tokenMint.equals(MINT_USDC)).toBe(true)
     expect(record.balance).toBe(1_000_000n)
-    expect(record.lockedAmount).toBe(100_000n)
     expect(record.cumulativeVolume).toBe(5_000_000n)
     expect(record.lastDepositAt).toBe(1711900800)
     expect(record.bump).toBe(253)
   })
 
   it('handles zero balance', () => {
-    const buf = buildDepositRecordBuffer({ balance: 0n, lockedAmount: 0n, cumulativeVolume: 0n })
+    const buf = buildDepositRecordBuffer({ balance: 0n, cumulativeVolume: 0n })
     const record = deserializeDepositRecord(buf)
     expect(record.balance).toBe(0n)
-    expect(record.lockedAmount).toBe(0n)
     expect(record.cumulativeVolume).toBe(0n)
   })
 
@@ -457,13 +449,6 @@ describe('deserializeDepositRecord', () => {
     buildDepositRecordBuffer().copy(buf)
     const record = deserializeDepositRecord(buf)
     expect(record.balance).toBe(1_000_000n)
-  })
-
-  it('roundtrips available balance calculation', () => {
-    const buf = buildDepositRecordBuffer({ balance: 500_000n, lockedAmount: 200_000n })
-    const record = deserializeDepositRecord(buf)
-    const available = record.balance - record.lockedAmount
-    expect(available).toBe(300_000n)
   })
 })
 

--- a/scripts/devnet-beta-gate-check.ts
+++ b/scripts/devnet-beta-gate-check.ts
@@ -59,8 +59,10 @@ type GateResult = {
   reverts: Revert[]
 }
 
-// Custom error codes from the sipher_vault IDL.
+// Custom error codes from the sipher_vault IDL (aligned to the B6 enum).
 // User errors are clearly caller-side mistakes; anything else is unexplained and fails C5.
+// NOTE: 6010 is now AnnouncementCpiFailed (a CPI/system failure, not a user error) —
+// the removed BalanceLocked variant no longer exists, so it is intentionally absent here.
 const USER_ERROR_CODES = new Set([
   6000, // ProgramPaused
   6001, // Unauthorized
@@ -68,7 +70,6 @@ const USER_ERROR_CODES = new Set([
   6004, // ZeroDeposit
   6005, // RefundNotExpired
   6006, // NothingToRefund
-  6010, // BalanceLocked
 ])
 
 function classifyError(err: unknown): { error: string; classification: 'user_error' | 'unexplained' } {


### PR DESCRIPTION
Brings sipher's vault SDK back in lockstep with the **merged** `sipher-vault` program (B6 hardening #1192 + universal-asset #1162 + `migrate_config` #1212, now on `sip-protocol` main + live on devnet). The committed IDL was the original v0.1.0 (7 instructions) and the hand-written decoders had drifted from the on-chain layout.

This is the **account layer** of the lockstep. The **event layer** (a `VaultWithdrawEvent` `mint`-field drift in the privacy-scanning path) is deliberately deferred to a focused follow-up → #337.

## What changed

**1. Regenerate the IDL** (`anchor idl build`) — v0.1.0/7-ix → current: 19 instructions, 15 errors (no `BalanceLocked`), `DepositRecord` without `locked_amount`, `VaultConfig` with trailing `pending_authority`, SOL vault/fee accounts. *(Reference artifact — nothing imports it at compile-time.)*

**2. Sync the `DepositRecord` layout** — B6 removed the inert `locked_amount` field (105→97 bytes). The decoder still read it and required ≥105 bytes, so it **threw on every new-layout record**. Realigned to the 97-byte record; dropped `lockedAmount` from `DepositRecord`/`VaultBalance` and all derivations (`available` is now `balance`; refund amount is the full `balance`); updated the agent balance tool + `vault-positions` response. Corrected size constants: `DEPOSIT_RECORD_SIZE` 105→97, `VAULT_CONFIG_SIZE` 68→101. **Behavior-preserving** — `locked_amount` was always zero on-chain.

**3. Align beta-gate error codes** — `devnet-beta-gate-check` treated `6010` as the removed `BalanceLocked` user-error; it's now `AnnouncementCpiFailed` (a CPI/system failure). Dropped from `USER_ERROR_CODES` so such reverts are flagged "unexplained" (fail-safe), not silently benign.

## Verification

- `pnpm typecheck` — clean (all packages)
- `pnpm build` — success
- SDK tests — **98 passed** (incl. `deserializeDepositRecord` rewritten for the 97-byte layout)
- Agent tests — **1715 passed**, 2 skipped

## Notes

- The regenerated IDL already shows the new `VaultWithdrawEvent` (with `mint`); the event **parser** sync is the tracked follow-up (#337), so there's a brief, intentional IDL-vs-parser gap on the event path only.
- 3 commits, each independently builds: IDL regen / DepositRecord sync / gate-check.