### PR TITLE
fix(sdk): parse the mint field in VaultWithdrawEvent (event-layer lockstep)

### DIFF
--- a/packages/agent/src/tools/claim-helpers.ts
+++ b/packages/agent/src/tools/claim-helpers.ts
@@ -1,6 +1,14 @@
 import { Buffer } from 'node:buffer'
 import { ed25519 } from '@noble/curves/ed25519'
-import { WSOL_MINT, USDC_MINT, USDT_MINT, getTokenDecimals, fromBaseUnits } from '@sipher/sdk'
+import {
+  WSOL_MINT,
+  USDC_MINT,
+  USDT_MINT,
+  getTokenDecimals,
+  fromBaseUnits,
+  WITHDRAW_EVENT_MIN_SIZE,
+  WITHDRAW_EVENT_WITH_MINT_SIZE,
+} from '@sipher/sdk'
 import {
   PublicKey,
   type Connection,
@@ -32,12 +40,6 @@ export interface StealthContext {
 }
 
 const PROGRAM_DATA_PREFIX = 'Program data: '
-/**
- * Minimum VaultWithdrawEvent bytes:
- * 8 (disc) + 32 (depositor) + 32 (stealth) + 33 (commitment) + 33 (ephemeral)
- *  + 32 (vk_hash) + 8 (amount) + 8 (fee) + 8 (ts) = 194
- */
-const WITHDRAW_EVENT_MIN_BYTES = 194
 const SPL_TOKEN_PROGRAMS = new Set(['spl-token', 'spl-token-2022'])
 
 function isParsedInstruction(
@@ -141,10 +143,11 @@ interface WithdrawEvent {
 
 /**
  * Parses the first decode-able VaultWithdrawEvent out of `Program data: <b64>`
- * log lines. Mirrors `parseWithdrawEvent` in packages/sdk/src/privacy.ts:413-454
+ * log lines. Mirrors `parseWithdrawEvent` in packages/sdk/src/privacy.ts
  * (no discriminator check — matches sipher's scan behavior; relies on the
  * 194-byte length floor and the downstream ATA-owner equality check to
- * filter spurious decodes).
+ * filter spurious decodes). Handles both the legacy 194-byte layout and the
+ * post-#1162 226-byte layout, which inserts a 32-byte `mint` after `depositor`.
  */
 function parseWithdrawEventFromLogs(logs: string[]): WithdrawEvent | null {
   for (const log of logs) {
@@ -157,14 +160,21 @@ function parseWithdrawEventFromLogs(logs: string[]): WithdrawEvent | null {
     } catch {
       continue
     }
-    if (data.length < WITHDRAW_EVENT_MIN_BYTES) continue
+    if (data.length < WITHDRAW_EVENT_MIN_SIZE) continue
     try {
-      // Layout (after 8-byte discriminator): depositor[32] | stealth[32]
-      //   | commitment[33] | ephemeral[33] | vk_hash[32] | amount[8] | fee[8] | ts[8]
-      const stealthBytes = data.subarray(40, 72)
+      // Layout (after 8-byte discriminator): depositor[32] [+ mint[32] since
+      //   #1162] | stealth[32] | commitment[33] | ephemeral[33] | vk_hash[32]
+      //   | amount[8] | fee[8] | ts[8]. Detect the mint by total length.
+      const mintSkip = data.length >= WITHDRAW_EVENT_WITH_MINT_SIZE ? 32 : 0
+      const stealthStart = 40 + mintSkip
+      const stealthBytes = data.subarray(stealthStart, stealthStart + 32)
       const stealthAddress = new PublicKey(stealthBytes).toBase58()
-      // Ephemeral is 33 bytes (0x00 prefix + 32-byte ed25519); strip prefix.
-      const ephRaw = data[105] === 0x00 ? data.subarray(106, 138) : data.subarray(105, 137)
+      // Ephemeral is 33 bytes (0x00 prefix + 32-byte ed25519), after stealth(32)
+      // + commitment(33); strip the prefix when present.
+      const ephStart = stealthStart + 65
+      const ephRaw = data[ephStart] === 0x00
+        ? data.subarray(ephStart + 1, ephStart + 33)
+        : data.subarray(ephStart, ephStart + 32)
       if (ephRaw.length !== 32) continue
       // Skip pre-integration placeholder events with zero-filled ephemeral.
       if (ephRaw.every((b) => b === 0)) continue

--- a/packages/agent/src/tools/viewing-key.ts
+++ b/packages/agent/src/tools/viewing-key.ts
@@ -2,7 +2,7 @@ import type { AnthropicTool } from '../pi/tool-adapter.js'
 import { generateViewingKey, deriveViewingKey } from '@sip-protocol/sdk'
 import { sha256 } from '@noble/hashes/sha256'
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils'
-import { createConnection } from '@sipher/sdk'
+import { createConnection, WITHDRAW_EVENT_WITH_MINT_SIZE } from '@sipher/sdk'
 import { loadNetworkConfig } from '../config/network.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -87,12 +87,15 @@ function packKeyForDownload(
 /**
  * Parse the VaultWithdrawEvent from transaction log data.
  *
- * Event layout (after 8-byte Anchor discriminator):
+ * Event layout (after 8-byte Anchor discriminator); since #1162 a 32-byte
+ * `mint` is inserted after `depositor` (the 226-byte layout), shifting every
+ * later field +32. Legacy offsets shown:
  *   depositor:        32 bytes  (offset  8)
- *   stealth:          32 bytes  (offset 40)
- *   commitment:       33 bytes  (offset 72)
- *   ephemeral:        33 bytes  (offset 105)
- *   viewing_key_hash: 32 bytes  (offset 138)
+ *   mint:             32 bytes  (offset 40, post-#1162 only)
+ *   stealth:          32 bytes  (offset 40 / 72)
+ *   commitment:       33 bytes  (offset 72 / 104)
+ *   ephemeral:        33 bytes  (offset 105 / 137)
+ *   viewing_key_hash: 32 bytes  (offset 138 / 170)
  *
  * Returns the 32-byte viewingKeyHash or null if not found.
  */
@@ -109,10 +112,13 @@ function parseViewingKeyHashFromLogs(logMessages: string[]): Uint8Array | null {
       continue
     }
 
-    // VaultWithdrawEvent: 8 (disc) + 32 + 32 + 33 + 33 + 32 = 170 bytes minimum
-    if (data.length < 170) continue
+    // The post-#1162 226-byte layout inserts a 32-byte mint after depositor,
+    // shifting viewing_key_hash forward by 32; detect it by total length.
+    const mintSkip = data.length >= WITHDRAW_EVENT_WITH_MINT_SIZE ? 32 : 0
+    const vkStart = 138 + mintSkip
+    if (data.length < vkStart + 32) continue
 
-    return new Uint8Array(data.slice(138, 170))
+    return new Uint8Array(data.slice(vkStart, vkStart + 32))
   }
 
   return null

--- a/packages/agent/tests/history.test.ts
+++ b/packages/agent/tests/history.test.ts
@@ -48,14 +48,20 @@ function buildDepositEventBase64(
   return buf.toString('base64')
 }
 
-/** Build a base64-encoded withdraw event (194 bytes) */
+/**
+ * Build a base64-encoded withdraw event. Legacy layout = 194 bytes; when a
+ * `mint` is supplied the post-#1162 (universal-asset) 226-byte layout is built
+ * with `mint` inserted right after `depositor`.
+ */
 function buildWithdrawEventBase64(
   depositor: string,
   amountLamports: bigint,
   feeLamports: bigint,
-  timestamp: number
+  timestamp: number,
+  mint?: string
 ): string {
-  const buf = Buffer.alloc(194)
+  const hasMint = mint != null
+  const buf = Buffer.alloc(hasMint ? 226 : 194)
   let offset = 0
 
   // Discriminator (8 bytes)
@@ -65,6 +71,12 @@ function buildWithdrawEventBase64(
   // Depositor (32 bytes)
   new PublicKey(depositor).toBuffer().copy(buf, offset)
   offset += 32
+
+  // Mint (32 bytes) — present only in the post-#1162 226-byte layout
+  if (hasMint) {
+    new PublicKey(mint).toBuffer().copy(buf, offset)
+    offset += 32
+  }
 
   // Stealth recipient (32 bytes) — dummy
   buf.fill(0x01, offset, offset + 32)
@@ -374,6 +386,24 @@ describe('parseVaultEvents (real SDK parser)', () => {
       2_000_000_000n, // 2 SOL
       2_000_000n,     // 0.002 SOL fee
       1712001000
+    )
+    const logs = [`Program data: ${withdrawB64}`]
+
+    const events = realParseVaultEvents(logs, FAKE_SIG, 1712001000)
+    expect(events).toHaveLength(1)
+    expect(events[0].type).toBe('send')
+    expect(events[0].wallet).toBe(VALID_WALLET)
+    expect(events[0].amount).toBe('2')
+    expect(events[0].timestamp).toBe(1712001000)
+  })
+
+  it('parses post-#1162 226-byte withdraw event (with mint) as type "send"', () => {
+    const withdrawB64 = buildWithdrawEventBase64(
+      VALID_WALLET,
+      2_000_000_000n, // 2 SOL
+      2_000_000n,
+      1712001000,
+      WSOL_MINT_STR, // → 226-byte layout with a mint field after depositor
     )
     const logs = [`Program data: ${withdrawB64}`]
 

--- a/packages/agent/tests/tools/claim-helpers.test.ts
+++ b/packages/agent/tests/tools/claim-helpers.test.ts
@@ -24,27 +24,27 @@ function buildWithdrawEventBytes(opts: {
   stealthBs58?: string
   ephemeralBs58?: string
   zeroEphemeral?: boolean
+  withMint?: boolean
 }): Buffer {
-  const buf = Buffer.alloc(194)
-  // [0, 8)  — Anchor event discriminator (arbitrary bytes; sipher doesn't validate)
+  // When `withMint`, build the post-#1162 226-byte layout (a 32-byte mint is
+  // inserted right after depositor); otherwise the legacy 194-byte layout.
+  const mintOffset = opts.withMint ? 32 : 0
+  const buf = Buffer.alloc(194 + mintOffset)
+  // [0, 8) — Anchor event discriminator (arbitrary bytes; sipher doesn't validate)
   buf.write('0011223344556677', 0, 'hex')
-  // [8, 40) — depositor (zeros, not used by resolver)
-  // [40, 72) — stealth_recipient
+  // [8, 40) — depositor (zeros); [40, 72) — mint (only when withMint); then stealth_recipient
+  const stealthStart = 40 + mintOffset
   const stealth = new PublicKey(opts.stealthBs58 ?? STEALTH_PUBKEY).toBytes()
-  Buffer.from(stealth).copy(buf, 40)
-  // [72, 105) — amount_commitment (zeros)
-  // [105, 138) — ephemeral_pubkey: 0x00 prefix + 32-byte ed25519 (per privacy.ts:339-341)
-  buf[105] = 0x00
+  Buffer.from(stealth).copy(buf, stealthStart)
+  // ephemeral_pubkey (0x00 prefix + 32-byte ed25519) sits after stealth(32) + commitment(33)
+  const ephStart = stealthStart + 65
+  buf[ephStart] = 0x00
   if (opts.zeroEphemeral) {
-    // intentionally leave [106..138] as zeros — should be skipped by resolver
+    // intentionally leave the ephemeral bytes as zeros — should be skipped by resolver
   } else {
     const eph = new PublicKey(opts.ephemeralBs58 ?? EPHEMERAL_PUBKEY).toBytes()
-    Buffer.from(eph).copy(buf, 106)
+    Buffer.from(eph).copy(buf, ephStart + 1)
   }
-  // [138, 170) — viewing_key_hash (zeros)
-  // [170, 178) — transfer_amount (zeros)
-  // [178, 186) — fee_amount (zeros)
-  // [186, 194) — timestamp (zeros)
   return buf
 }
 
@@ -57,7 +57,7 @@ function programDataLog(eventBytes: Buffer): string {
  * `ParsedTransactionWithMeta` for unit testing. Real responses contain
  * many more fields; the resolver only reads the keys touched below.
  */
-function mockTxWithEventAndSplTransfer(opts: { tokenProgram?: 'spl-token' | 'spl-token-2022'; inner?: boolean } = {}) {
+function mockTxWithEventAndSplTransfer(opts: { tokenProgram?: 'spl-token' | 'spl-token-2022'; inner?: boolean; withMint?: boolean } = {}) {
   const tokenProgram = opts.tokenProgram ?? 'spl-token'
   const splTokenIx = {
     program: tokenProgram,
@@ -85,7 +85,7 @@ function mockTxWithEventAndSplTransfer(opts: { tokenProgram?: 'spl-token' | 'spl
       err: null,
       logMessages: [
         'Program S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB invoke [1]',
-        programDataLog(buildWithdrawEventBytes({})),
+        programDataLog(buildWithdrawEventBytes({ withMint: opts.withMint })),
         'Program S1Phr5rmDfkZTyLXzH5qUHeiqZS3Uf517SQzRbU4kHB success',
       ],
       innerInstructions: opts.inner ? [{ index: 0, instructions: [splTokenIx] }] : [],
@@ -97,6 +97,21 @@ describe('resolveStealthContext — happy path', () => {
   it('returns stealth address, ephemeral pubkey, and mint from a VaultWithdrawEvent log + top-level SPL transfer', async () => {
     const mockConnection = {
       getParsedTransaction: vi.fn().mockResolvedValue(mockTxWithEventAndSplTransfer()),
+      getParsedAccountInfo: vi.fn().mockResolvedValue({
+        value: { data: { parsed: { info: { owner: STEALTH_PUBKEY, mint: MINT_USDC } } } },
+      }),
+    } as unknown as Connection
+
+    const ctx = await resolveStealthContext(mockConnection, DEPOSIT_SIG)
+
+    expect(ctx.stealthAddress).toBe(STEALTH_PUBKEY)
+    expect(ctx.ephemeralPublicKey).toBe(EPHEMERAL_PUBKEY)
+    expect(ctx.mint).toBe(MINT_USDC)
+  })
+
+  it('resolves the post-#1162 226-byte event layout (carries a mint field)', async () => {
+    const mockConnection = {
+      getParsedTransaction: vi.fn().mockResolvedValue(mockTxWithEventAndSplTransfer({ withMint: true })),
       getParsedAccountInfo: vi.fn().mockResolvedValue({
         value: { data: { parsed: { info: { owner: STEALTH_PUBKEY, mint: MINT_USDC } } } },
       }),

--- a/packages/agent/tests/viewing-key.test.ts
+++ b/packages/agent/tests/viewing-key.test.ts
@@ -53,6 +53,7 @@ vi.mock('@sipher/sdk', () => ({
   createConnection: vi.fn().mockReturnValue({
     getParsedTransaction: mockGetParsedTransaction,
   }),
+  WITHDRAW_EVENT_WITH_MINT_SIZE: 226,
 }))
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -71,22 +72,24 @@ const MOCK_CHILD_HASH = `0x${bytesToHex(sha256(hexToBytes('bb'.repeat(32))))}`
 // Helper: build a fake VaultWithdrawEvent log line
 // ─────────────────────────────────────────────────────────────────────────────
 
-function buildVaultWithdrawEventLog(viewingKeyHash: Uint8Array): string {
-  // 8 (discriminator) + 32 (depositor) + 32 (stealth) + 33 (commitment) + 33 (ephemeral) + 32 (viewingKeyHash) = 170
-  const buf = Buffer.alloc(170)
+function buildVaultWithdrawEventLog(viewingKeyHash: Uint8Array, withMint = false): string {
+  // legacy: 8 (disc) + 32 (depositor) + 32 (stealth) + 33 (commitment)
+  //   + 33 (ephemeral) + 32 (viewingKeyHash) = 170. The post-#1162 layout inserts
+  //   a 32-byte mint after depositor; length-based detection needs the FULL
+  //   226-byte event, so build that (trailing amount/fee/ts stay zero).
+  const buf = Buffer.alloc(withMint ? 226 : 170)
   // discriminator — arbitrary 8 bytes
   buf.writeUInt32LE(0x12345678, 0)
   buf.writeUInt32LE(0x9abcdef0, 4)
   // depositor — 32 bytes of 0x01
   buf.fill(0x01, 8, 40)
-  // stealth — 32 bytes of 0x02
-  buf.fill(0x02, 40, 72)
-  // commitment — 33 bytes of 0x03
-  buf.fill(0x03, 72, 105)
-  // ephemeral — 33 bytes of 0x04
-  buf.fill(0x04, 105, 138)
-  // viewingKeyHash at offset 138
-  viewingKeyHash.forEach((b, i) => buf[138 + i] = b)
+  let off = 40
+  // mint — 32 bytes of 0x09 (only in the post-#1162 layout)
+  if (withMint) { buf.fill(0x09, off, off + 32); off += 32 }
+  buf.fill(0x02, off, off + 32); off += 32 // stealth
+  buf.fill(0x03, off, off + 33); off += 33 // commitment
+  buf.fill(0x04, off, off + 33); off += 33 // ephemeral
+  viewingKeyHash.forEach((b, i) => buf[off + i] = b) // viewingKeyHash
 
   return `Program data: ${buf.toString('base64')}`
 }
@@ -269,6 +272,29 @@ describe('executeViewingKey — verify', () => {
     expect(result.details.verified).toBe(true)
     expect(result.details.txSignature).toBe('sig_match_123')
     expect(result.details.viewingKeyHash).toBeTruthy()
+    expect(result.details.note).toContain('matches')
+  })
+
+  it('verifies against the post-#1162 226-byte event layout (with mint)', async () => {
+    const keyBytes = hexToBytes(VALID_VIEWING_KEY)
+    const expectedHash = sha256(keyBytes)
+
+    mockGetParsedTransaction.mockResolvedValue({
+      meta: {
+        logMessages: [
+          'Program log: Instruction: WithdrawPrivate',
+          buildVaultWithdrawEventLog(expectedHash, true),
+        ],
+      },
+    })
+
+    const result = await executeViewingKey({
+      action: 'verify',
+      txSignature: 'sig_match_226',
+      viewingKeyHex: VALID_VIEWING_KEY,
+    })
+
+    expect(result.details.verified).toBe(true)
     expect(result.details.note).toContain('matches')
   })
 

--- a/packages/sdk/src/events.ts
+++ b/packages/sdk/src/events.ts
@@ -55,14 +55,17 @@ function mintToSymbol(mint: string): string {
 // ─────────────────────────────────────────────────────────────────────────────
 // Event layout sizes
 //
-// VaultWithdrawEvent (194+ bytes):
-//   disc(8) + depositor(32) + stealth(32) + commitment(33) + ephemeral(33)
-//   + vk_hash(32) + amount(8) + fee(8) + timestamp(8) = 194
+// VaultWithdrawEvent (194 legacy / 226 post-#1162 universal-asset):
+//   disc(8) + depositor(32) [+ mint(32) since #1162] + stealth(32)
+//   + commitment(33) + ephemeral(33) + vk_hash(32) + amount(8) + fee(8)
+//   + timestamp(8) = 194 (legacy) or 226 (with mint)
 //
 // VaultDepositEvent / VaultRefundEvent (88+ bytes):
 //   disc(8) + depositor(32) + token_mint(32) + amount(8) + timestamp(8) = 88
 // ─────────────────────────────────────────────────────────────────────────────
 
+// Legacy minimum; both the 194-byte and the 226-byte (with-mint) layouts route
+// to parseWithdrawEvent, which detects the mint by total length.
 const WITHDRAW_EVENT_MIN_SIZE = 194
 const DEPOSIT_EVENT_MIN_SIZE = 88
 
@@ -117,9 +120,11 @@ export function parseVaultEvents(
 /**
  * Parse a VaultWithdrawEvent → VaultEvent with type 'send'.
  *
- * Layout (after 8-byte discriminator):
- *   depositor(32) + stealth(32) + commitment(33) + ephemeral(33)
- *   + vk_hash(32) + transfer_amount(8) + fee_amount(8) + timestamp(8)
+ * Layout (after 8-byte discriminator). Since #1162 the event carries a `mint`
+ * field after `depositor` (226-byte layout); the legacy layout omits it (194):
+ *   depositor(32) [+ mint(32) since #1162] + stealth(32) + commitment(33)
+ *   + ephemeral(33) + vk_hash(32) + transfer_amount(8) + fee_amount(8)
+ *   + timestamp(8)
  */
 function parseWithdrawEvent(
   data: Buffer,
@@ -131,6 +136,9 @@ function parseWithdrawEvent(
 
     const wallet = new PublicKey(data.subarray(offset, offset + 32)).toBase58()
     offset += 32
+
+    // mint — present only in the post-#1162 226-byte layout; skip it
+    if (data.length >= 226) offset += 32
 
     // Skip stealth(32) + commitment(33) + ephemeral(33) + vk_hash(32)
     offset += 32 + 33 + 33 + 32
@@ -144,8 +152,9 @@ function parseWithdrawEvent(
     const eventTimestamp = Number(data.readBigInt64LE(offset))
     const timestamp = eventTimestamp > 0 ? eventTimestamp : fallbackTimestamp
 
-    // Withdraw events don't include the token_mint in the event data.
-    // Default to SOL since that's the primary vault token.
+    // The post-#1162 event now carries the real mint, but this history parser
+    // keeps the legacy SOL default for the token label. Reading the real mint to
+    // label non-SOL withdrawals correctly is a follow-up (issue #337).
     const mintKey = WSOL_MINT
     const decimals = getTokenDecimals(mintKey)
     const amount = fromBaseUnits(amountRaw, decimals)

--- a/packages/sdk/src/events.ts
+++ b/packages/sdk/src/events.ts
@@ -65,8 +65,12 @@ function mintToSymbol(mint: string): string {
 // ─────────────────────────────────────────────────────────────────────────────
 
 // Legacy minimum; both the 194-byte and the 226-byte (with-mint) layouts route
-// to parseWithdrawEvent, which detects the mint by total length.
-const WITHDRAW_EVENT_MIN_SIZE = 194
+// to parseWithdrawEvent, which detects the mint by total length. Exported so the
+// SDK's other withdraw-event decoders (privacy.ts) and the agent claim path
+// share one source of truth for these sizes.
+export const WITHDRAW_EVENT_MIN_SIZE = 194
+// Post-#1162 layout: the legacy size plus the inserted 32-byte `mint` field.
+export const WITHDRAW_EVENT_WITH_MINT_SIZE = WITHDRAW_EVENT_MIN_SIZE + 32
 const DEPOSIT_EVENT_MIN_SIZE = 88
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -138,7 +142,7 @@ function parseWithdrawEvent(
     offset += 32
 
     // mint — present only in the post-#1162 226-byte layout; skip it
-    if (data.length >= 226) offset += 32
+    if (data.length >= WITHDRAW_EVENT_WITH_MINT_SIZE) offset += 32
 
     // Skip stealth(32) + commitment(33) + ephemeral(33) + vk_hash(32)
     offset += 32 + 33 + 33 + 32

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -75,6 +75,8 @@ export type { PrivateSendParams, ScanParams } from './privacy.js'
 export {
   parseVaultEvents,
   getVaultHistory,
+  WITHDRAW_EVENT_MIN_SIZE,
+  WITHDRAW_EVENT_WITH_MINT_SIZE,
 } from './events.js'
 export type {
   VaultEventType,

--- a/packages/sdk/src/privacy.ts
+++ b/packages/sdk/src/privacy.ts
@@ -403,8 +403,13 @@ function deriveEd25519Scalar(privateKey: Uint8Array): bigint {
 /**
  * Parse a VaultWithdrawEvent from Anchor event data.
  *
- * Event layout (after 8-byte discriminator):
+ * Event layout (after 8-byte discriminator). The post-#1162 (universal-asset)
+ * program inserts a `mint` field after `depositor` (total 226 bytes); the legacy
+ * pre-#1162 layout omits it (194 bytes). Both are handled — we skip `mint` when
+ * present (StealthPayment is asset-agnostic; the claimer resolves the mint
+ * elsewhere):
  *   depositor:          Pubkey  (32)
+ *   mint:               Pubkey  (32)   ← present only in the 226-byte layout
  *   stealth_recipient:  Pubkey  (32)
  *   amount_commitment:  [u8;33] (33)
  *   ephemeral_pubkey:   [u8;33] (33)
@@ -423,6 +428,9 @@ function parseWithdrawEvent(
 
   // depositor (skip, not needed in StealthPayment)
   offset += 32
+
+  // mint — present only in the post-#1162 226-byte layout; skip it
+  if (data.length >= 226) offset += 32
 
   const stealthAddress = new PublicKey(data.subarray(offset, offset + 32))
   offset += 32

--- a/packages/sdk/src/privacy.ts
+++ b/packages/sdk/src/privacy.ts
@@ -23,6 +23,7 @@ import {
   ANCHOR_DISCRIMINATOR_SIZE,
 } from './config.js'
 import { anchorDiscriminator, deriveVaultConfigPDA } from './vault.js'
+import { WITHDRAW_EVENT_MIN_SIZE, WITHDRAW_EVENT_WITH_MINT_SIZE } from './events.js'
 import type { WithdrawResult, ScanResult, StealthPayment } from './types.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -330,7 +331,7 @@ export async function scanForPayments(
       // Skip events that are too small to be a VaultWithdrawEvent
       // Min size: 8 (disc) + 32 (depositor) + 32 (stealth) + 33 (commitment)
       //         + 33 (ephemeral) + 32 (vk_hash) + 8 (amount) + 8 (fee) + 8 (ts) = 194
-      if (eventData.length < 194) continue
+      if (eventData.length < WITHDRAW_EVENT_MIN_SIZE) continue
 
       try {
         const payment = parseWithdrawEvent(eventData, txSignatures[i])
@@ -422,7 +423,7 @@ function parseWithdrawEvent(
   data: Buffer,
   txSignature: string
 ): StealthPayment | null {
-  if (data.length < 194) return null
+  if (data.length < WITHDRAW_EVENT_MIN_SIZE) return null
 
   let offset = 8 // skip discriminator
 
@@ -430,7 +431,7 @@ function parseWithdrawEvent(
   offset += 32
 
   // mint — present only in the post-#1162 226-byte layout; skip it
-  if (data.length >= 226) offset += 32
+  if (data.length >= WITHDRAW_EVENT_WITH_MINT_SIZE) offset += 32
 
   const stealthAddress = new PublicKey(data.subarray(offset, offset + 32))
   offset += 32

--- a/packages/sdk/tests/privacy.test.ts
+++ b/packages/sdk/tests/privacy.test.ts
@@ -435,20 +435,26 @@ describe('Scan matching simulation', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Build a 194-byte VaultWithdrawEvent buffer addressed to a stealth recipient.
- * Mirrors the layout parsed by parseWithdrawEvent in src/privacy.ts:
- *   disc(8) + depositor(32) + stealth(32) + commitment(33) + ephemeral(33)
- *   + vk_hash(32) + amount(8) + fee(8) + timestamp(8)
+ * Build a VaultWithdrawEvent buffer addressed to a stealth recipient.
+ * Mirrors the layout parsed by parseWithdrawEvent in src/privacy.ts. When a
+ * `mintBytes` is supplied, the post-#1162 (universal-asset) 226-byte layout is
+ * produced with the `mint` field inserted right after `depositor`; otherwise the
+ * legacy 194-byte layout (no mint) is produced:
+ *   disc(8) + depositor(32) [+ mint(32)] + stealth(32) + commitment(33)
+ *   + ephemeral(33) + vk_hash(32) + amount(8) + fee(8) + timestamp(8)
  */
 function buildWithdrawEvent(
   stealthAddressHex: string,
   ephemeralHex: string,
   amount = 1_000_000_000n,
   fee = 5_000_000n,
+  mintBytes?: Uint8Array,
 ): Buffer {
-  const buf = Buffer.alloc(194)
+  const hasMint = mintBytes != null
+  const buf = Buffer.alloc(hasMint ? 226 : 194)
   let off = 8 // discriminator (unused by the parser)
   off += 32 // depositor (unused by matching)
+  if (hasMint) { Buffer.from(mintBytes).copy(buf, off); off += 32 } // mint
   Buffer.from(hexToBytes(stealthAddressHex)).copy(buf, off); off += 32
   off += 33 // amount_commitment (unused by matching)
   // ephemeral pubkey: on-chain 33-byte format = 0x00 prefix + 32-byte ed25519
@@ -490,6 +496,34 @@ describe('scanForPayments — canonical view-only round-trip', () => {
 
     expect(result.payments).toHaveLength(1)
     expect(result.payments[0].transferAmount).toBe(1_000_000_000n)
+    expect(result.payments[0].stealthAddress.toBase58()).toBe(
+      ed25519PublicKeyToSolanaAddress(stealth.stealthAddress.address),
+    )
+  })
+
+  it('finds a payment in the post-#1162 226-byte event layout (carries a mint field)', async () => {
+    const meta = generateEd25519StealthMetaAddress('solana')
+    const stealth = generateEd25519StealthAddress(meta.metaAddress)
+    const mint = new Uint8Array(32).fill(7) // any mint — parser must skip it, not misalign
+
+    const connection = mockConnectionWithEvent(
+      buildWithdrawEvent(
+        stealth.stealthAddress.address,
+        stealth.stealthAddress.ephemeralPublicKey,
+        2_000_000_000n,
+        5_000_000n,
+        mint,
+      ),
+    )
+
+    const result = await scanForPayments({
+      connection,
+      viewingPrivateKey: hexToBytes(meta.viewingPrivateKey),
+      spendingPublicKey: hexToBytes(meta.metaAddress.spendingKey),
+    })
+
+    expect(result.payments).toHaveLength(1)
+    expect(result.payments[0].transferAmount).toBe(2_000_000_000n)
     expect(result.payments[0].stealthAddress.toBase58()).toBe(
       ed25519PublicKeyToSolanaAddress(stealth.stealthAddress.address),
     )


### PR DESCRIPTION
The event-layer follow-up to #338. Closes #337.

`#1162` (universal-asset) inserted a **`mint: Pubkey`** field after `depositor` in `VaultWithdrawEvent` (`depositor, mint, stealth_recipient, …`; 194 → 226 bytes). sipher's two event parsers still read the legacy no-`mint` layout, so **every field after `depositor` shifted 32 bytes** — `scanForPayments` returned garbage stealth addresses/amounts and `history` read a wrong transfer amount on any post-upgrade withdrawal.

## Fix

Both parsers now **detect the layout by total length** and skip `mint` when present (`data.length >= 226`), while still handling the legacy 194-byte layout — so historical (pre-upgrade) and new events both parse correctly:

- `packages/sdk/src/privacy.ts` `parseWithdrawEvent` → `StealthPayment` (scanning). Skips `mint`; `StealthPayment` stays asset-agnostic.
- `packages/sdk/src/events.ts` `parseWithdrawEvent` → `VaultEvent` (history). Skips `mint`; keeps the pre-existing SOL token-label default.

Minimal, behavior-preserving scope: it fixes the **offset regression** only. `StealthPayment` shape is unchanged (no consumer ripple, no overlap with #338), so this branches cleanly off `main` in parallel.

## TDD

Red→green for both parsers — added a 226-byte (with-`mint`) event test alongside the existing 194-byte ones:
- `privacy.test.ts` — `scanForPayments` finds the payment in the 226-byte layout (failed before the fix)
- `history.test.ts` — `parseVaultEvents` reads the correct amount from the 226-byte layout (failed before the fix)

## Verification

- `pnpm typecheck` — clean (all packages)
- `pnpm build` — success
- SDK tests **100 passed**, agent tests **1716 passed** (2 skipped)

## Deferred (noted, not in scope)

- **Reading the real `mint`** to label non-SOL withdrawals in history (instead of the SOL default) — same "use the now-available mint" enhancement, left for later.
- The `events.ts` size classifier still has a `VaultDepositEvent`/`VaultRefundEvent` branch the program **never emits** (deposit emits no event) — pre-existing dead code, harmless (admin events are all < 88 bytes, so nothing misroutes), can be cleaned separately.