### PR TITLE
chore(deps): bump reqwest 0.12→0.13 in the Rust SDK

### DIFF
--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -13,9 +13,9 @@ serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart"] }
+reqwest = { version = "^0.13", default-features = false, features = ["json", "multipart", "query"] }
 
 [features]
 default = ["native-tls"]
 native-tls = ["reqwest/native-tls"]
-rustls-tls = ["reqwest/rustls-tls"]
+rustls-tls = ["reqwest/rustls"]


### PR DESCRIPTION
Adopts reqwest 0.13 in the generated Rust client (`/sdks/rust`). Dependabot's #322 was version-only, but 0.13 has breaking feature changes that need adaptation:

- **`query` is now an opt-in crate feature** (was implicit in 0.12). The generated client calls `.query()` (×2), so `query` is added to the feature list — otherwise it fails to compile.
- **The `rustls-tls` reqwest feature was renamed to `rustls`.** The SDK's optional `rustls-tls` feature now maps to `reqwest/rustls`.

Default feature stays `native-tls` (still valid in 0.13), so default consumers are unaffected.

> Heads-up for `rustls-tls` consumers: reqwest 0.13's rustls backend now defaults to **aws-lc-rs** (needs a C toolchain + cmake at build time) instead of ring. Only affects builds that enable `rustls-tls`.

### Verification (local — JS CI doesn't cover `/sdks/rust`)
- `cargo build` (default native-tls) — ok, reqwest 0.13.4
- `cargo build --no-default-features --features rustls-tls` — ok (aws-lc-sys built)
- `cargo test` — 0 tests (generated SDK has none)

Supersedes #322 (closed as superseded on merge).