### PR TITLE
chore(deps): bump Docker base node 22→24-alpine (LTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 # ── Stage 1: Build ───────────────────────────────────────────────────────────
 
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /app
 
@@ -37,7 +37,7 @@ RUN pnpm build \
 
 # ── Stage 2: Production ─────────────────────────────────────────────────────
 
-FROM node:22-alpine
+FROM node:24-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
Retargets the Docker base image to **node:24-alpine** (the Active LTS) rather than Dependabot's #328 pick of **node:26-alpine**.

node 26 is a **Current** release — it doesn't become Active LTS until ~Oct 2026. For the production runtime, node:24 (Active LTS, supported through ~Apr 2028) is the right target. node:22 (current base) is now Maintenance LTS.

Both build and runtime stages updated.

### Verification (local — CI's `build-and-push` is skipped on PRs)
- `docker build` (full multi-stage) — ok
- `node --version` in image — **v24.18.0**
- `better-sqlite3` native module (node-gyp rebuild against node 24 ABI) — loads + runs (in-memory DB round-trips a value)
- `packages/agent/dist/index.js` — built

Supersedes #328 (closed as superseded on merge).