### PR TITLE
feat(sdk): native-SOL transaction builders

### DIFF
--- a/docs/superpowers/plans/2026-06-24-sipher-sdk-native-sol-builders.md
+++ b/docs/superpowers/plans/2026-06-24-sipher-sdk-native-sol-builders.md
@@ -1,0 +1,1200 @@
+# Native-SOL Transaction Builders for `@sipher/sdk` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add native-SOL transaction builders to `@sipher/sdk`, mirroring the existing SPL builders, so consumers can drive the vault's `deposit_sol` / `withdraw_private_sol` / `refund_sol` / `authority_refund_sol` instructions.
+
+**Architecture:** Purely additive. Two new modules — `src/vault-sol.ts` (deposit/refund/authority-refund + SOL PDA derivations) and `src/privacy-sol.ts` (stealth withdraw) — plus three constants in `config.ts` and two result types in `types.ts`, all re-exported from the barrel. No existing export or signature changes. Native-SOL balance reads reuse the existing `getVaultBalance(…, NATIVE_SOL_MINT)`.
+
+**Tech Stack:** TypeScript (ESM), `@solana/web3.js`, Vitest. Spec: `docs/superpowers/specs/2026-06-24-sipher-sdk-native-sol-builders-design.md`.
+
+## Global Constraints
+
+- **Style:** 2-space indent, **no semicolons**, explicit types on public APIs (match existing SDK files exactly).
+- **ESM:** every relative import uses the `.js` extension (e.g. `from './config.js'`).
+- **Additive only:** do NOT change any existing export, signature, or behavior.
+- **Naming gate (repo is PUBLIC):** code, comments, and commit messages stay generic. No partner / integration / product-codename references anywhere.
+- **Account orders + instruction-data layouts are byte-exact** from the spec §4 tables (taken from `programs/sipher-vault/programs/sipher-vault/src/lib.rs`). A reordered or mis-flagged account is the most likely defect — assert the full `keys` array.
+- **Tests:** Vitest, pure unit. Mock `Connection` via `{ ...stubs } as unknown as Connection`. No live RPC, no bankrun.
+- **Commits:** conventional, GPG-signed (`git commit -S`), **no AI attribution** (no `Co-Authored-By`, no tool footer).
+- **Working directory:** the isolated worktree at `/Users/rector/local-dev/sipher-worktrees/sdk-native-sol-builders`, package `packages/sdk`. Branch `feat/sdk-native-sol-builders`.
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `packages/sdk/src/config.ts` | `NATIVE_SOL_MINT`, `VAULT_SOL_SEED`, `FEE_SOL_SEED` | Modify |
+| `packages/sdk/src/types.ts` | `SolDepositResult`, `SolRefundResult` | Modify |
+| `packages/sdk/src/vault-sol.ts` | SOL PDA derivations + deposit/refund/authority-refund/create-sol-vault builders | Create |
+| `packages/sdk/src/privacy-sol.ts` | `buildPrivateSendSolTx` + `PrivateSendSolParams` | Create |
+| `packages/sdk/src/index.ts` | Barrel re-exports of all new symbols | Modify |
+| `packages/sdk/tests/vault-sol.test.ts` | Unit tests: constants, PDAs, deposit/refund/authority-refund/create-sol-vault | Create |
+| `packages/sdk/tests/privacy-sol.test.ts` | Unit tests: `buildPrivateSendSolTx` incl. rent-exempt guard | Create |
+
+---
+
+## Setup (run once, before Task 1)
+
+- [ ] **Install deps in the worktree** (a fresh worktree has no `node_modules`):
+
+Run (from the worktree root):
+```bash
+cd /Users/rector/local-dev/sipher-worktrees/sdk-native-sol-builders
+pnpm install
+```
+Expected: install completes (pnpm hardlinks from the global store; fast). All subsequent commands run from `packages/sdk`.
+
+---
+
+## Task 1: Native-SOL constants + SOL PDA derivations
+
+**Files:**
+- Modify: `packages/sdk/src/config.ts`
+- Create: `packages/sdk/src/vault-sol.ts`
+- Modify: `packages/sdk/src/index.ts`
+- Test: `packages/sdk/tests/vault-sol.test.ts`
+
+**Interfaces:**
+- Consumes: `SIPHER_VAULT_PROGRAM_ID` (config.ts).
+- Produces: `NATIVE_SOL_MINT: PublicKey`, `VAULT_SOL_SEED: Buffer`, `FEE_SOL_SEED: Buffer`; `deriveSolVaultPDA(programId?: PublicKey): [PublicKey, number]`, `deriveSolFeePDA(programId?: PublicKey): [PublicKey, number]`.
+
+- [ ] **Step 1: Write the failing test** — create `packages/sdk/tests/vault-sol.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { PublicKey } from '@solana/web3.js'
+import {
+  NATIVE_SOL_MINT,
+  VAULT_SOL_SEED,
+  FEE_SOL_SEED,
+  deriveSolVaultPDA,
+  deriveSolFeePDA,
+} from '../src/index.js'
+
+describe('native-SOL constants', () => {
+  it('NATIVE_SOL_MINT is the all-zeros sentinel (not wSOL)', () => {
+    expect(NATIVE_SOL_MINT.toBase58()).toBe('11111111111111111111111111111111')
+    expect(NATIVE_SOL_MINT.toBytes().every((b) => b === 0)).toBe(true)
+  })
+
+  it('SOL vault seeds match the on-chain constants', () => {
+    expect(VAULT_SOL_SEED.toString()).toBe('vault_sol')
+    expect(FEE_SOL_SEED.toString()).toBe('fee_sol')
+  })
+})
+
+describe('native-SOL PDA derivation', () => {
+  it('deriveSolVaultPDA matches the live devnet SolVault', () => {
+    const [pda] = deriveSolVaultPDA()
+    expect(pda.toBase58()).toBe('8ZG46epBDrRbZ2oDneuemmSuQNNG3R58LhFo8Do2p6sq')
+  })
+
+  it('deriveSolFeePDA matches the live devnet SolFee', () => {
+    const [pda] = deriveSolFeePDA()
+    expect(pda.toBase58()).toBe('519L2NQN16H1fnN9iPu2r2ipmjPj156yWMPQumw8PkZ4')
+  })
+
+  it('derivations honor a programId override', () => {
+    const custom = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA')
+    const [vault] = deriveSolVaultPDA(custom)
+    const [expected] = PublicKey.findProgramAddressSync([VAULT_SOL_SEED], custom)
+    expect(vault.equals(expected)).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/vault-sol.test.ts`
+Expected: FAIL — `NATIVE_SOL_MINT`/`deriveSolVaultPDA` are not exported (import error).
+
+- [ ] **Step 3: Add the constants to `config.ts`** — insert after the existing `FEE_TOKEN_SEED` line (the token-seed block, ~line 25):
+
+```ts
+// Native-SOL sentinel mint. The vault seeds the native-SOL DepositRecord with the
+// all-zeros pubkey (on-chain: Pubkey::new_from_array([0u8; 32])). This is NOT wrapped
+// SOL — WSOL_MINT (So111…112) is a real SPL mint used by the token path; the native
+// path never wraps. Keep the two distinct.
+export const NATIVE_SOL_MINT = new PublicKey(new Uint8Array(32))
+
+// Native-SOL vault PDA seeds (must match on-chain constants.rs exactly)
+export const VAULT_SOL_SEED = Buffer.from('vault_sol')
+export const FEE_SOL_SEED = Buffer.from('fee_sol')
+```
+
+- [ ] **Step 4: Create `vault-sol.ts`** with the PDA derivations:
+
+```ts
+import { PublicKey } from '@solana/web3.js'
+import {
+  SIPHER_VAULT_PROGRAM_ID,
+  VAULT_SOL_SEED,
+  FEE_SOL_SEED,
+} from './config.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Native-SOL PDA derivation
+//
+// The native-SOL DepositRecord uses the EXISTING deriveDepositRecordPDA helper
+// with NATIVE_SOL_MINT as the mint seed — no dedicated helper is needed here.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Derive the singleton SolVault PDA (holds native lamports).
+ * Seeds: [b"vault_sol"]
+ */
+export function deriveSolVaultPDA(
+  programId: PublicKey = SIPHER_VAULT_PROGRAM_ID
+): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync([VAULT_SOL_SEED], programId)
+}
+
+/**
+ * Derive the singleton SolFee PDA (native-SOL fee sink).
+ * Seeds: [b"fee_sol"]
+ */
+export function deriveSolFeePDA(
+  programId: PublicKey = SIPHER_VAULT_PROGRAM_ID
+): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync([FEE_SOL_SEED], programId)
+}
+```
+
+- [ ] **Step 5: Export from the barrel** — in `src/index.ts`, add `NATIVE_SOL_MINT`, `VAULT_SOL_SEED`, `FEE_SOL_SEED` to the existing `export { … } from './config.js'` block, and add a new block after the `from './vault.js'` block:
+
+```ts
+// Native-SOL vault operations
+export {
+  deriveSolVaultPDA,
+  deriveSolFeePDA,
+} from './vault-sol.js'
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/vault-sol.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/sdk/src/config.ts packages/sdk/src/vault-sol.ts packages/sdk/src/index.ts packages/sdk/tests/vault-sol.test.ts
+git commit -S -m "feat(sdk): native-SOL sentinel mint + SolVault/SolFee PDA derivation"
+```
+
+---
+
+## Task 2: `buildDepositSolTx`
+
+**Files:**
+- Modify: `packages/sdk/src/types.ts`
+- Modify: `packages/sdk/src/vault-sol.ts`
+- Modify: `packages/sdk/src/index.ts`
+- Test: `packages/sdk/tests/vault-sol.test.ts`
+
+**Interfaces:**
+- Consumes: `deriveSolVaultPDA` (Task 1); `deriveVaultConfigPDA`, `deriveDepositRecordPDA`, `anchorDiscriminator` (vault.ts); `NATIVE_SOL_MINT` (config.ts).
+- Produces: `SolDepositResult { transaction, depositRecordAddress, solVaultAddress, amount }`; `buildDepositSolTx(connection, depositor, amount, programId?): Promise<SolDepositResult>`.
+
+- [ ] **Step 1: Write the failing test** — append to `tests/vault-sol.test.ts`:
+
+```ts
+// Add these as NEW import statements at the top of the file, alongside Task 1's
+// imports. Do NOT re-import names already imported in Task 1 (`PublicKey`,
+// `NATIVE_SOL_MINT`, `deriveSolVaultPDA`) — multiple disjoint imports from the same
+// module are legal; a duplicated binding is a compile error.
+import { Connection, SystemProgram } from '@solana/web3.js'
+import {
+  buildDepositSolTx,
+  deriveVaultConfigPDA,
+  deriveDepositRecordPDA,
+  anchorDiscriminator,
+  SIPHER_VAULT_PROGRAM_ID,
+} from '../src/index.js'
+
+const BLOCKHASH = 'GfVcyD4kkTrj4bKc7WA9sZCin9JDbdT458zqL4zjxx2v'
+const DEPOSITOR = new PublicKey('FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr')
+
+// Minimal Connection stub: only getLatestBlockhash is exercised by the deposit builder.
+function mockConnDeposit(): Connection {
+  return {
+    getLatestBlockhash: async () => ({ blockhash: BLOCKHASH, lastValidBlockHeight: 1 }),
+  } as unknown as Connection
+}
+
+describe('buildDepositSolTx', () => {
+  it('builds deposit_sol with the exact DepositSol account order + flags', async () => {
+    const res = await buildDepositSolTx(mockConnDeposit(), DEPOSITOR, 5_000_000n)
+    const ix = res.transaction.instructions[0]
+
+    const [config] = deriveVaultConfigPDA()
+    const [record] = deriveDepositRecordPDA(DEPOSITOR, NATIVE_SOL_MINT)
+    const [solVault] = deriveSolVaultPDA()
+
+    expect(ix.programId.equals(SIPHER_VAULT_PROGRAM_ID)).toBe(true)
+    expect(ix.keys.map((k) => k.pubkey.toBase58())).toEqual([
+      config.toBase58(),
+      record.toBase58(),
+      solVault.toBase58(),
+      DEPOSITOR.toBase58(),
+      SystemProgram.programId.toBase58(),
+    ])
+    expect(ix.keys.map((k) => k.isSigner)).toEqual([false, false, false, true, false])
+    expect(ix.keys.map((k) => k.isWritable)).toEqual([true, true, true, true, false])
+  })
+
+  it('encodes discriminator + amount and sets feePayer/blockhash', async () => {
+    const res = await buildDepositSolTx(mockConnDeposit(), DEPOSITOR, 5_000_000n)
+    const data = res.transaction.instructions[0].data
+    expect(data.length).toBe(16)
+    expect(data.subarray(0, 8).equals(anchorDiscriminator('deposit_sol'))).toBe(true)
+    expect(data.readBigUInt64LE(8)).toBe(5_000_000n)
+    expect(res.transaction.feePayer?.toBase58()).toBe(DEPOSITOR.toBase58())
+    expect(res.transaction.recentBlockhash).toBe(BLOCKHASH)
+    expect(res.amount).toBe(5_000_000n)
+    expect(res.solVaultAddress.equals(deriveSolVaultPDA()[0])).toBe(true)
+  })
+
+  it('rejects a non-positive amount', async () => {
+    await expect(buildDepositSolTx(mockConnDeposit(), DEPOSITOR, 0n)).rejects.toThrow(
+      'amount must be greater than zero',
+    )
+  })
+})
+```
+
+> `NATIVE_SOL_MINT` and `deriveSolVaultPDA` are already imported (Task 1); the test body uses them directly — do not re-import them.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/vault-sol.test.ts -t buildDepositSolTx`
+Expected: FAIL — `buildDepositSolTx` not exported.
+
+- [ ] **Step 3: Add the result type to `types.ts`** — after the existing `DepositResult` interface:
+
+```ts
+export interface SolDepositResult {
+  /** Unsigned transaction — caller signs with their wallet */
+  transaction: Transaction
+  /** The deposit record PDA (seeded by NATIVE_SOL_MINT) */
+  depositRecordAddress: PublicKey
+  /** The SolVault PDA that receives the lamports */
+  solVaultAddress: PublicKey
+  /** Amount in lamports */
+  amount: bigint
+}
+```
+
+- [ ] **Step 4: Implement `buildDepositSolTx`** — add to `vault-sol.ts` (extend the imports as shown, then append the function):
+
+```ts
+import {
+  Connection,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+} from '@solana/web3.js'
+import {
+  SIPHER_VAULT_PROGRAM_ID,
+  VAULT_SOL_SEED,
+  FEE_SOL_SEED,
+  NATIVE_SOL_MINT,
+} from './config.js'
+import {
+  anchorDiscriminator,
+  deriveVaultConfigPDA,
+  deriveDepositRecordPDA,
+} from './vault.js'
+import type { SolDepositResult } from './types.js'
+```
+
+```ts
+/**
+ * Build an unsigned native-SOL deposit transaction (deposit_sol).
+ *
+ * Accounts (order matches the DepositSol context in lib.rs):
+ *   0. config         (mut)         — VaultConfig PDA
+ *   1. deposit_record (mut)         — DepositRecord PDA [.., depositor, NATIVE_SOL_MINT]
+ *   2. sol_vault      (mut)         — SolVault PDA
+ *   3. depositor      (mut, signer)
+ *   4. system_program (ro)
+ */
+export async function buildDepositSolTx(
+  connection: Connection,
+  depositor: PublicKey,
+  amount: bigint,
+  programId: PublicKey = SIPHER_VAULT_PROGRAM_ID
+): Promise<SolDepositResult> {
+  if (amount <= 0n) {
+    throw new Error('Deposit amount must be greater than zero')
+  }
+
+  const [configPDA] = deriveVaultConfigPDA(programId)
+  const [depositRecordPDA] = deriveDepositRecordPDA(depositor, NATIVE_SOL_MINT, programId)
+  const [solVaultPDA] = deriveSolVaultPDA(programId)
+
+  // disc(8) + amount(u64 LE, 8) = 16 bytes
+  const data = Buffer.alloc(16)
+  anchorDiscriminator('deposit_sol').copy(data, 0)
+  data.writeBigUInt64LE(amount, 8)
+
+  const ix = new TransactionInstruction({
+    programId,
+    keys: [
+      { pubkey: configPDA, isSigner: false, isWritable: true },
+      { pubkey: depositRecordPDA, isSigner: false, isWritable: true },
+      { pubkey: solVaultPDA, isSigner: false, isWritable: true },
+      { pubkey: depositor, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data,
+  })
+
+  const tx = new Transaction()
+  tx.add(ix)
+  tx.feePayer = depositor
+
+  const { blockhash } = await connection.getLatestBlockhash()
+  tx.recentBlockhash = blockhash
+
+  return {
+    transaction: tx,
+    depositRecordAddress: depositRecordPDA,
+    solVaultAddress: solVaultPDA,
+    amount,
+  }
+}
+```
+
+- [ ] **Step 5: Export from the barrel** — add `buildDepositSolTx` to the `./vault-sol.js` export block in `index.ts`, and add `SolDepositResult` to the `export type { … } from './types.js'` block.
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/vault-sol.test.ts`
+Expected: PASS (8 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/sdk/src/types.ts packages/sdk/src/vault-sol.ts packages/sdk/src/index.ts packages/sdk/tests/vault-sol.test.ts
+git commit -S -m "feat(sdk): buildDepositSolTx for native-SOL deposits"
+```
+
+---
+
+## Task 3: `buildRefundSolTx` + `buildAuthorityRefundSolTx`
+
+**Files:**
+- Modify: `packages/sdk/src/types.ts`
+- Modify: `packages/sdk/src/vault-sol.ts`
+- Modify: `packages/sdk/src/index.ts`
+- Test: `packages/sdk/tests/vault-sol.test.ts`
+
+**Interfaces:**
+- Consumes: `deriveSolVaultPDA` (Task 1); `deserializeDepositRecord`, `deriveVaultConfigPDA`, `deriveDepositRecordPDA`, `anchorDiscriminator` (vault.ts).
+- Produces: `SolRefundResult { transaction, refundAmount, depositorAddress }`; `buildRefundSolTx(connection, depositor, programId?): Promise<SolRefundResult>`; `buildAuthorityRefundSolTx(connection, authority, depositor, programId?): Promise<SolRefundResult>`.
+
+- [ ] **Step 1: Write the failing test** — append to `tests/vault-sol.test.ts`:
+
+```ts
+import {
+  buildRefundSolTx,
+  buildAuthorityRefundSolTx,
+} from '../src/index.js'
+
+const AUTHORITY = new PublicKey('S1P6j1yeTm6zkewQVeihrTZvmfoHABRkHDhabWTuWMd')
+
+// DepositRecord buffer: 8 disc + depositor(32) + mint(32) + balance(8)
+// + cumulative(8) + last_deposit(8) + bump(1) = 97 bytes. balance at offset 72.
+function depositRecordBuf(balance: bigint): Buffer {
+  const buf = Buffer.alloc(8 + 89)
+  buf.writeBigUInt64LE(balance, 72)
+  return buf
+}
+
+function mockConnRefund(recordBuf: Buffer | null): Connection {
+  return {
+    getLatestBlockhash: async () => ({ blockhash: BLOCKHASH, lastValidBlockHeight: 1 }),
+    getAccountInfo: async () => (recordBuf ? ({ data: recordBuf } as never) : null),
+  } as unknown as Connection
+}
+
+describe('buildRefundSolTx', () => {
+  it('builds refund_sol with the exact RefundSol account order + flags', async () => {
+    const res = await buildRefundSolTx(mockConnRefund(depositRecordBuf(3_000_000n)), DEPOSITOR)
+    const ix = res.transaction.instructions[0]
+    const [config] = deriveVaultConfigPDA()
+    const [record] = deriveDepositRecordPDA(DEPOSITOR, NATIVE_SOL_MINT)
+    const [solVault] = deriveSolVaultPDA()
+
+    expect(ix.keys.map((k) => k.pubkey.toBase58())).toEqual([
+      config.toBase58(),
+      record.toBase58(),
+      solVault.toBase58(),
+      DEPOSITOR.toBase58(),
+    ])
+    expect(ix.keys.map((k) => k.isSigner)).toEqual([false, false, false, true])
+    expect(ix.keys.map((k) => k.isWritable)).toEqual([false, true, true, true])
+    expect(ix.data.equals(anchorDiscriminator('refund_sol'))).toBe(true)
+    expect(res.refundAmount).toBe(3_000_000n)
+    expect(res.depositorAddress.toBase58()).toBe(DEPOSITOR.toBase58())
+  })
+
+  it('throws when there is no deposit record', async () => {
+    await expect(buildRefundSolTx(mockConnRefund(null), DEPOSITOR)).rejects.toThrow(
+      'nothing to refund',
+    )
+  })
+
+  it('throws when the balance is zero', async () => {
+    await expect(
+      buildRefundSolTx(mockConnRefund(depositRecordBuf(0n)), DEPOSITOR),
+    ).rejects.toThrow('No balance to refund')
+  })
+})
+
+describe('buildAuthorityRefundSolTx', () => {
+  it('makes authority the signer and depositor a non-signer destination', async () => {
+    const res = await buildAuthorityRefundSolTx(
+      mockConnRefund(depositRecordBuf(4_000_000n)),
+      AUTHORITY,
+      DEPOSITOR,
+    )
+    const ix = res.transaction.instructions[0]
+    const [config] = deriveVaultConfigPDA()
+    const [record] = deriveDepositRecordPDA(DEPOSITOR, NATIVE_SOL_MINT)
+    const [solVault] = deriveSolVaultPDA()
+
+    expect(ix.keys.map((k) => k.pubkey.toBase58())).toEqual([
+      config.toBase58(),
+      record.toBase58(),
+      solVault.toBase58(),
+      DEPOSITOR.toBase58(),
+      AUTHORITY.toBase58(),
+    ])
+    expect(ix.keys.map((k) => k.isSigner)).toEqual([false, false, false, false, true])
+    expect(ix.keys.map((k) => k.isWritable)).toEqual([false, true, true, true, true])
+    expect(ix.data.equals(anchorDiscriminator('authority_refund_sol'))).toBe(true)
+    expect(res.transaction.feePayer?.toBase58()).toBe(AUTHORITY.toBase58())
+    expect(res.refundAmount).toBe(4_000_000n)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/vault-sol.test.ts -t Sol`
+Expected: FAIL — `buildRefundSolTx` / `buildAuthorityRefundSolTx` not exported.
+
+- [ ] **Step 3: Add the result type to `types.ts`** — after `RefundResult`:
+
+```ts
+export interface SolRefundResult {
+  transaction: Transaction
+  /** Amount being refunded (the depositor's available balance, in lamports) */
+  refundAmount: bigint
+  /** The depositor's main (system) account receiving the lamports */
+  depositorAddress: PublicKey
+}
+```
+
+- [ ] **Step 4: Implement both builders** — in `vault-sol.ts`, add `deserializeDepositRecord` to the `from './vault.js'` import, add `SolRefundResult` to the `from './types.js'` import, then append:
+
+```ts
+/**
+ * Build an unsigned native-SOL refund transaction (refund_sol). Depositor signs.
+ *
+ * Accounts (order matches the RefundSol context in lib.rs):
+ *   0. config         (ro)          — VaultConfig PDA
+ *   1. deposit_record (mut)         — DepositRecord PDA [.., depositor, NATIVE_SOL_MINT]
+ *   2. sol_vault      (mut)         — SolVault PDA
+ *   3. depositor      (mut, signer)
+ */
+export async function buildRefundSolTx(
+  connection: Connection,
+  depositor: PublicKey,
+  programId: PublicKey = SIPHER_VAULT_PROGRAM_ID
+): Promise<SolRefundResult> {
+  const [configPDA] = deriveVaultConfigPDA(programId)
+  const [depositRecordPDA] = deriveDepositRecordPDA(depositor, NATIVE_SOL_MINT, programId)
+  const [solVaultPDA] = deriveSolVaultPDA(programId)
+
+  const recordInfo = await connection.getAccountInfo(depositRecordPDA)
+  if (!recordInfo) {
+    throw new Error('No deposit record found — nothing to refund')
+  }
+  const record = deserializeDepositRecord(Buffer.from(recordInfo.data))
+  const refundAmount = record.balance
+  if (refundAmount <= 0n) {
+    throw new Error('No balance to refund')
+  }
+
+  const data = anchorDiscriminator('refund_sol')
+
+  const ix = new TransactionInstruction({
+    programId,
+    keys: [
+      { pubkey: configPDA, isSigner: false, isWritable: false },
+      { pubkey: depositRecordPDA, isSigner: false, isWritable: true },
+      { pubkey: solVaultPDA, isSigner: false, isWritable: true },
+      { pubkey: depositor, isSigner: true, isWritable: true },
+    ],
+    data,
+  })
+
+  const tx = new Transaction()
+  tx.add(ix)
+  tx.feePayer = depositor
+
+  const { blockhash } = await connection.getLatestBlockhash()
+  tx.recentBlockhash = blockhash
+
+  return { transaction: tx, refundAmount, depositorAddress: depositor }
+}
+
+/**
+ * Build an unsigned authority-signed native-SOL refund (authority_refund_sol).
+ * The authority signs on the depositor's behalf; the depositor is a non-signer
+ * lamport destination. The on-chain `has_one = depositor` guarantees principal
+ * returns to the original depositor, and the timeout is still enforced on-chain.
+ *
+ * Accounts (order matches the AuthorityRefundSol context in lib.rs):
+ *   0. config         (ro)          — VaultConfig PDA (has_one = authority)
+ *   1. deposit_record (mut)         — DepositRecord PDA [.., depositor, NATIVE_SOL_MINT]
+ *   2. sol_vault      (mut)         — SolVault PDA
+ *   3. depositor      (mut)         — NOT signer; validated by has_one
+ *   4. authority      (mut, signer)
+ */
+export async function buildAuthorityRefundSolTx(
+  connection: Connection,
+  authority: PublicKey,
+  depositor: PublicKey,
+  programId: PublicKey = SIPHER_VAULT_PROGRAM_ID
+): Promise<SolRefundResult> {
+  const [configPDA] = deriveVaultConfigPDA(programId)
+  const [depositRecordPDA] = deriveDepositRecordPDA(depositor, NATIVE_SOL_MINT, programId)
+  const [solVaultPDA] = deriveSolVaultPDA(programId)
+
+  const recordInfo = await connection.getAccountInfo(depositRecordPDA)
+  if (!recordInfo) {
+    throw new Error('No deposit record found — nothing to refund')
+  }
+  const record = deserializeDepositRecord(Buffer.from(recordInfo.data))
+  const refundAmount = record.balance
+  if (refundAmount <= 0n) {
+    throw new Error('No balance to refund')
+  }
+
+  const data = anchorDiscriminator('authority_refund_sol')
+
+  const ix = new TransactionInstruction({
+    programId,
+    keys: [
+      { pubkey: configPDA, isSigner: false, isWritable: false },
+      { pubkey: depositRecordPDA, isSigner: false, isWritable: true },
+      { pubkey: solVaultPDA, isSigner: false, isWritable: true },
+      { pubkey: depositor, isSigner: false, isWritable: true },
+      { pubkey: authority, isSigner: true, isWritable: true },
+    ],
+    data,
+  })
+
+  const tx = new Transaction()
+  tx.add(ix)
+  tx.feePayer = authority
+
+  const { blockhash } = await connection.getLatestBlockhash()
+  tx.recentBlockhash = blockhash
+
+  return { transaction: tx, refundAmount, depositorAddress: depositor }
+}
+```
+
+- [ ] **Step 5: Export from the barrel** — add `buildRefundSolTx`, `buildAuthorityRefundSolTx` to the `./vault-sol.js` block, and `SolRefundResult` to the `export type { … } from './types.js'` block.
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/vault-sol.test.ts`
+Expected: PASS (12 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/sdk/src/types.ts packages/sdk/src/vault-sol.ts packages/sdk/src/index.ts packages/sdk/tests/vault-sol.test.ts
+git commit -S -m "feat(sdk): buildRefundSolTx + buildAuthorityRefundSolTx"
+```
+
+---
+
+## Task 4: `buildPrivateSendSolTx` (native-SOL stealth withdraw)
+
+**Files:**
+- Create: `packages/sdk/src/privacy-sol.ts`
+- Modify: `packages/sdk/src/index.ts`
+- Test: `packages/sdk/tests/privacy-sol.test.ts`
+
+**Interfaces:**
+- Consumes: `deriveSolVaultPDA`, `deriveSolFeePDA` (Task 1); `anchorDiscriminator`, `deriveVaultConfigPDA`, `deriveDepositRecordPDA` (vault.ts); `NATIVE_SOL_MINT`, `SIP_PRIVACY_PROGRAM_ID`, `SIP_CONFIG_SEED`, `SIP_TRANSFER_RECORD_SEED`, `ANCHOR_DISCRIMINATOR_SIZE` (config.ts); `WithdrawResult` (types.ts).
+- Produces: `PrivateSendSolParams`; `buildPrivateSendSolTx(params: PrivateSendSolParams): Promise<WithdrawResult>`.
+
+- [ ] **Step 1: Write the failing test** — create `packages/sdk/tests/privacy-sol.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { Connection, PublicKey, SystemProgram } from '@solana/web3.js'
+import {
+  buildPrivateSendSolTx,
+  deriveVaultConfigPDA,
+  deriveDepositRecordPDA,
+  deriveSolVaultPDA,
+  deriveSolFeePDA,
+  anchorDiscriminator,
+  NATIVE_SOL_MINT,
+  SIP_PRIVACY_PROGRAM_ID,
+} from '../src/index.js'
+import { SIP_CONFIG_SEED } from '../src/config.js'
+
+const BLOCKHASH = 'GfVcyD4kkTrj4bKc7WA9sZCin9JDbdT458zqL4zjxx2v'
+const DEPOSITOR = new PublicKey('FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr')
+const STEALTH = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA')
+
+const commitment = new Uint8Array(33).fill(2)
+const ephemeral = new Uint8Array(33).fill(3)
+const vkHash = new Uint8Array(32).fill(4)
+const encrypted = new Uint8Array([9, 9, 9])
+const proof = new Uint8Array([])
+
+// Dispatching Connection stub. fee_bps lives at config offset 40 (u16 LE);
+// sip total_transfers at offset 8+32+2+1 = 43 (u64 LE).
+function mockConn(opts: {
+  feeBps?: number
+  stealthLamports?: number | null
+  rentExemptMin?: number
+} = {}): Connection {
+  const { feeBps = 10, stealthLamports = null, rentExemptMin = 890_880 } = opts
+  const configBuf = Buffer.alloc(60)
+  configBuf.writeUInt16LE(feeBps, 40)
+  const sipBuf = Buffer.alloc(8 + 32 + 2 + 1 + 8) // total_transfers = 0
+  const [cfg] = deriveVaultConfigPDA()
+  const [sip] = PublicKey.findProgramAddressSync([SIP_CONFIG_SEED], SIP_PRIVACY_PROGRAM_ID)
+  return {
+    getLatestBlockhash: async () => ({ blockhash: BLOCKHASH, lastValidBlockHeight: 1 }),
+    getMinimumBalanceForRentExemption: async () => rentExemptMin,
+    getAccountInfo: async (pk: PublicKey) => {
+      if (pk.equals(cfg)) return { data: configBuf } as never
+      if (pk.equals(sip)) return { data: sipBuf } as never
+      if (stealthLamports === null) return null
+      return { lamports: stealthLamports, data: Buffer.alloc(0) } as never
+    },
+  } as unknown as Connection
+}
+
+const baseParams = {
+  depositor: DEPOSITOR,
+  amount: 2_000_000n,
+  stealthPubkey: STEALTH,
+  amountCommitment: commitment,
+  ephemeralPubkey: ephemeral,
+  viewingKeyHash: vkHash,
+  encryptedAmount: encrypted,
+  proof,
+}
+
+describe('buildPrivateSendSolTx', () => {
+  it('builds withdraw_private_sol with the exact 10-account order + flags', async () => {
+    // stealth pre-funded above the rent floor so the guard passes
+    const res = await buildPrivateSendSolTx({
+      ...baseParams,
+      connection: mockConn({ stealthLamports: 1_000_000_000 }),
+    })
+    const ix = res.transaction.instructions[0]
+    const [config] = deriveVaultConfigPDA()
+    const [record] = deriveDepositRecordPDA(DEPOSITOR, NATIVE_SOL_MINT)
+    const [solVault] = deriveSolVaultPDA()
+    const [solFee] = deriveSolFeePDA()
+    const [sipConfig] = PublicKey.findProgramAddressSync([SIP_CONFIG_SEED], SIP_PRIVACY_PROGRAM_ID)
+
+    expect(ix.keys.length).toBe(10)
+    expect(ix.keys.slice(0, 6).map((k) => k.pubkey.toBase58())).toEqual([
+      config.toBase58(),
+      record.toBase58(),
+      solVault.toBase58(),
+      solFee.toBase58(),
+      STEALTH.toBase58(),
+      DEPOSITOR.toBase58(),
+    ])
+    expect(ix.keys[8].pubkey.toBase58()).toBe(SIP_PRIVACY_PROGRAM_ID.toBase58())
+    expect(ix.keys[9].pubkey.toBase58()).toBe(SystemProgram.programId.toBase58())
+    // only depositor (index 5) signs
+    expect(ix.keys.map((k) => k.isSigner)).toEqual([
+      false, false, false, false, false, true, false, false, false, false,
+    ])
+    // config(ro), sip_program(ro), system(ro) are non-writable; the rest writable
+    expect(ix.keys.map((k) => k.isWritable)).toEqual([
+      false, true, true, true, true, true, true, true, false, false,
+    ])
+    expect(ix.keys[6].pubkey.equals(sipConfig)).toBe(true)
+  })
+
+  it('encodes the discriminator + amount and computes fee/net from config', async () => {
+    const res = await buildPrivateSendSolTx({
+      ...baseParams,
+      connection: mockConn({ feeBps: 10, stealthLamports: 1_000_000_000 }),
+    })
+    const data = res.transaction.instructions[0].data
+    expect(data.subarray(0, 8).equals(anchorDiscriminator('withdraw_private_sol'))).toBe(true)
+    expect(data.readBigUInt64LE(8)).toBe(2_000_000n)
+    // 10 bps of 2_000_000 = 2_000
+    expect(res.feeAmount).toBe(2_000n)
+    expect(res.netAmount).toBe(1_998_000n)
+    expect(res.stealthAddress.toBase58()).toBe(STEALTH.toBase58())
+  })
+
+  it('throws when a fresh stealth recipient would be left below rent-exempt', async () => {
+    // stealth does not exist (0 lamports); net 1_998_000 < 890_880? No — so make the
+    // payout tiny: amount 1000 => net 999 < rent floor => must throw.
+    await expect(
+      buildPrivateSendSolTx({
+        ...baseParams,
+        amount: 1_000n,
+        connection: mockConn({ stealthLamports: null }),
+      }),
+    ).rejects.toThrow('rent-exempt minimum')
+  })
+
+  it('passes when the stealth recipient is already rent-exempt', async () => {
+    const res = await buildPrivateSendSolTx({
+      ...baseParams,
+      amount: 1_000n,
+      connection: mockConn({ stealthLamports: 890_880 }),
+    })
+    expect(res.transaction.instructions).toHaveLength(1)
+  })
+
+  it('rejects malformed crypto field lengths', async () => {
+    await expect(
+      buildPrivateSendSolTx({
+        ...baseParams,
+        amountCommitment: new Uint8Array(32), // wrong length
+        connection: mockConn({ stealthLamports: 1_000_000_000 }),
+      }),
+    ).rejects.toThrow('amountCommitment must be 33 bytes')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/privacy-sol.test.ts`
+Expected: FAIL — `buildPrivateSendSolTx` not exported.
+
+- [ ] **Step 3: Create `privacy-sol.ts`**:
+
+```ts
+import {
+  Connection,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+} from '@solana/web3.js'
+import {
+  SIPHER_VAULT_PROGRAM_ID,
+  SIP_PRIVACY_PROGRAM_ID,
+  SIP_CONFIG_SEED,
+  SIP_TRANSFER_RECORD_SEED,
+  NATIVE_SOL_MINT,
+  ANCHOR_DISCRIMINATOR_SIZE,
+} from './config.js'
+import {
+  anchorDiscriminator,
+  deriveVaultConfigPDA,
+  deriveDepositRecordPDA,
+} from './vault.js'
+import { deriveSolVaultPDA, deriveSolFeePDA } from './vault-sol.js'
+import type { WithdrawResult } from './types.js'
+
+export interface PrivateSendSolParams {
+  connection: Connection
+  /** The depositor who owns the native-SOL vault balance */
+  depositor: PublicKey
+  /** Amount of lamports to withdraw (gross, before fees) */
+  amount: bigint
+  /** The stealth recipient pubkey — also the plain SystemAccount that receives lamports */
+  stealthPubkey: PublicKey
+  /** Pedersen commitment: C = amount*G + blinding*H (33 bytes compressed) */
+  amountCommitment: Uint8Array
+  /** Ephemeral pubkey for ECDH (33 bytes compressed) */
+  ephemeralPubkey: Uint8Array
+  /** SHA-256 hash of the viewing key (32 bytes) */
+  viewingKeyHash: Uint8Array
+  /** Encrypted amount blob (for recipient to decrypt with viewing key) */
+  encryptedAmount: Uint8Array
+  /** ZK proof bytes (verified off-chain; may be empty) */
+  proof: Uint8Array
+  /** Program ID override */
+  programId?: PublicKey
+}
+
+/**
+ * Build an unsigned native-SOL withdraw_private_sol transaction: withdraw lamports
+ * from the shared SolVault to a stealth recipient, with a Pedersen commitment hiding
+ * the amount and a sip_privacy announcement CPI. Mirrors buildPrivateSendTx with the
+ * token accounts replaced by sol_vault / sol_fee and a plain SystemAccount recipient.
+ *
+ * Accounts (order matches the WithdrawPrivateSol context in lib.rs):
+ *   0. config              (ro)   — VaultConfig PDA
+ *   1. deposit_record      (mut)  — DepositRecord PDA [.., depositor, NATIVE_SOL_MINT]
+ *   2. sol_vault           (mut)  — SolVault PDA
+ *   3. sol_fee             (mut)  — SolFee PDA
+ *   4. stealth             (mut)  — stealth recipient (SystemAccount)
+ *   5. depositor           (mut, signer)
+ *   6. sip_config          (mut)  — SIP Privacy Config PDA (CPI)
+ *   7. sip_transfer_record (mut)  — TransferRecord PDA (init by CPI)
+ *   8. sip_privacy_program (ro)
+ *   9. system_program      (ro)
+ */
+export async function buildPrivateSendSolTx(
+  params: PrivateSendSolParams
+): Promise<WithdrawResult> {
+  const {
+    connection,
+    depositor,
+    amount,
+    stealthPubkey,
+    amountCommitment,
+    ephemeralPubkey,
+    viewingKeyHash,
+    encryptedAmount,
+    proof,
+    programId = SIPHER_VAULT_PROGRAM_ID,
+  } = params
+
+  if (amount <= 0n) {
+    throw new Error('Withdrawal amount must be greater than zero')
+  }
+  if (amountCommitment.length !== 33) {
+    throw new Error(`amountCommitment must be 33 bytes, got ${amountCommitment.length}`)
+  }
+  if (ephemeralPubkey.length !== 33) {
+    throw new Error(`ephemeralPubkey must be 33 bytes, got ${ephemeralPubkey.length}`)
+  }
+  if (viewingKeyHash.length !== 32) {
+    throw new Error(`viewingKeyHash must be 32 bytes, got ${viewingKeyHash.length}`)
+  }
+
+  const [configPDA] = deriveVaultConfigPDA(programId)
+  const [depositRecordPDA] = deriveDepositRecordPDA(depositor, NATIVE_SOL_MINT, programId)
+  const [solVaultPDA] = deriveSolVaultPDA(programId)
+  const [solFeePDA] = deriveSolFeePDA(programId)
+  const [sipConfigPDA] = PublicKey.findProgramAddressSync(
+    [SIP_CONFIG_SEED],
+    SIP_PRIVACY_PROGRAM_ID
+  )
+
+  // Parallel reads: vault config (fee), sip config (total_transfers), rent floor,
+  // and the stealth recipient's current balance (for the rent-exempt guard).
+  const [configInfo, sipConfigInfo, rentExemptMin, stealthInfo] = await Promise.all([
+    connection.getAccountInfo(configPDA),
+    connection.getAccountInfo(sipConfigPDA),
+    connection.getMinimumBalanceForRentExemption(0),
+    connection.getAccountInfo(stealthPubkey),
+  ])
+
+  let feeBps = 10 // fallback to default
+  if (configInfo) {
+    // fee_bps at offset 8 (disc) + 32 (authority) = 40, u16 LE
+    feeBps = configInfo.data.readUInt16LE(40)
+  }
+
+  let sipTotalTransfers = 0n
+  if (sipConfigInfo) {
+    // after 8-byte disc: authority(32) + fee_bps(2) + paused(1) + total_transfers(u64)
+    sipTotalTransfers = sipConfigInfo.data.readBigUInt64LE(
+      ANCHOR_DISCRIMINATOR_SIZE + 32 + 2 + 1
+    )
+  }
+
+  const totalTransfersBuffer = Buffer.alloc(8)
+  totalTransfersBuffer.writeBigUInt64LE(sipTotalTransfers)
+  const [sipTransferRecordPDA] = PublicKey.findProgramAddressSync(
+    [SIP_TRANSFER_RECORD_SEED, depositor.toBuffer(), totalTransfersBuffer],
+    SIP_PRIVACY_PROGRAM_ID
+  )
+
+  const feeAmount = (amount * BigInt(feeBps)) / 10_000n
+  const netAmount = amount - feeAmount
+
+  // Rent-exempt guard: the stealth recipient is a plain system account. The runtime
+  // rejects a tx that leaves a touched account with a non-zero balance below the
+  // rent-exempt minimum, so a small payout to a never-funded stealth would fail.
+  // Surface it with an actionable error instead of an opaque runtime reject.
+  const currentLamports = BigInt(stealthInfo?.lamports ?? 0)
+  if (currentLamports + netAmount < BigInt(rentExemptMin)) {
+    throw new Error(
+      `Stealth recipient ${stealthPubkey.toBase58()} would be left below the ` +
+        `rent-exempt minimum (needs >= ${rentExemptMin} lamports after the payout; ` +
+        `would have ${currentLamports + netAmount}). Pre-fund the stealth account to ` +
+        `at least ${rentExemptMin} lamports before withdrawing.`
+    )
+  }
+
+  // Serialize: disc(8) + amount(8) + commitment(33) + stealth_pubkey(32)
+  //          + ephemeral(33) + vk_hash(32) + encrypted(4+len) + proof(4+len)
+  const fixedSize = 8 + 8 + 33 + 32 + 33 + 32
+  const vecOverhead = 4 + encryptedAmount.length + 4 + proof.length
+  const data = Buffer.alloc(fixedSize + vecOverhead)
+  let offset = 0
+
+  anchorDiscriminator('withdraw_private_sol').copy(data, offset)
+  offset += 8
+  data.writeBigUInt64LE(amount, offset)
+  offset += 8
+  Buffer.from(amountCommitment).copy(data, offset)
+  offset += 33
+  stealthPubkey.toBuffer().copy(data, offset)
+  offset += 32
+  Buffer.from(ephemeralPubkey).copy(data, offset)
+  offset += 33
+  Buffer.from(viewingKeyHash).copy(data, offset)
+  offset += 32
+  data.writeUInt32LE(encryptedAmount.length, offset)
+  offset += 4
+  Buffer.from(encryptedAmount).copy(data, offset)
+  offset += encryptedAmount.length
+  data.writeUInt32LE(proof.length, offset)
+  offset += 4
+  Buffer.from(proof).copy(data, offset)
+
+  const ix = new TransactionInstruction({
+    programId,
+    keys: [
+      { pubkey: configPDA, isSigner: false, isWritable: false },
+      { pubkey: depositRecordPDA, isSigner: false, isWritable: true },
+      { pubkey: solVaultPDA, isSigner: false, isWritable: true },
+      { pubkey: solFeePDA, isSigner: false, isWritable: true },
+      { pubkey: stealthPubkey, isSigner: false, isWritable: true },
+      { pubkey: depositor, isSigner: true, isWritable: true },
+      { pubkey: sipConfigPDA, isSigner: false, isWritable: true },
+      { pubkey: sipTransferRecordPDA, isSigner: false, isWritable: true },
+      { pubkey: SIP_PRIVACY_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data,
+  })
+
+  const tx = new Transaction()
+  tx.add(ix)
+  tx.feePayer = depositor
+
+  const { blockhash } = await connection.getLatestBlockhash()
+  tx.recentBlockhash = blockhash
+
+  return {
+    transaction: tx,
+    netAmount,
+    feeAmount,
+    stealthAddress: stealthPubkey,
+  }
+}
+```
+
+- [ ] **Step 4: Export from the barrel** — add a new block in `index.ts` after the `./privacy.js` block:
+
+```ts
+// Native-SOL privacy operations
+export { buildPrivateSendSolTx } from './privacy-sol.js'
+export type { PrivateSendSolParams } from './privacy-sol.js'
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm vitest run tests/privacy-sol.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/sdk/src/privacy-sol.ts packages/sdk/src/index.ts packages/sdk/tests/privacy-sol.test.ts
+git commit -S -m "feat(sdk): buildPrivateSendSolTx with rent-exempt recipient guard"
+```
+
+---
+
+## Task 5: `buildCreateSolVaultTx` (optional) + barrel smoke test + full-green gate
+
+> `buildCreateSolVaultTx` is the lowest-priority surface item — the SOL PDAs already exist on the current devnet deployment, so it has no immediate consumer. Implement it for completeness; it is safe to skip without blocking the other builders.
+
+**Files:**
+- Modify: `packages/sdk/src/vault-sol.ts`
+- Modify: `packages/sdk/src/index.ts`
+- Test: `packages/sdk/tests/vault-sol.test.ts`
+
+**Interfaces:**
+- Consumes: `deriveSolVaultPDA`, `deriveSolFeePDA`, `deriveVaultConfigPDA`, `anchorDiscriminator`.
+- Produces: `buildCreateSolVaultTx(connection, payer, programId?): Promise<Transaction>`.
+
+- [ ] **Step 1: Write the failing test** — append to `tests/vault-sol.test.ts`:
+
+```ts
+import { buildCreateSolVaultTx } from '../src/index.js'
+
+describe('buildCreateSolVaultTx', () => {
+  it('builds create_sol_vault with the exact CreateSolVault account order + flags', async () => {
+    const payer = DEPOSITOR
+    const tx = await buildCreateSolVaultTx(mockConnDeposit(), payer)
+    const ix = tx.instructions[0]
+    const [config] = deriveVaultConfigPDA()
+    const [solVault] = deriveSolVaultPDA()
+    const [solFee] = deriveSolFeePDA()
+
+    expect(ix.keys.map((k) => k.pubkey.toBase58())).toEqual([
+      config.toBase58(),
+      solVault.toBase58(),
+      solFee.toBase58(),
+      payer.toBase58(),
+      SystemProgram.programId.toBase58(),
+    ])
+    expect(ix.keys.map((k) => k.isSigner)).toEqual([false, false, false, true, false])
+    expect(ix.keys.map((k) => k.isWritable)).toEqual([false, true, true, true, false])
+    expect(ix.data.equals(anchorDiscriminator('create_sol_vault'))).toBe(true)
+    expect(tx.feePayer?.toBase58()).toBe(payer.toBase58())
+  })
+})
+```
+
+> Note: `deriveSolFeePDA` must be in the test file's `../src/index.js` import.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run tests/vault-sol.test.ts -t buildCreateSolVaultTx`
+Expected: FAIL — `buildCreateSolVaultTx` not exported.
+
+- [ ] **Step 3: Implement `buildCreateSolVaultTx`** — append to `vault-sol.ts`:
+
+```ts
+/**
+ * Build an unsigned create_sol_vault transaction — one-time init of the singleton
+ * SolVault + SolFee PDAs. Payer funds the rent-exempt reserve for both. No args.
+ *
+ * Accounts (order matches the CreateSolVault context in lib.rs):
+ *   0. config         (ro)          — VaultConfig PDA
+ *   1. sol_vault      (init, mut)   — SolVault PDA
+ *   2. sol_fee        (init, mut)   — SolFee PDA
+ *   3. payer          (mut, signer)
+ *   4. system_program (ro)
+ */
+export async function buildCreateSolVaultTx(
+  connection: Connection,
+  payer: PublicKey,
+  programId: PublicKey = SIPHER_VAULT_PROGRAM_ID
+): Promise<Transaction> {
+  const [configPDA] = deriveVaultConfigPDA(programId)
+  const [solVaultPDA] = deriveSolVaultPDA(programId)
+  const [solFeePDA] = deriveSolFeePDA(programId)
+
+  const data = anchorDiscriminator('create_sol_vault')
+
+  const ix = new TransactionInstruction({
+    programId,
+    keys: [
+      { pubkey: configPDA, isSigner: false, isWritable: false },
+      { pubkey: solVaultPDA, isSigner: false, isWritable: true },
+      { pubkey: solFeePDA, isSigner: false, isWritable: true },
+      { pubkey: payer, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data,
+  })
+
+  const tx = new Transaction()
+  tx.add(ix)
+  tx.feePayer = payer
+
+  const { blockhash } = await connection.getLatestBlockhash()
+  tx.recentBlockhash = blockhash
+
+  return tx
+}
+```
+
+- [ ] **Step 4: Export from the barrel** — add `buildCreateSolVaultTx` to the `./vault-sol.js` block in `index.ts`.
+
+- [ ] **Step 5: Run the new test to verify it passes**
+
+Run: `pnpm vitest run tests/vault-sol.test.ts -t buildCreateSolVaultTx`
+Expected: PASS.
+
+- [ ] **Step 6: Add a barrel-export smoke test** — append to `tests/vault-sol.test.ts`:
+
+```ts
+import * as sdk from '../src/index.js'
+
+describe('barrel exports (native-SOL surface)', () => {
+  it('re-exports every native-SOL symbol', () => {
+    for (const name of [
+      'NATIVE_SOL_MINT',
+      'VAULT_SOL_SEED',
+      'FEE_SOL_SEED',
+      'deriveSolVaultPDA',
+      'deriveSolFeePDA',
+      'buildDepositSolTx',
+      'buildRefundSolTx',
+      'buildAuthorityRefundSolTx',
+      'buildCreateSolVaultTx',
+      'buildPrivateSendSolTx',
+    ]) {
+      expect(sdk).toHaveProperty(name)
+    }
+  })
+})
+```
+
+- [ ] **Step 7: Full green gate** — run the whole suite + typecheck:
+
+Run: `pnpm test`
+Expected: PASS — the entire SDK suite (existing tests + all new native-SOL tests) green.
+
+Run: `pnpm exec tsc --noEmit`
+Expected: no type errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/sdk/src/vault-sol.ts packages/sdk/src/index.ts packages/sdk/tests/vault-sol.test.ts
+git commit -S -m "feat(sdk): buildCreateSolVaultTx + native-SOL barrel export smoke test"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage**
+
+| Spec section | Task |
+|---|---|
+| §4.1 config consts (`NATIVE_SOL_MINT`, seeds) | Task 1 |
+| §4.2 PDA derivation (`deriveSolVaultPDA`/`deriveSolFeePDA`) | Task 1 |
+| §4.3 `buildDepositSolTx` | Task 2 |
+| §4.3 `buildRefundSolTx` / `buildAuthorityRefundSolTx` | Task 3 |
+| §4.3 `buildCreateSolVaultTx` (optional) | Task 5 |
+| §4.4 `buildPrivateSendSolTx` | Task 4 |
+| §4.5 reads (reuse `getVaultBalance`) | No code — documented; no task needed |
+| §4.6 result types (`SolDepositResult`/`SolRefundResult`) | Tasks 2, 3 |
+| §5 `NATIVE_SOL_MINT` sentinel test | Task 1 |
+| §6 rent-exempt guard | Task 4 |
+| §7 error handling | Tasks 2–4 (validation + guard) |
+| §8 testing (account order, fixtures, fee, guard) | All tasks |
+
+No gaps. (§4.5 is intentionally code-free — it documents reuse of the existing read.)
+
+**2. Placeholder scan:** none — every step has complete code/commands/expected output.
+
+**3. Type consistency:** `SolDepositResult`/`SolRefundResult`/`PrivateSendSolParams` and the function signatures are used identically across the producing task and the barrel exports. `WithdrawResult` is reused unchanged. `deriveSolVaultPDA`/`deriveSolFeePDA` names are consistent between Task 1 (definition) and Tasks 2–5 (consumption).
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-06-24-sipher-sdk-native-sol-builders.md`.

--- a/docs/superpowers/specs/2026-06-24-sipher-sdk-native-sol-builders-design.md
+++ b/docs/superpowers/specs/2026-06-24-sipher-sdk-native-sol-builders-design.md
@@ -1,0 +1,329 @@
+# Native-SOL Transaction Builders for `@sipher/sdk` — Design
+
+- **Date:** 2026-06-24
+- **Status:** Approved (design) — pending implementation plan
+- **Scope:** `packages/sdk` (`@sipher/sdk`) — additive, non-breaking
+- **Author:** SIPHER
+
+---
+
+## 1. Context & motivation
+
+The `sipher_vault` Solana program is a **universal-asset** vault: it custodies classic
+SPL tokens, Token-2022 tokens, **and native SOL**. The native-SOL support is a first-class
+instruction set on-chain:
+
+| Instruction | Purpose |
+|---|---|
+| `create_sol_vault` | One-time init of the singleton `SolVault` + `SolFee` PDAs |
+| `deposit_sol` | Deposit native lamports into the shared vault |
+| `withdraw_private_sol` | Withdraw lamports to a stealth recipient + emit the announcement |
+| `refund_sol` | Depositor reclaims their own balance |
+| `authority_refund_sol` | Authority reclaims an expired deposit on the depositor's behalf |
+| `collect_fee_sol` | Authority sweeps accrued SOL fees |
+
+`@sipher/sdk` today exposes builders for the **token** path only:
+`buildDepositTx`, `buildPrivateSendTx`, `buildRefundTx`, `buildAuthorityRefundTx`,
+`getVaultBalance`, `getVaultConfig`. Every token builder hardcodes `TOKEN_PROGRAM_ID`
+and takes `tokenMint` / token-account arguments. **There is no way to drive the vault's
+native-SOL instructions from the SDK** — a consumer that wants native-SOL custody must
+hand-roll raw `TransactionInstruction`s (as the program's own devnet scripts do).
+
+This design closes that gap: it adds native-SOL builders that mirror the existing token
+builders one-for-one, so a consumer can deposit / withdraw / refund native SOL with the
+same ergonomics it already has for SPL.
+
+## 2. Goals / non-goals
+
+**Goals**
+- Expose typed, unsigned-transaction builders for `deposit_sol`, `withdraw_private_sol`,
+  `refund_sol`, `authority_refund_sol`, and the PDA-derivation + sentinel-mint constants
+  they need.
+- Byte-for-byte parity with the on-chain account orders and instruction-data layouts.
+- 100% reuse of the existing read path: native-SOL balances are read with the **existing**
+  `getVaultBalance(connection, depositor, NATIVE_SOL_MINT)` — no new read function.
+- Test the same cheap way the token builders are tested: pure unit tests that assert the
+  built transaction's account ordering, signer/writable flags, and instruction bytes,
+  cross-checked against a real on-chain PDA fixture. No bankrun, no live RPC.
+
+**Non-goals**
+- The `collect_fee_sol` builder (authority fee-sweep — operational, not part of the
+  deposit→withdraw flow). Deferred.
+- A native-SOL **gasless** cash-out path (the current relayer targets stealth-ATA SPL
+  withdrawals; a SOL gasless path has its own rent-prefund requirement — separate work).
+- Publishing `@sipher/sdk` to npm. Deferred to whenever a downstream package needs to
+  `import` it; the builders land + are reviewed in-repo first.
+- Any change to the `sipher_vault` program. The instructions already exist on-chain.
+
+## 3. Approach
+
+**Separate `*Sol` builder functions** mirroring the existing token builders.
+
+Two alternatives were considered and rejected:
+- **Unified `asset` discriminator** on the existing builders (`{kind:'sol'|'spl'}`): a
+  breaking signature change, internal branching, and the account sets genuinely differ
+  (the SOL path has no mint, no ATA, no token-program account, and the recipient is a
+  plain system account). Lower clarity, higher risk to the working token path.
+- **A stateful `VaultClient` class**: the SDK is functional/stateless (free functions
+  returning unsigned transactions). A class breaks the paradigm; a consumer composes the
+  free functions directly.
+
+Separate `*Sol` functions match (a) the program's own design — native SOL is a distinct
+instruction set, not a parameter on the token instructions — and (b) the SDK's existing
+function-per-instruction shape. The change is purely additive: no existing export changes.
+
+## 4. API surface
+
+All builders return an **unsigned** `Transaction` with `feePayer` and `recentBlockhash`
+set, exactly like the token builders. The caller signs.
+
+### 4.1 `config.ts` additions
+
+```ts
+/** Native-SOL sentinel mint. The vault seeds the native-SOL DepositRecord with the
+ *  all-zeros pubkey (on-chain: `Pubkey::new_from_array([0u8; 32])`). This is NOT wrapped
+ *  SOL — `WSOL_MINT` (So111…112) is a real SPL mint used by the *token* path; the native
+ *  path never wraps. Keep the two distinct. */
+export const NATIVE_SOL_MINT = new PublicKey(new Uint8Array(32)) // 1111…1111 (all zeros)
+
+/** SolVault PDA seed — singleton lamport-holding account. */
+export const VAULT_SOL_SEED = Buffer.from('vault_sol')
+
+/** SolFee PDA seed — singleton lamport fee sink. */
+export const FEE_SOL_SEED = Buffer.from('fee_sol')
+```
+
+### 4.2 PDA derivation (`vault.ts`)
+
+```ts
+/** SolVault PDA — seeds [b"vault_sol"]. Singleton (no per-mint variant). */
+export function deriveSolVaultPDA(programId = SIPHER_VAULT_PROGRAM_ID): [PublicKey, number]
+
+/** SolFee PDA — seeds [b"fee_sol"]. Singleton. */
+export function deriveSolFeePDA(programId = SIPHER_VAULT_PROGRAM_ID): [PublicKey, number]
+```
+
+The native-SOL `DepositRecord` PDA needs no new helper — it is the **existing**
+`deriveDepositRecordPDA(depositor, NATIVE_SOL_MINT, programId)` (the program seeds it with
+`[b"deposit_record", depositor, NATIVE_SOL_MINT]`).
+
+### 4.3 `vault.ts` builders
+
+#### `buildDepositSolTx(connection, depositor, amount, programId?) → SolDepositResult`
+
+Instruction `deposit_sol`. Accounts (order = `DepositSol` context):
+
+| # | Account | Signer | Writable | Derivation |
+|---|---|---|---|---|
+| 0 | config | – | ✓ | `[vault_config]` |
+| 1 | deposit_record | – | ✓ | `[deposit_record, depositor, NATIVE_SOL_MINT]` |
+| 2 | sol_vault | – | ✓ | `[vault_sol]` |
+| 3 | depositor | ✓ | ✓ | (arg) |
+| 4 | system_program | – | – | `SystemProgram.programId` |
+
+Data: `disc("deposit_sol")` + `amount` (`u64` LE) = 16 bytes. Validates `amount > 0n`.
+
+#### `buildRefundSolTx(connection, depositor, programId?) → SolRefundResult`
+
+Instruction `refund_sol`. Pre-fetches the `DepositRecord` to compute `refundAmount`
+(throws if no record / zero balance). Accounts (order = `RefundSol`):
+
+| # | Account | Signer | Writable | Derivation |
+|---|---|---|---|---|
+| 0 | config | – | – | `[vault_config]` |
+| 1 | deposit_record | – | ✓ | `[deposit_record, depositor, NATIVE_SOL_MINT]` |
+| 2 | sol_vault | – | ✓ | `[vault_sol]` |
+| 3 | depositor | ✓ | ✓ | (arg) |
+
+Data: `disc("refund_sol")` only (8 bytes).
+
+#### `buildAuthorityRefundSolTx(connection, authority, depositor, programId?) → SolRefundResult`
+
+Instruction `authority_refund_sol`. Authority signs on the depositor's behalf; the
+depositor is a **non-signer** `SystemAccount` lamport destination (the on-chain
+`has_one = depositor` guarantees principal returns to the original depositor; the timeout
+is still enforced on-chain). Accounts (order = `AuthorityRefundSol`):
+
+| # | Account | Signer | Writable | Derivation |
+|---|---|---|---|---|
+| 0 | config | – | – | `[vault_config]` (`has_one = authority`) |
+| 1 | deposit_record | – | ✓ | `[deposit_record, depositor, NATIVE_SOL_MINT]` |
+| 2 | sol_vault | – | ✓ | `[vault_sol]` |
+| 3 | depositor | – | ✓ | (arg) — non-signer |
+| 4 | authority | ✓ | ✓ | (arg) |
+
+Data: `disc("authority_refund_sol")` only (8 bytes).
+
+#### `buildCreateSolVaultTx(payer, programId?) → Transaction` — optional / lowest priority
+
+Instruction `create_sol_vault` (one-time, no args). Accounts: config(ro), sol_vault(init,mut),
+sol_fee(init,mut), payer(signer,mut), system_program. Included for surface completeness so a
+fresh deployment can be bootstrapped through the SDK rather than the standalone script; the
+PDAs already exist on the current devnet deployment, so this is not on the critical path.
+
+### 4.4 `privacy.ts` builder — `buildPrivateSendSolTx(params) → WithdrawResult`
+
+Instruction `withdraw_private_sol`. Mirrors `buildPrivateSendTx` with every token account
+replaced by the lamport equivalents: the source is `sol_vault`, the fee sink is `sol_fee`,
+and the recipient is a **plain `SystemAccount`** — the raw stealth pubkey itself, with **no
+ATA and no mint check**. The four `sip_privacy` CPI accounts + system program are identical
+to the token context.
+
+`PrivateSendSolParams` drops `tokenMint` and `stealthTokenAccount` from the token version;
+the recipient is just `stealthPubkey` (used both as account #4 and inside the instruction
+data). All other fields are unchanged: `amount`, `amountCommitment` (33), `ephemeralPubkey`
+(33), `viewingKeyHash` (32), `encryptedAmount`, `proof`. The fee is read from `VaultConfig`
+(`fee_bps` at offset 40, `u16` LE) exactly as the token builder does.
+
+Accounts (order = `WithdrawPrivateSol` context):
+
+| # | Account | Signer | Writable | Derivation |
+|---|---|---|---|---|
+| 0 | config | – | – | `[vault_config]` |
+| 1 | deposit_record | – | ✓ | `[deposit_record, depositor, NATIVE_SOL_MINT]` |
+| 2 | sol_vault | – | ✓ | `[vault_sol]` |
+| 3 | sol_fee | – | ✓ | `[fee_sol]` |
+| 4 | stealth | – | ✓ | `stealthPubkey` (SystemAccount) |
+| 5 | depositor | ✓ | ✓ | (param) |
+| 6 | sip_config | – | ✓ | `[config]` @ `SIP_PRIVACY_PROGRAM_ID` |
+| 7 | sip_transfer_record | – | ✓ | `[transfer_record, depositor, total_transfers]` @ sip_privacy |
+| 8 | sip_privacy_program | – | – | `SIP_PRIVACY_PROGRAM_ID` |
+| 9 | system_program | – | – | `SystemProgram.programId` |
+
+Data layout (identical to the token withdraw): `disc("withdraw_private_sol")` + `amount`
+(`u64`) + `amount_commitment` (33) + `stealth_pubkey` (32) + `ephemeral_pubkey` (33) +
+`viewing_key_hash` (32) + `encrypted_amount` (`u32` len + bytes) + `proof` (`u32` len + bytes).
+
+The `sip_transfer_record` PDA is derived exactly as in `buildPrivateSendTx`: read
+`total_transfers` from the live `sip_privacy` Config, then
+`[b"transfer_record", depositor, total_transfers_le]`.
+
+### 4.5 Reads — no new function
+
+`getVaultBalance(connection, depositor, NATIVE_SOL_MINT)` already returns the native-SOL
+balance: the `DepositRecord` struct is asset-agnostic and is seeded by the sentinel mint.
+The design only documents this; it adds nothing.
+
+### 4.6 Result types (`types.ts`)
+
+`WithdrawResult` is reused as-is for `buildPrivateSendSolTx` — its fields
+(`transaction`, `netAmount`, `feeAmount`, `stealthAddress`) are all asset-accurate.
+
+The token `DepositResult` / `RefundResult` have token-specific field names
+(`vaultTokenAddress`, `depositorTokenAddress`) that would be wrong for SOL, so two small,
+honestly-named result types are added rather than overloading the token ones:
+
+```ts
+export interface SolDepositResult {
+  transaction: Transaction
+  depositRecordAddress: PublicKey
+  solVaultAddress: PublicKey
+  amount: bigint
+}
+
+export interface SolRefundResult {
+  transaction: Transaction
+  refundAmount: bigint
+  /** The depositor's main (system) account receiving the lamports. */
+  depositorAddress: PublicKey
+}
+```
+
+## 5. The `NATIVE_SOL_MINT` sentinel — the one easy-to-miss detail
+
+The native-SOL `DepositRecord` is seeded with the **all-zeros pubkey**, not wrapped-SOL.
+A reader who assumes "SOL = `WSOL_MINT`" will derive the wrong `DepositRecord` PDA and the
+builder will target a non-existent account. The constant is named, documented, and unit
+tests assert it derives the correct (real, on-chain) PDA — see §8.
+
+## 6. Rent-exempt floor on the stealth recipient — the SOL-specific safety wrinkle
+
+`withdraw_private_sol` pays a **plain `SystemAccount`** (the stealth pubkey directly).
+Solana **rejects** any transaction that leaves a touched account with a non-zero balance
+below its rent-exempt minimum (~890,880 lamports for a 0-data account). So a small payout
+to a **never-funded** stealth address fails at the runtime, not in the program. This is a
+known scar (the SDK/relayer must pre-fund fresh stealth payouts).
+
+**Resolution (decided): the builder throws a clear, actionable error by default.**
+
+`buildPrivateSendSolTx` will, before constructing the transaction:
+1. fetch the stealth account's current lamports (`getAccountInfo`, treat missing as `0`),
+2. fetch the 0-data rent-exempt minimum (`getMinimumBalanceForRentExemption(0)`),
+3. compute `net = amount - fee`,
+4. if `currentLamports + net < rentExemptMin`, throw:
+
+```
+Stealth recipient <pubkey> would be left below the rent-exempt minimum
+(needs >= <rentExemptMin> lamports after the payout; would have <current+net>).
+Pre-fund the stealth account to at least <rentExemptMin> lamports before withdrawing.
+```
+
+The caller (the eventual integration adapter, or a relayer) decides how to satisfy the
+floor — top up the stealth, or batch a funding transfer. The builder stays honest and does
+not silently move extra lamports. (An opt-in auto-prefund flag was considered and
+deliberately deferred — it needs a funding source and hides lamport movement.)
+
+## 7. Error handling
+
+Mirrors the existing builders' style — plain `Error` with a specific, actionable message
+(the SDK does not use a typed error hierarchy). Validation, before building:
+- `amount <= 0n` → "amount must be greater than zero" (all builders that take an amount).
+- `amountCommitment.length !== 33`, `ephemeralPubkey.length !== 33`,
+  `viewingKeyHash.length !== 32` → exact-byte-length errors (withdraw only; reuse the
+  token builder's checks verbatim).
+- refund builders: missing `DepositRecord` → "No deposit record found — nothing to refund";
+  zero balance → "No balance to refund".
+- withdraw: the rent-exempt guard in §6.
+
+No silent failures; every error names the offending value.
+
+## 8. Testing strategy
+
+Pure-unit, mirroring `tests/vault.test.ts` and `tests/privacy.test.ts` (build the tx →
+assert structure; mock `Connection`). New `tests/vault-sol.test.ts` plus native-SOL cases
+appended to the privacy suite.
+
+**PDA fixtures (real, on-chain — the strongest assertion):** the current devnet deployment
+has `SolVault = 8ZG46epBDrRbZ2oDneuemmSuQNNG3R58LhFo8Do2p6sq` and
+`SolFee = 519L2NQN16H1fnN9iPu2r2ipmjPj156yWMPQumw8PkZ4`. `deriveSolVaultPDA()` /
+`deriveSolFeePDA()` must reproduce these exactly.
+
+Per builder:
+- **Discriminator parity:** `anchorDiscriminator("deposit_sol" | "withdraw_private_sol" |
+  "refund_sol" | "authority_refund_sol")` equals the first 8 bytes of the built data.
+- **Account order + flags:** assert the full `keys` array (pubkey, `isSigner`, `isWritable`)
+  matches the program context tables in §4, index by index. This is the load-bearing test —
+  a reordered or mis-flagged account is the most likely defect.
+- **Instruction data:** byte-exact layout (offsets, LE encodings, vec length prefixes).
+- **`deposit_record` seed:** derived with `NATIVE_SOL_MINT`, not `WSOL_MINT`.
+- **`authority_refund_sol`:** depositor is **non-signer**, authority **signer** — explicit
+  assertion (the most security-relevant flag).
+- **withdraw fee:** computed from a mocked `VaultConfig` `fee_bps`; `netAmount`/`feeAmount`
+  correct.
+- **rent-exempt guard:** mock a fresh (0-lamport) stealth + a `net` below the rent floor →
+  expect the throw; mock a pre-funded stealth → expect success.
+- **feePayer / blockhash:** set correctly (depositor for deposit/refund/withdraw, authority
+  for authority-refund, payer for create-sol-vault).
+
+Connection mocking follows the existing suites: stub `getLatestBlockhash`,
+`getAccountInfo` (config / deposit_record / sip_config / stealth), and
+`getMinimumBalanceForRentExemption`.
+
+## 9. Out of scope (explicit)
+
+- `collect_fee_sol` builder (operational fee-sweep).
+- Native-SOL gasless cash-out (relayer integration).
+- Publishing `@sipher/sdk` to npm (deferred; needs its own access/README/changeset prep).
+- Any downstream consumer/adapter that uses these builders (separate work).
+- Any `sipher_vault` program change.
+
+## 10. Decisions log
+
+| # | Decision | Choice |
+|---|---|---|
+| D1 | API shape | Separate `*Sol` builders (mirror token builders + program design) |
+| D2 | Rent-exempt floor on stealth recipient | Builder throws a clear error by default; caller pre-funds |
+| D3 | Publish `@sipher/sdk` | Defer — builders + tests land in-repo this cycle |
+| D4 | Result types | Reuse `WithdrawResult`; add `SolDepositResult` / `SolRefundResult` |
+| D5 | Native-SOL balance reads | Reuse `getVaultBalance(…, NATIVE_SOL_MINT)` — no new fn |
+| D6 | `create_sol_vault` builder | Include as optional/lowest-priority surface completeness |

--- a/packages/sdk/src/config.ts
+++ b/packages/sdk/src/config.ts
@@ -24,6 +24,16 @@ export const DEPOSIT_RECORD_SEED = Buffer.from('deposit_record')
 export const VAULT_TOKEN_SEED = Buffer.from('vault_token')
 export const FEE_TOKEN_SEED = Buffer.from('fee_token')
 
+// Native-SOL sentinel mint. The vault seeds the native-SOL DepositRecord with the
+// all-zeros pubkey (on-chain: Pubkey::new_from_array([0u8; 32])). This is NOT wrapped
+// SOL — WSOL_MINT (So111…112) is a real SPL mint used by the token path; the native
+// path never wraps. Keep the two distinct.
+export const NATIVE_SOL_MINT = new PublicKey(new Uint8Array(32))
+
+// Native-SOL vault PDA seeds (must match on-chain constants.rs exactly)
+export const VAULT_SOL_SEED = Buffer.from('vault_sol')
+export const FEE_SOL_SEED = Buffer.from('fee_sol')
+
 // SIP Privacy program PDA seeds (must match sip_privacy constants)
 export const SIP_CONFIG_SEED = Buffer.from('config')
 export const SIP_TRANSFER_RECORD_SEED = Buffer.from('transfer_record')

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -22,6 +22,9 @@ export {
   DEPOSIT_RECORD_SEED,
   VAULT_TOKEN_SEED,
   FEE_TOKEN_SEED,
+  NATIVE_SOL_MINT,
+  VAULT_SOL_SEED,
+  FEE_SOL_SEED,
   DEFAULT_REFUND_TIMEOUT,
   DEFAULT_FEE_BPS,
   MAX_FEE_BPS,
@@ -63,6 +66,12 @@ export {
   fetchDepositRecord,
   buildAuthorityRefundTx,
 } from './vault.js'
+
+// Native-SOL vault operations
+export {
+  deriveSolVaultPDA,
+  deriveSolFeePDA,
+} from './vault-sol.js'
 
 // Privacy operations
 export {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -7,6 +7,7 @@ export type {
   VaultBalance,
   DepositResult,
   SolDepositResult,
+  SolRefundResult,
   WithdrawResult,
   RefundResult,
   StealthPayment,
@@ -73,6 +74,8 @@ export {
   deriveSolVaultPDA,
   deriveSolFeePDA,
   buildDepositSolTx,
+  buildRefundSolTx,
+  buildAuthorityRefundSolTx,
 } from './vault-sol.js'
 
 // Privacy operations

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -76,6 +76,7 @@ export {
   buildDepositSolTx,
   buildRefundSolTx,
   buildAuthorityRefundSolTx,
+  buildCreateSolVaultTx,
 } from './vault-sol.js'
 
 // Privacy operations

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -85,6 +85,10 @@ export {
 } from './privacy.js'
 export type { PrivateSendParams, ScanParams } from './privacy.js'
 
+// Native-SOL privacy operations
+export { buildPrivateSendSolTx } from './privacy-sol.js'
+export type { PrivateSendSolParams } from './privacy-sol.js'
+
 // Event parsing
 export {
   parseVaultEvents,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -6,6 +6,7 @@ export type {
   DepositRecord,
   VaultBalance,
   DepositResult,
+  SolDepositResult,
   WithdrawResult,
   RefundResult,
   StealthPayment,
@@ -71,6 +72,7 @@ export {
 export {
   deriveSolVaultPDA,
   deriveSolFeePDA,
+  buildDepositSolTx,
 } from './vault-sol.js'
 
 // Privacy operations

--- a/packages/sdk/src/privacy-sol.ts
+++ b/packages/sdk/src/privacy-sol.ts
@@ -115,7 +115,7 @@ export async function buildPrivateSendSolTx(
   }
 
   let sipTotalTransfers = 0n
-  if (sipConfigInfo) {
+  if (sipConfigInfo && sipConfigInfo.data.length >= ANCHOR_DISCRIMINATOR_SIZE + 32 + 2 + 1 + 8) {
     // after 8-byte disc: authority(32) + fee_bps(2) + paused(1) + total_transfers(u64)
     sipTotalTransfers = sipConfigInfo.data.readBigUInt64LE(
       ANCHOR_DISCRIMINATOR_SIZE + 32 + 2 + 1

--- a/packages/sdk/src/privacy-sol.ts
+++ b/packages/sdk/src/privacy-sol.ts
@@ -1,0 +1,206 @@
+import {
+  Connection,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+} from '@solana/web3.js'
+import {
+  SIPHER_VAULT_PROGRAM_ID,
+  SIP_PRIVACY_PROGRAM_ID,
+  SIP_CONFIG_SEED,
+  SIP_TRANSFER_RECORD_SEED,
+  NATIVE_SOL_MINT,
+  ANCHOR_DISCRIMINATOR_SIZE,
+} from './config.js'
+import {
+  anchorDiscriminator,
+  deriveVaultConfigPDA,
+  deriveDepositRecordPDA,
+} from './vault.js'
+import { deriveSolVaultPDA, deriveSolFeePDA } from './vault-sol.js'
+import type { WithdrawResult } from './types.js'
+
+export interface PrivateSendSolParams {
+  connection: Connection
+  /** The depositor who owns the native-SOL vault balance */
+  depositor: PublicKey
+  /** Amount of lamports to withdraw (gross, before fees) */
+  amount: bigint
+  /** The stealth recipient pubkey — also the plain SystemAccount that receives lamports */
+  stealthPubkey: PublicKey
+  /** Pedersen commitment: C = amount*G + blinding*H (33 bytes compressed) */
+  amountCommitment: Uint8Array
+  /** Ephemeral pubkey for ECDH (33 bytes compressed) */
+  ephemeralPubkey: Uint8Array
+  /** SHA-256 hash of the viewing key (32 bytes) */
+  viewingKeyHash: Uint8Array
+  /** Encrypted amount blob (for recipient to decrypt with viewing key) */
+  encryptedAmount: Uint8Array
+  /** ZK proof bytes (verified off-chain; may be empty) */
+  proof: Uint8Array
+  /** Program ID override */
+  programId?: PublicKey
+}
+
+/**
+ * Build an unsigned native-SOL withdraw_private_sol transaction: withdraw lamports
+ * from the shared SolVault to a stealth recipient, with a Pedersen commitment hiding
+ * the amount and a sip_privacy announcement CPI. Mirrors buildPrivateSendTx with the
+ * token accounts replaced by sol_vault / sol_fee and a plain SystemAccount recipient.
+ *
+ * Accounts (order matches the WithdrawPrivateSol context in lib.rs):
+ *   0. config              (ro)   — VaultConfig PDA
+ *   1. deposit_record      (mut)  — DepositRecord PDA [.., depositor, NATIVE_SOL_MINT]
+ *   2. sol_vault           (mut)  — SolVault PDA
+ *   3. sol_fee             (mut)  — SolFee PDA
+ *   4. stealth             (mut)  — stealth recipient (SystemAccount)
+ *   5. depositor           (mut, signer)
+ *   6. sip_config          (mut)  — SIP Privacy Config PDA (CPI)
+ *   7. sip_transfer_record (mut)  — TransferRecord PDA (init by CPI)
+ *   8. sip_privacy_program (ro)
+ *   9. system_program      (ro)
+ */
+export async function buildPrivateSendSolTx(
+  params: PrivateSendSolParams
+): Promise<WithdrawResult> {
+  const {
+    connection,
+    depositor,
+    amount,
+    stealthPubkey,
+    amountCommitment,
+    ephemeralPubkey,
+    viewingKeyHash,
+    encryptedAmount,
+    proof,
+    programId = SIPHER_VAULT_PROGRAM_ID,
+  } = params
+
+  if (amount <= 0n) {
+    throw new Error('Withdrawal amount must be greater than zero')
+  }
+  if (amountCommitment.length !== 33) {
+    throw new Error(`amountCommitment must be 33 bytes, got ${amountCommitment.length}`)
+  }
+  if (ephemeralPubkey.length !== 33) {
+    throw new Error(`ephemeralPubkey must be 33 bytes, got ${ephemeralPubkey.length}`)
+  }
+  if (viewingKeyHash.length !== 32) {
+    throw new Error(`viewingKeyHash must be 32 bytes, got ${viewingKeyHash.length}`)
+  }
+
+  const [configPDA] = deriveVaultConfigPDA(programId)
+  const [depositRecordPDA] = deriveDepositRecordPDA(depositor, NATIVE_SOL_MINT, programId)
+  const [solVaultPDA] = deriveSolVaultPDA(programId)
+  const [solFeePDA] = deriveSolFeePDA(programId)
+  const [sipConfigPDA] = PublicKey.findProgramAddressSync(
+    [SIP_CONFIG_SEED],
+    SIP_PRIVACY_PROGRAM_ID
+  )
+
+  // Parallel reads: vault config (fee), sip config (total_transfers), rent floor,
+  // and the stealth recipient's current balance (for the rent-exempt guard).
+  const [configInfo, sipConfigInfo, rentExemptMin, stealthInfo] = await Promise.all([
+    connection.getAccountInfo(configPDA),
+    connection.getAccountInfo(sipConfigPDA),
+    connection.getMinimumBalanceForRentExemption(0),
+    connection.getAccountInfo(stealthPubkey),
+  ])
+
+  let feeBps = 10 // fallback to default
+  if (configInfo) {
+    // fee_bps at offset 8 (disc) + 32 (authority) = 40, u16 LE
+    feeBps = configInfo.data.readUInt16LE(40)
+  }
+
+  let sipTotalTransfers = 0n
+  if (sipConfigInfo) {
+    // after 8-byte disc: authority(32) + fee_bps(2) + paused(1) + total_transfers(u64)
+    sipTotalTransfers = sipConfigInfo.data.readBigUInt64LE(
+      ANCHOR_DISCRIMINATOR_SIZE + 32 + 2 + 1
+    )
+  }
+
+  const totalTransfersBuffer = Buffer.alloc(8)
+  totalTransfersBuffer.writeBigUInt64LE(sipTotalTransfers)
+  const [sipTransferRecordPDA] = PublicKey.findProgramAddressSync(
+    [SIP_TRANSFER_RECORD_SEED, depositor.toBuffer(), totalTransfersBuffer],
+    SIP_PRIVACY_PROGRAM_ID
+  )
+
+  const feeAmount = (amount * BigInt(feeBps)) / 10_000n
+  const netAmount = amount - feeAmount
+
+  // Rent-exempt guard: the stealth recipient is a plain system account. The runtime
+  // rejects a tx that leaves a touched account with a non-zero balance below the
+  // rent-exempt minimum, so a small payout to a never-funded stealth would fail.
+  // Surface it with an actionable error instead of an opaque runtime reject.
+  const currentLamports = BigInt(stealthInfo?.lamports ?? 0)
+  if (currentLamports + netAmount < BigInt(rentExemptMin)) {
+    throw new Error(
+      `Stealth recipient ${stealthPubkey.toBase58()} would be left below the ` +
+        `rent-exempt minimum (needs >= ${rentExemptMin} lamports after the payout; ` +
+        `would have ${currentLamports + netAmount}). Pre-fund the stealth account to ` +
+        `at least ${rentExemptMin} lamports before withdrawing.`
+    )
+  }
+
+  // Serialize: disc(8) + amount(8) + commitment(33) + stealth_pubkey(32)
+  //          + ephemeral(33) + vk_hash(32) + encrypted(4+len) + proof(4+len)
+  const fixedSize = 8 + 8 + 33 + 32 + 33 + 32
+  const vecOverhead = 4 + encryptedAmount.length + 4 + proof.length
+  const data = Buffer.alloc(fixedSize + vecOverhead)
+  let offset = 0
+
+  anchorDiscriminator('withdraw_private_sol').copy(data, offset)
+  offset += 8
+  data.writeBigUInt64LE(amount, offset)
+  offset += 8
+  Buffer.from(amountCommitment).copy(data, offset)
+  offset += 33
+  stealthPubkey.toBuffer().copy(data, offset)
+  offset += 32
+  Buffer.from(ephemeralPubkey).copy(data, offset)
+  offset += 33
+  Buffer.from(viewingKeyHash).copy(data, offset)
+  offset += 32
+  data.writeUInt32LE(encryptedAmount.length, offset)
+  offset += 4
+  Buffer.from(encryptedAmount).copy(data, offset)
+  offset += encryptedAmount.length
+  data.writeUInt32LE(proof.length, offset)
+  offset += 4
+  Buffer.from(proof).copy(data, offset)
+
+  const ix = new TransactionInstruction({
+    programId,
+    keys: [
+      { pubkey: configPDA, isSigner: false, isWritable: false },
+      { pubkey: depositRecordPDA, isSigner: false, isWritable: true },
+      { pubkey: solVaultPDA, isSigner: false, isWritable: true },
+      { pubkey: solFeePDA, isSigner: false, isWritable: true },
+      { pubkey: stealthPubkey, isSigner: false, isWritable: true },
+      { pubkey: depositor, isSigner: true, isWritable: true },
+      { pubkey: sipConfigPDA, isSigner: false, isWritable: true },
+      { pubkey: sipTransferRecordPDA, isSigner: false, isWritable: true },
+      { pubkey: SIP_PRIVACY_PROGRAM_ID, isSigner: false, isWritable: false },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data,
+  })
+
+  const tx = new Transaction()
+  tx.add(ix)
+  tx.feePayer = depositor
+
+  const { blockhash } = await connection.getLatestBlockhash()
+  tx.recentBlockhash = blockhash
+
+  return {
+    transaction: tx,
+    netAmount,
+    feeAmount,
+    stealthAddress: stealthPubkey,
+  }
+}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -57,6 +57,17 @@ export interface DepositResult {
   amount: bigint
 }
 
+export interface SolDepositResult {
+  /** Unsigned transaction — caller signs with their wallet */
+  transaction: Transaction
+  /** The deposit record PDA (seeded by NATIVE_SOL_MINT) */
+  depositRecordAddress: PublicKey
+  /** The SolVault PDA that receives the lamports */
+  solVaultAddress: PublicKey
+  /** Amount in lamports */
+  amount: bigint
+}
+
 export interface WithdrawResult {
   transaction: Transaction
   /** Net amount after fees */

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -68,6 +68,14 @@ export interface SolDepositResult {
   amount: bigint
 }
 
+export interface SolRefundResult {
+  transaction: Transaction
+  /** Amount being refunded (the depositor's available balance, in lamports) */
+  refundAmount: bigint
+  /** The depositor's main (system) account receiving the lamports */
+  depositorAddress: PublicKey
+}
+
 export interface WithdrawResult {
   transaction: Transaction
   /** Net amount after fees */

--- a/packages/sdk/src/vault-sol.ts
+++ b/packages/sdk/src/vault-sol.ts
@@ -209,3 +209,47 @@ export async function buildAuthorityRefundSolTx(
 
   return { transaction: tx, refundAmount, depositorAddress: depositor }
 }
+
+/**
+ * Build an unsigned create_sol_vault transaction — one-time init of the singleton
+ * SolVault + SolFee PDAs. Payer funds the rent-exempt reserve for both. No args.
+ *
+ * Accounts (order matches the CreateSolVault context in lib.rs):
+ *   0. config         (ro)          — VaultConfig PDA
+ *   1. sol_vault      (init, mut)   — SolVault PDA
+ *   2. sol_fee        (init, mut)   — SolFee PDA
+ *   3. payer          (mut, signer)
+ *   4. system_program (ro)
+ */
+export async function buildCreateSolVaultTx(
+  connection: Connection,
+  payer: PublicKey,
+  programId: PublicKey = SIPHER_VAULT_PROGRAM_ID
+): Promise<Transaction> {
+  const [configPDA] = deriveVaultConfigPDA(programId)
+  const [solVaultPDA] = deriveSolVaultPDA(programId)
+  const [solFeePDA] = deriveSolFeePDA(programId)
+
+  const data = anchorDiscriminator('create_sol_vault')
+
+  const ix = new TransactionInstruction({
+    programId,
+    keys: [
+      { pubkey: configPDA, isSigner: false, isWritable: false },
+      { pubkey: solVaultPDA, isSigner: false, isWritable: true },
+      { pubkey: solFeePDA, isSigner: false, isWritable: true },
+      { pubkey: payer, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data,
+  })
+
+  const tx = new Transaction()
+  tx.add(ix)
+  tx.feePayer = payer
+
+  const { blockhash } = await connection.getLatestBlockhash()
+  tx.recentBlockhash = blockhash
+
+  return tx
+}

--- a/packages/sdk/src/vault-sol.ts
+++ b/packages/sdk/src/vault-sol.ts
@@ -15,8 +15,9 @@ import {
   anchorDiscriminator,
   deriveVaultConfigPDA,
   deriveDepositRecordPDA,
+  deserializeDepositRecord,
 } from './vault.js'
-import type { SolDepositResult } from './types.js'
+import type { SolDepositResult, SolRefundResult } from './types.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Native-SOL PDA derivation
@@ -99,4 +100,112 @@ export async function buildDepositSolTx(
     solVaultAddress: solVaultPDA,
     amount,
   }
+}
+
+/**
+ * Build an unsigned native-SOL refund transaction (refund_sol). Depositor signs.
+ *
+ * Accounts (order matches the RefundSol context in lib.rs):
+ *   0. config         (ro)          — VaultConfig PDA
+ *   1. deposit_record (mut)         — DepositRecord PDA [.., depositor, NATIVE_SOL_MINT]
+ *   2. sol_vault      (mut)         — SolVault PDA
+ *   3. depositor      (mut, signer)
+ */
+export async function buildRefundSolTx(
+  connection: Connection,
+  depositor: PublicKey,
+  programId: PublicKey = SIPHER_VAULT_PROGRAM_ID
+): Promise<SolRefundResult> {
+  const [configPDA] = deriveVaultConfigPDA(programId)
+  const [depositRecordPDA] = deriveDepositRecordPDA(depositor, NATIVE_SOL_MINT, programId)
+  const [solVaultPDA] = deriveSolVaultPDA(programId)
+
+  const recordInfo = await connection.getAccountInfo(depositRecordPDA)
+  if (!recordInfo) {
+    throw new Error('No deposit record found — nothing to refund')
+  }
+  const record = deserializeDepositRecord(Buffer.from(recordInfo.data))
+  const refundAmount = record.balance
+  if (refundAmount <= 0n) {
+    throw new Error('No balance to refund')
+  }
+
+  const data = anchorDiscriminator('refund_sol')
+
+  const ix = new TransactionInstruction({
+    programId,
+    keys: [
+      { pubkey: configPDA, isSigner: false, isWritable: false },
+      { pubkey: depositRecordPDA, isSigner: false, isWritable: true },
+      { pubkey: solVaultPDA, isSigner: false, isWritable: true },
+      { pubkey: depositor, isSigner: true, isWritable: true },
+    ],
+    data,
+  })
+
+  const tx = new Transaction()
+  tx.add(ix)
+  tx.feePayer = depositor
+
+  const { blockhash } = await connection.getLatestBlockhash()
+  tx.recentBlockhash = blockhash
+
+  return { transaction: tx, refundAmount, depositorAddress: depositor }
+}
+
+/**
+ * Build an unsigned authority-signed native-SOL refund (authority_refund_sol).
+ * The authority signs on the depositor's behalf; the depositor is a non-signer
+ * lamport destination. The on-chain `has_one = depositor` guarantees principal
+ * returns to the original depositor, and the timeout is still enforced on-chain.
+ *
+ * Accounts (order matches the AuthorityRefundSol context in lib.rs):
+ *   0. config         (ro)          — VaultConfig PDA (has_one = authority)
+ *   1. deposit_record (mut)         — DepositRecord PDA [.., depositor, NATIVE_SOL_MINT]
+ *   2. sol_vault      (mut)         — SolVault PDA
+ *   3. depositor      (mut)         — NOT signer; validated by has_one
+ *   4. authority      (mut, signer)
+ */
+export async function buildAuthorityRefundSolTx(
+  connection: Connection,
+  authority: PublicKey,
+  depositor: PublicKey,
+  programId: PublicKey = SIPHER_VAULT_PROGRAM_ID
+): Promise<SolRefundResult> {
+  const [configPDA] = deriveVaultConfigPDA(programId)
+  const [depositRecordPDA] = deriveDepositRecordPDA(depositor, NATIVE_SOL_MINT, programId)
+  const [solVaultPDA] = deriveSolVaultPDA(programId)
+
+  const recordInfo = await connection.getAccountInfo(depositRecordPDA)
+  if (!recordInfo) {
+    throw new Error('No deposit record found — nothing to refund')
+  }
+  const record = deserializeDepositRecord(Buffer.from(recordInfo.data))
+  const refundAmount = record.balance
+  if (refundAmount <= 0n) {
+    throw new Error('No balance to refund')
+  }
+
+  const data = anchorDiscriminator('authority_refund_sol')
+
+  const ix = new TransactionInstruction({
+    programId,
+    keys: [
+      { pubkey: configPDA, isSigner: false, isWritable: false },
+      { pubkey: depositRecordPDA, isSigner: false, isWritable: true },
+      { pubkey: solVaultPDA, isSigner: false, isWritable: true },
+      { pubkey: depositor, isSigner: false, isWritable: true },
+      { pubkey: authority, isSigner: true, isWritable: true },
+    ],
+    data,
+  })
+
+  const tx = new Transaction()
+  tx.add(ix)
+  tx.feePayer = authority
+
+  const { blockhash } = await connection.getLatestBlockhash()
+  tx.recentBlockhash = blockhash
+
+  return { transaction: tx, refundAmount, depositorAddress: depositor }
 }

--- a/packages/sdk/src/vault-sol.ts
+++ b/packages/sdk/src/vault-sol.ts
@@ -1,9 +1,22 @@
-import { PublicKey } from '@solana/web3.js'
+import {
+  Connection,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+} from '@solana/web3.js'
 import {
   SIPHER_VAULT_PROGRAM_ID,
   VAULT_SOL_SEED,
   FEE_SOL_SEED,
+  NATIVE_SOL_MINT,
 } from './config.js'
+import {
+  anchorDiscriminator,
+  deriveVaultConfigPDA,
+  deriveDepositRecordPDA,
+} from './vault.js'
+import type { SolDepositResult } from './types.js'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Native-SOL PDA derivation
@@ -30,4 +43,60 @@ export function deriveSolFeePDA(
   programId: PublicKey = SIPHER_VAULT_PROGRAM_ID
 ): [PublicKey, number] {
   return PublicKey.findProgramAddressSync([FEE_SOL_SEED], programId)
+}
+
+/**
+ * Build an unsigned native-SOL deposit transaction (deposit_sol).
+ *
+ * Accounts (order matches the DepositSol context in lib.rs):
+ *   0. config         (mut)         — VaultConfig PDA
+ *   1. deposit_record (mut)         — DepositRecord PDA [.., depositor, NATIVE_SOL_MINT]
+ *   2. sol_vault      (mut)         — SolVault PDA
+ *   3. depositor      (mut, signer)
+ *   4. system_program (ro)
+ */
+export async function buildDepositSolTx(
+  connection: Connection,
+  depositor: PublicKey,
+  amount: bigint,
+  programId: PublicKey = SIPHER_VAULT_PROGRAM_ID
+): Promise<SolDepositResult> {
+  if (amount <= 0n) {
+    throw new Error('Deposit amount must be greater than zero')
+  }
+
+  const [configPDA] = deriveVaultConfigPDA(programId)
+  const [depositRecordPDA] = deriveDepositRecordPDA(depositor, NATIVE_SOL_MINT, programId)
+  const [solVaultPDA] = deriveSolVaultPDA(programId)
+
+  // disc(8) + amount(u64 LE, 8) = 16 bytes
+  const data = Buffer.alloc(16)
+  anchorDiscriminator('deposit_sol').copy(data, 0)
+  data.writeBigUInt64LE(amount, 8)
+
+  const ix = new TransactionInstruction({
+    programId,
+    keys: [
+      { pubkey: configPDA, isSigner: false, isWritable: true },
+      { pubkey: depositRecordPDA, isSigner: false, isWritable: true },
+      { pubkey: solVaultPDA, isSigner: false, isWritable: true },
+      { pubkey: depositor, isSigner: true, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    ],
+    data,
+  })
+
+  const tx = new Transaction()
+  tx.add(ix)
+  tx.feePayer = depositor
+
+  const { blockhash } = await connection.getLatestBlockhash()
+  tx.recentBlockhash = blockhash
+
+  return {
+    transaction: tx,
+    depositRecordAddress: depositRecordPDA,
+    solVaultAddress: solVaultPDA,
+    amount,
+  }
 }

--- a/packages/sdk/src/vault-sol.ts
+++ b/packages/sdk/src/vault-sol.ts
@@ -1,0 +1,33 @@
+import { PublicKey } from '@solana/web3.js'
+import {
+  SIPHER_VAULT_PROGRAM_ID,
+  VAULT_SOL_SEED,
+  FEE_SOL_SEED,
+} from './config.js'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Native-SOL PDA derivation
+//
+// The native-SOL DepositRecord uses the EXISTING deriveDepositRecordPDA helper
+// with NATIVE_SOL_MINT as the mint seed — no dedicated helper is needed here.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Derive the singleton SolVault PDA (holds native lamports).
+ * Seeds: [b"vault_sol"]
+ */
+export function deriveSolVaultPDA(
+  programId: PublicKey = SIPHER_VAULT_PROGRAM_ID
+): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync([VAULT_SOL_SEED], programId)
+}
+
+/**
+ * Derive the singleton SolFee PDA (native-SOL fee sink).
+ * Seeds: [b"fee_sol"]
+ */
+export function deriveSolFeePDA(
+  programId: PublicKey = SIPHER_VAULT_PROGRAM_ID
+): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync([FEE_SOL_SEED], programId)
+}

--- a/packages/sdk/tests/privacy-sol.test.ts
+++ b/packages/sdk/tests/privacy-sol.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest'
+import { Connection, PublicKey, SystemProgram } from '@solana/web3.js'
+import {
+  buildPrivateSendSolTx,
+  deriveVaultConfigPDA,
+  deriveDepositRecordPDA,
+  deriveSolVaultPDA,
+  deriveSolFeePDA,
+  anchorDiscriminator,
+  NATIVE_SOL_MINT,
+  SIP_PRIVACY_PROGRAM_ID,
+} from '../src/index.js'
+import { SIP_CONFIG_SEED } from '../src/config.js'
+
+const BLOCKHASH = 'GfVcyD4kkTrj4bKc7WA9sZCin9JDbdT458zqL4zjxx2v'
+const DEPOSITOR = new PublicKey('FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr')
+const STEALTH = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA')
+
+const commitment = new Uint8Array(33).fill(2)
+const ephemeral = new Uint8Array(33).fill(3)
+const vkHash = new Uint8Array(32).fill(4)
+const encrypted = new Uint8Array([9, 9, 9])
+const proof = new Uint8Array([])
+
+// Dispatching Connection stub. fee_bps lives at config offset 40 (u16 LE);
+// sip total_transfers at offset 8+32+2+1 = 43 (u64 LE).
+function mockConn(opts: {
+  feeBps?: number
+  stealthLamports?: number | null
+  rentExemptMin?: number
+} = {}): Connection {
+  const { feeBps = 10, stealthLamports = null, rentExemptMin = 890_880 } = opts
+  const configBuf = Buffer.alloc(60)
+  configBuf.writeUInt16LE(feeBps, 40)
+  const sipBuf = Buffer.alloc(8 + 32 + 2 + 1 + 8) // total_transfers = 0
+  const [cfg] = deriveVaultConfigPDA()
+  const [sip] = PublicKey.findProgramAddressSync([SIP_CONFIG_SEED], SIP_PRIVACY_PROGRAM_ID)
+  return {
+    getLatestBlockhash: async () => ({ blockhash: BLOCKHASH, lastValidBlockHeight: 1 }),
+    getMinimumBalanceForRentExemption: async () => rentExemptMin,
+    getAccountInfo: async (pk: PublicKey) => {
+      if (pk.equals(cfg)) return { data: configBuf } as never
+      if (pk.equals(sip)) return { data: sipBuf } as never
+      if (stealthLamports === null) return null
+      return { lamports: stealthLamports, data: Buffer.alloc(0) } as never
+    },
+  } as unknown as Connection
+}
+
+const baseParams = {
+  depositor: DEPOSITOR,
+  amount: 2_000_000n,
+  stealthPubkey: STEALTH,
+  amountCommitment: commitment,
+  ephemeralPubkey: ephemeral,
+  viewingKeyHash: vkHash,
+  encryptedAmount: encrypted,
+  proof,
+}
+
+describe('buildPrivateSendSolTx', () => {
+  it('builds withdraw_private_sol with the exact 10-account order + flags', async () => {
+    // stealth pre-funded above the rent floor so the guard passes
+    const res = await buildPrivateSendSolTx({
+      ...baseParams,
+      connection: mockConn({ stealthLamports: 1_000_000_000 }),
+    })
+    const ix = res.transaction.instructions[0]
+    const [config] = deriveVaultConfigPDA()
+    const [record] = deriveDepositRecordPDA(DEPOSITOR, NATIVE_SOL_MINT)
+    const [solVault] = deriveSolVaultPDA()
+    const [solFee] = deriveSolFeePDA()
+    const [sipConfig] = PublicKey.findProgramAddressSync([SIP_CONFIG_SEED], SIP_PRIVACY_PROGRAM_ID)
+
+    expect(ix.keys.length).toBe(10)
+    expect(ix.keys.slice(0, 6).map((k) => k.pubkey.toBase58())).toEqual([
+      config.toBase58(),
+      record.toBase58(),
+      solVault.toBase58(),
+      solFee.toBase58(),
+      STEALTH.toBase58(),
+      DEPOSITOR.toBase58(),
+    ])
+    expect(ix.keys[8].pubkey.toBase58()).toBe(SIP_PRIVACY_PROGRAM_ID.toBase58())
+    expect(ix.keys[9].pubkey.toBase58()).toBe(SystemProgram.programId.toBase58())
+    // only depositor (index 5) signs
+    expect(ix.keys.map((k) => k.isSigner)).toEqual([
+      false, false, false, false, false, true, false, false, false, false,
+    ])
+    // config(ro), sip_program(ro), system(ro) are non-writable; the rest writable
+    expect(ix.keys.map((k) => k.isWritable)).toEqual([
+      false, true, true, true, true, true, true, true, false, false,
+    ])
+    expect(ix.keys[6].pubkey.equals(sipConfig)).toBe(true)
+  })
+
+  it('encodes the discriminator + amount and computes fee/net from config', async () => {
+    const res = await buildPrivateSendSolTx({
+      ...baseParams,
+      connection: mockConn({ feeBps: 10, stealthLamports: 1_000_000_000 }),
+    })
+    const data = res.transaction.instructions[0].data
+    expect(data.subarray(0, 8).equals(anchorDiscriminator('withdraw_private_sol'))).toBe(true)
+    expect(data.readBigUInt64LE(8)).toBe(2_000_000n)
+    // 10 bps of 2_000_000 = 2_000
+    expect(res.feeAmount).toBe(2_000n)
+    expect(res.netAmount).toBe(1_998_000n)
+    expect(res.stealthAddress.toBase58()).toBe(STEALTH.toBase58())
+  })
+
+  it('throws when a fresh stealth recipient would be left below rent-exempt', async () => {
+    // stealth does not exist (0 lamports); net 1_998_000 < 890_880? No — so make the
+    // payout tiny: amount 1000 => net 999 < rent floor => must throw.
+    await expect(
+      buildPrivateSendSolTx({
+        ...baseParams,
+        amount: 1_000n,
+        connection: mockConn({ stealthLamports: null }),
+      }),
+    ).rejects.toThrow('rent-exempt minimum')
+  })
+
+  it('passes when the stealth recipient is already rent-exempt', async () => {
+    const res = await buildPrivateSendSolTx({
+      ...baseParams,
+      amount: 1_000n,
+      connection: mockConn({ stealthLamports: 890_880 }),
+    })
+    expect(res.transaction.instructions).toHaveLength(1)
+  })
+
+  it('rejects malformed crypto field lengths', async () => {
+    await expect(
+      buildPrivateSendSolTx({
+        ...baseParams,
+        amountCommitment: new Uint8Array(32), // wrong length
+        connection: mockConn({ stealthLamports: 1_000_000_000 }),
+      }),
+    ).rejects.toThrow('amountCommitment must be 33 bytes')
+  })
+})

--- a/packages/sdk/tests/vault-sol.test.ts
+++ b/packages/sdk/tests/vault-sol.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { PublicKey } from '@solana/web3.js'
+import {
+  NATIVE_SOL_MINT,
+  VAULT_SOL_SEED,
+  FEE_SOL_SEED,
+  deriveSolVaultPDA,
+  deriveSolFeePDA,
+} from '../src/index.js'
+
+describe('native-SOL constants', () => {
+  it('NATIVE_SOL_MINT is the all-zeros sentinel (not wSOL)', () => {
+    expect(NATIVE_SOL_MINT.toBase58()).toBe('11111111111111111111111111111111')
+    expect(NATIVE_SOL_MINT.toBytes().every((b) => b === 0)).toBe(true)
+  })
+
+  it('SOL vault seeds match the on-chain constants', () => {
+    expect(VAULT_SOL_SEED.toString()).toBe('vault_sol')
+    expect(FEE_SOL_SEED.toString()).toBe('fee_sol')
+  })
+})
+
+describe('native-SOL PDA derivation', () => {
+  it('deriveSolVaultPDA matches the live devnet SolVault', () => {
+    const [pda] = deriveSolVaultPDA()
+    expect(pda.toBase58()).toBe('8ZG46epBDrRbZ2oDneuemmSuQNNG3R58LhFo8Do2p6sq')
+  })
+
+  it('deriveSolFeePDA matches the live devnet SolFee', () => {
+    const [pda] = deriveSolFeePDA()
+    expect(pda.toBase58()).toBe('519L2NQN16H1fnN9iPu2r2ipmjPj156yWMPQumw8PkZ4')
+  })
+
+  it('derivations honor a programId override', () => {
+    const custom = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA')
+    const [vault] = deriveSolVaultPDA(custom)
+    const [expected] = PublicKey.findProgramAddressSync([VAULT_SOL_SEED], custom)
+    expect(vault.equals(expected)).toBe(true)
+  })
+})

--- a/packages/sdk/tests/vault-sol.test.ts
+++ b/packages/sdk/tests/vault-sol.test.ts
@@ -7,6 +7,8 @@ import {
   deriveSolVaultPDA,
   deriveSolFeePDA,
   buildDepositSolTx,
+  buildRefundSolTx,
+  buildAuthorityRefundSolTx,
   deriveVaultConfigPDA,
   deriveDepositRecordPDA,
   anchorDiscriminator,
@@ -91,5 +93,83 @@ describe('buildDepositSolTx', () => {
     await expect(buildDepositSolTx(mockConnDeposit(), DEPOSITOR, 0n)).rejects.toThrow(
       'Deposit amount must be greater than zero',
     )
+  })
+})
+
+const AUTHORITY = new PublicKey('S1P6j1yeTm6zkewQVeihrTZvmfoHABRkHDhabWTuWMd')
+
+// DepositRecord buffer: 8 disc + depositor(32) + mint(32) + balance(8)
+// + cumulative(8) + last_deposit(8) + bump(1) = 97 bytes. balance at offset 72.
+function depositRecordBuf(balance: bigint): Buffer {
+  const buf = Buffer.alloc(8 + 89)
+  buf.writeBigUInt64LE(balance, 72)
+  return buf
+}
+
+function mockConnRefund(recordBuf: Buffer | null): Connection {
+  return {
+    getLatestBlockhash: async () => ({ blockhash: BLOCKHASH, lastValidBlockHeight: 1 }),
+    getAccountInfo: async () => (recordBuf ? ({ data: recordBuf } as never) : null),
+  } as unknown as Connection
+}
+
+describe('buildRefundSolTx', () => {
+  it('builds refund_sol with the exact RefundSol account order + flags', async () => {
+    const res = await buildRefundSolTx(mockConnRefund(depositRecordBuf(3_000_000n)), DEPOSITOR)
+    const ix = res.transaction.instructions[0]
+    const [config] = deriveVaultConfigPDA()
+    const [record] = deriveDepositRecordPDA(DEPOSITOR, NATIVE_SOL_MINT)
+    const [solVault] = deriveSolVaultPDA()
+
+    expect(ix.keys.map((k) => k.pubkey.toBase58())).toEqual([
+      config.toBase58(),
+      record.toBase58(),
+      solVault.toBase58(),
+      DEPOSITOR.toBase58(),
+    ])
+    expect(ix.keys.map((k) => k.isSigner)).toEqual([false, false, false, true])
+    expect(ix.keys.map((k) => k.isWritable)).toEqual([false, true, true, true])
+    expect(ix.data.equals(anchorDiscriminator('refund_sol'))).toBe(true)
+    expect(res.refundAmount).toBe(3_000_000n)
+    expect(res.depositorAddress.toBase58()).toBe(DEPOSITOR.toBase58())
+  })
+
+  it('throws when there is no deposit record', async () => {
+    await expect(buildRefundSolTx(mockConnRefund(null), DEPOSITOR)).rejects.toThrow(
+      'nothing to refund',
+    )
+  })
+
+  it('throws when the balance is zero', async () => {
+    await expect(
+      buildRefundSolTx(mockConnRefund(depositRecordBuf(0n)), DEPOSITOR),
+    ).rejects.toThrow('No balance to refund')
+  })
+})
+
+describe('buildAuthorityRefundSolTx', () => {
+  it('makes authority the signer and depositor a non-signer destination', async () => {
+    const res = await buildAuthorityRefundSolTx(
+      mockConnRefund(depositRecordBuf(4_000_000n)),
+      AUTHORITY,
+      DEPOSITOR,
+    )
+    const ix = res.transaction.instructions[0]
+    const [config] = deriveVaultConfigPDA()
+    const [record] = deriveDepositRecordPDA(DEPOSITOR, NATIVE_SOL_MINT)
+    const [solVault] = deriveSolVaultPDA()
+
+    expect(ix.keys.map((k) => k.pubkey.toBase58())).toEqual([
+      config.toBase58(),
+      record.toBase58(),
+      solVault.toBase58(),
+      DEPOSITOR.toBase58(),
+      AUTHORITY.toBase58(),
+    ])
+    expect(ix.keys.map((k) => k.isSigner)).toEqual([false, false, false, false, true])
+    expect(ix.keys.map((k) => k.isWritable)).toEqual([false, true, true, true, true])
+    expect(ix.data.equals(anchorDiscriminator('authority_refund_sol'))).toBe(true)
+    expect(res.transaction.feePayer?.toBase58()).toBe(AUTHORITY.toBase58())
+    expect(res.refundAmount).toBe(4_000_000n)
   })
 })

--- a/packages/sdk/tests/vault-sol.test.ts
+++ b/packages/sdk/tests/vault-sol.test.ts
@@ -9,11 +9,13 @@ import {
   buildDepositSolTx,
   buildRefundSolTx,
   buildAuthorityRefundSolTx,
+  buildCreateSolVaultTx,
   deriveVaultConfigPDA,
   deriveDepositRecordPDA,
   anchorDiscriminator,
   SIPHER_VAULT_PROGRAM_ID,
 } from '../src/index.js'
+import * as sdk from '../src/index.js'
 
 describe('native-SOL constants', () => {
   it('NATIVE_SOL_MINT is the all-zeros sentinel (not wSOL)', () => {
@@ -171,5 +173,47 @@ describe('buildAuthorityRefundSolTx', () => {
     expect(ix.data.equals(anchorDiscriminator('authority_refund_sol'))).toBe(true)
     expect(res.transaction.feePayer?.toBase58()).toBe(AUTHORITY.toBase58())
     expect(res.refundAmount).toBe(4_000_000n)
+  })
+})
+
+describe('buildCreateSolVaultTx', () => {
+  it('builds create_sol_vault with the exact CreateSolVault account order + flags', async () => {
+    const payer = DEPOSITOR
+    const tx = await buildCreateSolVaultTx(mockConnDeposit(), payer)
+    const ix = tx.instructions[0]
+    const [config] = deriveVaultConfigPDA()
+    const [solVault] = deriveSolVaultPDA()
+    const [solFee] = deriveSolFeePDA()
+
+    expect(ix.keys.map((k) => k.pubkey.toBase58())).toEqual([
+      config.toBase58(),
+      solVault.toBase58(),
+      solFee.toBase58(),
+      payer.toBase58(),
+      SystemProgram.programId.toBase58(),
+    ])
+    expect(ix.keys.map((k) => k.isSigner)).toEqual([false, false, false, true, false])
+    expect(ix.keys.map((k) => k.isWritable)).toEqual([false, true, true, true, false])
+    expect(ix.data.equals(anchorDiscriminator('create_sol_vault'))).toBe(true)
+    expect(tx.feePayer?.toBase58()).toBe(payer.toBase58())
+  })
+})
+
+describe('barrel exports (native-SOL surface)', () => {
+  it('re-exports every native-SOL symbol', () => {
+    for (const name of [
+      'NATIVE_SOL_MINT',
+      'VAULT_SOL_SEED',
+      'FEE_SOL_SEED',
+      'deriveSolVaultPDA',
+      'deriveSolFeePDA',
+      'buildDepositSolTx',
+      'buildRefundSolTx',
+      'buildAuthorityRefundSolTx',
+      'buildCreateSolVaultTx',
+      'buildPrivateSendSolTx',
+    ]) {
+      expect(sdk).toHaveProperty(name)
+    }
   })
 })

--- a/packages/sdk/tests/vault-sol.test.ts
+++ b/packages/sdk/tests/vault-sol.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect } from 'vitest'
-import { PublicKey } from '@solana/web3.js'
+import { PublicKey, Connection, SystemProgram } from '@solana/web3.js'
 import {
   NATIVE_SOL_MINT,
   VAULT_SOL_SEED,
   FEE_SOL_SEED,
   deriveSolVaultPDA,
   deriveSolFeePDA,
+  buildDepositSolTx,
+  deriveVaultConfigPDA,
+  deriveDepositRecordPDA,
+  anchorDiscriminator,
+  SIPHER_VAULT_PROGRAM_ID,
 } from '../src/index.js'
 
 describe('native-SOL constants', () => {
@@ -36,5 +41,55 @@ describe('native-SOL PDA derivation', () => {
     const [vault] = deriveSolVaultPDA(custom)
     const [expected] = PublicKey.findProgramAddressSync([VAULT_SOL_SEED], custom)
     expect(vault.equals(expected)).toBe(true)
+  })
+})
+
+const BLOCKHASH = 'GfVcyD4kkTrj4bKc7WA9sZCin9JDbdT458zqL4zjxx2v'
+const DEPOSITOR = new PublicKey('FGSkt8MwXH83daNNW8ZkoqhL1KLcLoZLcdGJz84BWWr')
+
+// Minimal Connection stub: only getLatestBlockhash is exercised by the deposit builder.
+function mockConnDeposit(): Connection {
+  return {
+    getLatestBlockhash: async () => ({ blockhash: BLOCKHASH, lastValidBlockHeight: 1 }),
+  } as unknown as Connection
+}
+
+describe('buildDepositSolTx', () => {
+  it('builds deposit_sol with the exact DepositSol account order + flags', async () => {
+    const res = await buildDepositSolTx(mockConnDeposit(), DEPOSITOR, 5_000_000n)
+    const ix = res.transaction.instructions[0]
+
+    const [config] = deriveVaultConfigPDA()
+    const [record] = deriveDepositRecordPDA(DEPOSITOR, NATIVE_SOL_MINT)
+    const [solVault] = deriveSolVaultPDA()
+
+    expect(ix.programId.equals(SIPHER_VAULT_PROGRAM_ID)).toBe(true)
+    expect(ix.keys.map((k) => k.pubkey.toBase58())).toEqual([
+      config.toBase58(),
+      record.toBase58(),
+      solVault.toBase58(),
+      DEPOSITOR.toBase58(),
+      SystemProgram.programId.toBase58(),
+    ])
+    expect(ix.keys.map((k) => k.isSigner)).toEqual([false, false, false, true, false])
+    expect(ix.keys.map((k) => k.isWritable)).toEqual([true, true, true, true, false])
+  })
+
+  it('encodes discriminator + amount and sets feePayer/blockhash', async () => {
+    const res = await buildDepositSolTx(mockConnDeposit(), DEPOSITOR, 5_000_000n)
+    const data = res.transaction.instructions[0].data
+    expect(data.length).toBe(16)
+    expect(data.subarray(0, 8).equals(anchorDiscriminator('deposit_sol'))).toBe(true)
+    expect(data.readBigUInt64LE(8)).toBe(5_000_000n)
+    expect(res.transaction.feePayer?.toBase58()).toBe(DEPOSITOR.toBase58())
+    expect(res.transaction.recentBlockhash).toBe(BLOCKHASH)
+    expect(res.amount).toBe(5_000_000n)
+    expect(res.solVaultAddress.equals(deriveSolVaultPDA()[0])).toBe(true)
+  })
+
+  it('rejects a non-positive amount', async () => {
+    await expect(buildDepositSolTx(mockConnDeposit(), DEPOSITOR, 0n)).rejects.toThrow(
+      'Deposit amount must be greater than zero',
+    )
   })
 })

--- a/packages/sdk/tests/vault-sol.test.ts
+++ b/packages/sdk/tests/vault-sol.test.ts
@@ -173,6 +173,7 @@ describe('buildAuthorityRefundSolTx', () => {
     expect(ix.data.equals(anchorDiscriminator('authority_refund_sol'))).toBe(true)
     expect(res.transaction.feePayer?.toBase58()).toBe(AUTHORITY.toBase58())
     expect(res.refundAmount).toBe(4_000_000n)
+    expect(res.depositorAddress.toBase58()).toBe(DEPOSITOR.toBase58())
   })
 })
 


### PR DESCRIPTION
## Summary

`sipher_vault` is a universal-asset vault — it custodies classic SPL tokens, Token-2022, **and native SOL** — but `@sipher/sdk` only shipped transaction builders for the token path. This PR adds the native-SOL builders, mirroring the existing SPL ones one-for-one. Purely additive: no existing export, signature, or behavior changes.

## What's added (`@sipher/sdk`)

| Symbol | Instruction / purpose |
|---|---|
| `NATIVE_SOL_MINT`, `VAULT_SOL_SEED`, `FEE_SOL_SEED` | native-SOL sentinel mint + SolVault/SolFee PDA seeds |
| `deriveSolVaultPDA`, `deriveSolFeePDA` | SolVault / SolFee PDA derivation |
| `buildDepositSolTx` | `deposit_sol` |
| `buildRefundSolTx`, `buildAuthorityRefundSolTx` | `refund_sol` / `authority_refund_sol` |
| `buildPrivateSendSolTx` | `withdraw_private_sol` (stealth payout + Pedersen commitment + announcement CPI) |
| `buildCreateSolVaultTx` | `create_sol_vault` (one-time PDA init) |
| `SolDepositResult`, `SolRefundResult` | result types (`WithdrawResult` reused for withdraw) |

Native-SOL balance reads reuse the existing `getVaultBalance(connection, depositor, NATIVE_SOL_MINT)` — no new read function.

## Design notes

- **`NATIVE_SOL_MINT` is the all-zeros sentinel** (`Pubkey::new_from_array([0u8; 32])`), **not** wrapped SOL — the native path never wraps; kept distinct from `WSOL_MINT`.
- **Rent-exempt guard:** `withdraw_private_sol` pays a plain `SystemAccount`, so a small payout to a never-funded stealth address would be rejected by the runtime. `buildPrivateSendSolTx` pre-flights the recipient's balance against the rent-exempt minimum and throws an actionable error (caller pre-funds) instead of letting the tx fail opaquely.
- Account orders and instruction-data layouts are byte-exact mirrors of the on-chain contexts; the SolVault/SolFee PDA fixtures are verified against the live devnet deployment.

## Testing

- 14 new `vault-sol` tests + 5 new `privacy-sol` tests. **Full suite: 118 passing; `tsc --noEmit`: 0 errors.**
- Tests assert the full account-order + signer/writable arrays, instruction-data byte layout, fee/net computation, and the rent-exempt guard (throw + boundary-pass).

## Review

Built test-first via per-task implement→review cycles; a final whole-branch review verified every account flag, instruction-data layout, and struct offset (`fee_bps` @40, `total_transfers` @43) against the deployed program.

Design + plan: `docs/superpowers/specs/2026-06-24-sipher-sdk-native-sol-builders-design.md`, `docs/superpowers/plans/2026-06-24-sipher-sdk-native-sol-builders.md`.

Deferred (non-blocking) polish: a few additional validation-throw test cases, and sharing the withdraw `fixedSize` constant with the SPL path.
